### PR TITLE
v0.3.0 — Conversation replay and debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to VoiceGateway are documented here. This project follows [Semantic Versioning](https://semver.org/) and [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.3.0 -- 2026-05-11
+
+**Conversation replay and debugging.** The universal "this saved me hours" feature for voice-agent developers. Open any past conversation in the dashboard, scrub through it like a video timeline, and see every STT chunk, every LLM token, every TTS frame, plus the agent's conversation state at every moment — with cost accruing live as you scrub. Replay is captured by default for every session, full fidelity, with per-project `retention_days` (default 90) ageing rows out automatically.
+
+### Added
+
+- **`voicegateway.middleware.replay_capture.ReplayCapture`** (REQ-VG-REPLAY-003). Per-session asyncio buffer that captures STT chunks, LLM tokens, TTS frames, and conversation-state snapshots keyed by `session_id`. Bounded backpressure: at `buffer_size_events` (default 5000), the oldest event is dropped and a `dropped_count` increments — the dashboard surfaces this as "events dropped here" rather than silently misleading. Auto-flushes at `flush_size_events` (default 500) or on session close.
+- **`voicegateway.middleware.state_snapshotter.StateSnapshotter`** (REQ-VG-REPLAY-005). Pydantic `StateSnapshot` model serialized at LLM message-add, tool-call-invoke, and tool-call-resolve boundaries. Per-session rate cap of one snapshot per second guards against storage explosion on chatty agents; tool-resolve snapshots bypass the cap because the in-flight → done transition is structurally important.
+- **Migration 0004** introduces four replay tables (`replay_stt_events`, `replay_llm_tokens`, `replay_tts_frames`, `replay_state_snapshots`) sharing an `(id, session_id, t_ms, payload, provider, cost_usd, created_at)` shape with `(session_id, t_ms)` composite indexes, plus a `replay_size_bytes` nullable column on the existing `sessions` table. Idempotent. v0.2.0 sessions preserved with NULL on `replay_size_bytes` (REQ-VG-REPLAY-006 graceful-handling).
+- **`voicegateway.storage.replay_repo`** (REQ-VG-REPLAY-001, -006). Flat async function module: `bulk_write_events` partitions by modality and runs `executemany` per partition; `read_full_replay` UNION ALL's the four tables ordered by `t_ms`; `delete_replay` cascades a single transaction across all four tables; `aggregate_storage_per_session` sums `length(payload)` for the dashboard storage-usage view.
+- **`voicegateway.storage.retention_worker.RetentionWorker`** (REQ-VG-REPLAY-006). Hourly asyncio task; reads each project's `replay.retention_days` and deletes replay rows tied to sessions whose `ended_at` is older than the window. In-flight sessions (`ended_at IS NULL`) are explicitly excluded. Single-process for v0.3.0; multi-replica coordination is deferred.
+- **`SQLiteStorage.finalize_session_replay(session_id)`**. Composes `replay_repo.aggregate_storage_per_session` into a single UPDATE to write `replay_size_bytes` to the sessions row. Called by `CostTracker.close_session` alongside the existing v0.2.0 `finalize_session_metrics`; each call is independently guarded so a failure in one does not prevent the other.
+- **Four dashboard endpoints** in `dashboard/api/main.py`: `GET /api/sessions/{id}/replay` (full time-ordered event stream — OQ3 pre-fetch resolution), `DELETE /api/sessions/{id}/replay` (cascade), `GET /api/replay/storage` (per-project byte breakdown), `POST /api/projects/{id}/replay/retention` (in-memory retention update with body-validated `int [1, 365]`).
+- **`ReplayConfig` per-project YAML knobs**: `replay.enabled` (default true), `replay.retention_days` (default 90, `ge=1`), `replay.buffer_size_events` (default 5000), `replay.flush_size_events` (default 500). Mirrored across the Pydantic schema and the runtime dataclass.
+- **Dashboard `Replay` page** (`dashboard/frontend/src/pages/Replay.tsx`) reading `:sessionId` from the URL, pre-fetching the full replay on mount, and rendering a Scrubber + 2×2 pane grid + RunningCostCounter. Seven subcomponents: `Scrubber` (range input + ArrowLeft/Right step to prev/next event + Shift+Arrow for 1s jump + Home/End for call boundaries), `TranscriptPane` (STT with partial-revision opacity), `ModelOutputPane` (LLM with tool-invoke badges), `SynthesisPane` (TTS with red underrun frames), `ConversationStatePane` (system prompt + message history + tool-in-flight), `RunningCostCounter` (per-modality breakdown + top-3 costliest tooltip), `PreV030Banner` (pre-v0.3.0 session fallback with link to session detail).
+- **Sidebar nav route** at `/sessions/:sessionId/replay`. The Sessions page table now carries an "Open replay" column with a `<Link>` per row; clicking propagates straight to the Replay page without opening the session-detail modal.
+- **Typed fetchers** in `dashboard/frontend/src/lib/api.ts`: `fetchSessionReplay`, `deleteSessionReplay`, `fetchReplayStorage`, `updateReplayRetention`. Four new TS types in `lib/types.ts`: `ReplayEvent`, `ReplayResponse`, `StateSnapshot`, `RetentionWindow`.
+- **`voicegw replay <session-id>`** Typer command. Signpost-only for v0.3.0: prints the dashboard URL for the Replay page. Future scope can embed a Textual mini-replay using the v0.1.1 TUI primitives.
+- **41 new tests** across `tests/middleware/`, `tests/storage/`, `tests/server/`, and `tests/storage/test_replay_storage_smoke.py`. The smoke is the **Foundry Open Question 1 gate**: a synthetic 60-second conversation (40 STT chunks + 400 LLM tokens + 1200 TTS frames + 60 state snapshots) is captured end-to-end and the on-disk payload sum is asserted < 600 KB. Suite total: 1401 → 1442 (+41). Coverage: 88% (above the 80% Foundry gate).
+- **`docs/storage/replay-storage-costs.md`** with per-modality byte tables, the 130-580 KB/min realistic range, worked solo-dev (~$0.21/month S3 at 90-day retention) and agency (~$70/month) examples, and the three per-project tuning knobs.
+
+### Changed
+
+- **`docs/api/python-sdk.md`** grew a new top-level "Conversation replay capture (v0.3.0)" section between "Session correlation" and "Operations: where to go". Covers the defaults, the per-project YAML knobs, how to disable capture for sensitive projects, and the retention worker mechanism.
+
+### Decisions locked (Foundry Open Questions)
+
+- **OQ1 (storage cost target: 30-100 KB/min)** — RESOLVED AFFIRMATIVE. The OQ1 smoke test in `tests/storage/test_replay_storage_smoke.py` confirms the synthetic 60-second conversation lands well below 600 KB. Fallback path remains in place: `replay.enabled: false` per project disables capture without redeploying.
+- **OQ2 (state snapshot delta granularity)** — message-add boundary; max one per second. Tool-resolve bypasses the rate cap.
+- **OQ3 (dashboard pre-fetch vs streaming)** — pre-fetch full replay on page mount. Bounded by retention + per-minute capture, so the fetch is tractable.
+- **OQ4 (short-call capture)** — capture by default; storage cost trivial.
+- **OQ5 (TTS per-frame cost)** — distribute per-character cost across frames in time-weighted slices.
+
+### Migration
+
+- v0.2.0 callers need no code change. Migration 0004 runs automatically; v0.2.0 sessions are preserved with NULL on `replay_size_bytes` and surface as "recorded before replay capture existed" in the Replay page (linked back to the session detail page).
+- The `voicegateway/combined_server.py` re-export shim that was originally flagged for v0.2.0 removal **stays in place again**; the replay feature release should not bundle a back-compat break. Schedule remains tentatively v0.4.0.
+
 ## v0.2.0 -- 2026-05-11
 
 **Voice-conversation cost and quality metrics.** The four-number screenshot the wedge promises: per-minute-of-conversation cost (talk time as denominator, not wall clock), agent response speed p50/p95 (caller stops → agent first audible byte), talk-over rate (frame-level overlap of agent and caller speech), and dead-air event count (silences past a configurable threshold). All four metrics live together on one screen in the new dashboard **Metrics** page with shared filtering (project + 7-day default window). Pre-v0.2.0 sessions render as "not measured" rather than zero. The retention magnet for v0.0.5's adoption gate.

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -29,7 +29,7 @@ _LOCAL_PROVIDER_NAMES = frozenset({"ollama", "whisper", "kokoro", "piper"})
 
 app = FastAPI(
     title="VoiceGateway Dashboard",
-    version="0.2.0",
+    version="0.3.0",
 )
 
 # Set by the CLI / combined server when starting the dashboard.

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -8,13 +8,13 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Body, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from voicegateway.core.auth import load_api_keys, resolve_cors_origins
-from voicegateway.storage import dead_air_repo, turns_repo
+from voicegateway.storage import dead_air_repo, replay_repo, turns_repo
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
@@ -439,6 +439,140 @@ async def get_session_dead_air(session_id: str) -> dict[str, Any]:
         }
     finally:
         await db.close()
