### PR TITLE
Fix Docker Hub README updates with proper authentication

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,11 +94,17 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
 
+      # Docker Hub's REST API (used to PATCH the README) rejects tokens
+      # scoped only to repo push/pull. Supply DOCKERHUB_PASSWORD as either
+      # the account password or a PAT with Read/Write/Delete permissions.
+      # Falls back to DOCKERHUB_TOKEN and is non-fatal so a failed
+      # description update doesn't fail an otherwise successful release.
       - name: Update Docker Hub README
         uses: peter-evans/dockerhub-description@v4
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_TOKEN }}
           repository: ${{ env.CORE_IMAGE }}
           readme-filepath: ./docker/README.voicegateway.md
           short-description: "Self-hosted inference gateway for voice AI with MCP"
@@ -160,11 +166,14 @@ jobs:
           cache-from: type=gha,scope=dashboard
           cache-to: type=gha,mode=max,scope=dashboard
 
+      # See note in publish-core: requires DOCKERHUB_PASSWORD (account
+      # password or PAT with Read/Write/Delete) to update the Hub README.
       - name: Update Docker Hub README
         uses: peter-evans/dockerhub-description@v4
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_TOKEN }}
           repository: ${{ env.DASHBOARD_IMAGE }}
           readme-filepath: ./docker/README.dashboard.md
           short-description: "Web dashboard for VoiceGateway"


### PR DESCRIPTION
## Summary
Updated Docker Hub README update steps in the CI/CD workflow to use proper authentication credentials and handle failures gracefully.

## Key Changes
- Changed authentication from `DOCKERHUB_TOKEN` to `DOCKERHUB_PASSWORD` (with fallback to `DOCKERHUB_TOKEN`) for both the core and dashboard Docker Hub README update steps
  - Docker Hub's REST API requires account password or a PAT with Read/Write/Delete permissions, not just repo push/pull scoped tokens
- Added `continue-on-error: true` to both README update steps to prevent failed description updates from failing the entire release workflow
- Added clarifying comments explaining the authentication requirements and fallback behavior

## Implementation Details
- The changes apply to two separate jobs: `publish-core` and `publish-dashboard`
- Both jobs now use the same authentication pattern: `${{ secrets.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_TOKEN }}`
- This allows flexibility for users to provide either a full account password or a properly scoped PAT while maintaining backward compatibility with existing `DOCKERHUB_TOKEN` secrets
- The `continue-on-error: true` flag ensures that Docker image publishing succeeds even if the README update fails, preventing release blockers from authentication issues

https://claude.ai/code/session_01Fgfv7oS4BuMzFFeFtcFXBe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image publication workflow to tolerate README update failures without blocking the publish job, improving overall resilience.
  * Updated authentication configuration for Docker Hub integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->