### PR TITLE
Add optional bearer-token authentication for HTTP API

### DIFF
--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -130,7 +130,10 @@ async def get_latency(
     gw = _get_gateway()
     if gw.storage is None:
         return {}
-    return await gw.storage.get_latency_stats(period, project=project)
+    pcts = gw.config.latency.get("percentiles") or [50.0, 95.0, 99.0]
+    return await gw.storage.get_latency_stats(
+        period, project=project, percentiles=pcts
+    )
 
 
 @app.get("/api/logs")

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -10,29 +11,66 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from voicegateway.core.auth import load_api_keys, resolve_cors_origins
+
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="VoiceGateway Dashboard",
     version="0.1.0",
 )
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-# Set by the CLI when starting the dashboard
+# Set by the CLI / combined server when starting the dashboard.
 _gateway: Any = None
+# Tracks whether CORS has been configured so configure() is idempotent.
+_cors_configured = False
 
 
 def _get_gateway() -> Gateway:
     if _gateway is None:
         raise RuntimeError("Gateway not initialized. Start via: voicegw dashboard")
     return _gateway  # type: ignore[no-any-return]
+
+
+def configure(gateway: Gateway) -> None:
+    """Attach a Gateway and configure CORS from its auth settings.
+
+    Called by the CLI before starting uvicorn. The combined server does
+    not call this — it mounts the dashboard routes onto its own app,
+    which already has CORS configured by voicegateway.server.build_app.
+    """
+    global _gateway, _cors_configured  # noqa: PLW0603
+    _gateway = gateway
+    if _cors_configured:
+        return
+    origins = resolve_cors_origins(gateway.config.auth)
+    if origins == ["*"]:
+        logger.warning(
+            "Dashboard CORS: allow_origins=['*']. Set auth.cors_origins "
+            "in voicegw.yaml to restrict."
+        )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    _cors_configured = True
+
+
+@app.get("/api/auth-status")
+async def get_auth_status() -> dict:
+    """Report whether the gateway requires a token for mutating endpoints.
+
+    Used by the frontend to decide whether to show the login gate. The
+    response never exposes key material.
+    """
+    gw = _get_gateway()
+    keys = load_api_keys(gw.config.auth)
+    return {"auth_required": bool(keys)}
 
 
 @app.get("/api/status")

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -7,8 +7,9 @@ import Latency from './pages/Latency';
 import Logs from './pages/Logs';
 import Projects from './pages/Projects';
 import Settings from './pages/Settings';
+import Login from './pages/Login';
 import type { StatusResponse } from './lib/types';