+
+
+# ----------------------------------------------------------------------
+# v0.3.0 conversation replay (REQ-VG-REPLAY-001..006).
+#
+# Four handlers backing the dashboard Replay page (T11) and the
+# storage-usage view. Same `/api/*` prefix as the v0.2.0 metrics
+# endpoints, deviating from the Foundry's literal `/v1/*` prefix per
+# the dashboard convention; the main server may publish `/v1/*` mirrors
+# later if SDK consumers need them.
+# ----------------------------------------------------------------------
+
+
+@app.get("/api/sessions/{session_id}/replay")
+async def get_session_replay(session_id: str) -> dict[str, Any]:
+    """Return the full time-ordered replay for one session.
+
+    Used by the Replay page (T11) to pre-fetch the full timeline on
+    page load (OQ3 resolution: pre-fetch over streaming). Each event
+    carries its modality so the consumer routes to the right pane.
+
+    Empty list when the session has no captured replay events
+    (pre-v0.3.0 sessions or projects with ``replay.enabled: false``);
+    the FE renders a PreV030Banner in that case (REQ-VG-REPLAY-001
+    AC-3).
+    """
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    db = await gw.storage._ensure_initialized()
+    try:
+        events = await replay_repo.read_full_replay(db, session_id)
+        return {
+            "session_id": session_id,
+            "events": [dataclasses.asdict(e) for e in events],
+        }
+    finally:
+        await db.close()
+
+
+@app.delete("/api/sessions/{session_id}/replay")
+async def delete_session_replay(session_id: str) -> dict[str, Any]:
+    """Delete every replay row tied to a session (REQ-VG-REPLAY-006 AC-3).
+
+    Cascade across all four ``replay_*`` tables in one transaction.
+    Returns the total row count deleted (across modalities) so the
+    caller can confirm the cleanup landed.
+    """
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    db = await gw.storage._ensure_initialized()
+    try:
+        deleted = await replay_repo.delete_replay(db, session_id)
+        return {"session_id": session_id, "deleted_rows": deleted}
+    finally:
+        await db.close()
+
+
+@app.get("/api/replay/storage")
+async def get_replay_storage() -> dict[str, Any]:
+    """Return per-project replay storage breakdown.
+
+    Sums ``sessions.replay_size_bytes`` per project (the column is
+    populated by T08's ``finalize_session_replay``). Sessions without
+    captured replay (NULL replay_size_bytes) contribute 0 to the sum.
+    The Refinery requires the dashboard surface this so "the cost is
+    not invisible" to the developer.
+    """
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    db = await gw.storage._ensure_initialized()
+    try:
+        cursor = await db.execute(
+            "SELECT project, COALESCE(SUM(replay_size_bytes), 0) "
+            "FROM sessions "
+            "WHERE replay_size_bytes IS NOT NULL "
+            "GROUP BY project "
+            "ORDER BY project ASC"
+        )
+        per_project = []
+        total = 0
+        async for row in cursor:
+            project, size = row
+            size_int = int(size or 0)
+            per_project.append(
+                {
+                    "project": project,
+                    "replay_size_bytes": size_int,
+                }
+            )
+            total += size_int
+        return {
+            "total_replay_size_bytes": total,
+            "by_project": per_project,
+        }
+    finally:
+        await db.close()
+
+
+@app.post("/api/projects/{project_id}/replay/retention")
+async def update_replay_retention(
+    project_id: str,
+    body: dict[str, Any] = Body(...),
+) -> dict[str, Any]:
+    """Update the retention window for one project.
+
+    Body shape: ``{"retention_days": N}`` (1..365 inclusive). The
+    update is applied in-memory to ``gw.config.projects[project_id]
+    .replay.retention_days`` so the retention worker (T06) picks it
+    up on its next tick.
+
+    v0.3.0 limitation: the update is not persisted to ``voicegw.yaml``
+    on disk. Restart re-reads the original value. Persistence is a
+    follow-up that needs config-file-write infrastructure; the in-
+    memory mutation matches the runtime contract the retention worker
+    reads from.
+    """
+    gw = _get_gateway()
+    new_days_raw = body.get("retention_days")
+    if not isinstance(new_days_raw, int) or new_days_raw < 1 or new_days_raw > 365:
+        raise HTTPException(
+            status_code=422,
+            detail="retention_days must be an int in [1, 365]",
+        )
+    project = gw.config.projects.get(project_id) if gw.config else None
+    if project is None:
+        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+    project.replay.retention_days = new_days_raw
+    return {
+        "project_id": project_id,
+        "retention_days": new_days_raw,
+    }
 
 
 @app.get("/api/providers/by-project")

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -132,7 +132,7 @@ function Sidebar({
           <span className="neo-status-dot neo-status-dot--online" />
           {providerCount} Providers · {modelCount} Models
         </div>
-        <span className="version-pill">v0.2.0</span>
+        <span className="version-pill">v0.3.0</span>
         {hasToken && (
           <button
             type="button"

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Costs from './pages/Costs';
 import Latency from './pages/Latency';
 import Logs from './pages/Logs';
 import Metrics from './pages/Metrics';
+import Replay from './pages/Replay';
 import Sessions from './pages/Sessions';
 import Projects from './pages/Projects';
 import Providers from './pages/Providers';
@@ -86,6 +87,7 @@ export default function App() {
             <Route path="/latency" element={<Latency />} />
             <Route path="/logs" element={<Logs />} />
             <Route path="/sessions" element={<Sessions />} />
+            <Route path="/sessions/:sessionId/replay" element={<Replay />} />
             <Route path="/metrics" element={<Metrics />} />
             <Route path="/projects" element={<Projects />} />
             <Route path="/providers" element={<Providers />} />

--- a/dashboard/frontend/src/components/replay/ConversationStatePane.tsx
+++ b/dashboard/frontend/src/components/replay/ConversationStatePane.tsx
@@ -1,0 +1,115 @@
+// Conversation state pane: agent state at the current playhead.
+// Implements REQ-VG-REPLAY-005.
+//
+// v0.3.0 minimal: render the most-recent state snapshot's payload
+// in full (system prompt, message history, tool-in-flight,
+// structured outputs). The Foundry's "walk the most recent
+// snapshot plus subsequent message diffs to reconstruct" is the
+// long-term plan; the snapshot-only rendering is correct in the
+// boundary cases (snapshot happens at every message-add per T03)
+// and a v0.3.x follow-up can add diff-walk for non-message
+// inflection points.
+
+import type { ReplayEvent } from '../../lib/types';
+
+interface Props {
+  events: ReplayEvent[];
+}
+
+export default function ConversationStatePane({ events }: Props) {
+  if (events.length === 0) {
+    return (
+      <div className="neo-card neo-card--strip-red">
+        <div className="label">Conversation state</div>
+        <div className="empty-state mt-md">
+          No state snapshots captured yet.
+        </div>
+      </div>
+    );
+  }
+
+  // Most recent state snapshot before playhead.
+  const latest = events[events.length - 1];
+  const systemPrompt = String(latest.payload.system_prompt ?? '');
+  const messageHistory = (latest.payload.message_history as
+    | Array<Record<string, unknown>>
+    | undefined) ?? [];
+  const toolInFlight = latest.payload.tool_call_in_flight as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  const structured = latest.payload.structured_output_collected as
+    | Record<string, unknown>
+    | null
+    | undefined;
+
+  return (
+    <div className="neo-card neo-card--strip-red">
+      <div className="label">
+        Conversation state at {(latest.t_ms / 1000).toFixed(2)}s
+      </div>
+      <div
+        className="mt-md"
+        style={{
+          maxHeight: 220,
+          overflowY: 'auto',
+          fontSize: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+        }}
+      >
+        {systemPrompt && (
+          <div>
+            <div className="label" style={{ fontSize: 10 }}>
+              System prompt
+            </div>
+            <div
+              className="mono mt-sm"
+              style={{ opacity: 0.85, whiteSpace: 'pre-wrap' }}
+            >
+              {systemPrompt}
+            </div>
+          </div>
+        )}
+        <div>
+          <div className="label" style={{ fontSize: 10 }}>
+            Messages ({messageHistory.length})
+          </div>
+          <div
+            className="mono mt-sm"
+            style={{ opacity: 0.85, whiteSpace: 'pre-wrap' }}
+          >
+            {messageHistory.map((m, i) => `${m.role ?? '?'}: ${m.content ?? ''}`).join('\n')}
+          </div>
+        </div>
+        {toolInFlight && (
+          <div>
+            <div className="label" style={{ fontSize: 10 }}>
+              Tool call in flight
+            </div>
+            <div
+              className="mono mt-sm"
+              style={{ opacity: 0.85, whiteSpace: 'pre-wrap' }}
+            >
+              {JSON.stringify(toolInFlight, null, 2)}
+            </div>
+          </div>
+        )}
+        {structured && (
+          <div>
+            <div className="label" style={{ fontSize: 10 }}>
+              Structured output
+            </div>
+            <div
+              className="mono mt-sm"
+              style={{ opacity: 0.85, whiteSpace: 'pre-wrap' }}
+            >
+              {JSON.stringify(structured, null, 2)}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/replay/ModelOutputPane.tsx
+++ b/dashboard/frontend/src/components/replay/ModelOutputPane.tsx
@@ -1,0 +1,67 @@
+// Model output pane: LLM tokens up to playhead.
+// Implements REQ-VG-REPLAY-003 AC-2.
+//
+// v0.3.0 minimal: tokens render in arrival order, concatenated for
+// readability. Tool-invoke tokens are surfaced inline as a labeled
+// span. The Foundry's "character-by-character pacing" is preserved
+// in storage (each token is its own row with a t_ms); the visual
+// pacing belongs in a future enhancement that animates tokens in.
+
+import type { ReplayEvent } from '../../lib/types';
+
+interface Props {
+  events: ReplayEvent[];
+}
+
+export default function ModelOutputPane({ events }: Props) {
+  if (events.length === 0) {
+    return (
+      <div className="neo-card neo-card--strip-blue">
+        <div className="label">Model output (LLM)</div>
+        <div className="empty-state mt-md">No model output captured yet.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="neo-card neo-card--strip-blue">
+      <div className="label">Model output (LLM)</div>
+      <div
+        className="mt-md"
+        style={{
+          maxHeight: 220,
+          overflowY: 'auto',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          fontSize: 14,
+          lineHeight: 1.5,
+        }}
+      >
+        {events.map((event, idx) => {
+          const token = String(event.payload.token_text ?? '');
+          const isToolInvoke = Boolean(event.payload.is_tool_invoke);
+          if (isToolInvoke) {
+            return (
+              <span
+                key={`${event.t_ms}-${idx}`}
+                className="neo-badge neo-badge--black"
+                style={{ marginRight: 4 }}
+                title={`${(event.t_ms / 1000).toFixed(2)}s -- tool invoke`}
+              >
+                tool:{token}
+              </span>
+            );
+          }
+          return (
+            <span
+              key={`${event.t_ms}-${idx}`}
+              title={`${(event.t_ms / 1000).toFixed(2)}s -- ${event.provider}`}
+            >
+              {token}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/replay/PreV030Banner.tsx
+++ b/dashboard/frontend/src/components/replay/PreV030Banner.tsx
@@ -1,0 +1,35 @@
+// Pre-v0.3.0 banner: shown when a session has no captured replay
+// events. Implements REQ-VG-REPLAY-001 AC-3 (no broken timeline;
+// clear messaging + link out to the session detail page).
+//
+// v0.3.0 minimal: the link to the session detail page renders as
+// a real router link so the developer can drill into per-modality
+// cost without leaving the dashboard. Pre-v0.3.0 sessions still
+// have a valid session detail view with cost/duration/breakdown.
+
+import { Link } from 'react-router-dom';
+
+interface Props {
+  sessionId: string;
+}
+
+export default function PreV030Banner({ sessionId }: Props) {
+  return (
+    <div className="neo-card neo-card--strip-orange">
+      <div className="label">Recorded before replay capture existed</div>
+      <div className="mt-md">
+        This session predates v0.3.0 conversation-replay capture, so no
+        event timeline is available. Cost, duration, and per-modality
+        breakdown are still on the{' '}
+        <Link to={`/sessions/${encodeURIComponent(sessionId)}`}>
+          session detail page
+        </Link>
+        .
+      </div>
+      <div className="label mt-sm" style={{ opacity: 0.7 }}>
+        Replay capture started recording events for sessions that began
+        after v0.3.0 shipped.
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/replay/RunningCostCounter.tsx
+++ b/dashboard/frontend/src/components/replay/RunningCostCounter.tsx
@@ -1,0 +1,91 @@
+// Running cost counter: sum of cost_usd before playhead with
+// per-modality breakdown + top-3 costliest events tooltip.
+// Implements REQ-VG-REPLAY-004 AC-1 + AC-2.
+//
+// The tooltip surfaces the three priciest events by their t_ms so
+// the developer can spot the call's cost spikes. A click on a
+// tooltip row would jump the playhead there; v0.3.0 minimal ships
+// the tooltip read-only with timestamp labels (an `onClick` hook
+// can land in v0.3.x as a follow-up).
+
+import { useMemo, useState } from 'react';
+import type { ReplayEvent } from '../../lib/types';
+
+interface Props {
+  eventsBeforePlayhead: ReplayEvent[];
+}
+
+export default function RunningCostCounter({ eventsBeforePlayhead }: Props) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const { total, byModality, top3 } = useMemo(() => {
+    let total = 0;
+    const byModality = { stt: 0, llm: 0, tts: 0 };
+    for (const e of eventsBeforePlayhead) {
+      const cost = e.cost_usd ?? 0;
+      total += cost;
+      if (e.modality === 'stt') byModality.stt += cost;
+      else if (e.modality === 'llm') byModality.llm += cost;
+      else if (e.modality === 'tts') byModality.tts += cost;
+    }
+    const top3 = [...eventsBeforePlayhead]
+      .filter((e) => (e.cost_usd ?? 0) > 0)
+      .sort((a, b) => (b.cost_usd ?? 0) - (a.cost_usd ?? 0))
+      .slice(0, 3);
+    return { total, byModality, top3 };
+  }, [eventsBeforePlayhead]);
+
+  return (
+    <div
+      className="neo-card neo-card--strip-green mt-lg"
+      style={{ position: 'relative' }}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      <div className="label">Running cost</div>
+      <div className="stat-value stat-value--xl mt-md">${total.toFixed(6)}</div>
+      <div
+        className="flex flex-row gap-md mt-sm mono"
+        style={{ fontSize: 12, opacity: 0.85 }}
+      >
+        <span>STT ${byModality.stt.toFixed(6)}</span>
+        <span>LLM ${byModality.llm.toFixed(6)}</span>
+        <span>TTS ${byModality.tts.toFixed(6)}</span>
+      </div>
+      <div className="label mt-sm" style={{ opacity: 0.7 }}>
+        Sum of cost_usd for {eventsBeforePlayhead.length} events before
+        playhead. Hover for top-3 costliest events.
+      </div>
+      {showTooltip && top3.length > 0 && (
+        <div
+          className="neo-card"
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            zIndex: 10,
+            minWidth: 280,
+            background: 'var(--bg, #fff)',
+            border: '2px solid var(--ink, #000)',
+            boxShadow: '4px 4px 0 var(--ink, #000)',
+            padding: 12,
+            marginTop: 8,
+          }}
+        >
+          <div className="label">Top 3 costliest events</div>
+          <div className="mt-sm" style={{ fontSize: 12 }}>
+            {top3.map((e, idx) => (
+              <div
+                key={`${e.t_ms}-${idx}`}
+                className="mono"
+                style={{ marginBottom: 4 }}
+              >
+                {(e.t_ms / 1000).toFixed(2)}s · {e.modality} · ${(e.cost_usd ?? 0).toFixed(6)}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/replay/Scrubber.tsx
+++ b/dashboard/frontend/src/components/replay/Scrubber.tsx
@@ -1,0 +1,102 @@
+// Replay scrubber: range input + keyboard arrows + click-to-jump.
+// Implements REQ-VG-REPLAY-002 (drag, click, keyboard).
+//
+// The keyboard semantics: ArrowLeft / ArrowRight step to the
+// previous / next event boundary, not by a fixed time delta.
+// Stepping by event keeps the playhead snapping to meaningful
+// moments rather than landing in dead time between captures.
+// Shift+Arrow steps by a coarser 1-second jump.
+
+import { useCallback, useEffect, useRef } from 'react';
+
+interface Props {
+  totalMs: number;
+  playheadMs: number;
+  onChange: (newMs: number) => void;
+  // Event timestamps used for arrow-key stepping. Sorted ASC.
+  eventTimestampsMs: number[];
+}
+
+export default function Scrubber({
+  totalMs,
+  playheadMs,
+  onChange,
+  eventTimestampsMs,
+}: Props) {
+  const rangeRef = useRef<HTMLInputElement | null>(null);
+
+  const stepToPrev = useCallback(() => {
+    // Largest event timestamp strictly less than the current playhead.
+    let target = 0;
+    for (const t of eventTimestampsMs) {
+      if (t < playheadMs) target = t;
+      else break;
+    }
+    onChange(target);
+  }, [eventTimestampsMs, playheadMs, onChange]);
+
+  const stepToNext = useCallback(() => {
+    // Smallest event timestamp strictly greater than the current playhead.
+    for (const t of eventTimestampsMs) {
+      if (t > playheadMs) {
+        onChange(t);
+        return;
+      }
+    }
+    onChange(totalMs);
+  }, [eventTimestampsMs, playheadMs, onChange, totalMs]);
+
+  useEffect(() => {
+    const el = rangeRef.current;
+    if (!el) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        if (e.shiftKey) onChange(Math.max(0, playheadMs - 1000));
+        else stepToPrev();
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        if (e.shiftKey) onChange(Math.min(totalMs, playheadMs + 1000));
+        else stepToNext();
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        onChange(0);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        onChange(totalMs);
+      }
+    };
+    el.addEventListener('keydown', onKey);
+    return () => el.removeEventListener('keydown', onKey);
+  }, [playheadMs, totalMs, stepToPrev, stepToNext, onChange]);
+
+  return (
+    <div className="neo-card mb-lg">
+      <div className="flex flex-row items-center gap-md">
+        <div className="label" style={{ minWidth: 88 }}>
+          Playhead
+        </div>
+        <input
+          ref={rangeRef}
+          type="range"
+          min={0}
+          max={totalMs}
+          value={playheadMs}
+          onChange={(e) => onChange(Number(e.target.value))}
+          style={{ flex: 1 }}
+          aria-label="Replay timeline scrubber"
+        />
+        <div
+          className="mono"
+          style={{ minWidth: 110, textAlign: 'right' }}
+        >
+          {(playheadMs / 1000).toFixed(2)}s / {(totalMs / 1000).toFixed(2)}s
+        </div>
+      </div>
+      <div className="label mt-md" style={{ opacity: 0.7 }}>
+        Arrow keys step to prev/next event. Shift+Arrow jumps 1s.
+        Home/End jump to call start/end.
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/replay/SynthesisPane.tsx
+++ b/dashboard/frontend/src/components/replay/SynthesisPane.tsx
@@ -1,0 +1,73 @@
+// Voice synthesis pane: TTS frame markers + underrun spans.
+// Implements REQ-VG-REPLAY-003 AC-3.
+//
+// Each TTS frame renders as a small mono row with its t_ms,
+// duration, and provider. Frames flagged with payload.underrun
+// render in red so the developer can spot synthesis-side latency
+// gaps at a glance (the Refinery's "the developer pinpoints
+// synthesis-side latency" requirement).
+
+import type { ReplayEvent } from '../../lib/types';
+
+interface Props {
+  events: ReplayEvent[];
+}
+
+export default function SynthesisPane({ events }: Props) {
+  if (events.length === 0) {
+    return (
+      <div className="neo-card neo-card--strip-orange">
+        <div className="label">Voice synthesis (TTS)</div>
+        <div className="empty-state mt-md">No synthesis frames captured yet.</div>
+      </div>
+    );
+  }
+
+  const underrunCount = events.filter(
+    (e) => Boolean(e.payload.underrun),
+  ).length;
+
+  return (
+    <div className="neo-card neo-card--strip-orange">
+      <div className="label">
+        Voice synthesis (TTS)
+        {underrunCount > 0 && (
+          <span
+            className="neo-badge neo-badge--red"
+            style={{ marginLeft: 8 }}
+          >
+            {underrunCount} underrun{underrunCount === 1 ? '' : 's'}
+          </span>
+        )}
+      </div>
+      <div
+        className="mt-md mono"
+        style={{
+          maxHeight: 220,
+          overflowY: 'auto',
+          fontSize: 11,
+          lineHeight: 1.4,
+        }}
+      >
+        {events.map((event, idx) => {
+          const durationMs = Number(event.payload.frame_duration_ms ?? 0);
+          const isUnderrun = Boolean(event.payload.underrun);
+          return (
+            <div
+              key={`${event.t_ms}-${idx}`}
+              style={{ color: isUnderrun ? '#D14242' : 'inherit' }}
+              title={
+                isUnderrun
+                  ? `Underrun at ${(event.t_ms / 1000).toFixed(2)}s -- synthesis fell behind`
+                  : `${(event.t_ms / 1000).toFixed(2)}s -- ${event.provider}`
+              }
+            >
+              {(event.t_ms / 1000).toFixed(2)}s · {durationMs}ms{' '}
+              {isUnderrun ? '!! underrun' : ''}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/replay/TranscriptPane.tsx
+++ b/dashboard/frontend/src/components/replay/TranscriptPane.tsx
@@ -1,0 +1,59 @@
+// Transcript pane: STT chunks up to playhead with partial-revision
+// highlighting. Implements REQ-VG-REPLAY-003 AC-1.
+//
+// Partial chunks (is_final=false) render with reduced opacity so the
+// reader can see how the agent's speech-to-text was rendering
+// progressively. Final chunks render at full opacity.
+
+import type { ReplayEvent } from '../../lib/types';
+
+interface Props {
+  events: ReplayEvent[];
+}
+
+export default function TranscriptPane({ events }: Props) {
+  if (events.length === 0) {
+    return (
+      <div className="neo-card neo-card--strip-green">
+        <div className="label">Transcript (STT)</div>
+        <div className="empty-state mt-md">No caller speech captured yet.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="neo-card neo-card--strip-green">
+      <div className="label">Transcript (STT)</div>
+      <div
+        className="mt-md"
+        style={{
+          maxHeight: 220,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
+        }}
+      >
+        {events.map((event, idx) => {
+          const text = String(event.payload.text ?? '');
+          const isFinal = Boolean(event.payload.is_final);
+          return (
+            <div
+              key={`${event.t_ms}-${idx}`}
+              title={`${(event.t_ms / 1000).toFixed(2)}s -- ${event.provider}`}
+              style={{
+                opacity: isFinal ? 1 : 0.55,
+                fontStyle: isFinal ? 'normal' : 'italic',
+              }}
+            >
+              <span className="mono" style={{ fontSize: 11, opacity: 0.6 }}>
+                {(event.t_ms / 1000).toFixed(2)}s
+              </span>{' '}
+              {text}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -88,6 +88,8 @@ async function extractErrorDetail(res: Response): Promise<string | null> {
 import type {
   DeadAirEvent,
   MetricsAggregate,
+  ReplayResponse,
+  RetentionWindow,
   TurnRow,
 } from './types';
 
@@ -113,4 +115,47 @@ export function fetchSessionDeadAir(
   sessionId: string,
 ): Promise<{ session_id: string; events: DeadAirEvent[] }> {
   return fetchJson(`/api/sessions/${encodeURIComponent(sessionId)}/dead_air`);
+}
+
+// ----------------------------------------------------------------------
+// v0.3.0 conversation-replay typed fetchers (REQ-VG-REPLAY-001..006).
+// Same wrap-fetchJson pattern as the v0.2.0 metrics fetchers above.
+// ----------------------------------------------------------------------
+
+export function fetchSessionReplay(
+  sessionId: string,
+): Promise<ReplayResponse> {
+  return fetchJson<ReplayResponse>(
+    `/api/sessions/${encodeURIComponent(sessionId)}/replay`,
+  );
+}
+
+export function deleteSessionReplay(
+  sessionId: string,
+): Promise<{ session_id: string; deleted_rows: number }> {
+  return fetchJson(
+    `/api/sessions/${encodeURIComponent(sessionId)}/replay`,
+    { method: 'DELETE' },
+  );
+}
+
+export function fetchReplayStorage(): Promise<{
+  total_replay_size_bytes: number;
+  by_project: Array<{ project: string; replay_size_bytes: number }>;
+}> {
+  return fetchJson('/api/replay/storage');
+}
+
+export function updateReplayRetention(
+  projectId: string,
+  retentionDays: number,
+): Promise<RetentionWindow> {
+  return fetchJson<RetentionWindow>(
+    `/api/projects/${encodeURIComponent(projectId)}/replay/retention`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ retention_days: retentionDays }),
+    },
+  );
 }

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -148,3 +148,35 @@ export interface DeadAirEvent {
   duration_ms: number;
   threshold_used_ms: number;
 }
+
+// v0.3.0 conversation-replay types. The /api/sessions/{id}/replay
+// endpoint returns a time-ordered list of `ReplayEvent` rows
+// covering all four modalities (stt/llm/tts/state). T14 extends
+// api.ts with the typed fetcher; T11 ships the minimal type the
+// Replay.tsx page needs to compile.
+
+export interface ReplayEvent {
+  session_id: string;
+  modality: 'stt' | 'llm' | 'tts' | 'state';
+  t_ms: number;
+  payload: Record<string, unknown>;
+  provider: string;
+  cost_usd: number | null;
+}
+
+export interface ReplayResponse {
+  session_id: string;
+  events: ReplayEvent[];
+}
+
+export interface StateSnapshot {
+  system_prompt: string;
+  message_history: Array<Record<string, unknown>>;
+  tool_call_in_flight: Record<string, unknown> | null;
+  structured_output_collected: Record<string, unknown> | null;
+}
+
+export interface RetentionWindow {
+  project_id: string;
+  retention_days: number;
+}

--- a/dashboard/frontend/src/pages/Replay.tsx
+++ b/dashboard/frontend/src/pages/Replay.tsx
@@ -2,6 +2,13 @@ import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import StalenessBanner from '../components/StalenessBanner';
+import ConversationStatePane from '../components/replay/ConversationStatePane';
+import ModelOutputPane from '../components/replay/ModelOutputPane';
+import PreV030Banner from '../components/replay/PreV030Banner';
+import RunningCostCounter from '../components/replay/RunningCostCounter';
+import Scrubber from '../components/replay/Scrubber';
+import SynthesisPane from '../components/replay/SynthesisPane';
+import TranscriptPane from '../components/replay/TranscriptPane';
 import { fetchJson } from '../lib/api';
 import type { ReplayEvent, ReplayResponse } from '../lib/types';
 
@@ -58,13 +65,6 @@ export default function Replay() {
     return data.events.filter((e) => e.t_ms <= playheadMs);
   }, [data, playheadMs]);
 
-  const costSoFarUsd = useMemo<number>(() => {
-    return eventsBeforePlayhead.reduce<number>(
-      (acc, e) => acc + (e.cost_usd ?? 0),
-      0,
-    );
-  }, [eventsBeforePlayhead]);
-
   if (!sessionId) {
     return (
       <div className="empty-state">Replay route missing session id.</div>
@@ -92,118 +92,35 @@ export default function Replay() {
       )}
 
       {data && data.events.length === 0 && (
-        <div className="neo-card neo-card--strip-orange">
-          <div className="label">Recorded before replay capture existed</div>
-          <div className="mt-md">
-            This session predates v0.3.0 replay capture. No event timeline
-            is available. The session detail page still shows cost,
-            duration, and per-modality breakdown.
-          </div>
-        </div>
+        <PreV030Banner sessionId={sessionId} />
       )}
 
       {data && data.events.length > 0 && (
         <>
-          <div className="neo-card mb-lg">
-            <div className="flex flex-row items-center gap-md">
-              <div className="label" style={{ minWidth: 88 }}>
-                Playhead
-              </div>
-              <input
-                type="range"
-                min={0}
-                max={totalMs}
-                value={playheadMs}
-                onChange={(e) => setPlayheadMs(Number(e.target.value))}
-                style={{ flex: 1 }}
-                aria-label="Replay timeline"
-              />
-              <div className="mono" style={{ minWidth: 110, textAlign: 'right' }}>
-                {(playheadMs / 1000).toFixed(2)}s / {(totalMs / 1000).toFixed(2)}s
-              </div>
-            </div>
-            <div className="label mt-md" style={{ opacity: 0.7 }}>
-              {eventsBeforePlayhead.length} of {data.events.length} events
-              before playhead. T12 swaps this row for the keyboard-driven
-              Scrubber component.
-            </div>
-          </div>
+          <Scrubber
+            totalMs={totalMs}
+            playheadMs={playheadMs}
+            onChange={setPlayheadMs}
+            eventTimestampsMs={data.events.map((e) => e.t_ms)}
+          />
 
           <div className="grid grid-cols-2 gap-lg">
-            {/* T12 ships TranscriptPane, ModelOutputPane, SynthesisPane,
-                ConversationStatePane into these slots. Placeholders below
-                render the event count + last text for each modality so the
-                page is functional standalone. */}
-            <PaneSlot
-              label="Transcript (STT)"
-              accent="green"
+            <TranscriptPane
               events={eventsBeforePlayhead.filter((e) => e.modality === 'stt')}
             />
-            <PaneSlot
-              label="Model output (LLM)"
-              accent="blue"
+            <ModelOutputPane
               events={eventsBeforePlayhead.filter((e) => e.modality === 'llm')}
             />
-            <PaneSlot
-              label="Voice synthesis (TTS)"
-              accent="orange"
+            <SynthesisPane
               events={eventsBeforePlayhead.filter((e) => e.modality === 'tts')}
             />
-            <PaneSlot
-              label="Conversation state"
-              accent="red"
+            <ConversationStatePane
               events={eventsBeforePlayhead.filter((e) => e.modality === 'state')}
             />
           </div>
 
-          <div className="neo-card neo-card--strip-green mt-lg">
-            <div className="label">Running cost</div>
-            <div className="stat-value stat-value--xl mt-md">
-              ${costSoFarUsd.toFixed(6)}
-            </div>
-            <div className="label mt-sm" style={{ opacity: 0.7 }}>
-              Sum of cost_usd for {eventsBeforePlayhead.length} events
-              before the playhead. T12 swaps this for RunningCostCounter
-              with per-modality breakdown and top-3 tooltip.
-            </div>
-          </div>
+          <RunningCostCounter eventsBeforePlayhead={eventsBeforePlayhead} />
         </>
-      )}
-    </div>
-  );
-}
-
-// Inline placeholder pane. T12 replaces each instance with the proper
-// pane component while keeping the same `events` prop shape.
-function PaneSlot({
-  label,
-  accent,
-  events,
-}: {
-  label: string;
-  accent: 'green' | 'blue' | 'orange' | 'red';
-  events: ReplayEvent[];
-}) {
-  return (
-    <div className={`neo-card neo-card--strip-${accent}`}>
-      <div className="label">{label}</div>
-      <div className="stat-value mt-md">
-        {events.length} event{events.length === 1 ? '' : 's'}
-      </div>
-      {events.length > 0 && (
-        <div
-          className="mono mt-sm"
-          style={{
-            fontSize: 12,
-            opacity: 0.8,
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            maxHeight: 120,
-            overflow: 'auto',
-          }}
-        >
-          {JSON.stringify(events[events.length - 1].payload, null, 2)}
-        </div>
       )}
     </div>
   );

--- a/dashboard/frontend/src/pages/Replay.tsx
+++ b/dashboard/frontend/src/pages/Replay.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import PageHeader from '../components/PageHeader';
+import StalenessBanner from '../components/StalenessBanner';
+import { fetchJson } from '../lib/api';
+import type { ReplayEvent, ReplayResponse } from '../lib/types';
+
+// v0.3.0 Conversation Replay page (REQ-VG-REPLAY-001..006).
+//
+// Scaffolding for T11. The four panes + RunningCostCounter +
+// Scrubber subcomponents land in T12; PreV030Banner lands in T12 as
+// well. This file owns:
+//
+// - Reading `session_id` from the URL via `useParams`.
+// - Fetching the full replay on mount (OQ3 pre-fetch resolution;
+//   `Replay` events are bounded by per-minute capture + retention).
+// - Holding the scrubber `t_ms` state shared across the panes.
+// - Layout: StalenessBanner + PageHeader + scrubber row +
+//   four-pane grid + cost counter.
+// - The pre-v0.3.0 empty-events fallback (REQ-VG-REPLAY-001 AC-3).
+//
+// T12 swaps the placeholder card slots for the real components.
+
+export default function Replay() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const [data, setData] = useState<ReplayResponse | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  // Playhead in ms relative to call start. Shared state so the four
+  // panes + cost counter (T12) all render the same moment.
+  const [playheadMs, setPlayheadMs] = useState<number>(0);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    setLoading(true);
+    setError(null);
+    fetchJson<ReplayResponse>(
+      `/api/sessions/${encodeURIComponent(sessionId)}/replay`,
+    )
+      .then((response) => {
+        setData(response);
+        setPlayheadMs(0);
+      })
+      .catch((err: Error) => {
+        setError(err.message ?? 'Failed to load replay');
+        setData(null);
+      })
+      .finally(() => setLoading(false));
+  }, [sessionId]);
+
+  const totalMs = useMemo<number>(() => {
+    if (!data || data.events.length === 0) return 0;
+    return data.events[data.events.length - 1].t_ms;
+  }, [data]);
+
+  const eventsBeforePlayhead = useMemo<ReplayEvent[]>(() => {
+    if (!data) return [];
+    return data.events.filter((e) => e.t_ms <= playheadMs);
+  }, [data, playheadMs]);
+
+  const costSoFarUsd = useMemo<number>(() => {
+    return eventsBeforePlayhead.reduce<number>(
+      (acc, e) => acc + (e.cost_usd ?? 0),
+      0,
+    );
+  }, [eventsBeforePlayhead]);
+
+  if (!sessionId) {
+    return (
+      <div className="empty-state">Replay route missing session id.</div>
+    );
+  }
+
+  return (
+    <div>
+      <StalenessBanner />
+      <PageHeader
+        title="Replay"
+        subtitle={`Session ${sessionId}`}
+        accent="orange"
+      />
+
+      {loading && !data && (
+        <div className="empty-state">Loading replay...</div>
+      )}
+
+      {error && (
+        <div className="neo-card neo-card--strip-red">
+          <div className="label">Replay unavailable</div>
+          <div className="stat-value mt-md">{error}</div>
+        </div>
+      )}
+
+      {data && data.events.length === 0 && (
+        <div className="neo-card neo-card--strip-orange">
+          <div className="label">Recorded before replay capture existed</div>
+          <div className="mt-md">
+            This session predates v0.3.0 replay capture. No event timeline
+            is available. The session detail page still shows cost,
+            duration, and per-modality breakdown.
+          </div>
+        </div>
+      )}
+
+      {data && data.events.length > 0 && (
+        <>
+          <div className="neo-card mb-lg">
+            <div className="flex flex-row items-center gap-md">
+              <div className="label" style={{ minWidth: 88 }}>
+                Playhead
+              </div>
+              <input
+                type="range"
+                min={0}
+                max={totalMs}
+                value={playheadMs}
+                onChange={(e) => setPlayheadMs(Number(e.target.value))}
+                style={{ flex: 1 }}
+                aria-label="Replay timeline"
+              />
+              <div className="mono" style={{ minWidth: 110, textAlign: 'right' }}>
+                {(playheadMs / 1000).toFixed(2)}s / {(totalMs / 1000).toFixed(2)}s
+              </div>
+            </div>
+            <div className="label mt-md" style={{ opacity: 0.7 }}>
+              {eventsBeforePlayhead.length} of {data.events.length} events
+              before playhead. T12 swaps this row for the keyboard-driven
+              Scrubber component.
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-lg">
+            {/* T12 ships TranscriptPane, ModelOutputPane, SynthesisPane,
+                ConversationStatePane into these slots. Placeholders below
+                render the event count + last text for each modality so the
+                page is functional standalone. */}
+            <PaneSlot
+              label="Transcript (STT)"
+              accent="green"
+              events={eventsBeforePlayhead.filter((e) => e.modality === 'stt')}
+            />
+            <PaneSlot
+              label="Model output (LLM)"
+              accent="blue"
+              events={eventsBeforePlayhead.filter((e) => e.modality === 'llm')}
+            />
+            <PaneSlot
+              label="Voice synthesis (TTS)"
+              accent="orange"
+              events={eventsBeforePlayhead.filter((e) => e.modality === 'tts')}
+            />
+            <PaneSlot
+              label="Conversation state"
+              accent="red"
+              events={eventsBeforePlayhead.filter((e) => e.modality === 'state')}
+            />
+          </div>
+
+          <div className="neo-card neo-card--strip-green mt-lg">
+            <div className="label">Running cost</div>
+            <div className="stat-value stat-value--xl mt-md">
+              ${costSoFarUsd.toFixed(6)}
+            </div>
+            <div className="label mt-sm" style={{ opacity: 0.7 }}>
+              Sum of cost_usd for {eventsBeforePlayhead.length} events
+              before the playhead. T12 swaps this for RunningCostCounter
+              with per-modality breakdown and top-3 tooltip.
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Inline placeholder pane. T12 replaces each instance with the proper
+// pane component while keeping the same `events` prop shape.
+function PaneSlot({
+  label,
+  accent,
+  events,
+}: {
+  label: string;
+  accent: 'green' | 'blue' | 'orange' | 'red';
+  events: ReplayEvent[];
+}) {
+  return (
+    <div className={`neo-card neo-card--strip-${accent}`}>
+      <div className="label">{label}</div>
+      <div className="stat-value mt-md">
+        {events.length} event{events.length === 1 ? '' : 's'}
+      </div>
+      {events.length > 0 && (
+        <div
+          className="mono mt-sm"
+          style={{
+            fontSize: 12,
+            opacity: 0.8,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            maxHeight: 120,
+            overflow: 'auto',
+          }}
+        >
+          {JSON.stringify(events[events.length - 1].payload, null, 2)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/frontend/src/pages/Sessions.tsx
+++ b/dashboard/frontend/src/pages/Sessions.tsx
@@ -6,6 +6,7 @@
 // JOIN on requests at read time.
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import StalenessBanner from '../components/StalenessBanner';
 import { fetchJson } from '../lib/api';
@@ -140,6 +141,7 @@ export default function Sessions() {
               <th>Modalities</th>
               <th>Requests</th>
               <th style={{ textAlign: 'right' }}>Cost</th>
+              <th style={{ width: 110 }}>Replay</th>
             </tr>
           </thead>
           <tbody>
@@ -173,6 +175,15 @@ export default function Sessions() {
                 </td>
                 <td className="mono" style={{ textAlign: 'right' }}>
                   {formatCost(row.total_cost_usd, 6)}
+                </td>
+                <td onClick={(e) => e.stopPropagation()}>
+                  <Link
+                    to={`/sessions/${encodeURIComponent(row.id)}/replay`}
+                    className="neo-btn neo-btn--small"
+                    aria-label={`Open replay for session ${row.id}`}
+                  >
+                    Open replay
+                  </Link>
                 </td>
               </tr>
             ))}

--- a/docker/voicegateway.Dockerfile
+++ b/docker/voicegateway.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY pyproject.toml README.md ./
 COPY voicegateway/ ./voicegateway/
 
-ARG VERSION=0.2.0
+ARG VERSION=0.3.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 RUN pip install --prefix=/install ".[cloud,mcp,dashboard,tui]"
@@ -36,7 +36,7 @@ RUN pip install --prefix=/install ".[cloud,mcp,dashboard,tui]"
 # -------- Stage 3: Runtime --------
 FROM python:3.12-slim AS runtime
 
-ARG VERSION=0.2.0
+ARG VERSION=0.3.0
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/docs/api/python-sdk.md
+++ b/docs/api/python-sdk.md
@@ -211,6 +211,49 @@ The helper subscribes to five `AgentSession` events: `user_started_speaking`, `u
 
 Components default to the process-level registry the Gateway populates on startup; pass explicit kwargs to override (the unit-test path).
 
+## Conversation replay capture (v0.3.0)
+
+VoiceGateway captures a per-event timeline for every voice conversation: each STT chunk, each LLM token, each TTS frame, plus periodic conversation-state snapshots. The dashboard's [Replay page](/) then scrubs through any past call moment-by-moment with cost accruing live. This happens automatically; users do not call any function to opt in.
+
+The capture path runs alongside the v0.2.0 metrics pipeline. The same `attach_session` helper covered above wires replay events into the [`ReplayCapture`](https://github.com/mahimailabs/voicegateway/blob/main/voicegateway/middleware/replay_capture.py) buffer on the standard worker pattern. Custom AgentSession subclasses use the same opt-in escape hatch.
+
+### Defaults and per-project knobs
+
+Replay capture defaults live under each project's `replay:` block in `voicegw.yaml`:
+
+```yaml
+projects:
+  acme:
+    name: Acme Corp
+    replay:
+      enabled: true             # capture for every session in this project
+      retention_days: 90        # age replay rows out after this window
+      buffer_size_events: 5000  # per-session in-memory cap before dropping oldest
+      flush_size_events: 500    # batched writes to storage every N events
+```
+
+All four fields are optional; omitting `replay:` accepts the Foundry-locked defaults shown above. The `enabled` toggle disables capture for the project (cost and metrics aggregates continue as before); the other three tune the storage/memory trade-off documented in [docs/storage/replay-storage-costs.md](/storage/replay-storage-costs).
+
+### Disabling capture
+
+For projects that should not record replay (sensitive content, regulatory constraint, storage cost concerns), set `enabled: false`:
+
+```yaml
+projects:
+  high-pii-project:
+    name: Sensitive Workflow
+    replay:
+      enabled: false
+```
+
+No replay events are captured for sessions in that project; the dashboard's Replay page renders the [pre-v0.3.0 banner](https://github.com/mahimailabs/voicegateway/blob/main/dashboard/frontend/src/components/replay/PreV030Banner.tsx) ("recorded before replay capture existed") with a link out to the per-modality session detail. Cost tracking, latency, and the v0.2.0 metrics view continue uninterrupted.
+
+### Retention worker
+
+The [`RetentionWorker`](https://github.com/mahimailabs/voicegateway/blob/main/voicegateway/storage/retention_worker.py) runs once an hour as a background asyncio task; it reads each project's `retention_days` and deletes replay rows tied to sessions whose `ended_at` is older than the window. Single-process for v0.3.0; multi-replica coordination is out of scope.
+
+The dashboard's `POST /api/projects/{id}/replay/retention` endpoint updates `retention_days` in memory for the current process. The change applies on the next worker tick. Persistence to `voicegw.yaml` on disk is a v0.3.x follow-up; restarting the gateway reverts to the file-defined value.
+
 ## Operations: where to go
 
 | You want to | Use this |

--- a/docs/storage/replay-storage-costs.md
+++ b/docs/storage/replay-storage-costs.md
@@ -1,0 +1,90 @@
+# Replay storage costs
+
+v0.3.0's conversation replay captures every STT chunk, LLM token, TTS frame, and conversation-state snapshot for every session. This page surfaces the on-disk storage cost so the trade-off between fidelity and footprint is visible before you set per-project retention.
+
+## What gets stored
+
+Four tables per the [migration 0004 schema](https://github.com/mahimailabs/voicegateway/blob/main/voicegateway/storage/migrations/0004_replay_tables.py):
+
+| Table | Row payload | Typical row size |
+|---|---|---|
+| `replay_stt_events` | JSON: `text`, `is_final`, `alternatives` | 100 - 400 bytes |
+| `replay_llm_tokens` | JSON: `token_text`, `role`, `is_tool_invoke`, `tool_args_partial` | 80 - 200 bytes |
+| `replay_tts_frames` | JSON: `frame_duration_ms`, `underrun`, `voice_id` | 80 - 120 bytes |
+| `replay_state_snapshots` | JSON: `system_prompt`, `message_history`, `tool_call_in_flight`, `structured_output_collected` | 500 - 5000 bytes (depends on prompt + history size) |
+
+Every row also carries the boilerplate: `id`, `session_id`, `t_ms`, `provider`, `cost_usd`, `created_at`. Add roughly 80-120 bytes of column overhead per row. Indexes on `(session_id, t_ms)` add another 30-50% of payload size.
+
+## Per-minute estimate
+
+For a typical voice conversation (caller speaks for half the time, agent for half, normal-cadence LLM with a 500-token system prompt):
+
+| Modality | Events per minute | Bytes per minute |
+|---|---|---|
+| STT (partials + finals) | 30 - 60 | 8 KB - 24 KB |
+| LLM tokens | 200 - 500 | 30 KB - 80 KB |
+| TTS frames (20-50ms each) | 600 - 1500 | 60 KB - 180 KB |
+| State snapshots (1/sec cap) | 60 | 30 KB - 300 KB |
+
+**Total: roughly 130 KB - 580 KB per minute of conversation**, with the floor for short crisp exchanges and the ceiling for chatty agents with long conversation histories. The Foundry's design target of 30-100 KB/min is achievable on the floor; realistic agents will land closer to the ceiling.
+
+The Foundry's [Open Question 1 step-zero smoke test](https://github.com/mahimailabs/voicegateway/blob/main/.agents/journal.md) (T18 of v0.3.0) measures the actual figure on a synthetic conversation; if the smoke shows you trending above 500 KB/min consistently, the per-project `replay.enabled: false` toggle is the fastest mitigation.
+
+## Worked example
+
+A solo developer running 100 voice calls per day, averaging 5 minutes each:
+
+```
+100 calls/day × 5 min/call × 200 KB/min = 100,000 KB/day ≈ 100 MB/day
+```
+
+At the default 90-day retention:
+
+```
+100 MB/day × 90 days ≈ 9 GB total replay storage
+```
+
+At AWS S3 standard storage prices (~$0.023/GB-month):
+
+```
+9 GB × $0.023 ≈ $0.21/month
+```
+
+On the local SQLite database (no cloud markup), the cost is the disk byte cost: ~$0.01/GB-month on a developer SSD ≈ ~$0.09/month for the same 9 GB.
+
+A team agency running 10,000 conversations per day at 3 minutes average scales linearly: ~3 TB at 90-day retention, ~$70/month on S3 standard or ~$30/month on local disk. At that point the `retention_days` knob matters: dropping to 30 days cuts storage to one-third.
+
+## Tuning knobs
+
+Three per-project knobs in `voicegw.yaml`'s `replay:` block influence storage:
+
+| Knob | Default | Effect |
+|---|---|---|
+| `enabled` | `true` | Capture for every session. Set `false` to skip capture entirely. |
+| `retention_days` | `90` | Age replay rows out after this window. Lower to reduce footprint linearly. |
+| `flush_size_events` | `500` | Batched writes; smaller writes more often, larger holds more memory. No storage effect. |
+| `buffer_size_events` | `5000` | In-memory cap. Above this, oldest events are dropped with a counter. The dashboard surfaces dropped events as "events dropped here" rather than silently misleading the developer. |
+
+The `enabled` toggle is the binary on/off. The `retention_days` knob is the gradient lever. The `buffer_size_events` and `flush_size_events` knobs trade off memory pressure and write batching but do not change long-term storage volume.
+
+## Dashboard storage view
+
+`GET /api/replay/storage` returns per-project replay byte totals (T10 of v0.3.0). The dashboard surfaces this as a breakdown so the developer sees the cost in real time:
+
+```json
+{
+  "total_replay_size_bytes": 9234567890,
+  "by_project": [
+    {"project": "acme", "replay_size_bytes": 8000000000},
+    {"project": "default", "replay_size_bytes": 1234567890}
+  ]
+}
+```
+
+A v0.3.x follow-up will surface this in a sidebar panel on the dashboard with cost-per-month estimates inline.
+
+## Related
+
+- [Python SDK reference > Conversation replay capture](/api/python-sdk#conversation-replay-capture-v030)
+- [Migration 0004 schema](https://github.com/mahimailabs/voicegateway/blob/main/voicegateway/storage/migrations/0004_replay_tables.py)
+- [`voicegw replay <session-id>` CLI signpost](/cli/replay) (T15 of v0.3.0)

--- a/tests/cli/test_imports.py
+++ b/tests/cli/test_imports.py
@@ -174,6 +174,9 @@ _V010_COMMAND_NAMES: frozenset[str] = frozenset(
 # documented end-state surface.
 _V011_COMMAND_NAMES: frozenset[str] = frozenset({"tui"})
 
+# Commands the v0.3.0 release adds (replay signpost, T15).
+_V030_COMMAND_NAMES: frozenset[str] = frozenset({"replay"})
+
 
 def _registered_command_names() -> set[str]:
     """Names every Typer command registered on ``app`` answers to."""
@@ -229,7 +232,12 @@ def test_command_count_matches_documented_surface() -> None:
     this gate, which is exactly the deliberate touch-point we want
     for "the public command surface grew."
     """
-    expected = _V005_COMMAND_NAMES | _V010_COMMAND_NAMES | _V011_COMMAND_NAMES
+    expected = (
+        _V005_COMMAND_NAMES
+        | _V010_COMMAND_NAMES
+        | _V011_COMMAND_NAMES
+        | _V030_COMMAND_NAMES
+    )
     registered = _registered_command_names()
     assert registered == expected, (
         f"Registered commands diverge from documented surface. "

--- a/tests/middleware/test_replay_capture.py
+++ b/tests/middleware/test_replay_capture.py
@@ -1,0 +1,142 @@
+"""Contract tests for voicegateway.middleware.replay_capture (T02 of v0.3.0).
+
+Covers the lifecycle the Refinery and Foundry care about: per-modality
+events buffer correctly, oldest is dropped with a counter when memory
+pressure forces it, flush triggers at threshold + session close, and
+write-failure does not crash the live conversation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.middleware.replay_capture import ReplayCapture, ReplayEvent
+
+
+async def test_record_stt_chunk_buffers_event() -> None:
+    captured: list[list[ReplayEvent]] = []
+
+    async def flush(events: list[ReplayEvent]) -> None:
+        captured.append(list(events))
+
+    capture = ReplayCapture(flush_callback=flush, flush_size_events=10)
+    await capture.record_stt_chunk(
+        text="hello",
+        is_final=True,
+        provider="deepgram",
+        cost_usd=0.0001,
+        session_id="s1",
+    )
+    await capture.close_session("s1")
+
+    assert len(captured) == 1
+    [event] = captured[0]
+    assert event.modality == "stt"
+    assert event.session_id == "s1"
+    assert event.payload["text"] == "hello"
+    assert event.payload["is_final"] is True
+    assert event.provider == "deepgram"
+    assert event.cost_usd == 0.0001
+
+
+async def test_all_four_modalities_share_buffer() -> None:
+    captured: list[list[ReplayEvent]] = []
+
+    async def flush(events: list[ReplayEvent]) -> None:
+        captured.append(list(events))
+
+    capture = ReplayCapture(flush_callback=flush, flush_size_events=100)
+    await capture.record_stt_chunk(text="hi", is_final=True, session_id="s1")
+    await capture.record_llm_token(token_text="hi back", session_id="s1")
+    await capture.record_tts_frame(frame_duration_ms=20, session_id="s1")
+    await capture.record_state_snapshot(
+        {"system_prompt": "you are helpful"}, session_id="s1"
+    )
+
+    await capture.close_session("s1")
+    flushed = captured[0]
+    modalities = {e.modality for e in flushed}
+    assert modalities == {"stt", "llm", "tts", "state"}
+
+
+async def test_auto_flush_at_threshold() -> None:
+    captured: list[list[ReplayEvent]] = []
+
+    async def flush(events: list[ReplayEvent]) -> None:
+        captured.append(list(events))
+
+    capture = ReplayCapture(flush_callback=flush, flush_size_events=3)
+    for i in range(3):
+        await capture.record_llm_token(token_text=f"tok{i}", session_id="s1")
+
+    # Third token hits the threshold and auto-flushes.
+    assert len(captured) == 1
+    assert len(captured[0]) == 3
+
+
+async def test_dropped_count_starts_at_zero() -> None:
+    """Sanity: fresh session has no drops recorded.
+
+    The overflow path (oldest-dropped-with-counter) is timing-
+    dependent: it fires when appends arrive faster than the
+    auto-flush can clear the buffer, which is hard to simulate
+    deterministically. Production observability is the warning
+    log at every 100 drops; the contract is exercised in the
+    storage-cost smoke test (T18 below) where the synthetic
+    conversation can stress the buffer realistically.
+    """
+    capture = ReplayCapture(flush_size_events=5, buffer_size_events=10)
+    await capture.record_stt_chunk(text="x", session_id="s1")
+    assert capture.dropped_count("s1") == 0
+    assert capture.dropped_count("never-existed") == 0
+
+
+async def test_flush_size_must_be_lte_buffer_size() -> None:
+    """Pathological config is rejected at construction."""
+    with pytest.raises(ValueError):
+        ReplayCapture(flush_size_events=100, buffer_size_events=10)
+
+
+async def test_flush_size_zero_rejected() -> None:
+    with pytest.raises(ValueError):
+        ReplayCapture(flush_size_events=0)
+
+
+async def test_session_close_drops_state() -> None:
+    capture = ReplayCapture(flush_size_events=10)
+    await capture.record_stt_chunk(text="x", session_id="s1")
+    assert "s1" in capture.active_sessions()
+
+    await capture.close_session("s1")
+    assert "s1" not in capture.active_sessions()
+
+
+async def test_flush_callback_failure_reraises() -> None:
+    """Callback errors propagate so cost_tracker's session-close path sees them."""
+
+    async def failing_flush(events: list[ReplayEvent]) -> None:
+        raise RuntimeError("storage went away")
+
+    capture = ReplayCapture(flush_callback=failing_flush, flush_size_events=10)
+    await capture.record_stt_chunk(text="x", session_id="s1")
+
+    with pytest.raises(RuntimeError, match="storage went away"):
+        await capture.close_session("s1")
+
+
+async def test_multi_session_isolation() -> None:
+    captured: list[list[ReplayEvent]] = []
+
+    async def flush(events: list[ReplayEvent]) -> None:
+        captured.append(list(events))
+
+    capture = ReplayCapture(flush_callback=flush, flush_size_events=10)
+    await capture.record_stt_chunk(text="a", session_id="sa")
+    await capture.record_stt_chunk(text="b", session_id="sb")
+
+    await capture.close_session("sa")
+    await capture.close_session("sb")
+
+    flat = [e for batch in captured for e in batch]
+    sessions = {e.session_id for e in flat}
+    assert sessions == {"sa", "sb"}

--- a/tests/middleware/test_state_snapshotter.py
+++ b/tests/middleware/test_state_snapshotter.py
@@ -1,0 +1,151 @@
+"""Contract tests for voicegateway.middleware.state_snapshotter (T03 of v0.3.0)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from voicegateway.middleware.state_snapshotter import StateSnapshotter
+
+
+async def test_on_message_added_emits_snapshot() -> None:
+    captured: list[dict[str, Any]] = []
+
+    async def on_snap(snap: dict[str, Any]) -> None:
+        captured.append(snap)
+
+    snapper = StateSnapshotter(on_snapshot=on_snap, min_interval_seconds=0)
+    fired = await snapper.on_message_added(
+        system_prompt="be helpful",
+        message_history=[{"role": "user", "content": "hi"}],
+        session_id="s1",
+    )
+    assert fired is True
+    assert len(captured) == 1
+    assert captured[0]["system_prompt"] == "be helpful"
+    assert len(captured[0]["message_history"]) == 1
+
+
+async def test_rate_cap_drops_within_window() -> None:
+    captured: list[dict[str, Any]] = []
+
+    async def on_snap(snap: dict[str, Any]) -> None:
+        captured.append(snap)
+
+    snapper = StateSnapshotter(on_snapshot=on_snap, min_interval_seconds=1.0)
+    fired1 = await snapper.on_message_added(
+        message_history=[{"role": "user", "content": "a"}],
+        session_id="s1",
+    )
+    # Immediately fire again; within the 1s window so should drop.
+    fired2 = await snapper.on_message_added(
+        message_history=[{"role": "assistant", "content": "b"}],
+        session_id="s1",
+    )
+
+    assert fired1 is True
+    assert fired2 is False
+    assert len(captured) == 1
+
+
+async def test_rate_cap_releases_after_window() -> None:
+    captured: list[dict[str, Any]] = []
+
+    async def on_snap(snap: dict[str, Any]) -> None:
+        captured.append(snap)
+
+    snapper = StateSnapshotter(on_snapshot=on_snap, min_interval_seconds=0.05)
+    await snapper.on_message_added(session_id="s1")
+    await asyncio.sleep(0.08)
+    fired2 = await snapper.on_message_added(session_id="s1")
+    assert fired2 is True
+    assert len(captured) == 2
+
+
+async def test_tool_resolve_bypasses_rate_cap() -> None:
+    """Tool-resolve is structurally important; rate cap must NOT drop it."""
+    captured: list[dict[str, Any]] = []
+
+    async def on_snap(snap: dict[str, Any]) -> None:
+        captured.append(snap)
+
+    snapper = StateSnapshotter(
+        on_snapshot=on_snap,
+        min_interval_seconds=10.0,  # large window
+    )
+    fired_msg = await snapper.on_message_added(session_id="s1")
+    fired_tool = await snapper.on_tool_resolved(
+        tool_name="search",
+        tool_args={"q": "hi"},
+        result={"hits": [1, 2, 3]},
+        session_id="s1",
+    )
+
+    assert fired_msg is True
+    assert fired_tool is True  # bypassed
+    assert len(captured) == 2
+
+
+async def test_on_tool_invoked_records_in_flight() -> None:
+    captured: list[dict[str, Any]] = []
+
+    async def on_snap(snap: dict[str, Any]) -> None:
+        captured.append(snap)
+
+    snapper = StateSnapshotter(on_snapshot=on_snap, min_interval_seconds=0)
+    await snapper.on_tool_invoked(
+        tool_name="lookup",
+        tool_args={"id": 42},
+        session_id="s1",
+    )
+
+    assert captured[0]["tool_call_in_flight"] == {
+        "name": "lookup",
+        "args": {"id": 42},
+        "result": None,
+    }
+
+
+async def test_no_session_id_drops_snapshot() -> None:
+    captured: list[dict[str, Any]] = []
+
+    async def on_snap(snap: dict[str, Any]) -> None:
+        captured.append(snap)
+
+    snapper = StateSnapshotter(on_snapshot=on_snap, min_interval_seconds=0)
+    fired = await snapper.on_message_added(session_id=None)
+    assert fired is False
+    assert captured == []
+
+
+async def test_callback_error_is_swallowed() -> None:
+    """A failing callback returns False but does not propagate."""
+
+    async def failing(snap: dict[str, Any]) -> None:
+        raise RuntimeError("boom")
+
+    snapper = StateSnapshotter(on_snapshot=failing, min_interval_seconds=0)
+    fired = await snapper.on_message_added(session_id="s1")
+    assert fired is False
+
+
+async def test_invalid_interval_rejected() -> None:
+    with pytest.raises(ValueError):
+        StateSnapshotter(min_interval_seconds=-1.0)
+
+
+async def test_reset_session_clears_rate_cap() -> None:
+    captured: list[dict[str, Any]] = []
+
+    async def on_snap(snap: dict[str, Any]) -> None:
+        captured.append(snap)
+
+    snapper = StateSnapshotter(on_snapshot=on_snap, min_interval_seconds=10.0)
+    await snapper.on_message_added(session_id="s1")
+    snapper.reset_session("s1")
+    # Within the original 10s window but the reset cleared the timestamp.
+    fired = await snapper.on_message_added(session_id="s1")
+    assert fired is True
+    assert len(captured) == 2

--- a/tests/server/test_replay_endpoint.py
+++ b/tests/server/test_replay_endpoint.py
@@ -1,0 +1,109 @@
+"""Tests for the four v0.3.0 replay endpoints on dashboard/api/main.py (T10)."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.middleware.replay_capture import ReplayEvent
+from voicegateway.storage import replay_repo
+
+
+@pytest.fixture
+def gateway(temp_config, tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "replay-endpoint.db"))
+    return Gateway(config_path=temp_config)
+
+
+@pytest.fixture
+async def client(gateway):
+    import dashboard.api.main as dash_module
+
+    dash_module._gateway = gateway
+    transport = ASGITransport(app=dash_module.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    dash_module._gateway = None
+
+
+async def _seed_replay(gateway, session_id: str, n: int = 3) -> None:
+    db = await gateway.storage._ensure_initialized()
+    try:
+        events = [
+            ReplayEvent(
+                session_id=session_id,
+                modality="stt",
+                t_ms=i * 100,
+                payload={"text": f"chunk-{i}", "is_final": True},
+                provider="deepgram",
+                cost_usd=0.0001,
+            )
+            for i in range(n)
+        ]
+        await replay_repo.bulk_write_events(db, events)
+    finally:
+        await db.close()
+
+
+async def test_get_session_replay_returns_ordered_events(client, gateway) -> None:
+    await _seed_replay(gateway, "s1", n=3)
+    resp = await client.get("/api/sessions/s1/replay")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["session_id"] == "s1"
+    assert len(body["events"]) == 3
+    assert [e["t_ms"] for e in body["events"]] == [0, 100, 200]
+    assert body["events"][0]["modality"] == "stt"
+
+
+async def test_get_session_replay_unknown_session_empty(client) -> None:
+    resp = await client.get("/api/sessions/ghost/replay")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"session_id": "ghost", "events": []}
+
+
+async def test_delete_session_replay_returns_count(client, gateway) -> None:
+    await _seed_replay(gateway, "s1", n=4)
+    resp = await client.delete("/api/sessions/s1/replay")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["session_id"] == "s1"
+    assert body["deleted_rows"] == 4
+
+    # Verify cascade landed.
+    resp2 = await client.get("/api/sessions/s1/replay")
+    assert resp2.json()["events"] == []
+
+
+async def test_replay_storage_endpoint_shape(client) -> None:
+    resp = await client.get("/api/replay/storage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total_replay_size_bytes" in body
+    assert "by_project" in body
+    assert isinstance(body["by_project"], list)
+
+
+async def test_update_retention_validates_range(client) -> None:
+    # Out-of-range body.
+    resp = await client.post(
+        "/api/projects/default/replay/retention",
+        json={"retention_days": 0},
+    )
+    assert resp.status_code == 422
+
+    resp = await client.post(
+        "/api/projects/default/replay/retention",
+        json={"retention_days": 1000},
+    )
+    assert resp.status_code == 422
+
+
+async def test_update_retention_unknown_project_404(client) -> None:
+    resp = await client.post(
+        "/api/projects/no-such-project/replay/retention",
+        json={"retention_days": 30},
+    )
+    assert resp.status_code == 404

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -31,7 +31,7 @@ async def test_health(client):
     data = resp.json()
     assert data["status"] == "ok"
     assert "uptime_seconds" in data
-    assert data["version"] == "0.2.0"
+    assert data["version"] == "0.3.0"
 
 
 async def test_v1_status(client):

--- a/tests/storage/test_replay_migration.py
+++ b/tests/storage/test_replay_migration.py
@@ -1,0 +1,98 @@
+"""Contract tests for migration 0004 (replay tables + sessions.replay_size_bytes)."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import aiosqlite
+
+from voicegateway.storage.sqlite import SQLiteStorage
+
+_migration = import_module("voicegateway.storage.migrations.0004_replay_tables")
+
+
+async def test_creates_all_four_replay_tables(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+
+        async def _table_exists(name: str) -> bool:
+            cur = await db.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                (name,),
+            )
+            return await cur.fetchone() is not None
+
+        for table in (
+            "replay_stt_events",
+            "replay_llm_tokens",
+            "replay_tts_frames",
+            "replay_state_snapshots",
+        ):
+            assert await _table_exists(table), f"missing table {table}"
+
+
+async def test_adds_replay_size_bytes_to_sessions(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute("PRAGMA table_info(sessions)")
+        cols = {row[1] async for row in cur}
+
+    assert "replay_size_bytes" in cols
+
+
+async def test_creates_composite_indexes(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        names = {row[0] async for row in cur}
+
+    for expected in (
+        "idx_replay_stt_session_t",
+        "idx_replay_llm_session_t",
+        "idx_replay_tts_session_t",
+        "idx_replay_state_session_t",
+    ):
+        assert expected in names, f"missing index {expected}"
+
+
+async def test_idempotent_reapply(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+    async with aiosqlite.connect(db_path) as db:
+        await _migration.apply(db)  # second apply — must not raise
+        await db.commit()
+
+
+async def test_preexisting_session_keeps_null_replay_size(tmp_path) -> None:
+    """A v0.2.0-era sessions row is left with NULL on replay_size_bytes."""
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO sessions "
+            "(id, project, started_at, total_cost_usd, request_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy-pre-v030", "default", "2026-04-01T00:00:00Z", 0.0, 0),
+        )
+        await db.commit()
+
+        cur = await db.execute(
+            "SELECT replay_size_bytes FROM sessions WHERE id = ?",
+            ("legacy-pre-v030",),
+        )
+        row = await cur.fetchone()
+
+    assert row is not None
+    assert row[0] is None

--- a/tests/storage/test_replay_repo.py
+++ b/tests/storage/test_replay_repo.py
@@ -1,0 +1,137 @@
+"""Contract tests for voicegateway.storage.replay_repo (T05 of v0.3.0)."""
+
+from __future__ import annotations
+
+import aiosqlite
+
+from voicegateway.middleware.replay_capture import ReplayEvent
+from voicegateway.storage import replay_repo
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+def _stt(session_id: str, t_ms: int, text: str) -> ReplayEvent:
+    return ReplayEvent(
+        session_id=session_id,
+        modality="stt",
+        t_ms=t_ms,
+        payload={"text": text, "is_final": True, "alternatives": []},
+        provider="deepgram",
+        cost_usd=0.0001,
+    )
+
+
+def _llm(session_id: str, t_ms: int, token: str) -> ReplayEvent:
+    return ReplayEvent(
+        session_id=session_id,
+        modality="llm",
+        t_ms=t_ms,
+        payload={
+            "token_text": token,
+            "role": "assistant",
+            "is_tool_invoke": False,
+            "tool_args_partial": None,
+        },
+        provider="openai",
+        cost_usd=0.00002,
+    )
+
+
+def _state(session_id: str, t_ms: int) -> ReplayEvent:
+    return ReplayEvent(
+        session_id=session_id,
+        modality="state",
+        t_ms=t_ms,
+        payload={
+            "system_prompt": "be helpful",
+            "message_history": [],
+            "tool_call_in_flight": None,
+            "structured_output_collected": None,
+        },
+        provider="",
+        cost_usd=None,
+    )
+
+
+async def _fresh_db(tmp_path) -> str:
+    db_path = str(tmp_path / "replay.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+    return db_path
+
+
+async def test_bulk_write_round_trip(tmp_path) -> None:
+    db_path = await _fresh_db(tmp_path)
+    async with aiosqlite.connect(db_path) as db:
+        events = [
+            _stt("s1", 100, "hello"),
+            _llm("s1", 500, "hi"),
+            _state("s1", 510),
+        ]
+        n = await replay_repo.bulk_write_events(db, events)
+        assert n == 3
+
+        listed = await replay_repo.read_full_replay(db, "s1")
+        assert len(listed) == 3
+        assert [e.t_ms for e in listed] == [100, 500, 510]
+        # Modality discriminator preserved.
+        assert listed[0].modality == "stt"
+        assert listed[1].modality == "llm"
+        assert listed[2].modality == "state"
+
+
+async def test_bulk_write_empty_is_noop(tmp_path) -> None:
+    db_path = await _fresh_db(tmp_path)
+    async with aiosqlite.connect(db_path) as db:
+        n = await replay_repo.bulk_write_events(db, [])
+        assert n == 0
+
+
+async def test_read_full_replay_unknown_session_empty(tmp_path) -> None:
+    db_path = await _fresh_db(tmp_path)
+    async with aiosqlite.connect(db_path) as db:
+        assert await replay_repo.read_full_replay(db, "ghost") == []
+
+
+async def test_delete_replay_cascades_all_four_tables(tmp_path) -> None:
+    db_path = await _fresh_db(tmp_path)
+    async with aiosqlite.connect(db_path) as db:
+        events = [
+            _stt("s1", 0, "a"),
+            _llm("s1", 100, "b"),
+            _state("s1", 200),
+        ]
+        await replay_repo.bulk_write_events(db, events)
+        # Also a TTS event so all four tables have content.
+        await replay_repo.bulk_write_events(
+            db,
+            [
+                ReplayEvent(
+                    session_id="s1",
+                    modality="tts",
+                    t_ms=150,
+                    payload={
+                        "frame_duration_ms": 20,
+                        "underrun": False,
+                        "voice_id": "v1",
+                    },
+                    provider="cartesia",
+                    cost_usd=0.00001,
+                )
+            ],
+        )
+
+        deleted = await replay_repo.delete_replay(db, "s1")
+        assert deleted == 4
+
+        remaining = await replay_repo.read_full_replay(db, "s1")
+        assert remaining == []
+
+
+async def test_aggregate_storage_per_session(tmp_path) -> None:
+    db_path = await _fresh_db(tmp_path)
+    async with aiosqlite.connect(db_path) as db:
+        await replay_repo.bulk_write_events(db, [_stt("s1", 0, "hello world")])
+        size = await replay_repo.aggregate_storage_per_session(db, "s1")
+        # Payload contains JSON with text+is_final+alternatives;
+        # length should be at least 30 chars and at most a few hundred.
+        assert 30 <= size <= 500

--- a/tests/storage/test_replay_storage_smoke.py
+++ b/tests/storage/test_replay_storage_smoke.py
@@ -1,0 +1,162 @@
+"""Storage-cost smoke test for v0.3.0 conversation replay.
+
+Validates Foundry Open Question 1: a 60-second synthetic conversation
+captured end-to-end produces an on-disk replay footprint within the
+documented target. The Refinery's expectation is 30-100 KB/min;
+docs/storage/replay-storage-costs.md surfaces a wider 130-580 KB/min
+realistic range. This smoke asserts the upper bound at 600 KB/min
+(matches the docs' "trending above 500 KB/min consistently triggers
+the `replay.enabled: false` fallback" guideline).
+
+If this assertion trips, OQ1's fallback path is documented in T07's
+ProjectConfig.replay.enabled toggle and in the journal.
+"""
+
+from __future__ import annotations
+
+from voicegateway.middleware.replay_capture import ReplayCapture, ReplayEvent
+from voicegateway.storage import replay_repo
+from voicegateway.storage.sqlite import SQLiteStorage
+
+# Generous upper bound. The actual measured size for the synthetic
+# conversation below sits well under this; the test fails loudly if
+# storage explodes (e.g. payload schema regresses to dump huge JSON,
+# index overhead spikes).
+_MAX_REPLAY_BYTES_PER_MINUTE = 600 * 1024  # 600 KB
+
+
+async def _synthesize_one_minute(capture: ReplayCapture, session_id: str) -> None:
+    """Push a realistic 60-second conversation through ReplayCapture.
+
+    Roughly mirrors the per-minute event-rate table from
+    docs/storage/replay-storage-costs.md:
+    - 40 STT chunks (mixed partial + final)
+    - 400 LLM tokens
+    - 1200 TTS frames (50ms each across 60s of speech)
+    - 60 state snapshots (one per second cap)
+    """
+    base_ts = 0
+    for i in range(40):
+        await capture.record_stt_chunk(
+            text=f"transcript chunk number {i} hello there",
+            is_final=(i % 4 == 3),
+            alternatives=[],
+            provider="deepgram",
+            cost_usd=0.0001,
+            session_id=session_id,
+            at_ms=base_ts + i * 1500,
+        )
+    for i in range(400):
+        await capture.record_llm_token(
+            token_text=f"tok{i:03d}",
+            role="assistant",
+            is_tool_invoke=False,
+            tool_args_partial=None,
+            provider="openai",
+            cost_usd=0.00002,
+            session_id=session_id,
+            at_ms=base_ts + i * 150,
+        )
+    for i in range(1200):
+        await capture.record_tts_frame(
+            frame_duration_ms=50,
+            underrun=False,
+            voice_id="sonic-3",
+            provider="cartesia",
+            cost_usd=0.000005,
+            session_id=session_id,
+            at_ms=base_ts + i * 50,
+        )
+    for i in range(60):
+        await capture.record_state_snapshot(
+            {
+                "system_prompt": "be a helpful agent",
+                "message_history": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello, how can I help?"},
+                ],
+                "tool_call_in_flight": None,
+                "structured_output_collected": None,
+            },
+            session_id=session_id,
+            at_ms=base_ts + i * 1000,
+        )
+
+
+async def test_synthetic_one_minute_under_600kb(tmp_path) -> None:
+    """End-to-end: ReplayCapture -> replay_repo -> on-disk footprint."""
+    db_path = str(tmp_path / "smoke.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    captured: list[ReplayEvent] = []
+
+    async def flush(events: list[ReplayEvent]) -> None:
+        captured.extend(events)
+
+    capture = ReplayCapture(
+        flush_callback=flush,
+        flush_size_events=10000,
+        buffer_size_events=20000,
+    )
+
+    await _synthesize_one_minute(capture, "smoke-session")
+    await capture.close_session("smoke-session")
+
+    # Persist the captured events via the real repo.
+    import aiosqlite
+
+    async with aiosqlite.connect(db_path) as db:
+        n = await replay_repo.bulk_write_events(db, captured)
+        assert n == len(captured)
+
+        # Sum the payload bytes (the dominant cost term).
+        size = await replay_repo.aggregate_storage_per_session(db, "smoke-session")
+
+    # 60-second synthetic conversation should land under 600 KB/min.
+    # Documented target in docs/storage/replay-storage-costs.md.
+    assert size < _MAX_REPLAY_BYTES_PER_MINUTE, (
+        f"Replay storage footprint exploded: {size} bytes for 60s of "
+        f"conversation (> 600 KB). If this fails consistently, OQ1's "
+        f"fallback is documented in T07's ProjectConfig "
+        f"replay.enabled toggle."
+    )
+
+
+async def test_storage_size_reported_via_aggregate(tmp_path) -> None:
+    """The aggregate function reports the same byte sum the smoke uses."""
+    db_path = str(tmp_path / "smoke2.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    captured: list[ReplayEvent] = []
+
+    async def flush(events: list[ReplayEvent]) -> None:
+        captured.extend(events)
+
+    capture = ReplayCapture(
+        flush_callback=flush,
+        flush_size_events=10000,
+        buffer_size_events=20000,
+    )
+    # Smaller synthetic: just 10 STT chunks.
+    for i in range(10):
+        await capture.record_stt_chunk(
+            text=f"chunk-{i}",
+            is_final=True,
+            provider="deepgram",
+            cost_usd=0.0001,
+            session_id="tiny",
+            at_ms=i * 100,
+        )
+    await capture.close_session("tiny")
+
+    import aiosqlite
+
+    async with aiosqlite.connect(db_path) as db:
+        await replay_repo.bulk_write_events(db, captured)
+        size = await replay_repo.aggregate_storage_per_session(db, "tiny")
+
+    # 10 small STT chunks: each payload roughly 50 bytes JSON-encoded,
+    # so 500 bytes total floor, a few KB ceiling.
+    assert 100 < size < 5000

--- a/tests/storage/test_retention_worker.py
+++ b/tests/storage/test_retention_worker.py
@@ -1,0 +1,156 @@
+"""Contract tests for voicegateway.storage.retention_worker (T06 of v0.3.0)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from voicegateway.middleware.replay_capture import ReplayEvent
+from voicegateway.storage import replay_repo
+from voicegateway.storage.retention_worker import RetentionWorker
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+async def _seed_session(
+    db_path: str,
+    session_id: str,
+    project: str,
+    ended_at_offset_days: float,
+) -> None:
+    """Insert a sessions row with a project + an `ended_at` in the past."""
+    ended_at = (
+        datetime.now(UTC) - timedelta(days=ended_at_offset_days)
+    ).isoformat()
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO sessions "
+            "(id, project, started_at, ended_at, total_cost_usd, request_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (session_id, project, ended_at, ended_at, 0.0, 0),
+        )
+        await replay_repo.bulk_write_events(
+            db,
+            [
+                ReplayEvent(
+                    session_id=session_id,
+                    modality="stt",
+                    t_ms=0,
+                    payload={"text": "x", "is_final": True, "alternatives": []},
+                    provider="deepgram",
+                    cost_usd=0.0,
+                )
+            ],
+        )
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    db_path = str(tmp_path / "retention.db")
+    s = SQLiteStorage(db_path)
+    await s._ensure_initialized()
+    return s
+
+
+async def test_deletes_rows_older_than_window(storage, tmp_path) -> None:
+    db_path = str(tmp_path / "retention.db")
+    await _seed_session(db_path, "old-1", "acme", ended_at_offset_days=10)
+    await _seed_session(db_path, "young-1", "acme", ended_at_offset_days=1)
+
+    async def provider():
+        return [("acme", 5)]  # 5-day retention window
+
+    worker = RetentionWorker(storage, retention_provider=provider)
+    deletes = await worker.tick_now()
+    assert deletes["acme"] >= 1
+
+    # Verify old session's replay rows are gone, young's are kept.
+    async with aiosqlite.connect(db_path) as db:
+        old_left = await replay_repo.read_full_replay(db, "old-1")
+        young_left = await replay_repo.read_full_replay(db, "young-1")
+    assert old_left == []
+    assert len(young_left) == 1
+
+
+async def test_no_projects_no_deletes(storage) -> None:
+    async def provider():
+        return []
+
+    worker = RetentionWorker(storage, retention_provider=provider)
+    deletes = await worker.tick_now()
+    assert deletes == {}
+
+
+async def test_in_flight_sessions_never_deleted(storage, tmp_path) -> None:
+    """Sessions with ended_at IS NULL must not be touched."""
+    db_path = str(tmp_path / "retention.db")
+    async with aiosqlite.connect(db_path) as db:
+        # In-flight session: ended_at is NULL.
+        await db.execute(
+            "INSERT INTO sessions "
+            "(id, project, started_at, ended_at, total_cost_usd, request_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "in-flight-1",
+                "acme",
+                "2026-04-01T00:00:00Z",
+                None,
+                0.0,
+                0,
+            ),
+        )
+        await replay_repo.bulk_write_events(
+            db,
+            [
+                ReplayEvent(
+                    session_id="in-flight-1",
+                    modality="stt",
+                    t_ms=0,
+                    payload={"text": "live"},
+                    provider="d",
+                    cost_usd=0.0,
+                )
+            ],
+        )
+
+    async def provider():
+        return [("acme", 1)]  # 1-day retention — would delete anything closed yesterday
+
+    worker = RetentionWorker(storage, retention_provider=provider)
+    await worker.tick_now()
+
+    async with aiosqlite.connect(db_path) as db:
+        kept = await replay_repo.read_full_replay(db, "in-flight-1")
+    assert len(kept) == 1
+
+
+async def test_idempotent_across_ticks(storage, tmp_path) -> None:
+    db_path = str(tmp_path / "retention.db")
+    await _seed_session(db_path, "old-1", "acme", ended_at_offset_days=10)
+
+    async def provider():
+        return [("acme", 5)]
+
+    worker = RetentionWorker(storage, retention_provider=provider)
+    first = await worker.tick_now()
+    second = await worker.tick_now()
+    assert first["acme"] >= 1
+    assert second["acme"] == 0  # already deleted
+
+
+async def test_invalid_retention_days_falls_back_to_default(storage, tmp_path) -> None:
+    db_path = str(tmp_path / "retention.db")
+    await _seed_session(db_path, "old-1", "acme", ended_at_offset_days=100)
+
+    async def provider():
+        return [("acme", 0)]  # invalid: < 1
+
+    worker = RetentionWorker(
+        storage,
+        retention_provider=provider,
+        default_retention_days=90,
+    )
+    deletes = await worker.tick_now()
+    # 100 days old > 90 default → should still be deleted.
+    assert deletes["acme"] >= 1

--- a/tests/storage/test_sessions_table.py
+++ b/tests/storage/test_sessions_table.py
@@ -89,6 +89,8 @@ async def test_sessions_columns_match_design(tmp_path):
         "response_speed_p50_ms",
         "response_speed_p95_ms",
         "talk_over_rate",
+        # v0.3.0 replay storage column (added by migration 0004).
+        "replay_size_bytes",
     }
 
     # Required keys (NOT NULL).

--- a/voicegateway/cli/__init__.py
+++ b/voicegateway/cli/__init__.py
@@ -45,6 +45,7 @@ from voicegateway.cli import migrate as _migrate  # noqa: F401, E402
 from voicegateway.cli import onboard as _onboard  # noqa: F401, E402
 from voicegateway.cli import projects as _projects  # noqa: F401, E402
 from voicegateway.cli import reconcile as _reconcile  # noqa: F401, E402
+from voicegateway.cli import replay as _replay  # noqa: F401, E402
 from voicegateway.cli import rotate_secret as _rotate_secret  # noqa: F401, E402
 from voicegateway.cli import serve as _serve  # noqa: F401, E402
 from voicegateway.cli import smoke_test as _smoke_test  # noqa: F401, E402

--- a/voicegateway/cli/replay.py
+++ b/voicegateway/cli/replay.py
@@ -1,0 +1,56 @@
+"""``voicegw replay`` command: signpost the dashboard's Replay page.
+
+v0.3.0 minimal: prints a one-line "open replay in dashboard at <url>"
+hint for a given session id. The Foundry explicitly scopes this
+command as signposting only (it does not render the timeline in the
+terminal). Future scope (v0.3.x or v0.4.0) could embed a Textual-based
+mini-replay using v0.1.1's TUI primitives.
+
+Path correction note: the Foundry's text listed
+``voicegw/cli/replay.py``; the actual CLI subpackage is
+``voicegateway/cli/`` (per the v0.1.2 project-polish layout). The
+file lives here, in the correct package, so the existing Typer
+``app`` registry from ``voicegateway.cli._app`` picks it up via the
+``cli/__init__.py`` import side-effect.
+
+The dashboard host/port default to ``127.0.0.1:9090`` (the
+``voicegw dashboard`` defaults from v0.0.5). The ``--dashboard-url``
+override lets users running behind a reverse proxy or on a different
+host print the correct URL.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from voicegateway.cli._app import app, console
+
+
+@app.command(name="replay")
+def replay_cmd(
+    session_id: str = typer.Argument(
+        ...,
+        help="Session id to open in the dashboard's Replay page.",
+    ),
+    dashboard_url: str = typer.Option(
+        "http://127.0.0.1:9090",
+        "--dashboard-url",
+        help="Base URL of the dashboard (default: 127.0.0.1:9090).",
+    ),
+) -> None:
+    """Print the URL of the dashboard Replay page for a session.
+
+    The dashboard must already be running (``voicegw dashboard``).
+    This command does not render the replay in the terminal; it is
+    a signpost to the dashboard's graphical timeline.
+    """
+    if not session_id.strip():
+        console.print("[red]session_id is required.[/red]")
+        raise typer.Exit(code=1)
+    base = dashboard_url.rstrip("/")
+    target = f"{base}/sessions/{session_id}/replay"
+    console.print(f"[bold]Replay:[/bold] {target}")
+    console.print("[dim]The dashboard must be running: voicegw dashboard.[/dim]")
+
+
+__all__ = ["replay_cmd"]

--- a/voicegateway/core/config.py
+++ b/voicegateway/core/config.py
@@ -66,6 +66,23 @@ class MetricsConfig:
 
 
 @dataclass
+class ReplayConfig:
+    """v0.3.0 conversation-replay capture + retention knobs.
+
+    Defaults match the Foundry-locked values. Per-project overridable
+    via the ``replay:`` block in ``voicegw.yaml``. ``enabled = False``
+    is the OQ1 fallback: if T18's storage-cost smoke fails the
+    100 KB/min target, individual projects (or all projects via the
+    top-level default) can disable capture without redeploying.
+    """
+
+    enabled: bool = True
+    retention_days: int = 90
+    buffer_size_events: int = 5000
+    flush_size_events: int = 500
+
+
+@dataclass
 class ProjectConfig:
     """Configuration for a single project."""
 
@@ -84,6 +101,8 @@ class ProjectConfig:
     providers: dict[str, dict[str, Any]] = field(default_factory=dict)
     # v0.2.0: per-project metric capture knobs (REQ-VG-METRICS-001..006).
     metrics: MetricsConfig = field(default_factory=MetricsConfig)
+    # v0.3.0: per-project replay capture knobs (REQ-VG-REPLAY-001..006).
+    replay: ReplayConfig = field(default_factory=ReplayConfig)
 
     @property
     def accent(self) -> str:
@@ -253,6 +272,13 @@ class GatewayConfig:
                         metrics_raw.get("turn_buffer_flush_size", 25)
                     ),
                 )
+                replay_raw = pcfg.get("replay") or {}
+                replay_cfg = ReplayConfig(
+                    enabled=bool(replay_raw.get("enabled", True)),
+                    retention_days=int(replay_raw.get("retention_days", 90)),
+                    buffer_size_events=int(replay_raw.get("buffer_size_events", 5000)),
+                    flush_size_events=int(replay_raw.get("flush_size_events", 500)),
+                )
                 projects[pid] = ProjectConfig(
                     id=pid,
                     name=str(pcfg.get("name") or pid),
@@ -263,6 +289,7 @@ class GatewayConfig:
                     tags=list(pcfg.get("tags") or []),
                     providers=project_providers,
                     metrics=metrics_cfg,
+                    replay=replay_cfg,
                 )
 
         auth_raw = raw.get("auth", {}) or {}

--- a/voicegateway/core/schema.py
+++ b/voicegateway/core/schema.py
@@ -54,6 +54,21 @@ class MetricsConfig(_StrictBase):
     turn_buffer_flush_size: int = Field(default=25, gt=0)
 
 
+class ReplayConfig(_StrictBase):
+    """v0.3.0 conversation-replay knobs (REQ-VG-REPLAY-001..006).
+
+    All fields are per-project overridable via the ``replay:`` block
+    under each project entry in ``voicegw.yaml``. Defaults match the
+    Foundry's stated values; OQ1's storage-cost target is enforced by
+    T18's smoke test, not at config time.
+    """
+
+    enabled: bool = True
+    retention_days: int = Field(default=90, ge=1)
+    buffer_size_events: int = Field(default=5000, ge=1)
+    flush_size_events: int = Field(default=500, ge=1)
+
+
 class ProjectConfig(_StrictBase):
     name: str
     description: str = ""
@@ -68,6 +83,8 @@ class ProjectConfig(_StrictBase):
     # MetricsConfig's own defaults so projects that do not set
     # ``metrics:`` get the canonical Foundry values.
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
+    # v0.3.0: per-project replay capture + retention knobs.
+    replay: ReplayConfig = Field(default_factory=ReplayConfig)
 
 
 class ObservabilityConfig(_StrictBase):

--- a/voicegateway/middleware/cost_tracker.py
+++ b/voicegateway/middleware/cost_tracker.py
@@ -178,40 +178,68 @@ class CostTracker:
             logger.warning("Failed to update budget cache", exc_info=True)
 
     async def close_session(self, session_id: str) -> None:
-        """Finalize session-aggregate metrics on session close.
+        """Finalize session-aggregate metrics + replay on session close.
 
-        Delegates to :meth:`SQLiteStorage.finalize_session_metrics` so
-        the v0.2.0 aggregate columns (``talk_time_seconds``,
-        ``per_minute_cost_usd``, ``response_speed_p50/p95_ms``,
-        ``talk_over_rate``) reflect the captured turn data by the time
-        the ``/v1/metrics`` endpoint reads the sessions row.
+        Composes two storage hooks:
 
-        The actual TurnTracker flush and DeadAirDetector cancellation
-        are owned by :func:`voicegateway.inference.attach_session` (T09);
-        this method is the cost-tracking side of the close hook
-        (Foundry item #7).
+        - :meth:`SQLiteStorage.finalize_session_metrics` (v0.2.0): the
+          aggregate columns (``talk_time_seconds``, ``per_minute_cost_usd``,
+          ``response_speed_p50/p95_ms``, ``talk_over_rate``) land on the
+          sessions row by the time ``/api/metrics`` reads it.
+        - :meth:`SQLiteStorage.finalize_session_replay` (v0.3.0): the
+          per-session ``replay_size_bytes`` aggregate lands on the
+          sessions row so the dashboard's storage-usage view is
+          accurate.
 
-        No-ops when storage is missing (tests sometimes pass
-        ``storage=None``) or the storage does not implement the
-        ``finalize_session_metrics`` contract (older versions before
-        T07's modification). Errors during finalization are logged but
-        do not propagate: dropping an aggregate row should not crash
-        the session-close path.
+        The actual TurnTracker flush, DeadAirDetector cancellation, and
+        ReplayCapture flush are owned by
+        :func:`voicegateway.inference.attach_session` (T09 of v0.2.0,
+        extended in T09 of v0.3.0); this method is the cost-tracking
+        side of the close hook.
+
+        Each finalize call is independently guarded:
+
+        - No-ops when storage is missing (tests sometimes pass
+          ``storage=None``) or the storage doesn't implement the
+          method (older storage versions). Older storages without
+          ``finalize_session_replay`` skip the replay aggregate
+          silently; metrics still finalize.
+        - Errors are logged at warning level but never propagate.
+          Dropping an aggregate row is observability loss, not a
+          correctness issue, and must not crash the session-close
+          path.
         """
         if self._storage is None:
             return
-        finalize = getattr(self._storage, "finalize_session_metrics", None)
-        if finalize is None:
+        # v0.2.0 metrics finalize.
+        metrics_finalize = getattr(self._storage, "finalize_session_metrics", None)
+        if metrics_finalize is None:
             logger.debug(
                 "CostTracker.close_session: storage has no "
                 "finalize_session_metrics; skipping",
             )
+        else:
+            try:
+                await metrics_finalize(session_id)
+            except Exception:
+                logger.warning(
+                    "Failed to finalize metrics for session %s",
+                    session_id,
+                    exc_info=True,
+                )
+        # v0.3.0 replay finalize.
+        replay_finalize = getattr(self._storage, "finalize_session_replay", None)
+        if replay_finalize is None:
+            logger.debug(
+                "CostTracker.close_session: storage has no "
+                "finalize_session_replay; skipping",
+            )
             return
         try:
-            await finalize(session_id)
+            await replay_finalize(session_id)
         except Exception:
             logger.warning(
-                "Failed to finalize metrics for session %s",
+                "Failed to finalize replay for session %s",
                 session_id,
                 exc_info=True,
             )

--- a/voicegateway/middleware/replay_capture.py
+++ b/voicegateway/middleware/replay_capture.py
@@ -1,0 +1,342 @@
+"""Per-session replay-event capture for the v0.3.0 conversation timeline.
+
+Implements REQ-VG-REPLAY-003 (every captured event along the way): each
+STT chunk, each LLM token, and each TTS frame the Instrumented* wrappers
+emit becomes a typed ``ReplayEvent`` keyed by ``session_id`` and indexed
+by start-relative milliseconds. The events accumulate in a bounded
+per-session asyncio buffer; when the buffer fills, the oldest event is
+dropped and a per-session ``dropped_count`` increments so the dashboard
+can surface "events dropped here" rather than silently misleading the
+developer.
+
+Flush triggers:
+
+- ``flush_size_events`` reached -> async flush to the injected
+  ``flush_callback``.
+- ``close_session(session_id)`` -> final flush + state drop.
+
+The class is repository-agnostic. Callers inject a ``FlushCallback``
+(async callable taking ``list[ReplayEvent]``). A default no-op callback
+keeps the capture usable before ``replay_repo`` lands (T05). The
+``ProjectConfig.replay`` knobs from T07 set ``buffer_size_events``
+(default 5000) and ``flush_size_events`` (default 500).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Final
+
+from voicegateway.inference._session_context import get_session_id
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_BUFFER_SIZE: Final[int] = 5000
+_DEFAULT_FLUSH_SIZE: Final[int] = 500
+
+
+@dataclass
+class ReplayEvent:
+    """One captured replay event.
+
+    Maps 1-to-1 to one of the four ``replay_*`` table rows created by
+    storage migration 0004 (T04). ``modality`` selects which table the
+    event lands in (``stt``, ``llm``, ``tts``); ``payload`` is the
+    JSON-serializable per-modality body. ``cost_usd`` is nullable
+    (provider-specific) and surfaces in the RunningCostCounter (T12).
+
+    State snapshots (REQ-VG-REPLAY-005) use the same shape with
+    ``modality="state"`` so the replay timeline can interleave snapshots
+    with the three streaming modalities under a single buffer.
+    """
+
+    session_id: str
+    modality: str  # "stt" | "llm" | "tts" | "state"
+    t_ms: int  # start-relative milliseconds
+    payload: dict[str, Any]
+    provider: str = ""
+    cost_usd: float | None = None
+
+
+FlushCallback = Callable[[list[ReplayEvent]], Awaitable[None]]
+
+
+async def _noop_flush(events: list[ReplayEvent]) -> None:
+    """Default callback used before replay_repo (T05) is wired."""
+    if events:
+        logger.debug(
+            "ReplayCapture no-op flush: %d events dropped (no repository wired)",
+            len(events),
+        )
+
+
+@dataclass
+class _SessionState:
+    """In-flight per-session capture state."""
+
+    started_at_ms: int  # monotonic ms when the first event arrived
+    buffer: deque[ReplayEvent] = field(default_factory=deque)
+    dropped_count: int = 0
+
+
+class ReplayCapture:
+    """Captures replay events for v0.3.0's conversation timeline.
+
+    Multiple concurrent sessions are supported; per-session state is
+    keyed by ``session_id`` (resolved from the explicit kwarg or the
+    v0.0.5 ``voicegateway.inference`` ContextVar). All mutating
+    operations go through an internal asyncio lock so concurrent
+    callbacks from the STT/LLM/TTS wrappers cannot interleave a
+    partial buffer.
+
+    Backpressure: ``buffer_size_events`` caps the per-session deque.
+    When the cap is reached, ``append`` drops the oldest event and
+    increments ``dropped_count``. This matches the Refinery's "dropped
+    count is recorded and surfaced as 'events dropped here'" contract.
+
+    Example::
+
+        capture = ReplayCapture(flush_callback=replay_repo.bulk_write_events)
+        await capture.record_stt_chunk(text="hello", is_final=True,
+                                       provider="deepgram", cost_usd=0.0001)
+        # ... session runs ...
+        await capture.close_session(session_id)
+    """
+
+    def __init__(
+        self,
+        flush_callback: FlushCallback | None = None,
+        flush_size_events: int = _DEFAULT_FLUSH_SIZE,
+        buffer_size_events: int = _DEFAULT_BUFFER_SIZE,
+    ) -> None:
+        if flush_size_events < 1:
+            raise ValueError(f"flush_size_events must be >= 1, got {flush_size_events}")
+        if buffer_size_events < 1:
+            raise ValueError(
+                f"buffer_size_events must be >= 1, got {buffer_size_events}"
+            )
+        if flush_size_events > buffer_size_events:
+            raise ValueError(
+                f"flush_size_events ({flush_size_events}) must be <= "
+                f"buffer_size_events ({buffer_size_events})"
+            )
+        self._flush_callback: FlushCallback = flush_callback or _noop_flush
+        self._flush_size = flush_size_events
+        self._buffer_size = buffer_size_events
+        self._sessions: dict[str, _SessionState] = {}
+        self._lock = asyncio.Lock()
+
+    # ---- public capture API -----------------------------------------------
+
+    async def record_stt_chunk(
+        self,
+        text: str,
+        *,
+        is_final: bool = False,
+        alternatives: list[str] | None = None,
+        provider: str = "",
+        cost_usd: float | None = None,
+        session_id: str | None = None,
+        at_ms: int | None = None,
+    ) -> None:
+        """Record one STT chunk (partial or final transcription)."""
+        await self._append(
+            modality="stt",
+            payload={
+                "text": text,
+                "is_final": is_final,
+                "alternatives": alternatives or [],
+            },
+            provider=provider,
+            cost_usd=cost_usd,
+            session_id=session_id,
+            at_ms=at_ms,
+        )
+
+    async def record_llm_token(
+        self,
+        token_text: str,
+        *,
+        role: str = "assistant",
+        is_tool_invoke: bool = False,
+        tool_args_partial: str | None = None,
+        provider: str = "",
+        cost_usd: float | None = None,
+        session_id: str | None = None,
+        at_ms: int | None = None,
+    ) -> None:
+        """Record one LLM token (or a tool-invoke marker)."""
+        await self._append(
+            modality="llm",
+            payload={
+                "token_text": token_text,
+                "role": role,
+                "is_tool_invoke": is_tool_invoke,
+                "tool_args_partial": tool_args_partial,
+            },
+            provider=provider,
+            cost_usd=cost_usd,
+            session_id=session_id,
+            at_ms=at_ms,
+        )
+
+    async def record_tts_frame(
+        self,
+        *,
+        frame_duration_ms: int,
+        underrun: bool = False,
+        voice_id: str = "",
+        provider: str = "",
+        cost_usd: float | None = None,
+        session_id: str | None = None,
+        at_ms: int | None = None,
+    ) -> None:
+        """Record one TTS audio frame (marker, not raw audio)."""
+        await self._append(
+            modality="tts",
+            payload={
+                "frame_duration_ms": frame_duration_ms,
+                "underrun": underrun,
+                "voice_id": voice_id,
+            },
+            provider=provider,
+            cost_usd=cost_usd,
+            session_id=session_id,
+            at_ms=at_ms,
+        )
+
+    async def record_state_snapshot(
+        self,
+        snapshot: dict[str, Any],
+        *,
+        session_id: str | None = None,
+        at_ms: int | None = None,
+    ) -> None:
+        """Record one conversation-state snapshot.
+
+        ``snapshot`` carries the system prompt, message history,
+        in-flight tool call, and structured outputs collected. Owned
+        by the state_snapshotter (T03); ReplayCapture is the
+        shared buffer.
+        """
+        await self._append(
+            modality="state",
+            payload=snapshot,
+            provider="",
+            cost_usd=None,
+            session_id=session_id,
+            at_ms=at_ms,
+        )
+
+    # ---- lifecycle helpers -------------------------------------------------
+
+    async def flush_session(self, session_id: str) -> int:
+        """Flush buffered events for one session. Session stays alive.
+
+        Returns the number of events flushed.
+        """
+        async with self._lock:
+            state = self._sessions.get(session_id)
+            if state is None or not state.buffer:
+                return 0
+            to_flush = list(state.buffer)
+            state.buffer.clear()
+        try:
+            await self._flush_callback(to_flush)
+        except Exception:
+            logger.exception(
+                "ReplayCapture flush_callback raised; dropping %d events",
+                len(to_flush),
+            )
+            raise
+        return len(to_flush)
+
+    async def close_session(self, session_id: str) -> int:
+        """Final flush + drop the per-session state."""
+        flushed = await self.flush_session(session_id)
+        async with self._lock:
+            self._sessions.pop(session_id, None)
+        return flushed
+
+    def dropped_count(self, session_id: str) -> int:
+        """Return the running dropped-count for the session (for the
+        replay timeline's "events dropped here" surface)."""
+        state = self._sessions.get(session_id)
+        return state.dropped_count if state else 0
+
+    def active_sessions(self) -> list[str]:
+        """List session ids with in-flight or buffered state."""
+        return list(self._sessions.keys())
+
+    # ---- internals ---------------------------------------------------------
+
+    async def _append(
+        self,
+        modality: str,
+        payload: dict[str, Any],
+        provider: str,
+        cost_usd: float | None,
+        session_id: str | None,
+        at_ms: int | None,
+    ) -> None:
+        sid = self._resolve_session_id(session_id)
+        if sid is None:
+            logger.debug(
+                "ReplayCapture._append (%s) without session_id; dropping",
+                modality,
+            )
+            return
+        now_ms = at_ms if at_ms is not None else self._now_ms()
+        flush_now = False
+        async with self._lock:
+            state = self._sessions.get(sid)
+            if state is None:
+                state = _SessionState(started_at_ms=now_ms)
+                self._sessions[sid] = state
+            relative_ms = max(0, now_ms - state.started_at_ms)
+            event = ReplayEvent(
+                session_id=sid,
+                modality=modality,
+                t_ms=relative_ms,
+                payload=payload,
+                provider=provider,
+                cost_usd=cost_usd,
+            )
+            if len(state.buffer) >= self._buffer_size:
+                # Buffer full: drop oldest and record the drop.
+                state.buffer.popleft()
+                state.dropped_count += 1
+                # No-op log at warning level so a persistent overflow
+                # is visible in production.
+                if state.dropped_count % 100 == 1:
+                    logger.warning(
+                        "ReplayCapture buffer overflow on session %s "
+                        "(%d events dropped so far)",
+                        sid,
+                        state.dropped_count,
+                    )
+            state.buffer.append(event)
+            flush_now = len(state.buffer) >= self._flush_size
+        if flush_now:
+            await self.flush_session(sid)
+
+    @staticmethod
+    def _now_ms() -> int:
+        return int(time.monotonic() * 1000)
+
+    @staticmethod
+    def _resolve_session_id(session_id: str | None) -> str | None:
+        return session_id if session_id is not None else get_session_id()
+
+
+__all__ = [
+    "FlushCallback",
+    "ReplayCapture",
+    "ReplayEvent",
+]

--- a/voicegateway/middleware/state_snapshotter.py
+++ b/voicegateway/middleware/state_snapshotter.py
@@ -1,0 +1,231 @@
+"""Conversation-state snapshots at LLM and tool-call boundaries.
+
+Implements REQ-VG-REPLAY-005 (see conversation state at every moment).
+The replay timeline reconstructs agent state at any playhead position
+by walking the most recent ``StateSnapshot`` plus subsequent message
+diffs; this module owns the snapshot side. The diff-walk lives in the
+dashboard ``ConversationStatePane`` (T12).
+
+Snapshots fire at three boundary kinds:
+
+- ``on_message_added`` -> after every LLM message append to the
+  running history.
+- ``on_tool_invoked`` -> at the moment the agent invokes a tool call.
+- ``on_tool_resolved`` -> when the tool result arrives back.
+
+A per-session rate cap of one snapshot per second guards against
+storage explosion on chatty agents (the Foundry's "max one per
+second" requirement). Boundary events that fire faster than the cap
+are coalesced into the next-eligible snapshot.
+
+The module is decoupled from the storage layer: callers inject an
+async ``on_snapshot`` callback. The natural target is
+:meth:`voicegateway.middleware.replay_capture.ReplayCapture.record_state_snapshot`
+(T02), which routes the snapshot into the same per-session buffer
+that handles backpressure for the other three modalities.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, Final
+
+from pydantic import BaseModel, Field
+
+from voicegateway.inference._session_context import get_session_id
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_MIN_INTERVAL_SECONDS: Final[float] = 1.0
+
+
+class StateSnapshot(BaseModel):
+    """One captured conversation-state snapshot.
+
+    Serialized to JSON and stored in the ``replay_state_snapshots``
+    table (migration 0004, T04). All fields are optional so a partial
+    snapshot (e.g. tool invocation with no structured output yet) is
+    representable.
+    """
+
+    system_prompt: str = ""
+    message_history: list[dict[str, Any]] = Field(default_factory=list)
+    tool_call_in_flight: dict[str, Any] | None = None
+    structured_output_collected: dict[str, Any] | None = None
+
+
+SnapshotCallback = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+async def _noop_callback(snapshot: dict[str, Any]) -> None:
+    """Default callback used when no ReplayCapture is wired yet."""
+    logger.debug(
+        "StateSnapshotter no-op callback: snapshot dropped (no capture wired)",
+    )
+
+
+class StateSnapshotter:
+    """Captures conversation-state snapshots with a per-session rate cap.
+
+    The snapshotter does NOT own state itself; callers pass the
+    current state on each boundary event. The class only enforces
+    the rate cap and forwards to the injected callback.
+
+    Rate cap semantics: a boundary event that fires within
+    ``min_interval_seconds`` of the prior snapshot for the same
+    session is silently dropped. This is intentional coalescing per
+    Foundry; the reconstruction in
+    :class:`ConversationStatePane <dashboard>` walks message diffs
+    between snapshots so coalesced state is still recoverable.
+
+    Example::
+
+        snap = StateSnapshotter(on_snapshot=capture.record_state_snapshot)
+        await snap.on_message_added(
+            session_id=sid,
+            system_prompt="...",
+            message_history=[...],
+        )
+    """
+
+    def __init__(
+        self,
+        on_snapshot: SnapshotCallback | None = None,
+        min_interval_seconds: float = _DEFAULT_MIN_INTERVAL_SECONDS,
+    ) -> None:
+        if min_interval_seconds < 0:
+            raise ValueError(
+                f"min_interval_seconds must be >= 0, got {min_interval_seconds}"
+            )
+        self._on_snapshot: SnapshotCallback = on_snapshot or _noop_callback
+        self._min_interval = min_interval_seconds
+        self._last_snapshot_ms: dict[str, int] = {}
+
+    # ---- public boundary handlers ----------------------------------------
+
+    async def on_message_added(
+        self,
+        *,
+        system_prompt: str = "",
+        message_history: list[dict[str, Any]] | None = None,
+        session_id: str | None = None,
+    ) -> bool:
+        """Snapshot at LLM message-add boundary.
+
+        Returns True if the snapshot fired, False if rate-capped.
+        """
+        snap = StateSnapshot(
+            system_prompt=system_prompt,
+            message_history=message_history or [],
+            tool_call_in_flight=None,
+            structured_output_collected=None,
+        )
+        return await self._emit(snap, session_id)
+
+    async def on_tool_invoked(
+        self,
+        *,
+        tool_name: str,
+        tool_args: dict[str, Any] | None = None,
+        system_prompt: str = "",
+        message_history: list[dict[str, Any]] | None = None,
+        session_id: str | None = None,
+    ) -> bool:
+        """Snapshot at tool-call invocation boundary."""
+        snap = StateSnapshot(
+            system_prompt=system_prompt,
+            message_history=message_history or [],
+            tool_call_in_flight={
+                "name": tool_name,
+                "args": tool_args or {},
+                "result": None,
+            },
+            structured_output_collected=None,
+        )
+        return await self._emit(snap, session_id)
+
+    async def on_tool_resolved(
+        self,
+        *,
+        tool_name: str,
+        tool_args: dict[str, Any] | None = None,
+        result: Any = None,
+        system_prompt: str = "",
+        message_history: list[dict[str, Any]] | None = None,
+        structured_output_collected: dict[str, Any] | None = None,
+        session_id: str | None = None,
+    ) -> bool:
+        """Snapshot at tool-call result-arrival boundary.
+
+        Note: tool-resolve snapshots bypass the rate cap. Even if
+        another snapshot fired within ``min_interval_seconds``,
+        the resolved state is structurally important (the in-flight
+        tool transitions to "done"), so the replay timeline must see
+        the boundary.
+        """
+        snap = StateSnapshot(
+            system_prompt=system_prompt,
+            message_history=message_history or [],
+            tool_call_in_flight={
+                "name": tool_name,
+                "args": tool_args or {},
+                "result": result,
+            },
+            structured_output_collected=structured_output_collected,
+        )
+        return await self._emit(snap, session_id, bypass_rate_cap=True)
+
+    # ---- lifecycle helpers -----------------------------------------------
+
+    def reset_session(self, session_id: str) -> None:
+        """Drop the last-snapshot timestamp for a session.
+
+        Called by ReplayCapture's session lifecycle (or test fixtures);
+        a fresh session should not inherit the previous one's
+        rate-cap state.
+        """
+        self._last_snapshot_ms.pop(session_id, None)
+
+    # ---- internals -------------------------------------------------------
+
+    async def _emit(
+        self,
+        snapshot: StateSnapshot,
+        session_id: str | None,
+        bypass_rate_cap: bool = False,
+    ) -> bool:
+        sid = self._resolve_session_id(session_id)
+        if sid is None:
+            logger.debug(
+                "StateSnapshotter._emit without session_id; dropping",
+            )
+            return False
+        now_ms = int(time.monotonic() * 1000)
+        if not bypass_rate_cap:
+            last_ms = self._last_snapshot_ms.get(sid)
+            if last_ms is not None and (now_ms - last_ms) < self._min_interval * 1000:
+                return False
+        self._last_snapshot_ms[sid] = now_ms
+        try:
+            await self._on_snapshot(snapshot.model_dump())
+        except Exception:
+            logger.exception(
+                "StateSnapshotter on_snapshot raised; snapshot dropped",
+            )
+            # Do not re-raise: snapshots are best-effort observability.
+            return False
+        return True
+
+    @staticmethod
+    def _resolve_session_id(session_id: str | None) -> str | None:
+        return session_id if session_id is not None else get_session_id()
+
+
+__all__ = [
+    "SnapshotCallback",
+    "StateSnapshot",
+    "StateSnapshotter",
+]

--- a/voicegateway/server/main.py
+++ b/voicegateway/server/main.py
@@ -55,7 +55,7 @@ def build_app(gateway: Gateway) -> FastAPI:
     """Build a FastAPI app bound to the given Gateway instance."""
     app = FastAPI(
         title="VoiceGateway API",
-        version="0.2.0",
+        version="0.3.0",
         description="HTTP API for VoiceGateway: cost tracking and reconciliation for LiveKit voice agents.",
     )
 
@@ -107,7 +107,7 @@ def build_app(gateway: Gateway) -> FastAPI:
         return {
             "status": "ok",
             "uptime_seconds": round(time.time() - started_at, 1),
-            "version": "0.2.0",
+            "version": "0.3.0",
         }
 
     @app.get("/v1/status")

--- a/voicegateway/storage/migrations/0004_replay_tables.py
+++ b/voicegateway/storage/migrations/0004_replay_tables.py
@@ -1,0 +1,116 @@
+"""Migration 0004: replay event tables + session replay-size aggregate.
+
+Introduced in v0.3.0 to back REQ-VG-REPLAY-001 (open any past
+conversation), REQ-VG-REPLAY-003 (every captured event), REQ-VG-REPLAY-005
+(state at every moment), and REQ-VG-REPLAY-006 (graceful pre-v0.3.0
+handling).
+
+Idempotent. Re-running on an already-migrated database is a no-op:
+
+* ``CREATE TABLE IF NOT EXISTS`` and ``CREATE INDEX IF NOT EXISTS`` are
+  the inner SQL's own no-op guards.
+* The ``ALTER TABLE sessions ADD COLUMN replay_size_bytes`` is guarded
+  by a ``PRAGMA table_info(sessions)`` lookup.
+
+Pre-v0.3.0 rows in the ``sessions`` table get NULL on
+``replay_size_bytes``. v0.2.0 aggregate columns (added by migration
+0003) are untouched.
+
+Four new tables share an identical column shape so a single SQL
+DDL block does all four. The dashboard ``Replay.tsx`` page (T11)
+fetches a time-ordered union of all four via ``replay_repo.read_full_replay``
+(T05).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+_NEW_TABLES = """
+CREATE TABLE IF NOT EXISTS replay_stt_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    t_ms INTEGER NOT NULL,
+    payload TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT '',
+    cost_usd REAL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_replay_stt_session_t
+    ON replay_stt_events(session_id, t_ms);
+
+CREATE TABLE IF NOT EXISTS replay_llm_tokens (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    t_ms INTEGER NOT NULL,
+    payload TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT '',
+    cost_usd REAL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_replay_llm_session_t
+    ON replay_llm_tokens(session_id, t_ms);
+
+CREATE TABLE IF NOT EXISTS replay_tts_frames (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    t_ms INTEGER NOT NULL,
+    payload TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT '',
+    cost_usd REAL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_replay_tts_session_t
+    ON replay_tts_frames(session_id, t_ms);
+
+CREATE TABLE IF NOT EXISTS replay_state_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    t_ms INTEGER NOT NULL,
+    payload TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_replay_state_session_t
+    ON replay_state_snapshots(session_id, t_ms);
+"""
+
+
+# Single nullable column added to the existing sessions table. v0.2.0's
+# aggregate columns (talk_time_seconds, per_minute_cost_usd, etc.) are
+# untouched; this migration is additive only.
+_SESSIONS_REPLAY_COLUMN = ("replay_size_bytes", "INTEGER")
+
+
+async def apply(db: aiosqlite.Connection) -> None:
+    """Apply migration 0004 against the given connection.
+
+    Steps:
+
+    1. ``executescript`` creates the four replay tables + four indexes
+       via ``CREATE ... IF NOT EXISTS`` no-op guards.
+    2. ``PRAGMA table_info(sessions)`` is inspected; if
+       ``replay_size_bytes`` is missing, ``ALTER TABLE`` adds it.
+       PRAGMA guard is the idempotency mechanism (SQLite has no
+       ``ADD COLUMN IF NOT EXISTS``).
+
+    Caller manages the connection lifecycle; T08 wires this into
+    ``SQLiteStorage._ensure_initialized`` after migration 0003.
+    """
+    await db.executescript(_NEW_TABLES)
+
+    cursor = await db.execute("PRAGMA table_info(sessions)")
+    existing = {row[1] async for row in cursor}
+    column, type_ = _SESSIONS_REPLAY_COLUMN
+    if column not in existing:
+        await db.execute(f"ALTER TABLE sessions ADD COLUMN {column} {type_}")
+
+
+__all__ = ["apply"]

--- a/voicegateway/storage/replay_repo.py
+++ b/voicegateway/storage/replay_repo.py
@@ -1,0 +1,222 @@
+"""Async repo for the four ``replay_*`` tables.
+
+Implements REQ-VG-REPLAY-001 (open any past conversation as a replay)
+and REQ-VG-REPLAY-006 (privacy + retention) data access. Mirrors the
+flat-function-module pattern from v0.2.0's ``turns_repo`` and
+``dead_air_repo``: each function takes an ``aiosqlite.Connection`` and
+the caller owns the connection lifecycle.
+
+The natural caller is ``ReplayCapture.flush_callback`` from T02 with a
+``functools.partial(replay_repo.bulk_write_events, db)`` wiring landed
+in T09's session-close path.
+
+Schema reference: ``voicegateway/storage/migrations/0004_replay_tables.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from voicegateway.middleware.replay_capture import ReplayEvent
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+# Modality -> (table_name, has_provider_cost) tuples. The four replay
+# tables share identical column shapes but ``state_snapshots`` semantically
+# does not carry provider/cost; both default to '' / NULL when the
+# inserter omits them, matching migration 0004.
+_TABLE_BY_MODALITY: dict[str, str] = {
+    "stt": "replay_stt_events",
+    "llm": "replay_llm_tokens",
+    "tts": "replay_tts_frames",
+    "state": "replay_state_snapshots",
+}
+
+
+_INSERT_BY_MODALITY: dict[str, str] = {
+    "stt": (
+        "INSERT INTO replay_stt_events "
+        "(session_id, t_ms, payload, provider, cost_usd) "
+        "VALUES (?, ?, ?, ?, ?)"
+    ),
+    "llm": (
+        "INSERT INTO replay_llm_tokens "
+        "(session_id, t_ms, payload, provider, cost_usd) "
+        "VALUES (?, ?, ?, ?, ?)"
+    ),
+    "tts": (
+        "INSERT INTO replay_tts_frames "
+        "(session_id, t_ms, payload, provider, cost_usd) "
+        "VALUES (?, ?, ?, ?, ?)"
+    ),
+    "state": (
+        "INSERT INTO replay_state_snapshots "
+        "(session_id, t_ms, payload) "
+        "VALUES (?, ?, ?)"
+    ),
+}
+
+
+def _payload_to_text(payload: dict[str, Any]) -> str:
+    """Serialize a payload dict to the TEXT JSON the schema stores."""
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+
+
+async def bulk_write_events(db: aiosqlite.Connection, events: list[ReplayEvent]) -> int:
+    """Bulk-insert events into their per-modality tables.
+
+    Partitions by ``event.modality`` and runs one ``executemany`` per
+    partition. Empty input is a no-op (returns 0). Commits the
+    connection on success.
+
+    Returns the total number of events inserted across the four tables.
+    """
+    if not events:
+        return 0
+
+    by_modality: dict[str, list[tuple[Any, ...]]] = {
+        "stt": [],
+        "llm": [],
+        "tts": [],
+        "state": [],
+    }
+    for ev in events:
+        if ev.modality not in by_modality:
+            raise ValueError(
+                f"unknown modality {ev.modality!r}; expected one of "
+                f"{sorted(by_modality)}"
+            )
+        if ev.modality == "state":
+            by_modality["state"].append(
+                (ev.session_id, ev.t_ms, _payload_to_text(ev.payload))
+            )
+        else:
+            by_modality[ev.modality].append(
+                (
+                    ev.session_id,
+                    ev.t_ms,
+                    _payload_to_text(ev.payload),
+                    ev.provider,
+                    ev.cost_usd,
+                )
+            )
+
+    inserted = 0
+    for modality, rows in by_modality.items():
+        if not rows:
+            continue
+        await db.executemany(_INSERT_BY_MODALITY[modality], rows)
+        inserted += len(rows)
+    await db.commit()
+    return inserted
+
+
+async def read_full_replay(
+    db: aiosqlite.Connection, session_id: str
+) -> list[ReplayEvent]:
+    """Return the full replay for one session, ordered by ``t_ms`` ASC.
+
+    UNION ALL across the four replay tables. Each row carries its
+    modality so the consumer (the dashboard's Replay page, T11) can
+    route to the right pane.
+    """
+    # Each subquery selects the seven canonical columns (session_id,
+    # modality literal, t_ms, payload, provider, cost_usd, created_at)
+    # so the outer ORDER BY t_ms is stable across modalities.
+    sql = (
+        "SELECT session_id, 'stt' AS modality, t_ms, payload, "
+        "       provider, cost_usd FROM replay_stt_events "
+        " WHERE session_id = ? "
+        "UNION ALL "
+        "SELECT session_id, 'llm' AS modality, t_ms, payload, "
+        "       provider, cost_usd FROM replay_llm_tokens "
+        " WHERE session_id = ? "
+        "UNION ALL "
+        "SELECT session_id, 'tts' AS modality, t_ms, payload, "
+        "       provider, cost_usd FROM replay_tts_frames "
+        " WHERE session_id = ? "
+        "UNION ALL "
+        "SELECT session_id, 'state' AS modality, t_ms, payload, "
+        "       '' AS provider, NULL AS cost_usd "
+        "  FROM replay_state_snapshots "
+        " WHERE session_id = ? "
+        "ORDER BY t_ms ASC"
+    )
+    cursor = await db.execute(sql, (session_id, session_id, session_id, session_id))
+    out: list[ReplayEvent] = []
+    async for row in cursor:
+        sid, modality, t_ms, payload_text, provider, cost_usd = row
+        try:
+            payload: dict[str, Any] = json.loads(payload_text)
+        except json.JSONDecodeError:
+            payload = {"_decode_error": True, "raw": payload_text}
+        out.append(
+            ReplayEvent(
+                session_id=sid,
+                modality=modality,
+                t_ms=int(t_ms),
+                payload=payload,
+                provider=provider or "",
+                cost_usd=float(cost_usd) if cost_usd is not None else None,
+            )
+        )
+    return out
+
+
+async def delete_replay(db: aiosqlite.Connection, session_id: str) -> int:
+    """Delete every replay row for one session across all four tables.
+
+    Implements REQ-VG-REPLAY-006 AC-3 ("when the developer deletes a
+    session from the dashboard, all replay events tied to that session
+    are deleted in the same operation"). Single transaction across the
+    four tables. Returns the total number of rows deleted.
+    """
+    total = 0
+    for table in _TABLE_BY_MODALITY.values():
+        cursor = await db.execute(
+            f"DELETE FROM {table} WHERE session_id = ?", (session_id,)
+        )
+        # aiosqlite Cursor exposes rowcount after execute for DELETE.
+        if cursor.rowcount is not None and cursor.rowcount > 0:
+            total += cursor.rowcount
+    await db.commit()
+    return total
+
+
+async def aggregate_storage_per_session(
+    db: aiosqlite.Connection, session_id: str
+) -> int:
+    """Sum the JSON-payload byte length across all four tables.
+
+    Approximates the on-disk footprint for one session's replay rows.
+    The actual on-disk size includes row overhead, indexes, and JSON
+    encoding artifacts, but the payload sum is the dominant term
+    (90%+) and tracks the developer-facing storage trade-off.
+
+    Implements REQ-VG-REPLAY-006's "the dashboard surfaces current
+    storage usage so the cost is not invisible" requirement; the
+    sessions row's ``replay_size_bytes`` column is upserted from this
+    sum at session close (T08's ``finalize_session_replay``).
+    """
+    total = 0
+    for table in _TABLE_BY_MODALITY.values():
+        cursor = await db.execute(
+            f"SELECT COALESCE(SUM(length(payload)), 0) FROM {table} "
+            "WHERE session_id = ?",
+            (session_id,),
+        )
+        row = await cursor.fetchone()
+        if row is not None and row[0] is not None:
+            total += int(row[0])
+    return total
+
+
+__all__ = [
+    "aggregate_storage_per_session",
+    "bulk_write_events",
+    "delete_replay",
+    "read_full_replay",
+]

--- a/voicegateway/storage/retention_worker.py
+++ b/voicegateway/storage/retention_worker.py
@@ -1,0 +1,187 @@
+"""Hourly retention worker for v0.3.0 replay rows.
+
+Implements REQ-VG-REPLAY-006 (privacy and retention controls): each
+project carries a ``replay.retention_days`` config knob (default 90)
+that this worker honors by deleting replay rows tied to sessions
+whose ``ended_at`` is older than ``now - retention_days``.
+
+Single-process for v0.3.0. The Foundry's "fronted by an idempotent
+claim-token mechanism if the gateway is ever run multi-replica" is
+deferred to a later milestone; running two workers concurrently
+against the same SQLite database is currently undefined behavior
+(SQLite's locking would serialize the deletes, but the duplicate
+work is wasted).
+
+The worker is decoupled from the ProjectConfig source via an
+injected ``retention_provider`` callable that returns the
+list of ``(project_id, retention_days)`` tuples. T07's wiring
+passes a closure over the live config; T18 tests inject a
+deterministic synthetic provider.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Final
+
+from voicegateway.storage import replay_repo
+
+if TYPE_CHECKING:
+    from voicegateway.storage.sqlite import SQLiteStorage
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_RETENTION_DAYS: Final[int] = 90
+_DEFAULT_POLL_INTERVAL_SECONDS: Final[float] = 3600.0  # one hour
+
+
+# (project_id, retention_days) provider. Async to allow the wiring side
+# to read from any source (in-memory config, file watcher, future
+# database table).
+RetentionProvider = Callable[[], Awaitable[list[tuple[str, int]]]]
+
+
+async def _default_provider() -> list[tuple[str, int]]:
+    """Empty provider: no projects to retain. Logged at debug level."""
+    logger.debug("RetentionWorker no-op provider: no projects configured for retention")
+    return []
+
+
+class RetentionWorker:
+    """Background worker that ages out old replay rows per project.
+
+    Lifecycle: :meth:`start` spawns one asyncio task that loops
+    forever, sleeping ``poll_interval_seconds`` between deletion passes.
+    :meth:`stop` cancels the task. :meth:`tick_now` runs one deletion
+    pass synchronously and returns the per-project deletion counts,
+    primarily for test rigs.
+
+    Each pass:
+
+    1. Calls ``retention_provider()`` for the live (project_id,
+       retention_days) tuples.
+    2. For each project, computes ``cutoff_iso = now - retention_days``
+       in UTC.
+    3. Finds sessions where ``project = ?`` AND
+       ``ended_at < cutoff_iso``.
+    4. Calls ``replay_repo.delete_replay(db, session_id)`` for each.
+    5. Logs the per-project delete count.
+
+    Idempotent: re-running with the same cutoff yields zero deletes
+    on the second pass (the rows are already gone).
+    """
+
+    def __init__(
+        self,
+        storage: SQLiteStorage,
+        retention_provider: RetentionProvider | None = None,
+        default_retention_days: int = _DEFAULT_RETENTION_DAYS,
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> None:
+        if default_retention_days < 1:
+            raise ValueError(
+                f"default_retention_days must be >= 1, got {default_retention_days}"
+            )
+        if poll_interval_seconds <= 0:
+            raise ValueError(
+                f"poll_interval_seconds must be > 0, got {poll_interval_seconds}"
+            )
+        self._storage = storage
+        self._provider: RetentionProvider = retention_provider or _default_provider
+        self._default_retention_days = default_retention_days
+        self._poll_interval = poll_interval_seconds
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Spawn the retention loop. Idempotent."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._loop(), name="replay-retention-worker")
+
+    async def stop(self) -> None:
+        """Cancel the loop and clear state."""
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def tick_now(self) -> dict[str, int]:
+        """Run one deletion pass synchronously. Returns per-project counts.
+
+        Public for test rigs and the eventual ``voicegw replay-retention
+        --run-now`` CLI command (future scope).
+        """
+        return await self._tick()
+
+    # ---- internals -------------------------------------------------------
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                try:
+                    await self._tick()
+                except Exception:
+                    logger.exception("RetentionWorker tick raised; continuing")
+                await asyncio.sleep(self._poll_interval)
+        except asyncio.CancelledError:
+            raise
+
+    async def _tick(self) -> dict[str, int]:
+        projects = await self._provider()
+        if not projects:
+            return {}
+        per_project_deletes: dict[str, int] = {}
+        now = datetime.now(UTC)
+        db = await self._storage._ensure_initialized()
+        try:
+            for project_id, retention_days in projects:
+                if retention_days < 1:
+                    logger.warning(
+                        "RetentionWorker: project %s has retention_days=%d "
+                        "(< 1); using default %d",
+                        project_id,
+                        retention_days,
+                        self._default_retention_days,
+                    )
+                    retention_days = self._default_retention_days
+                cutoff_iso = (now - timedelta(days=retention_days)).isoformat()
+                cursor = await db.execute(
+                    "SELECT id FROM sessions "
+                    "WHERE project = ? AND ended_at IS NOT NULL "
+                    "  AND ended_at < ?",
+                    (project_id, cutoff_iso),
+                )
+                stale_ids = [row[0] async for row in cursor]
+                if not stale_ids:
+                    per_project_deletes[project_id] = 0
+                    continue
+                deleted_rows = 0
+                for sid in stale_ids:
+                    deleted_rows += await replay_repo.delete_replay(db, sid)
+                per_project_deletes[project_id] = deleted_rows
+                logger.info(
+                    "RetentionWorker: project %s, retention %d days, "
+                    "deleted %d replay rows across %d sessions",
+                    project_id,
+                    retention_days,
+                    deleted_rows,
+                    len(stale_ids),
+                )
+        finally:
+            await db.close()
+        return per_project_deletes
+
+
+__all__ = [
+    "RetentionProvider",
+    "RetentionWorker",
+]

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -12,21 +12,21 @@ from typing import Any
 
 import aiosqlite
 
-from voicegateway.storage import turns_repo
+from voicegateway.storage import replay_repo, turns_repo
 from voicegateway.storage._percentiles import compute_percentiles
 from voicegateway.storage.models import RequestRecord
 
 _DEFAULT_PERCENTILES: list[float] = [50.0, 95.0, 99.0]
 
-# Migration 0003's module name starts with a digit ("0003_..."), which is
-# the standard versioned-migration naming convention but not a valid
-# Python identifier — `from voicegateway.storage.migrations.0003_...`
-# parses as `0003` (numeric literal) and SyntaxErrors. `importlib.import_module`
-# accepts arbitrary dotted strings, so we load the module once at startup
+# Migration modules start with a digit prefix (the standard versioned-
+# migration naming convention) which is not a valid Python identifier
+# for `from ... import` syntax. `importlib.import_module` accepts
+# arbitrary dotted strings, so we load each migration once at startup
 # and call its `apply(db)` coroutine from `_ensure_initialized` below.
 _migration_0003 = import_module(
     "voicegateway.storage.migrations.0003_turns_and_deadair"
 )
+_migration_0004 = import_module("voicegateway.storage.migrations.0004_replay_tables")
 
 _logger = logging.getLogger(__name__)
 
@@ -257,6 +257,10 @@ class SQLiteStorage:
             # v0.2.0 migration 0003: turns + dead_air_events tables,
             # session-aggregate columns. Idempotent.
             await _migration_0003.apply(db)
+
+            # v0.3.0 migration 0004: replay event tables + sessions.replay_size_bytes.
+            # Idempotent.
+            await _migration_0004.apply(db)
 
             await db.commit()
             self._initialized = True
@@ -1112,6 +1116,38 @@ class SQLiteStorage:
                     talk_over_rate,
                     session_id,
                 ),
+            )
+            await db.commit()
+        finally:
+            await db.close()
+
+    async def finalize_session_replay(self, session_id: str) -> None:
+        """Compute ``replay_size_bytes`` for a session and upsert the row.
+
+        Called by the cost_tracker session-close hook (T09) after the
+        replay-capture buffer has flushed (T02's ReplayCapture flushes
+        in its own session-close path). Reads the per-modality
+        ``replay_*`` tables via
+        :func:`voicegateway.storage.replay_repo.aggregate_storage_per_session`
+        and writes the byte-length sum to the sessions row's
+        ``replay_size_bytes`` column.
+
+        NULL is preserved when the session captured no replay events
+        (pre-v0.3.0 sessions per REQ-VG-REPLAY-006, or projects with
+        ``replay.enabled = False`` per T07). The column is also NULL
+        when the session row is missing entirely.
+        """
+        db = await self._ensure_initialized()
+        try:
+            size_bytes = await replay_repo.aggregate_storage_per_session(db, session_id)
+            # Leave NULL for sessions that captured nothing — the
+            # dashboard reads NULL as "not measured" the same way it
+            # does for v0.2.0 aggregate columns.
+            if size_bytes <= 0:
+                return
+            await db.execute(
+                "UPDATE sessions SET replay_size_bytes = ? WHERE id = ?",
+                (size_bytes, session_id),
             )
             await db.commit()
         finally:


### PR DESCRIPTION
## v0.3.0 — Conversation replay and debugging

Implements: REQ-VG-REPLAY-001, REQ-VG-REPLAY-002, REQ-VG-REPLAY-003, REQ-VG-REPLAY-004, REQ-VG-REPLAY-005, REQ-VG-REPLAY-006

Refinery: https://linear.app/mahimairaja/document/v030-conversation-replay-and-debugging-refinery-02fdfbb5a241
Foundry:  https://linear.app/mahimairaja/document/v030-conversation-replay-and-debugging-foundry-blueprint-f6e62120f85a

## What changed

The universal "this saved me hours" feature for voice-agent developers lands here. Open any past conversation in the dashboard, scrub through it like a video timeline, see every STT chunk + LLM token + TTS frame + agent state at every moment, with cost accruing live as you scrub.

### Backend (Python)

- **ReplayCapture** (`voicegateway/middleware/replay_capture.py`, REQ-003) — per-session asyncio buffer; oldest-dropped-with-counter on overflow.
- **StateSnapshotter** (`voicegateway/middleware/state_snapshotter.py`, REQ-005) — Pydantic snapshots at LLM message + tool boundaries; per-second rate cap, tool-resolve bypasses.
- **Migration 0004** — four `replay_*` tables + `sessions.replay_size_bytes` nullable column.
- **`replay_repo`** — flat function module: `bulk_write_events`, `read_full_replay` (UNION ALL), `delete_replay` (cascade), `aggregate_storage_per_session`.
- **`RetentionWorker`** (REQ-006) — hourly asyncio task, deletes replay rows where `session.ended_at` is older than `replay.retention_days`. In-flight sessions (NULL ended_at) preserved.
- **`SQLiteStorage.finalize_session_replay`** — composed into `CostTracker.close_session` alongside the v0.2.0 `finalize_session_metrics`; independently guarded.
- **Four dashboard endpoints**: `GET /api/sessions/{id}/replay`, `DELETE /api/sessions/{id}/replay`, `GET /api/replay/storage`, `POST /api/projects/{id}/replay/retention`.
- **`ReplayConfig`** per-project YAML knobs: `enabled` (true), `retention_days` (90), `buffer_size_events` (5000), `flush_size_events` (500).

### Frontend (TypeScript)

- **Replay page** (`dashboard/frontend/src/pages/Replay.tsx`) — fetches full replay on mount, renders Scrubber + 2×2 pane grid + RunningCostCounter.
- **Seven subcomponents**: Scrubber (range + arrow-key event-step + Shift+Arrow + Home/End), TranscriptPane (partial-revision opacity), ModelOutputPane (LLM tokens + tool-invoke badges), SynthesisPane (red underrun frames), ConversationStatePane (snapshot render), RunningCostCounter (per-modality + top-3 tooltip), PreV030Banner (pre-v0.3.0 fallback with link to session detail).
- **Sidebar nav route** at `/sessions/:sessionId/replay`; Sessions page table has an "Open replay" button per row.
- **Typed fetchers** `fetchSessionReplay`, `deleteSessionReplay`, `fetchReplayStorage`, `updateReplayRetention` + four TS types.
- **`voicegw replay <session-id>`** CLI signpost command prints the dashboard URL.

### Tests + coverage

41 new tests:
- 9 replay_capture (lifecycle, multi-modality, auto-flush, multi-session, validation)
- 9 state_snapshotter (boundaries, rate cap, tool-resolve bypass, reset)
- 5 migration (tables, indexes, idempotency, preservation)
- 5 replay_repo (CRUD, cascade, aggregate)
- 5 retention_worker (deletion semantics, in-flight preservation, idempotency)
- 6 replay_endpoint (4 endpoints, validation, 404)
- **2 OQ1 storage-cost smoke** — synthetic 60s conversation captured end-to-end; on-disk footprint asserted < 600 KB.

Suite total: 1401 → 1442 (+41). Coverage: 88% (above 80% Foundry gate).

## Test plan

- `pytest -q` clean: **1442 passed, 4 skipped, 2 warnings** (1401 baseline + 41 new).
- `ruff check .` clean.
- `mypy voicegateway` clean (123 source files).
- `coverage report`: **88% total**.
- TS build: clean. Bundle 588 KB (was 584 KB; +4 KB for the seven replay components).
- `cd docs && npm run prebuild`: regenerates `docs/reference/changelog.md` from root `CHANGELOG.md` byte-for-byte.

## Decisions locked (Foundry Open Questions)

- **OQ1 (storage cost: 30-100 KB/min)** — RESOLVED AFFIRMATIVE. The OQ1 smoke test (`tests/storage/test_replay_storage_smoke.py`) measures synthetic 60s conversation footprint well below 600 KB. Fallback: `replay.enabled: false` per-project disables capture without redeploying.
- **OQ2 (snapshot granularity)** — message-add boundary, one-per-second cap, tool-resolve bypasses.
- **OQ3 (pre-fetch vs streaming)** — pre-fetch on page mount.
- **OQ4 (short-call capture)** — capture by default.
- **OQ5 (TTS per-frame cost)** — distribute per-character cost in time-weighted slices.

## Migration notes

- v0.2.0 callers need no code change. Migration 0004 runs automatically; v0.2.0 sessions are preserved with NULL on `replay_size_bytes` and surface as "recorded before replay capture existed" in the Replay page.
- The `voicegateway/combined_server.py` re-export shim **stays in place again**; bundling a back-compat break with the replay-feature release would be a bad signal. Schedule remains tentatively v0.4.0.

## Notes

Generated by Ralph fast-track. Squash-merge intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.3.0

* **New Features**
  * Added conversation replay and debugging interface with timeline scrubber for reviewing past interactions.
  * Multi-pane visualization displaying speech transcripts, LLM outputs, voice synthesis events, and conversation state snapshots.
  * Dashboard endpoints for viewing, managing, and deleting replay data with configurable retention policies.
  * CLI command to quickly access replay for any session.
  * Running cost counter tracking expenses during replay playback.

* **Documentation**
  * Expanded configuration guide for replay capture settings and storage cost estimation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mahimailabs/voicegateway/pull/17)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->