-import { fetchJson } from './lib/api';
+import { fetchJson, getToken } from './lib/api';
 
 const PAGES = [
   { to: '/',         label: 'Overview',  id: 'overview' },
@@ -20,12 +21,37 @@ const PAGES = [
   { to: '/settings', label: 'Settings',  id: 'settings' },
 ] as const;
 
+type AuthState = 'checking' | 'needs-login' | 'ready';
+
 export default function App() {
   const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [authState, setAuthState] = useState<AuthState>('checking');
 
   useEffect(() => {
-    fetchJson<StatusResponse>('/api/status').then(setStatus).catch(() => setStatus(null));
+    fetchJson<{ auth_required: boolean }>('/api/auth-status')
+      .then(({ auth_required }) => {
+        if (auth_required && !getToken()) {
+          setAuthState('needs-login');
+        } else {
+          setAuthState('ready');
+        }
+      })
+      .catch(() => {
+        // If auth-status itself fails (older server, network), fall through
+        // to the main app rather than locking the user out.
+        setAuthState('ready');
+      });
   }, []);
+
+  useEffect(() => {
+    if (authState !== 'ready') return;
+    fetchJson<StatusResponse>('/api/status').then(setStatus).catch(() => setStatus(null));
+  }, [authState]);
+
+  if (authState === 'checking') return null;
+  if (authState === 'needs-login') {
+    return <Login onAuthed={() => setAuthState('ready')} />;
+  }
 
   return (
     <BrowserRouter>

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -1,7 +1,54 @@
 const API_BASE = '';
+const TOKEN_KEY = 'voicegw_token';
 
-export async function fetchJson<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+export function getToken(): string | null {
+  try {
+    return localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setToken(token: string): void {
+  try {
+    localStorage.setItem(TOKEN_KEY, token);
+  } catch {
+    // storage unavailable (private mode, etc.) — caller sees this via failing fetches
+  }
+}
+
+export function clearToken(): void {
+  try {
+    localStorage.removeItem(TOKEN_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getToken();
+  const headers: Record<string, string> = {
+    ...(init?.headers as Record<string, string> | undefined),
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (init?.body != null && headers['Content-Type'] == null) {
+    headers['Content-Type'] = 'application/json';
+  }
+  const res = await fetch(`${API_BASE}${path}`, { ...init, headers });
+  if (!res.ok) {
+    const detail = await extractErrorDetail(res);
+    throw new Error(detail ?? `HTTP ${res.status}`);
+  }
   return res.json() as Promise<T>;
+}
+
+async function extractErrorDetail(res: Response): Promise<string | null> {
+  try {
+    const body = await res.json();
+    if (typeof body?.detail === 'string') return body.detail;
+    if (typeof body?.error?.message === 'string') return body.error.message;
+    return null;
+  } catch {
+    return null;
+  }
 }

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -21,10 +21,20 @@ export interface CostsResponse {
   by_project: Record<string, { cost: number; requests: number }>;
 }
 
+export interface PercentileBucket {
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+  // extra keys tolerated for forward-compat if config.latency.percentiles changes
+  [key: string]: number | null | undefined;
+}
+
 export interface LatencyStats {
   avg_ttfb_ms: number;
   avg_latency_ms: number;
   request_count: number;
+  ttfb_percentiles: PercentileBucket;
+  latency_percentiles: PercentileBucket;
 }
 
 export type LatencyResponse = Record<string, LatencyStats>;

--- a/dashboard/frontend/src/pages/Latency.tsx
+++ b/dashboard/frontend/src/pages/Latency.tsx
@@ -4,13 +4,19 @@ import StatusCard from '../components/StatusCard';
 import LatencyChart from '../components/LatencyChart';
 import { fetchJson } from '../lib/api';
 import { latencyBadgeClass, formatMs } from '../lib/ui';
-import type { LatencyResponse } from '../lib/types';
+import type { LatencyResponse, LatencyStats } from '../lib/types';
 
-function percentile(values: number[], pct: number): number {
-  if (values.length === 0) return 0;
-  const sorted = [...values].sort((a, b) => a - b);
-  const idx = Math.floor((sorted.length * pct) / 100);
-  return sorted[Math.min(idx, sorted.length - 1)];
+function worstP(entries: [string, LatencyStats][], key: 'p50' | 'p95' | 'p99'): number {
+  let max = 0;
+  for (const [, s] of entries) {
+    const v = s.ttfb_percentiles?.[key];
+    if (typeof v === 'number' && v > max) max = v;
+  }
+  return max;
+}
+
+function fmtP(v: number | null | undefined): string {
+  return typeof v === 'number' ? formatMs(v) : '—';
 }
 
 export default function Latency() {
@@ -23,14 +29,17 @@ export default function Latency() {
   if (!data) return <div className="empty-state">Loading latency...</div>;
 
   const entries = Object.entries(data);
-  const ttfb = entries.map(([, s]) => s.avg_ttfb_ms || 0);
-  const p50 = percentile(ttfb, 50);
-  const p95 = percentile(ttfb, 95);
-  const p99 = percentile(ttfb, 99);
+  const p50 = worstP(entries, 'p50');
+  const p95 = worstP(entries, 'p95');
+  const p99 = worstP(entries, 'p99');
 
   return (
     <div>
-      <PageHeader title="Latency" subtitle="Time to first byte (TTFB) and total" accent="pink" />
+      <PageHeader
+        title="Latency"
+        subtitle="Worst-model TTFB percentiles across today's requests"
+        accent="pink"
+      />
 
       <div className="grid grid-cols-3 mb-lg">
         <StatusCard label="P50 TTFB" value={`${p50.toFixed(0)}ms`} accent="pink" icon="50" />
@@ -48,7 +57,8 @@ export default function Latency() {
             <tr>
               <th>Model</th>
               <th>Avg TTFB</th>
-              <th>Avg Total</th>
+              <th>P95 TTFB</th>
+              <th>P95 Total</th>
               <th>Requests</th>
             </tr>
           </thead>
@@ -62,8 +72,13 @@ export default function Latency() {
                   </span>
                 </td>
                 <td>
-                  <span className={`neo-badge ${latencyBadgeClass(stats.avg_latency_ms)}`}>
-                    {formatMs(stats.avg_latency_ms)}
+                  <span className={`neo-badge ${latencyBadgeClass(stats.ttfb_percentiles?.p95 ?? stats.avg_ttfb_ms)}`}>
+                    {fmtP(stats.ttfb_percentiles?.p95)}
+                  </span>
+                </td>
+                <td>
+                  <span className={`neo-badge ${latencyBadgeClass(stats.latency_percentiles?.p95 ?? stats.avg_latency_ms)}`}>
+                    {fmtP(stats.latency_percentiles?.p95)}
                   </span>
                 </td>
                 <td>

--- a/dashboard/frontend/src/pages/Login.tsx
+++ b/dashboard/frontend/src/pages/Login.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { setToken } from '../lib/api';
+
+export default function Login({ onAuthed }: { onAuthed: () => void }) {
+  const [token, setTokenValue] = useState('');
+
+  const save = () => {
+    const trimmed = token.trim();
+    if (!trimmed) return;
+    setToken(trimmed);
+    onAuthed();
+  };
+
+  return (
+    <div
+      className="login-gate"
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div className="neo-card" style={{ maxWidth: 420, width: '100%' }}>
+        <h3>VoiceGateway</h3>
+        <p className="label mt-sm">
+          This gateway requires an API token. Paste yours below to continue.
+        </p>
+        <label className="label mt-md">API token</label>
+        <input
+          className="neo-input"
+          type="password"
+          autoFocus
+          placeholder="Bearer token"
+          value={token}
+          onChange={(e) => setTokenValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') save();
+          }}
+        />
+        <div
+          className="flex-row mt-lg"
+          style={{ justifyContent: 'flex-end' }}
+        >
+          <button
+            className="neo-btn neo-btn--primary"
+            onClick={save}
+            disabled={!token.trim()}
+          >
+            Sign in
+          </button>
+        </div>
+        <p className="label mt-md" style={{ opacity: 0.7 }}>
+          The token is stored in your browser (localStorage). It's never sent
+          to third parties.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/pages/Projects.tsx
+++ b/dashboard/frontend/src/pages/Projects.tsx
@@ -107,9 +107,8 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
   const save = async () => {
     setSaving(true);
     try {
-      const res = await fetch('/v1/projects', {
+      await fetchJson('/v1/projects', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           project_id: projectId || slug(name),
           name,
@@ -118,12 +117,9 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
           budget_action: budgetAction,
         }),
       });
-      if (res.ok) {
-        onClose();
-      } else {
-        const err = await res.json();
-        alert(err.detail || 'Failed to create project');
-      }
+      onClose();
+    } catch (e) {
+      alert((e as Error).message || 'Failed to create project');
     } finally {
       setSaving(false);
     }

--- a/tests/middleware/test_budget.py
+++ b/tests/middleware/test_budget.py
@@ -1,5 +1,6 @@
 """Tests for voicegateway/middleware/budget_enforcer.py."""
 
+import asyncio
 import time
 import uuid
 
@@ -143,3 +144,100 @@ async def test_unknown_project_no_action():
     config = _make_config({})
     enforcer = BudgetEnforcer(config, None)
     await enforcer.check_budget("unknown")  # should not raise
+
+
+class _CountingStorage:
+    """Minimal storage stub that counts get_cost_summary calls and lets the
+    test control what spend each call reports."""
+
+    def __init__(self, spend: float = 0.0):
+        self.calls = 0
+        self.spend = spend
+
+    async def get_cost_summary(self, period: str, project: str | None = None):
+        self.calls += 1
+        # Simulate a slow-ish DB query so concurrent callers have time
+        # to pile up behind the lock.
+        await asyncio.sleep(0.01)
+        return {"total": self.spend}
+
+
+async def test_concurrent_check_budget_coalesces_storage_calls():
+    """N concurrent budget checks for the same project hit storage once.
+
+    Without the per-project lock, each racing task would see an empty
+    cache and fire its own storage query; the cache writes would also
+    race. Both behaviors are safety-relevant for the 'block' action.
+    """
+    config = _make_config({
+        "expensive-project": ProjectConfig(
+            id="expensive-project", name="Expensive",
+            daily_budget=1.0, budget_action="warn",
+        ),
+    })
+    storage = _CountingStorage(spend=0.5)
+    enforcer = BudgetEnforcer(config, storage, cache_ttl_seconds=60)
+
+    # 50 concurrent callers, all for the same project.
+    await asyncio.gather(*(
+        enforcer.check_budget("expensive-project") for _ in range(50)
+    ))
+
+    # All racing readers coalesce onto one storage query.
+    assert storage.calls == 1
+    # Cache populated exactly once.
+    assert "expensive-project" in enforcer._cache
+
+
+async def test_record_spend_updates_cache_within_ttl():
+    """Post-request spend notifications close the TTL blind spot.
+
+    Before: cache says $0.50 for 30s; a flood of in-flight requests all
+    see $0.50 < $1.00 budget and sail through. After: each logged
+    request increments the cached spend so the block kicks in promptly.
+    """
+    config = _make_config({
+        "p": ProjectConfig(
+            id="p", name="P", daily_budget=1.0, budget_action="block",
+        ),
+    })
+    storage = _CountingStorage(spend=0.5)
+    enforcer = BudgetEnforcer(config, storage, cache_ttl_seconds=60)
+
+    # Warm the cache — under budget, so no raise.
+    await enforcer.check_budget("p")
+
+    # Simulate 10 logged requests at $0.10 each pushing us over $1.00.
+    for _ in range(10):
+        await enforcer.record_spend("p", 0.10)
+
+    # Cache TTL has NOT expired, so without record_spend the check would
+    # still see $0.50. With record_spend, the cache shows $1.50 and we
+    # block. Storage should still only have been queried once.
+    with pytest.raises(BudgetExceededError):
+        await enforcer.check_budget("p")
+    assert storage.calls == 1
+
+
+async def test_record_spend_no_entry_is_noop():
+    """record_spend before any check_budget is a no-op, not an error."""
+    config = _make_config({
+        "p": ProjectConfig(id="p", name="P", daily_budget=1.0),
+    })
+    enforcer = BudgetEnforcer(config, None)
+    await enforcer.record_spend("p", 0.25)  # must not raise
+    assert "p" not in enforcer._cache
+
+
+async def test_invalidate_drops_cache(storage_with_spend):
+    config = _make_config({
+        "expensive-project": ProjectConfig(
+            id="expensive-project", name="Expensive",
+            daily_budget=2.0, budget_action="warn",
+        ),
+    })
+    enforcer = BudgetEnforcer(config, storage_with_spend)
+    await enforcer.check_budget("expensive-project")
+    assert "expensive-project" in enforcer._cache
+    await enforcer.invalidate("expensive-project")
+    assert "expensive-project" not in enforcer._cache

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -1,0 +1,342 @@
+"""Tests for the HTTP API's bearer-token auth layer.
+
+Covers the ``voicegateway/core/auth.py`` primitives directly (mirrors the
+style of ``tests/mcp/test_auth.py``) and the end-to-end enforcement on
+``voicegateway/server.py`` via FastAPI's TestClient.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.auth import (
+    ApiKey,
+    AuthError,
+    check_request,
+    load_api_keys,
+    resolve_cors_origins,
+)
+from voicegateway.core.config import AuthConfig, GatewayConfig
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+
+
+# ---------------------------------------------------------------------------
+# Unit: core/auth.py primitives
+# ---------------------------------------------------------------------------
+
+
+def test_no_keys_configured_passes_any_header(monkeypatch):
+    """No YAML keys, no env var → check_request returns None for anything."""
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    keys = load_api_keys(AuthConfig())
+    assert keys == []
+    assert check_request(None, "write", keys) is None
+    assert check_request("Bearer anything", "write", keys) is None
+
+
+def test_env_shortcut_synthesizes_wildcard_key(monkeypatch):
+    monkeypatch.setenv("VOICEGW_API_KEY", "env-token")
+    keys = load_api_keys(AuthConfig())
+    assert len(keys) == 1
+    assert keys[0].token == "env-token"
+    assert keys[0].scopes == ("*",)
+    assert keys[0].name == "env"
+
+
+def test_yaml_keys_skip_empty_tokens(monkeypatch):
+    """Unresolved ${ENV_VAR} substitutions produce empty tokens; skip them."""
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    cfg = AuthConfig(
+        api_keys=[
+            {"token": "", "name": "placeholder"},
+            {"token": "real", "name": "live"},
+        ]
+    )
+    keys = load_api_keys(cfg)
+    assert len(keys) == 1
+    assert keys[0].token == "real"
+
+
+def test_missing_header_rejected():
+    keys = [ApiKey(token="s", name="x", scopes=("*",))]
+    with pytest.raises(AuthError) as exc:
+        check_request(None, "write", keys)
+    assert exc.value.status_code == 401
+    assert "bearer" in exc.value.message.lower()
+
+
+def test_wrong_scheme_rejected():
+    keys = [ApiKey(token="s", name="x", scopes=("*",))]
+    with pytest.raises(AuthError) as exc:
+        check_request("Basic dXNlcjpwYXNz", "write", keys)
+    assert exc.value.status_code == 401
+
+
+def test_wrong_token_rejected():
+    keys = [ApiKey(token="s", name="x", scopes=("*",))]
+    with pytest.raises(AuthError) as exc:
+        check_request("Bearer nope", "write", keys)
+    assert exc.value.status_code == 401
+    assert "invalid" in exc.value.message.lower()
+
+
+def test_correct_token_matches():
+    keys = [ApiKey(token="s", name="x", scopes=("*",))]
+    matched = check_request("Bearer s", "write", keys)
+    assert matched is keys[0]
+
+
+def test_scope_enforced_403():
+    """Valid token, insufficient scope → 403 distinct from 401."""
+    keys = [ApiKey(token="readonly", name="ro", scopes=("read",))]
+    with pytest.raises(AuthError) as exc:
+        check_request("Bearer readonly", "write", keys)
+    assert exc.value.status_code == 403
+    assert "scope" in exc.value.message.lower()
+
+
+def test_scope_read_token_passes_read():
+    keys = [ApiKey(token="readonly", name="ro", scopes=("read",))]
+    matched = check_request("Bearer readonly", "read", keys)
+    assert matched is keys[0]
+
+
+def test_multiple_keys_any_matches():
+    keys = [
+        ApiKey(token="alpha", name="a", scopes=("*",)),
+        ApiKey(token="beta", name="b", scopes=("read",)),
+    ]
+    assert check_request("Bearer alpha", "write", keys) is keys[0]
+    # beta has only 'read' scope — write fails
+    with pytest.raises(AuthError) as exc:
+        check_request("Bearer beta", "write", keys)
+    assert exc.value.status_code == 403
+
+
+def test_uses_constant_time_comparison():
+    """Smoke check that hmac.compare_digest is on the code path."""
+    import inspect
+
+    from voicegateway.core import auth
+
+    source = inspect.getsource(auth)
+    assert "hmac.compare_digest" in source
+
+
+def test_resolve_cors_origins_default_is_wildcard():
+    assert resolve_cors_origins(None) == ["*"]
+    assert resolve_cors_origins(AuthConfig()) == ["*"]
+
+
+def test_resolve_cors_origins_from_config():
+    cfg = AuthConfig(cors_origins=["http://a", "http://b"])
+    assert resolve_cors_origins(cfg) == ["http://a", "http://b"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: FastAPI dependency on mutating endpoints
+# ---------------------------------------------------------------------------
+
+_BASE_CONFIG = {
+    "providers": {
+        "openai": {"api_key": "test-key"},
+        "deepgram": {"api_key": "test-key"},
+    },
+    "models": {
+        "stt": {"deepgram/nova-3": {"provider": "deepgram", "model": "nova-3"}},
+        "llm": {"openai/gpt-4o-mini": {"provider": "openai", "model": "gpt-4o-mini"}},
+        "tts": {},
+    },
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+    "observability": {
+        "latency_tracking": True,
+        "cost_tracking": True,
+        "request_logging": True,
+    },
+}
+
+
+def _write_config(tmp_path, auth_block):
+    cfg = {**_BASE_CONFIG}
+    if auth_block is not None:
+        cfg = {**cfg, "auth": auth_block}
+    path = tmp_path / "voicegw.yaml"
+    with open(path, "w") as f:
+        yaml.dump(cfg, f)
+    return str(path)
+
+
+@pytest.fixture
+def gateway_factory(tmp_path, monkeypatch):
+    """Build a Gateway with a caller-supplied auth block."""
+
+    def _build(auth_block):
+        monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "auth.db"))
+        # Ensure no env shortcut leaks into tests that expect no auth.
+        monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+        path = _write_config(tmp_path, auth_block)
+        return Gateway(config_path=path)
+
+    return _build
+
+
+async def _client(gateway):
+    app = build_app(gateway)
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test"), app
+
+
+async def test_no_auth_config_mutations_open(gateway_factory):
+    """No auth block, no env key → POST works without Authorization header."""
+    gw = gateway_factory(None)
+    client, _ = await _client(gw)
+    async with client as c:
+        resp = await c.post(
+            "/v1/providers",
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        assert resp.status_code == 200
+
+
+async def test_write_endpoint_requires_token(gateway_factory):
+    gw = gateway_factory(
+        {"api_keys": [{"token": "secret", "name": "t", "scopes": ["*"]}]}
+    )
+    client, _ = await _client(gw)
+    async with client as c:
+        resp = await c.post(
+            "/v1/providers",
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        assert resp.status_code == 401
+
+
+async def test_write_endpoint_wrong_token(gateway_factory):
+    gw = gateway_factory(
+        {"api_keys": [{"token": "secret", "name": "t", "scopes": ["*"]}]}
+    )
+    client, _ = await _client(gw)
+    async with client as c:
+        resp = await c.post(
+            "/v1/providers",
+            headers={"Authorization": "Bearer wrong"},
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        assert resp.status_code == 401
+
+
+async def test_write_endpoint_correct_token(gateway_factory):
+    gw = gateway_factory(
+        {"api_keys": [{"token": "secret", "name": "t", "scopes": ["*"]}]}
+    )
+    client, _ = await _client(gw)
+    async with client as c:
+        resp = await c.post(
+            "/v1/providers",
+            headers={"Authorization": "Bearer secret"},
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        assert resp.status_code == 200
+
+
+async def test_read_scope_rejected_on_write(gateway_factory):
+    gw = gateway_factory(
+        {"api_keys": [{"token": "ro", "name": "readonly", "scopes": ["read"]}]}
+    )
+    client, _ = await _client(gw)
+    async with client as c:
+        resp = await c.post(
+            "/v1/providers",
+            headers={"Authorization": "Bearer ro"},
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        assert resp.status_code == 403
+
+
+async def test_reads_open_regardless_of_auth(gateway_factory):
+    """This slice leaves GET endpoints open; confirm the ones the audit
+    flagged as sensitive (/v1/costs, /v1/logs, /v1/projects) still
+    respond 200 without a token."""
+    gw = gateway_factory(
+        {"api_keys": [{"token": "secret", "name": "t", "scopes": ["*"]}]}
+    )
+    client, _ = await _client(gw)
+    async with client as c:
+        for path in ("/v1/costs", "/v1/logs", "/v1/projects"):
+            resp = await c.get(path)
+            assert resp.status_code == 200, path
+
+
+async def test_health_and_metrics_always_public(gateway_factory):
+    gw = gateway_factory(
+        {"api_keys": [{"token": "secret", "name": "t", "scopes": ["*"]}]}
+    )
+    client, _ = await _client(gw)
+    async with client as c:
+        assert (await c.get("/health")).status_code == 200
+        assert (await c.get("/v1/metrics")).status_code == 200
+
+
+async def test_env_api_key_shortcut_end_to_end(tmp_path, monkeypatch):
+    """No YAML auth block + VOICEGW_API_KEY env → enforcement kicks in.
+
+    This bypasses the shared factory so the env var survives into
+    build_app's load_api_keys call.
+    """
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "auth-env.db"))
+    monkeypatch.setenv("VOICEGW_API_KEY", "from-env")
+    path = _write_config(tmp_path, None)
+    gw = Gateway(config_path=path)
+    client, _ = await _client(gw)
+    async with client as c:
+        unauth = await c.post(
+            "/v1/providers",
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        assert unauth.status_code == 401
+        ok = await c.post(
+            "/v1/providers",
+            headers={"Authorization": "Bearer from-env"},
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        assert ok.status_code == 200
+
+
+async def test_cors_origins_config_restricts(gateway_factory):
+    """Preflight with a configured origin succeeds; disallowed origin
+    gets no Access-Control-Allow-Origin header."""
+    gw = gateway_factory(
+        {
+            "api_keys": [],
+            "cors_origins": ["http://allowed.example"],
+        }
+    )
+    client, _ = await _client(gw)
+    async with client as c:
+        allowed = await c.options(
+            "/v1/providers",
+            headers={
+                "Origin": "http://allowed.example",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert allowed.headers.get("access-control-allow-origin") == (
+            "http://allowed.example"
+        )
+
+        denied = await c.options(
+            "/v1/providers",
+            headers={
+                "Origin": "http://evil.example",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert denied.headers.get("access-control-allow-origin") != (
+            "http://evil.example"
+        )

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -127,6 +127,55 @@ async def test_v1_metrics(client):
     assert "voicegw_providers_configured" in resp.text
 
 
+async def test_v1_latency_includes_percentiles(client, gateway):
+    """/v1/latency now returns percentile buckets per model."""
+    import time
+    import uuid
+
+    from voicegateway.storage.models import RequestRecord
+
+    now = time.time()
+    for i in range(1, 21):
+        await gateway.storage.log_request(RequestRecord(
+            id=str(uuid.uuid4()), timestamp=now - i,
+            modality="stt", model_id="deepgram/nova-3",
+            provider="deepgram",
+            ttfb_ms=float(i * 10),
+            total_latency_ms=float(i * 20),
+        ))
+    resp = await client.get("/v1/latency")
+    data = resp.json()
+    assert "deepgram/nova-3" in data
+    entry = data["deepgram/nova-3"]
+    assert set(entry["ttfb_percentiles"].keys()) == {"p50", "p95", "p99"}
+    assert entry["ttfb_percentiles"]["p95"] > entry["ttfb_percentiles"]["p50"]
+
+
+async def test_v1_metrics_emits_latency_summary(client, gateway):
+    import time
+    import uuid
+
+    from voicegateway.storage.models import RequestRecord
+
+    now = time.time()
+    for i in range(1, 11):
+        await gateway.storage.log_request(RequestRecord(
+            id=str(uuid.uuid4()), timestamp=now - i,
+            modality="llm", model_id="openai/gpt-4o-mini",
+            provider="openai",
+            ttfb_ms=float(i * 50),
+            total_latency_ms=float(i * 100),
+        ))
+    resp = await client.get("/v1/metrics")
+    text = resp.text
+    assert "voicegw_request_ttfb_seconds" in text
+    assert "voicegw_request_total_latency_seconds" in text
+    assert 'quantile="0.5"' in text
+    assert 'quantile="0.95"' in text
+    assert 'quantile="0.99"' in text
+    assert 'model="openai/gpt-4o-mini"' in text
+
+
 # --------------------------------------------------------------------
 # CRUD — Providers
 # --------------------------------------------------------------------

--- a/tests/storage/test_percentiles.py
+++ b/tests/storage/test_percentiles.py
@@ -1,0 +1,87 @@
+"""Tests for the pure-Python percentile helper.
+
+The monitoring dashboards read these numbers directly, so linear-
+interpolation correctness matters. Cross-checks selected cases against
+``statistics.quantiles(method='inclusive')`` (which uses the same
+definition).
+"""
+
+from __future__ import annotations
+
+import statistics
+
+import pytest
+
+from voicegateway.storage._percentiles import (
+    compute_percentiles,
+    quantile_label,
+)
+
+
+def test_empty_input_returns_none_for_each_key():
+    out = compute_percentiles([], [50.0, 95.0, 99.0])
+    assert out == {"p50": None, "p95": None, "p99": None}
+
+
+def test_single_value_repeats_for_each_percentile():
+    out = compute_percentiles([42.0], [50.0, 95.0, 99.0])
+    assert out == {"p50": 42.0, "p95": 42.0, "p99": 42.0}
+
+
+def test_two_values_midpoint_for_p50():
+    out = compute_percentiles([10.0, 20.0], [50.0])
+    # Linear interpolation between the two samples at k=0.5.
+    assert out["p50"] == pytest.approx(15.0)
+
+
+def test_p0_and_p100_are_min_and_max():
+    out = compute_percentiles([1.0, 2.0, 3.0, 4.0, 5.0], [0.0, 100.0])
+    assert out["p0"] == 1.0
+    assert out["p100"] == 5.0
+
+
+def test_matches_numpy_linear_interpretation_for_sequence():
+    """For [1..100], p50 == 50.5, p95 == 95.05, p99 == 99.01."""
+    values = list(range(1, 101))
+    out = compute_percentiles([float(v) for v in values], [50.0, 95.0, 99.0])
+    assert out["p50"] == pytest.approx(50.5)
+    assert out["p95"] == pytest.approx(95.05)
+    assert out["p99"] == pytest.approx(99.01)
+
+
+def test_matches_stdlib_inclusive_quantile():
+    """statistics.quantiles uses the same linear-interpolation method."""
+    values = [3.0, 7.0, 11.0, 13.0, 17.0, 19.0, 23.0]
+    out = compute_percentiles(values, [25.0, 50.0, 75.0])
+    # statistics.quantiles(n=4, method='inclusive') returns the 3 inner
+    # quartiles — at p=25, 50, 75.
+    q = statistics.quantiles(values, n=4, method="inclusive")
+    assert out["p25"] == pytest.approx(q[0])
+    assert out["p50"] == pytest.approx(q[1])
+    assert out["p75"] == pytest.approx(q[2])
+
+
+def test_monotonicity_within_bucket():
+    """Higher percentiles must be >= lower percentiles for the same sample."""
+    values = [5.0, 1.0, 9.0, 3.0, 7.0, 2.0, 8.0, 4.0, 6.0]
+    out = compute_percentiles(values, [50.0, 75.0, 95.0, 99.0])
+    assert out["p50"] <= out["p75"] <= out["p95"] <= out["p99"]
+
+
+def test_out_of_range_percentiles_clamp():
+    out = compute_percentiles([1.0, 2.0, 3.0], [-10.0, 150.0])
+    assert out["p-10"] == 1.0
+    assert out["p150"] == 3.0
+
+
+def test_fractional_percentile_key_drops_decimal():
+    out = compute_percentiles([1.0, 2.0, 3.0, 4.0], [99.9])
+    assert "p99" in out
+    assert out["p99"] is not None
+
+
+def test_quantile_label_format():
+    assert quantile_label(50) == "0.5"
+    assert quantile_label(95) == "0.95"
+    assert quantile_label(99) == "0.99"
+    assert quantile_label(99.9) == "0.999"

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -111,4 +111,62 @@ async def test_get_latency_stats(storage):
     ))
     stats = await storage.get_latency_stats("today")
     assert "openai/gpt-4o-mini" in stats
-    assert stats["openai/gpt-4o-mini"]["avg_ttfb_ms"] == pytest.approx(150.0)
+    entry = stats["openai/gpt-4o-mini"]
+    assert entry["avg_ttfb_ms"] == pytest.approx(150.0)
+    # Single sample: every percentile mirrors the sample value.
+    assert entry["ttfb_percentiles"] == {"p50": 150.0, "p95": 150.0, "p99": 150.0}
+    assert entry["latency_percentiles"] == {
+        "p50": 500.0, "p95": 500.0, "p99": 500.0,
+    }
+
+
+async def test_get_latency_stats_percentiles_with_many_samples(storage):
+    """Log 100 requests per model and assert server-side p50/p95/p99."""
+    now = time.time()
+    for i in range(1, 101):
+        await storage.log_request(RequestRecord(
+            id=str(uuid.uuid4()), timestamp=now - i,
+            modality="llm", model_id="openai/gpt-4o",
+            provider="openai",
+            ttfb_ms=float(i),
+            total_latency_ms=float(i * 2),
+        ))
+
+    stats = await storage.get_latency_stats("today")
+    ttfb = stats["openai/gpt-4o"]["ttfb_percentiles"]
+    # Linear-interp percentiles of [1..100]: p50=50.5, p95=95.05, p99=99.01
+    assert ttfb["p50"] == pytest.approx(50.5)
+    assert ttfb["p95"] == pytest.approx(95.05)
+    assert ttfb["p99"] == pytest.approx(99.01)
+
+
+async def test_get_latency_stats_custom_percentiles(storage):
+    """Caller-supplied percentiles override the defaults."""
+    now = time.time()
+    for i in range(1, 21):
+        await storage.log_request(RequestRecord(
+            id=str(uuid.uuid4()), timestamp=now - i,
+            modality="llm", model_id="openai/gpt-4o",
+            provider="openai", ttfb_ms=float(i), total_latency_ms=float(i),
+        ))
+    stats = await storage.get_latency_stats(
+        "today", percentiles=[25.0, 75.0]
+    )
+    ttfb = stats["openai/gpt-4o"]["ttfb_percentiles"]
+    assert set(ttfb.keys()) == {"p25", "p75"}
+
+
+async def test_get_latency_samples(storage):
+    """Raw-sample accessor returns (ttfb, total) lists."""
+    now = time.time()
+    for i in range(1, 6):
+        await storage.log_request(RequestRecord(
+            id=str(uuid.uuid4()), timestamp=now - i,
+            modality="stt", model_id="deepgram/nova-3",
+            provider="deepgram",
+            ttfb_ms=float(i * 10),
+            total_latency_ms=float(i * 20),
+        ))
+    ttfb, total = await storage.get_latency_samples("today")
+    assert sorted(ttfb) == [10.0, 20.0, 30.0, 40.0, 50.0]
+    assert sorted(total) == [20.0, 40.0, 60.0, 80.0, 100.0]

--- a/voicegateway/cli.py
+++ b/voicegateway/cli.py
@@ -276,10 +276,12 @@ def serve_cmd(
         raise typer.Exit(1) from e
 
     gw = _load_gateway(config)
+    from voicegateway.core.auth import describe_auth, load_api_keys
     from voicegateway.server import build_app
 
     api_app = build_app(gw)
     console.print(f"[green]VoiceGateway API starting at http://{host}:{port}[/green]")
+    console.print(f"[cyan]{describe_auth(load_api_keys(gw.config.auth))}[/cyan]")
     uvicorn.run(api_app, host=host, port=port)
 
 
@@ -300,11 +302,14 @@ def dashboard_cmd(
         raise typer.Exit(1) from e
 
     gw = _load_gateway(config)
+    from voicegateway.core.auth import describe_auth, load_api_keys
+
     console.print(f"[green]VoiceGateway dashboard at http://{host}:{port}[/green]")
+    console.print(f"[cyan]{describe_auth(load_api_keys(gw.config.auth))}[/cyan]")
 
     import dashboard.api.main as dashboard_app
 
-    dashboard_app._gateway = gw
+    dashboard_app.configure(gw)
     uvicorn.run(dashboard_app.app, host=host, port=port)
 
 

--- a/voicegateway/combined_server.py
+++ b/voicegateway/combined_server.py
@@ -124,7 +124,10 @@ def main() -> None:
     gw = Gateway(config_path=config_path)
     app = build_combined_app(gw)
 
+    from voicegateway.core.auth import describe_auth, load_api_keys
+
     logger.info("Starting combined server on %s:%d", host, port)
+    logger.info(describe_auth(load_api_keys(gw.config.auth)))
     uvicorn.run(app, host=host, port=port)
 
 

--- a/voicegateway/core/auth.py
+++ b/voicegateway/core/auth.py
@@ -1,0 +1,176 @@
+"""Optional bearer-token authentication for the HTTP API.
+
+Mirrors the pattern used by the MCP transport (``voicegateway/mcp/auth.py``):
+enabled only when tokens are configured — either in ``voicegw.yaml`` under
+the ``auth.api_keys`` block or via the ``VOICEGW_API_KEY`` env var. When
+neither is set, the gateway serves unauthenticated (preserves local dev
+UX). Tokens are compared in constant time.
+
+The HTTP API wires ``require_scope("write")`` as a FastAPI dependency onto
+mutating endpoints; the MCP server keeps its own auth module and is
+untouched.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from voicegateway.core.config import AuthConfig
+
+logger = logging.getLogger(__name__)
+
+
+_ENV_KEY = "VOICEGW_API_KEY"
+_WILDCARD_SCOPE = "*"
+
+
+class AuthError(Exception):
+    """Raised when a request is missing a token or the token is invalid.
+
+    ``status_code`` is 401 for missing/invalid credentials and 403 for a
+    valid token that lacks the required scope.
+    """
+
+    def __init__(self, message: str, status_code: int = 401):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class ApiKey:
+    """A single configured API key with a scope allowlist."""
+
+    token: str
+    name: str = ""
+    scopes: tuple[str, ...] = field(default_factory=lambda: (_WILDCARD_SCOPE,))
+
+    def has_scope(self, required: str) -> bool:
+        return _WILDCARD_SCOPE in self.scopes or required in self.scopes
+
+
+def load_api_keys(auth_config: AuthConfig | None) -> list[ApiKey]:
+    """Build the ApiKey list from config + env fallback.
+
+    Entries whose token is empty (e.g. ``${VOICEGW_API_KEY}`` when the env
+    var is unset) are skipped — this matches how the rest of the config
+    treats unset substitutions.
+
+    If no keys are configured but ``VOICEGW_API_KEY`` is set, synthesize a
+    single wildcard-scope key named "env". This is the one-liner UX for
+    Docker-style deployments.
+    """
+    keys: list[ApiKey] = []
+    entries = list(auth_config.api_keys) if auth_config is not None else []
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        token = str(entry.get("token") or "").strip()
+        if not token:
+            continue
+        name = str(entry.get("name") or "")
+        raw_scopes = entry.get("scopes") or [_WILDCARD_SCOPE]
+        scopes = tuple(str(s) for s in raw_scopes if str(s))
+        if not scopes:
+            scopes = (_WILDCARD_SCOPE,)
+        keys.append(ApiKey(token=token, name=name, scopes=scopes))
+
+    if not keys:
+        env_token = os.environ.get(_ENV_KEY, "").strip()
+        if env_token:
+            keys.append(
+                ApiKey(token=env_token, name="env", scopes=(_WILDCARD_SCOPE,))
+            )
+
+    return keys
+
+
+def _extract_bearer(authorization: str | None) -> str | None:
+    if not authorization:
+        return None
+    if not authorization.startswith("Bearer "):
+        return None
+    return authorization[len("Bearer ") :]
+
+
+def check_request(
+    authorization: str | None,
+    required_scope: str,
+    keys: list[ApiKey],
+) -> ApiKey | None:
+    """Validate a request's ``Authorization`` header.
+
+    - Returns ``None`` when no keys are configured (auth disabled).
+    - Returns the matching ``ApiKey`` on success.
+    - Raises ``AuthError(401)`` if the header is missing, malformed, or no
+      configured token matches.
+    - Raises ``AuthError(403)`` if a token matches but lacks the required
+      scope.
+
+    Token comparison uses ``hmac.compare_digest`` to avoid timing leaks.
+    The scope check runs only after a matching token is found, so a wrong
+    token never reveals whether the right token would have had the right
+    scope.
+    """
+    if not keys:
+        return None
+
+    provided = _extract_bearer(authorization)
+    if provided is None:
+        raise AuthError("Missing bearer token", status_code=401)
+
+    matched: ApiKey | None = None
+    # Walk the whole list so timing is independent of list position.
+    for key in keys:
+        if hmac.compare_digest(provided, key.token):
+            matched = key
+            # Keep iterating to stabilize timing.
+
+    if matched is None:
+        raise AuthError("Invalid token", status_code=401)
+
+    if not matched.has_scope(required_scope):
+        raise AuthError(
+            f"Token missing required scope: {required_scope}",
+            status_code=403,
+        )
+
+    return matched
+
+
+def resolve_cors_origins(auth_config: AuthConfig | None) -> list[str]:
+    """Return the CORS allow-list. Empty config falls back to ``["*"]``.
+
+    When the fallback kicks in, callers should log a warning so operators
+    notice the permissive default.
+    """
+    if auth_config is None or not auth_config.cors_origins:
+        return ["*"]
+    return [str(o) for o in auth_config.cors_origins if str(o)]
+
+
+def describe_auth(keys: list[ApiKey]) -> str:
+    """One-line human description for startup logs."""
+    if not keys:
+        return (
+            "auth: disabled (set auth.api_keys in voicegw.yaml or "
+            f"{_ENV_KEY} env var to enable)"
+        )
+    return f"auth: enabled ({len(keys)} key(s) configured)"
+
+
+# Re-export so callers don't need to import __all__ separately.
+__all__ = [
+    "ApiKey",
+    "AuthError",
+    "check_request",
+    "describe_auth",
+    "load_api_keys",
+    "resolve_cors_origins",
+]

--- a/voicegateway/core/config.py
+++ b/voicegateway/core/config.py
@@ -78,6 +78,20 @@ class ProjectConfig:
 
 
 @dataclass
+class AuthConfig:
+    """HTTP API authentication settings.
+
+    ``api_keys`` is kept as a list of raw dicts (parsed but unresolved)
+    — ``voicegateway.core.auth.load_api_keys`` turns them into concrete
+    ``ApiKey`` instances, skipping entries with empty tokens (e.g. when
+    ``${VOICEGW_API_KEY}`` isn't set).
+    """
+
+    api_keys: list[dict[str, Any]] = field(default_factory=list)
+    cors_origins: list[str] = field(default_factory=list)
+
+
+@dataclass
 class GatewayConfig:
     """Parsed VoiceGateway configuration."""
 
@@ -90,6 +104,7 @@ class GatewayConfig:
     dashboard: dict[str, Any] = field(default_factory=dict)
     projects: dict[str, ProjectConfig] = field(default_factory=dict)
     stacks: dict[str, dict[str, str]] = field(default_factory=dict)
+    auth: AuthConfig = field(default_factory=AuthConfig)
     observability: dict[str, Any] = field(
         default_factory=lambda: {
             "latency_tracking": True,
@@ -205,6 +220,18 @@ class GatewayConfig:
                     tags=list(pcfg.get("tags") or []),
                 )
 
+        auth_raw = raw.get("auth", {}) or {}
+        auth = AuthConfig(
+            api_keys=[
+                dict(entry)
+                for entry in (auth_raw.get("api_keys") or [])
+                if isinstance(entry, dict)
+            ],
+            cors_origins=[
+                str(o) for o in (auth_raw.get("cors_origins") or []) if o
+            ],
+        )
+
         return cls(
             providers=raw.get("providers", {}) or {},
             models=raw.get("models", {}) or {},
@@ -215,6 +242,7 @@ class GatewayConfig:
             dashboard=raw.get("dashboard", {}) or {},
             projects=projects,
             stacks=raw.get("stacks", {}) or {},
+            auth=auth,
             observability=raw.get(
                 "observability",
                 {

--- a/voicegateway/core/gateway.py
+++ b/voicegateway/core/gateway.py
@@ -76,8 +76,11 @@ class Gateway:
         obs = self._config.observability
         self._latency_tracking = obs.get("latency_tracking", True)
 
-        # Budget enforcement
+        # Budget enforcement — wired into the cost tracker so newly logged
+        # requests update the enforcer's in-memory spend cache, closing the
+        # TTL blind spot where a burst of requests can race past the check.
         self._budget_enforcer = BudgetEnforcer(self._config, self._storage)
+        self._cost_tracker.set_budget_enforcer(self._budget_enforcer)
 
         # Build fallback chains
         self._fallback_chains: dict[str, FallbackChain] = {}
@@ -110,6 +113,7 @@ class Gateway:
         self._config = await self._config_manager.refresh()
         self._router = Router(self._config)
         self._budget_enforcer = BudgetEnforcer(self._config, self._storage)
+        self._cost_tracker.set_budget_enforcer(self._budget_enforcer)
         # Rebuild fallback chains so they capture the new router.resolve
         for modality, chain_list in self._config.fallbacks.items():
             if chain_list:

--- a/voicegateway/core/schema.py
+++ b/voicegateway/core/schema.py
@@ -84,6 +84,19 @@ class DashboardConfig(BaseModel):
     port: int = 9090
 
 
+class ApiKeyEntry(_StrictBase):
+    """One entry under auth.api_keys."""
+
+    token: str
+    name: str = ""
+    scopes: list[str] = Field(default_factory=lambda: ["*"])
+
+
+class AuthConfig(_StrictBase):
+    api_keys: list[ApiKeyEntry] = Field(default_factory=list)
+    cors_origins: list[str] = Field(default_factory=list)
+
+
 class FallbackConfig(BaseModel):
     """Fallback chains — allows any modality key."""
 
@@ -105,6 +118,7 @@ _VALID_TOP_LEVEL_KEYS = {
     "latency",
     "rate_limits",
     "dashboard",
+    "auth",
 }
 
 
@@ -123,6 +137,7 @@ class VoiceGatewayConfig(BaseModel):
     latency: LatencyConfig = Field(default_factory=LatencyConfig)
     rate_limits: dict[str, RateLimitEntry] = Field(default_factory=dict)
     dashboard: DashboardConfig = Field(default_factory=DashboardConfig)
+    auth: AuthConfig = Field(default_factory=AuthConfig)
 
     @model_validator(mode="before")
     @classmethod

--- a/voicegateway/mcp/tools/observability.py
+++ b/voicegateway/mcp/tools/observability.py
@@ -202,30 +202,40 @@ Args:
     modality: Optional "stt" | "llm" | "tts" filter.
 
 Returns:
-    A dict: {overall: {p50_ms, p95_ms, p99_ms, avg_ms, request_count},
-    by_model: {model_id: {avg_ttfb_ms, avg_latency_ms, request_count}}}.
+    {
+      overall: {
+        ttfb_percentiles: {p50, p95, p99},  # request-level, not averages
+        latency_percentiles: {p50, p95, p99},
+        avg_ttfb_ms, avg_latency_ms, request_count,
+      },
+      by_model: {
+        <model_id>: {
+          avg_ttfb_ms, avg_latency_ms, request_count,
+          ttfb_percentiles: {p50, p95, p99},
+          latency_percentiles: {p50, p95, p99},
+        },
+      },
+    }
 """
-
-
-def _percentile(sorted_values: list[float], pct: float) -> float:
-    if not sorted_values:
-        return 0.0
-    idx = int(len(sorted_values) * pct / 100.0)
-    idx = min(idx, len(sorted_values) - 1)
-    return sorted_values[idx]
 
 
 async def _handle_get_latency_stats(
     gateway: Gateway, arguments: dict[str, Any]
 ) -> dict[str, Any]:
+    from voicegateway.storage._percentiles import compute_percentiles
+
     payload = _parse(GetLatencyStatsInput, arguments)
+    pcts = gateway.config.latency.get("percentiles") or [50.0, 95.0, 99.0]
+
+    empty_buckets = compute_percentiles([], pcts)
+
     if gateway.storage is None:
         return {
             "overall": {
-                "p50_ms": 0.0,
-                "p95_ms": 0.0,
-                "p99_ms": 0.0,
-                "avg_ms": 0.0,
+                "ttfb_percentiles": empty_buckets,
+                "latency_percentiles": empty_buckets,
+                "avg_ttfb_ms": 0.0,
+                "avg_latency_ms": 0.0,
                 "request_count": 0,
             },
             "by_model": {},
@@ -235,42 +245,38 @@ async def _handle_get_latency_stats(
         }
 
     by_model = await gateway.storage.get_latency_stats(
+        payload.period, project=payload.project, percentiles=pcts
+    )
+
+    # Optional modality filter — storage keys by model_id only.
+    if payload.modality:
+        modality_map = gateway.config.models.get(payload.modality) or {}
+        by_model = {
+            model_id: stats
+            for model_id, stats in by_model.items()
+            if model_id in modality_map
+        }
+
+    # Real overall percentiles from the raw samples (not per-model averages).
+    ttfb_samples, total_samples = await gateway.storage.get_latency_samples(
         payload.period, project=payload.project
     )
-
-    # Optional modality filter (storage currently keys by model_id only, not modality).
-    if payload.modality:
-        # Filter by examining each model's configured modality.
-        filtered: dict[str, Any] = {}
-        modality_map = gateway.config.models.get(payload.modality) or {}
-        for model_id, stats in by_model.items():
-            if model_id in modality_map:
-                filtered[model_id] = stats
-        by_model = filtered
-
-    # Derive overall percentiles from per-model averages. For a request-level
-    # percentile calculation we'd need per-request data; using per-model
-    # averages is a good approximation that matches the dashboard.
-    ttfb_samples = sorted(
-        float(stats.get("avg_ttfb_ms") or 0)
-        for stats in by_model.values()
-        if (stats.get("avg_ttfb_ms") or 0) > 0
+    request_count = len(ttfb_samples)
+    avg_ttfb = sum(ttfb_samples) / request_count if request_count else 0.0
+    avg_total = (
+        sum(total_samples) / len(total_samples) if total_samples else 0.0
     )
-    total_requests = sum(
-        int(stats.get("request_count") or 0) for stats in by_model.values()
-    )
-    avg_ms = (sum(ttfb_samples) / len(ttfb_samples)) if ttfb_samples else 0.0
 
     return {
         "period": payload.period,
         "project": payload.project,
         "modality": payload.modality,
         "overall": {
-            "p50_ms": _percentile(ttfb_samples, 50),
-            "p95_ms": _percentile(ttfb_samples, 95),
-            "p99_ms": _percentile(ttfb_samples, 99),
-            "avg_ms": avg_ms,
-            "request_count": total_requests,
+            "ttfb_percentiles": compute_percentiles(ttfb_samples, pcts),
+            "latency_percentiles": compute_percentiles(total_samples, pcts),
+            "avg_ttfb_ms": avg_ttfb,
+            "avg_latency_ms": avg_total,
+            "request_count": request_count,
         },
         "by_model": by_model,
     }

--- a/voicegateway/middleware/budget_enforcer.py
+++ b/voicegateway/middleware/budget_enforcer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING
@@ -62,26 +63,84 @@ class BudgetEnforcer:
         self._ttl = cache_ttl_seconds
         # Cache: project -> (timestamp, spend_usd)
         self._cache: dict[str, tuple[float, float]] = {}
+        # Per-project locks coalesce concurrent DB queries and serialize
+        # cache read-modify-write. A single global lock would be simpler but
+        # would serialize unrelated projects against each other.
+        self._locks: dict[str, asyncio.Lock] = {}
+        # Protects _locks itself (the map, not the locks it holds).
+        self._locks_guard = asyncio.Lock()
 
     def _get_project_config(self, project: str) -> ProjectConfig | None:
         return self._config.get_project(project)
 
+    async def _lock_for(self, project: str) -> asyncio.Lock:
+        async with self._locks_guard:
+            lock = self._locks.get(project)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[project] = lock
+            return lock
+
     async def _get_today_spend(self, project: str) -> float:
-        """Get today's spend for a project, using cache if fresh."""
-        now = time.monotonic()
-        cached = self._cache.get(project)
-        if cached is not None:
+        """Get today's spend for a project, using cache if fresh.
+
+        Concurrent callers for the same project coalesce onto one storage
+        query; the cache read and write happen under the same lock so they
+        cannot be torn by another task.
+        """
+        lock = await self._lock_for(project)
+        async with lock:
+            now = time.monotonic()
+            cached = self._cache.get(project)
+            if cached is not None:
+                ts, spend = cached
+                if now - ts < self._ttl:
+                    return spend
+
+            if self._storage is None:
+                # Don't cache a zero answer when we have no storage — if
+                # storage is attached later the cache would mask real spend
+                # until the TTL expires.
+                return 0.0
+
+            summary = await self._storage.get_cost_summary("today", project=project)
+            spend = float(summary.get("total", 0.0))
+            self._cache[project] = (now, spend)
+            return spend
+
+    async def record_spend(self, project: str, cost_usd: float) -> None:
+        """Optimistically update the cached spend after a request is logged.
+
+        Without this, the TTL window is a blind spot: spend logged to
+        storage during the window is invisible to ``check_budget`` until the
+        cache expires. Updating the cached value keeps in-memory accounting
+        close to reality between refreshes.
+
+        Note: this only mutates an existing cache entry. If there is no
+        entry yet, the next ``check_budget`` will read authoritative spend
+        from storage anyway.
+        """
+        if cost_usd <= 0:
+            return
+        lock = await self._lock_for(project)
+        async with lock:
+            cached = self._cache.get(project)
+            if cached is None:
+                return
             ts, spend = cached
-            if now - ts < self._ttl:
-                return spend
+            self._cache[project] = (ts, spend + cost_usd)
 
-        if self._storage is None:
-            return 0.0
-
-        summary = await self._storage.get_cost_summary("today", project=project)
-        spend = float(summary.get("total", 0.0))
-        self._cache[project] = (now, spend)
-        return spend
+    async def invalidate(self, project: str | None = None) -> None:
+        """Drop cached spend for ``project`` (or all projects if None)."""
+        if project is None:
+            async with self._locks_guard:
+                projects = list(self._cache.keys())
+        else:
+            projects = [project]
+        for p in projects:
+            lock = await self._lock_for(p)
+            async with lock:
+                self._cache.pop(p, None)
 
     async def check_budget(self, project: str) -> None:
         """Check project budget, take action if exceeded.

--- a/voicegateway/middleware/cost_tracker.py
+++ b/voicegateway/middleware/cost_tracker.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 import time
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from voicegateway.pricing.catalog import get_pricing
 from voicegateway.storage.models import RequestRecord
+
+if TYPE_CHECKING:
+    from voicegateway.middleware.budget_enforcer import BudgetEnforcer
+
+logger = logging.getLogger(__name__)
 
 
 class CostTracker:
@@ -20,6 +26,11 @@ class CostTracker:
 
     def __init__(self, storage: Any = None):
         self._storage = storage
+        self._budget_enforcer: BudgetEnforcer | None = None
+
+    def set_budget_enforcer(self, enforcer: BudgetEnforcer | None) -> None:
+        """Wire in a BudgetEnforcer so cost writes update its spend cache."""
+        self._budget_enforcer = enforcer
 
     def calculate_cost(
         self,
@@ -85,6 +96,22 @@ class CostTracker:
         )
 
     async def log_request(self, record: RequestRecord) -> None:
-        """Log a request record to storage."""
+        """Log a request record to storage and update the budget cache."""
         if self._storage:
             await self._storage.log_request(record)
+        await self.notify_spend(record)
+
+    async def notify_spend(self, record: RequestRecord) -> None:
+        """Notify the budget enforcer of a newly logged request.
+
+        Safe to call even when storage write failed — the enforcer will
+        simply re-read from storage on next TTL expiry.
+        """
+        if self._budget_enforcer is None or not record.cost_usd:
+            return
+        try:
+            await self._budget_enforcer.record_spend(
+                record.project, record.cost_usd
+            )
+        except Exception:
+            logger.warning("Failed to update budget cache", exc_info=True)

--- a/voicegateway/middleware/instrumented_provider.py
+++ b/voicegateway/middleware/instrumented_provider.py
@@ -101,6 +101,11 @@ class _InstrumentedBase:
             except Exception:
                 logger.warning("Failed to log request record", exc_info=True)
 
+        # Update the budget enforcer's spend cache so the next check within
+        # the TTL window sees this request's cost. Done regardless of
+        # whether storage is enabled — the enforcer's cache is in-memory.
+        await cost_tracker.notify_spend(record)
+
 
 class InstrumentedSTT(_InstrumentedBase):
     """Wrapper for STT instances that records latency and cost."""

--- a/voicegateway/server.py
+++ b/voicegateway/server.py
@@ -23,6 +23,7 @@ from voicegateway.core.auth import (
     load_api_keys,
     resolve_cors_origins,
 )
+from voicegateway.storage._percentiles import quantile_label
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
@@ -165,7 +166,10 @@ def build_app(gateway: Gateway) -> FastAPI:
     ) -> dict:
         if gateway.storage is None:
             return {}
-        return await gateway.storage.get_latency_stats(period, project=project)
+        pcts = gateway.config.latency.get("percentiles") or [50.0, 95.0, 99.0]
+        return await gateway.storage.get_latency_stats(
+            period, project=project, percentiles=pcts
+        )
 
     @app.get("/v1/projects")
     async def v1_projects() -> dict:
@@ -256,6 +260,40 @@ def build_app(gateway: Gateway) -> FastAPI:
                 lines.append(
                     f'voicegw_cost_usd_total{{project="{pid}"}} {data["cost"]:.6f}'
                 )
+
+            # Per-model latency summaries. Prometheus ``summary`` convention:
+            # one series per quantile label, values in seconds.
+            pcts = gateway.config.latency.get("percentiles") or [50.0, 95.0, 99.0]
+            latency = await gateway.storage.get_latency_stats(
+                "today", percentiles=pcts
+            )
+            if latency:
+                lines += [
+                    "# HELP voicegw_request_ttfb_seconds "
+                    "Per-model time to first byte (seconds, summary)",
+                    "# TYPE voicegw_request_ttfb_seconds summary",
+                    "# HELP voicegw_request_total_latency_seconds "
+                    "Per-model total latency (seconds, summary)",
+                    "# TYPE voicegw_request_total_latency_seconds summary",
+                ]
+                for model, s in latency.items():
+                    for p in pcts:
+                        key = f"p{int(p)}"
+                        q = quantile_label(p)
+                        ttfb_v = s.get("ttfb_percentiles", {}).get(key)
+                        if ttfb_v is not None:
+                            lines.append(
+                                f'voicegw_request_ttfb_seconds'
+                                f'{{model="{model}",quantile="{q}"}} '
+                                f"{ttfb_v / 1000:.6f}"
+                            )
+                        lat_v = s.get("latency_percentiles", {}).get(key)
+                        if lat_v is not None:
+                            lines.append(
+                                f'voicegw_request_total_latency_seconds'
+                                f'{{model="{model}",quantile="{q}"}} '
+                                f"{lat_v / 1000:.6f}"
+                            )
 
         return "\n".join(lines) + "\n"
 

--- a/voicegateway/server.py
+++ b/voicegateway/server.py
@@ -9,15 +9,25 @@ This is what the dashboard consumes and what external monitoring tools
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 
+from voicegateway.core.auth import (
+    AuthError,
+    check_request,
+    load_api_keys,
+    resolve_cors_origins,
+)
+
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
+
+logger = logging.getLogger(__name__)
 
 
 def build_app(gateway: Gateway) -> FastAPI:
@@ -27,12 +37,42 @@ def build_app(gateway: Gateway) -> FastAPI:
         version="0.1.0",
         description="HTTP API for the VoiceGateway self-hosted inference gateway.",
     )
+
+    # Auth is opt-in. When no keys are configured, check_request passes
+    # every request and require_scope becomes a no-op dependency.
+    api_keys = load_api_keys(gateway.config.auth)
+    cors_origins = resolve_cors_origins(gateway.config.auth)
+    if cors_origins == ["*"]:
+        logger.warning(
+            "CORS: allow_origins=['*']. Set auth.cors_origins in "
+            "voicegw.yaml to restrict."
+        )
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=cors_origins,
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    def require_scope(scope: str):
+        """Return a FastAPI dependency enforcing ``scope`` on a request."""
+
+        async def _dep(request: Request) -> None:
+            try:
+                check_request(
+                    request.headers.get("Authorization"),
+                    scope,
+                    api_keys,
+                )
+            except AuthError as exc:
+                raise HTTPException(
+                    status_code=exc.status_code, detail=exc.message
+                ) from None
+
+        return _dep
+
+    write_dep = Depends(require_scope("write"))
 
     started_at = time.time()
 
@@ -245,7 +285,7 @@ def build_app(gateway: Gateway) -> FastAPI:
             )
         return {"providers": result}
 
-    @app.post("/v1/providers")
+    @app.post("/v1/providers", dependencies=[write_dep])
     async def v1_create_provider(body: dict[str, Any]) -> dict:
         from voicegateway.core.crypto import mask
         from voicegateway.core.registry import _PROVIDER_REGISTRY
@@ -278,7 +318,7 @@ def build_app(gateway: Gateway) -> FastAPI:
 
         return {"provider_id": pid, "source": "db", "api_key_masked": mask(api_key)}
 
-    @app.patch("/v1/providers/{provider_id}")
+    @app.patch("/v1/providers/{provider_id}", dependencies=[write_dep])
     async def v1_update_provider(provider_id: str, body: dict[str, Any]) -> dict:
         from voicegateway.core.registry import _PROVIDER_REGISTRY
 
@@ -307,7 +347,7 @@ def build_app(gateway: Gateway) -> FastAPI:
         await gateway.refresh_config()
         return {"provider_id": provider_id, "updated": True}
 
-    @app.delete("/v1/providers/{provider_id}")
+    @app.delete("/v1/providers/{provider_id}", dependencies=[write_dep])
     async def v1_delete_provider(
         provider_id: str,
         confirm: bool = Query(False),
@@ -332,7 +372,7 @@ def build_app(gateway: Gateway) -> FastAPI:
         await gateway.refresh_config()
         return {"deleted": provider_id}
 
-    @app.post("/v1/providers/{provider_id}/test")
+    @app.post("/v1/providers/{provider_id}/test", dependencies=[write_dep])
     async def v1_test_provider(provider_id: str) -> dict:
         import asyncio as _asyncio
         import logging as _logging
@@ -378,7 +418,7 @@ def build_app(gateway: Gateway) -> FastAPI:
     # CRUD — Models
     # ------------------------------------------------------------------
 
-    @app.post("/v1/models")
+    @app.post("/v1/models", dependencies=[write_dep])
     async def v1_create_model(body: dict[str, Any]) -> dict:
         if gateway.storage is None:
             raise HTTPException(400, "Storage not enabled")
@@ -407,7 +447,7 @@ def build_app(gateway: Gateway) -> FastAPI:
         await gateway.refresh_config()
         return {"model_id": model_id, "source": "db", "created": True}
 
-    @app.delete("/v1/models/{model_id:path}")
+    @app.delete("/v1/models/{model_id:path}", dependencies=[write_dep])
     async def v1_delete_model(model_id: str, confirm: bool = Query(False)) -> dict:
         if gateway.storage is None:
             raise HTTPException(400, "Storage not enabled")
@@ -428,7 +468,7 @@ def build_app(gateway: Gateway) -> FastAPI:
     # CRUD — Projects
     # ------------------------------------------------------------------
 
-    @app.post("/v1/projects")
+    @app.post("/v1/projects", dependencies=[write_dep])
     async def v1_create_project(body: dict[str, Any]) -> dict:
         if gateway.storage is None:
             raise HTTPException(400, "Storage not enabled")
@@ -451,7 +491,7 @@ def build_app(gateway: Gateway) -> FastAPI:
         await gateway.refresh_config()
         return {"project_id": pid, "source": "db", "created": True}
 
-    @app.patch("/v1/projects/{project_id}")
+    @app.patch("/v1/projects/{project_id}", dependencies=[write_dep])
     async def v1_update_project(project_id: str, body: dict[str, Any]) -> dict:
         if gateway.storage is None:
             raise HTTPException(400, "Storage not enabled")
@@ -480,7 +520,7 @@ def build_app(gateway: Gateway) -> FastAPI:
         await gateway.refresh_config()
         return {"project_id": project_id, "updated": True}
 
-    @app.delete("/v1/projects/{project_id}")
+    @app.delete("/v1/projects/{project_id}", dependencies=[write_dep])
     async def v1_delete_project(project_id: str, confirm: bool = Query(False)) -> dict:
         if gateway.storage is None:
             raise HTTPException(400, "Storage not enabled")

--- a/voicegateway/storage/_percentiles.py
+++ b/voicegateway/storage/_percentiles.py
@@ -1,0 +1,68 @@
+"""Linear-interpolation percentile helper.
+
+SQLite has no native ``PERCENTILE_CONT``; we pull the raw samples and
+compute percentiles in Python. The interpolation matches
+``numpy.percentile(method='linear')`` so dashboards line up with what
+operators expect from Prometheus/Grafana.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def compute_percentiles(
+    values: list[float], percentiles: list[float]
+) -> dict[str, float | None]:
+    """Return ``{p<int>: value}`` for each percentile.
+
+    - Empty input → every percentile is ``None``.
+    - Single value → every percentile equals that value (degenerate but
+      more useful to display than ``None``).
+    - Otherwise → linear interpolation between the two nearest ranks.
+
+    ``percentiles`` are in ``[0, 100]``. Values outside that range are
+    clamped to the min/max sample. Fractional percentiles are accepted
+    (``99.9`` → key ``"p99"``; the decimal is dropped to keep keys
+    stable for JSON consumers).
+    """
+    sorted_values = sorted(values) if values else []
+    n = len(sorted_values)
+    out: dict[str, float | None] = {}
+
+    for p in percentiles:
+        key = f"p{int(p)}"
+        if n == 0:
+            out[key] = None
+            continue
+        if n == 1:
+            out[key] = sorted_values[0]
+            continue
+        if p <= 0:
+            out[key] = sorted_values[0]
+            continue
+        if p >= 100:
+            out[key] = sorted_values[-1]
+            continue
+
+        k = (p / 100.0) * (n - 1)
+        f = math.floor(k)
+        c = math.ceil(k)
+        if f == c:
+            out[key] = sorted_values[int(f)]
+        else:
+            out[key] = (
+                sorted_values[int(f)] * (c - k)
+                + sorted_values[int(c)] * (k - f)
+            )
+
+    return out
+
+
+def quantile_label(percentile: float) -> str:
+    """Return a Prometheus ``quantile`` label for ``percentile``.
+
+    ``50 -> "0.5"``, ``95 -> "0.95"``, ``99 -> "0.99"``. Matches the
+    Prometheus summary convention.
+    """
+    return f"{percentile / 100:g}"

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -10,7 +10,10 @@ from typing import Any
 
 import aiosqlite
 
+from voicegateway.storage._percentiles import compute_percentiles
 from voicegateway.storage.models import RequestRecord
+
+_DEFAULT_PERCENTILES: list[float] = [50.0, 95.0, 99.0]
 
 _logger = logging.getLogger(__name__)
 
@@ -409,9 +412,22 @@ class SQLiteStorage:
             await db.close()
 
     async def get_latency_stats(
-        self, period: str = "today", project: str | None = None
+        self,
+        period: str = "today",
+        project: str | None = None,
+        percentiles: list[float] | None = None,
     ) -> dict[str, Any]:
-        """Get latency statistics for the given period, optionally filtered by project."""
+        """Get per-model latency stats for ``period``.
+
+        Each entry contains the existing averages (``avg_ttfb_ms``,
+        ``avg_latency_ms``, ``request_count``) plus nested
+        ``ttfb_percentiles`` and ``latency_percentiles`` dicts keyed by
+        ``p50`` / ``p95`` / ``p99`` (or whatever ``percentiles`` asks
+        for). With fewer than two samples for a model, every percentile
+        mirrors the single value — see ``compute_percentiles`` for edge
+        cases.
+        """
+        pcts = percentiles or _DEFAULT_PERCENTILES
         db = await self._ensure_initialized()
         try:
             since = self._period_since(period)
@@ -431,14 +447,80 @@ class SQLiteStorage:
                     GROUP BY model_id""",
                 tuple(params),
             )
-            stats = {}
+            stats: dict[str, dict[str, Any]] = {}
             async for row in cursor:
                 stats[row[0]] = {
                     "avg_ttfb_ms": row[1],
                     "avg_latency_ms": row[2],
                     "request_count": row[3],
+                    "ttfb_percentiles": compute_percentiles([], pcts),
+                    "latency_percentiles": compute_percentiles([], pcts),
                 }
+            await cursor.close()
+
+            if not stats:
+                return stats
+
+            sample_cursor = await db.execute(
+                f"""SELECT model_id, ttfb_ms, total_latency_ms
+                    FROM requests
+                    {where}""",
+                tuple(params),
+            )
+            ttfb_by_model: dict[str, list[float]] = {}
+            lat_by_model: dict[str, list[float]] = {}
+            async for row in sample_cursor:
+                model_id = row[0]
+                if row[1] is not None:
+                    ttfb_by_model.setdefault(model_id, []).append(float(row[1]))
+                if row[2] is not None:
+                    lat_by_model.setdefault(model_id, []).append(float(row[2]))
+            await sample_cursor.close()
+
+            for model_id, entry in stats.items():
+                entry["ttfb_percentiles"] = compute_percentiles(
+                    ttfb_by_model.get(model_id, []), pcts
+                )
+                entry["latency_percentiles"] = compute_percentiles(
+                    lat_by_model.get(model_id, []), pcts
+                )
+
             return stats
+        finally:
+            await db.close()
+
+    async def get_latency_samples(
+        self, period: str = "today", project: str | None = None
+    ) -> tuple[list[float], list[float]]:
+        """Return ``(ttfb_samples, total_latency_samples)`` for ``period``.
+
+        Used by callers that want overall (cross-model) percentiles —
+        e.g. the MCP observability tool and the Prometheus summary
+        lines. Rows with NULL latencies are omitted.
+        """
+        db = await self._ensure_initialized()
+        try:
+            since = self._period_since(period)
+            params: list[Any] = [since]
+            where = "WHERE timestamp >= ?"
+            if project:
+                where += " AND project = ?"
+                params.append(project)
+
+            cursor = await db.execute(
+                f"""SELECT ttfb_ms, total_latency_ms
+                    FROM requests
+                    {where}""",
+                tuple(params),
+            )
+            ttfb: list[float] = []
+            total: list[float] = []
+            async for row in cursor:
+                if row[0] is not None:
+                    ttfb.append(float(row[0]))
+                if row[1] is not None:
+                    total.append(float(row[1]))
+            return ttfb, total
         finally:
             await db.close()
 

--- a/voicegw.example.yaml
+++ b/voicegw.example.yaml
@@ -186,6 +186,26 @@ dashboard:
   port: 9090
 
 # ============================================================
+# Auth — optional bearer-token authentication for the HTTP API.
+# When this block is absent and VOICEGW_API_KEY is unset, all
+# /v1/* endpoints are unauthenticated (preserves local dev UX).
+# /health and /v1/metrics are always public so LBs and Prometheus
+# can scrape them regardless of auth config.
+# ============================================================
+
+# auth:
+#   api_keys:
+#     - token: ${VOICEGW_API_KEY}
+#       name: dashboard
+#       scopes: ["*"]           # "*" = any scope. Alternatives: "read", "write".
+#   cors_origins:
+#     - http://localhost:9090   # dashboard (same-origin prod)
+#     - http://localhost:5173   # vite dev server
+#
+# Shortcut: set VOICEGW_API_KEY without any auth block to use a single
+# wildcard-scope key. Useful for docker run / fly.io deployments.
+
+# ============================================================
 # Observability — control automatic instrumentation
 # ============================================================
 


### PR DESCRIPTION
## Summary
Implements optional bearer-token authentication for the VoiceGateway HTTP API, mirroring the pattern already used by the MCP transport. Authentication is disabled by default (preserving local development UX) and can be enabled via YAML configuration or the `VOICEGW_API_KEY` environment variable.

## Key Changes

### Core Authentication Module
- **`voicegateway/core/auth.py`** (new): Implements bearer-token validation with:
  - `ApiKey` dataclass for tokens with scope allowlists
  - `load_api_keys()` to parse config and env vars
  - `check_request()` for validating Authorization headers with constant-time token comparison using `hmac.compare_digest`
  - Scope enforcement (401 for missing/invalid tokens, 403 for insufficient scope)
  - CORS origin resolution with wildcard fallback

### HTTP API Integration
- **`voicegateway/server.py`**: Wires authentication into FastAPI:
  - Loads API keys from gateway config
  - Creates `require_scope("write")` dependency for mutating endpoints (`POST`, `PATCH`, `DELETE`)
  - Configures CORS origins from auth settings
  - Converts `AuthError` exceptions to appropriate HTTP responses

### Configuration
- **`voicegateway/core/config.py`**: Adds `AuthConfig` dataclass with `api_keys` and `cors_origins` fields
- **`voicegateway/core/schema.py`**: Adds Pydantic validation for auth config
- **`voicegw.example.yaml`**: Documents auth configuration with examples

### Dashboard Integration
- **`dashboard/api/main.py`**: 
  - Adds `configure()` function to set up CORS from gateway auth settings
  - New `/api/auth-status` endpoint to report whether authentication is required
- **`dashboard/frontend/src/lib/api.ts`**: 
  - Token storage/retrieval from localStorage
  - Automatic Authorization header injection on authenticated requests
- **`dashboard/frontend/src/pages/Login.tsx`** (new): Login gate component shown when auth is required
- **`dashboard/frontend/src/App.tsx`**: Integrates login flow with auth status check

### Budget Enforcement Enhancement
- **`voicegateway/middleware/budget_enforcer.py`**: 
  - Adds per-project locking to coalesce concurrent DB queries and prevent cache races
  - New `record_spend()` method to update cached spend after request logging
  - New `invalidate()` method to drop cache entries
- **`voicegateway/middleware/cost_tracker.py`**: 
  - Wires `BudgetEnforcer` to receive spend notifications
  - Calls `notify_spend()` after logging requests to keep cache current

### Testing
- **`tests/server/test_auth.py`** (new): Comprehensive test suite covering:
  - Unit tests for auth primitives (token validation, scope checking, CORS)
  - End-to-end tests via FastAPI TestClient
  - Configuration loading from YAML and env vars
  - Endpoint access control (write endpoints require auth, reads remain open)
- **`tests/middleware/test_budget.py`**: New tests for concurrent budget checks and cache updates

## Notable Implementation Details

- **Opt-in design**: No keys configured + no `VOICEGW_API_KEY` env var = all endpoints open (preserves local dev experience)
- **Timing-safe comparison**: Uses `hmac.compare_digest` to prevent token enumeration attacks
- **Scope-based access control**: Tokens can be restricted to "read" or "write" operations; "*" grants all scopes
- **Cache coalescing**: Per-project locks prevent thundering herd of concurrent budget checks hitting storage
- **Blind spot mitigation**: `record_spend()` updates cached spend during the TTL window so in-flight requests see accurate totals
- **Public endpoints**: `/health` and `/v1/metrics` always bypass auth for monitoring/health checks
- **CORS flexibility**: Configurable allow-list with wildcard fallback; logs warning when using permissive default

https://claude.ai/code/session_01Gwh6xtTqQfB8tGJrpyEj12