### PR TITLE
v0.4.0 — Multi-tenant cost attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to VoiceGateway are documented here. This project follows [Semantic Versioning](https://semver.org/) and [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.4.0 -- 2026-05-11
+
+**Multi-tenant cost attribution.** VoiceGateway now tags every voice session with an optional `tenant_id` so a single deployment can serve many customers and account for each one separately. Three independent surfaces set the tenant: an `attach_session(tenant_id=...)` kwarg for owner-of-AgentSession code, an `inference.set_tenant("…")` ContextVar API, and scoped virtual API keys that auto-attribute at the auth layer. Every cost row, metric row, and replay event for an attributed session lands tagged with the tenant; pre-v0.4.0 rows stay in the "unattributed" bucket (NULL `tenant_id`). The dashboard's existing Costs, Sessions, Metrics, and Replay pages all rescope when a tenant is selected from the new shared `FilterBar`; a new `Virtual Keys` page issues, lists, and revokes keys with a one-time plaintext modal.
+
+### Added
+
+- **Migration 0005** (REQ-VG-TENANT-001 + REQ-VG-TENANT-003): creates the `virtual_keys` table with bcrypt-hashed key storage + visible-prefix index + tenant scope, and adds `tenant_id TEXT` to `sessions`, `requests`, `turns`, `dead_air_events`, and the four `replay_*` tables. Idempotent. The derived-table ALTERs are guarded by a `sqlite_master` presence check (Foundry OQ4) so a v0.0.5-only baseline runs the migration cleanly without erroring on absent v0.2.0 / v0.3.0 tables.
+- **`voicegateway.inference._session_context`** gains `set_tenant`, `current_tenant`, and `reset_tenant_id` (REQ-VG-TENANT-001 AC-4). The `tenant_id_ctx` ContextVar propagates the active scope through every gateway call within a session without re-passing. 128-char UTF-8 cap (OQ2 lock) enforced at `set_tenant` time.
+- **`voicegateway.storage.virtual_keys_repo`** (REQ-VG-TENANT-003). Flat async function module: `create_virtual_key` (returns plaintext exactly once), `verify` (prefix-scan + bcrypt; revoked keys filtered inside), `revoke` (soft per OQ5), `mark_used`, `list_keys`, `list_stale`, `get_by_id`. Key shape: `vk_` + 32 base32 random chars (35 total); visible 8-char prefix indexed for O(1) candidate lookup; full key bcrypt-hashed at cost 12. Added `bcrypt>=4.0` to `[project] dependencies`.
+- **`voicegateway.storage.tenants_repo`** (REQ-VG-TENANT-002). Read-side derived view over `DISTINCT sessions.tenant_id`: `list_tenants` (substring typeahead with `%`/`_` escaped to literal characters), `get_tenant`, `count_tenants`, `get_unattributed_aggregates`. No separate tenants table; aggregates roll up live from the sessions UPSERT.
+- **Auth middleware in `voicegateway/server/main.py::build_app`** detects `vk_`-prefixed bearer tokens, resolves them via `virtual_keys_repo.verify`, bumps `last_used_at`, sets the tenant ContextVar if scoped, and stashes `virtual_key_id` + `virtual_key_tenant_id` on `request.state` for downstream conflict checks. Static keys are unchanged. New `voicegateway.core.auth` helpers: `is_virtual_key_token`, `verify_virtual_key`, `check_tenant_body_conflict` (403 on scoped-key + body-tenant mismatch).
+- **`attach_session(..., tenant_id="…")`** kwarg threads the tenant through the v0.2.0 session-attach helper. Setting it pushes onto `tenant_id_ctx` so the first `log_request` for the session picks it up. Omitting it leaves the ContextVar alone (a virtual-key-set scope still wins).
+- **`log_request` writes `tenant_id`** to both the `requests` and the `sessions` rows from `current_tenant()`. The sessions UPSERT uses `COALESCE(tenant_id, excluded.tenant_id)` so the first tenant-bearing request stamps the row for its lifetime; later unattributed requests cannot blank it. `turns_repo`, `dead_air_repo`, and `replay_repo` write functions accept an optional `tenant_id` kwarg defaulting to `current_tenant()` for per-batch propagation.
+- **`TenantConfig` per-project YAML knob**: `tenant.virtual_key_stale_days` (default 90, `ge=1`). Mirrored across the Pydantic schema and the runtime dataclass.
+- **Five new dashboard endpoints**: `GET /api/tenants` (list + unattributed aggregates), `GET /api/tenants/{id}` (single-tenant aggregates, 404 when unseen), `GET /api/virtual_keys` (list, plaintext never appears), `POST /api/virtual_keys` (issue, plaintext ONCE), `POST /api/virtual_keys/{id}/revoke` (soft). Existing handlers `/api/costs`, `/api/latency`, `/api/logs`, `/api/sessions`, `/api/metrics` accept a `tenant` query param (`null` = no filter, `""` = unattributed, value = that tenant).
+- **Storage methods extended**: `get_cost_summary`, `get_cost_by_project`, `get_recent_requests`, `list_sessions`, `get_latency_stats` accept a `tenant: str | None = None` kwarg with the same three-state convention. `list_sessions` / `get_session` SELECT `tenant_id` and `_row_to_session` surfaces it on the returned dict.
+- **`dashboard/frontend/src/pages/VirtualKeys.tsx`**. Issue / list / revoke flow with the show-key-once modal that puts the plaintext in a yellow card with copy-to-clipboard (REQ-VG-TENANT-003 AC-2). Active / stale / revoked status badges; 90-day default stale threshold.
+- **`dashboard/frontend/src/components/{TenantFilter,TenantPill,FilterBar}.tsx`**. `TenantFilter` is a 200ms-debounced typeahead with All-tenants / Unattributed / per-tenant sections. `TenantPill` renders attributed vs muted-unattributed in three modes. `FilterBar` is a shared filter strip with URL sync via `useSearchParams`, plus a `useTenantFilter()` hook.
+- **Costs, Sessions, Metrics pages** now consume `FilterBar` and forward the tenant param to their data fetches. Sessions gains a Tenant column with `TenantPill asLink` (one-click rescope) and a TenantPill in the SessionDetail modal header.
+- **App nav** registers `/virtual-keys` route and a Virtual Keys sidebar entry between Providers and Settings.
+- **Typed fetchers + types** in `dashboard/frontend/src/lib/{api,types}.ts`: `TenantRow`, `UnattributedAggregates`, `TenantsResponse`, `TenantFilter` union, `VirtualKey`, `CreatedVirtualKey`; `fetchTenants`, `fetchTenant`, `fetchVirtualKeys`, `createVirtualKey`, `revokeVirtualKey`, `appendTenantParam` helper, and a `tenant` kwarg on `fetchMetricsSummary`.
+- **`voicegw tenant` command group** with `list` and `show <id>` subcommands. Read-only (issuing keys stays a dashboard-only flow per REQ-VG-TENANT-003 AC-2). `--json` flag on both for CI scripts.
+- **67 new tests** across `tests/storage/` (migration 0005, virtual_keys_repo, tenants_repo), `tests/server/` (virtual key auth, session-create tenant, tenant filter), `tests/inference/` (three-tenant aggregation). Full suite: 1442 → 1509 (+67). Coverage: 87.58% (above the 80% Foundry gate).
+- **`docs/api/python-sdk.md`** grew a "Tenant attribution (v0.4.0)" section after `attach_session`.
+- **`docs/guide/multi-tenant-quickstart.md`** is the operator-facing walkthrough: tag at session-create, issue a virtual key, view per-tenant data, export.
+
+### Changed
+
+- **Embedded version strings** bumped from `0.3.0` to `0.4.0` in `voicegateway/server/main.py` (FastAPI ctor + `/health.version`), `dashboard/api/main.py` (FastAPI ctor), `tests/server/test_server.py` (version assertion), `docker/voicegateway.Dockerfile` (`ARG VERSION`), and the dashboard sidebar pill in `dashboard/frontend/src/App.tsx`.
+
+### Decisions locked (Foundry Open Questions)
+
+- **OQ1 virtual key shape** — `vk_` + 32 base32 random chars (35 total). 8-char visible prefix (`vk_` + 5 random) stored to bound the bcrypt candidate set; full key hashed at cost 12.
+- **OQ2 tenant identifier** — 128-char UTF-8 max. Spaces and unicode allowed; the tenants_repo typeahead disambiguates confusable names.
+- **OQ3 backfill** — NO. Migration 0005 adds `tenant_id` nullable with no DEFAULT; pre-v0.4.0 rows stay NULL forever and the FE renders them as the muted "unattributed" pill.
+- **OQ4 conditional ALTER** — `sqlite_master` presence check before each derived-table ALTER. v0.0.5-only deployments run migration 0005 cleanly without erroring on absent `turns` / `dead_air_events` / `replay_*` tables.
+- **OQ5 revocation** — Soft. `UPDATE virtual_keys SET revoked_at = CURRENT_TIMESTAMP`. The row persists for audit + stale-key detection; hard delete is out of scope.
+
+### Notes
+
+- **No automatic backfill** of pre-v0.4.0 sessions. They stay `tenant_id = NULL` (the unattributed bucket).
+- **No CLI issuance of virtual keys** per REQ-VG-TENANT-003 AC-2.
+- **No `voicegw costs --tenant` flag yet** — the dashboard's `/api/costs?tenant=…` is the canonical per-tenant cost source for v0.4.0.
+- **No re-tag affordance for already-attributed sessions.** The COALESCE rule fills NULL slots only; a re-tag flow for unattributed sessions is on the v0.4.x roadmap.
+- **Virtual keys do not carry RBAC scopes** in v0.4.0 — a verified vk satisfies every scope. RBAC layering follows in a future release.
+
 ## v0.3.0 -- 2026-05-11
 
 **Conversation replay and debugging.** The universal "this saved me hours" feature for voice-agent developers. Open any past conversation in the dashboard, scrub through it like a video timeline, and see every STT chunk, every LLM token, every TTS frame, plus the agent's conversation state at every moment — with cost accruing live as you scrub. Replay is captured by default for every session, full fidelity, with per-project `retention_days` (default 90) ageing rows out automatically.

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -14,7 +14,13 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from voicegateway.core.auth import load_api_keys, resolve_cors_origins
-from voicegateway.storage import dead_air_repo, replay_repo, turns_repo
+from voicegateway.storage import (
+    dead_air_repo,
+    replay_repo,
+    tenants_repo,
+    turns_repo,
+    virtual_keys_repo,
+)
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
@@ -139,13 +145,15 @@ async def get_status() -> dict:
 async def get_costs(
     period: str = Query("today", enum=["today", "week", "month", "all"]),
     project: str | None = Query(None),
+    tenant: str | None = Query(None),
 ) -> dict:
-    """Get cost summary for a period, optionally filtered by project.
+    """Get cost summary for a period, optionally filtered by project and tenant.
 
     Each ``by_model`` entry carries a ``pricing_source`` string (e.g.
     ``"genai-prices@0.0.57"`` or ``"voicegateway-catalog@2026-05-04"``)
     so the dashboard can render the cost-staleness banner without a
-    second round-trip.
+    second round-trip. ``tenant`` accepts a tenant id; pass the empty
+    string to scope to the unattributed bucket (REQ-VG-TENANT-002).
     """
     gw = _get_gateway()
     if gw.storage is None:
@@ -158,10 +166,12 @@ async def get_costs(
             "by_project": {},
         }
     summary = await gw.storage.get_cost_summary(
-        period, project=project, include_pricing_source=True
+        period, project=project, include_pricing_source=True, tenant=tenant
     )
     if project is None:
-        summary["by_project"] = await gw.storage.get_cost_by_project(period)
+        summary["by_project"] = await gw.storage.get_cost_by_project(
+            period, tenant=tenant
+        )
     else:
         summary["by_project"] = {}
     return summary
@@ -171,13 +181,16 @@ async def get_costs(
 async def get_latency(
     period: str = Query("today", enum=["today", "week"]),
     project: str | None = Query(None),
+    tenant: str | None = Query(None),
 ) -> dict:
-    """Get latency statistics, optionally filtered by project."""
+    """Get latency statistics, optionally filtered by project and tenant."""
     gw = _get_gateway()
     if gw.storage is None:
         return {}
     pcts = gw.config.latency.get("percentiles") or [50.0, 95.0, 99.0]
-    return await gw.storage.get_latency_stats(period, project=project, percentiles=pcts)
+    return await gw.storage.get_latency_stats(
+        period, project=project, percentiles=pcts, tenant=tenant
+    )
 
 
 @app.get("/api/logs")
@@ -185,13 +198,14 @@ async def get_logs(
     limit: int = Query(100, ge=1, le=1000),
     modality: str | None = Query(None, enum=["stt", "llm", "tts"]),
     project: str | None = Query(None),
+    tenant: str | None = Query(None),
 ) -> list[dict]:
-    """Get recent request logs, optionally filtered by modality and/or project."""
+    """Get recent request logs, optionally filtered by modality, project, and tenant."""
     gw = _get_gateway()
     if gw.storage is None:
         return []
     return await gw.storage.get_recent_requests(
-        limit=limit, modality=modality, project=project
+        limit=limit, modality=modality, project=project, tenant=tenant
     )
 
 
@@ -246,6 +260,7 @@ async def get_projects() -> dict:
 async def get_sessions(
     limit: int = Query(100, ge=1, le=1000),
     project: str | None = Query(None),
+    tenant: str | None = Query(None),
     order_by: str = Query(
         "started_at_desc",
         pattern="^(started_at_desc|started_at_asc|cost_desc|cost_asc)$",
@@ -255,13 +270,14 @@ async def get_sessions(
 
     Mirror of the /v1/sessions endpoint so the dashboard frontend
     can stay on a single origin in dev mode (the Vite proxy only
-    forwards /api). Storage method is shared.
+    forwards /api). Storage method is shared. ``tenant`` (v0.4.0)
+    scopes the result; empty string targets the unattributed bucket.
     """
     gw = _get_gateway()
     if gw.storage is None:
         return []
     return await gw.storage.list_sessions(
-        limit=limit, project=project, order_by=order_by
+        limit=limit, project=project, order_by=order_by, tenant=tenant
     )
 
 
@@ -647,6 +663,137 @@ async def get_providers_by_project(project: str | None = Query(None)) -> dict:
 
     rows.sort(key=lambda r: (r["project"], r["provider"]))
     return {"providers": rows}
+
+
+# ---------------------------------------------------------------------------
+# v0.4.0 multi-tenant API surface (REQ-VG-TENANT-002 + REQ-VG-TENANT-003).
+#
+# Tenants are derived from DISTINCT sessions.tenant_id; the dashboard's
+# filter feed and per-tenant overview are read-only here. Virtual keys
+# expose plaintext exactly once at creation (the "show key once" modal
+# on the FE owns persistence to the operator's clipboard) and support
+# soft revocation per OQ5.
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/tenants")
+async def list_tenants_endpoint(
+    limit: int = Query(50, ge=1, le=1000),
+    q: str | None = Query(None, max_length=128),
+) -> dict[str, Any]:
+    """Return the tenant index for the dashboard filter typeahead.
+
+    ``q`` is a substring match against tenant_id (``%`` and ``_``
+    escaped to literal characters). The implicit unattributed bucket
+    (NULL tenant_id) is included as a separate ``unattributed`` field
+    so the FE can render it as a muted pill below the tenant list.
+    """
+    gw = _get_gateway()
+    if gw.storage is None:
+        return {
+            "tenants": [],
+            "unattributed": {
+                "session_count": 0,
+                "total_cost_usd": 0.0,
+                "first_seen": None,
+                "last_seen": None,
+            },
+        }
+    db = await gw.storage._ensure_initialized()
+    rows = await tenants_repo.list_tenants(db, limit=limit, query=q)
+    u = await tenants_repo.get_unattributed_aggregates(db)
+    return {
+        "tenants": [dataclasses.asdict(r) for r in rows],
+        "unattributed": dataclasses.asdict(u),
+    }
+
+
+@app.get("/api/tenants/{tenant_id}")
+async def get_tenant_endpoint(tenant_id: str) -> dict[str, Any]:
+    """Return aggregates for a single tenant. 404 when unseen."""
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=404, detail=f"Tenant {tenant_id!r} not found")
+    db = await gw.storage._ensure_initialized()
+    row = await tenants_repo.get_tenant(db, tenant_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Tenant {tenant_id!r} not found")
+    return dataclasses.asdict(row)
+
+
+@app.get("/api/virtual_keys")
+async def list_virtual_keys_endpoint(
+    include_revoked: bool = Query(True),
+) -> dict[str, Any]:
+    """Return all virtual keys. The plaintext key never appears here.
+
+    Each row carries ``key_prefix`` (the 8-char visible prefix) but
+    not the bcrypt hash. ``include_revoked=False`` filters out soft-
+    revoked entries.
+    """
+    gw = _get_gateway()
+    if gw.storage is None:
+        return {"keys": []}
+    db = await gw.storage._ensure_initialized()
+    rows = await virtual_keys_repo.list_keys(db, include_revoked=include_revoked)
+    return {"keys": [dataclasses.asdict(r) for r in rows]}
+
+
+@app.post("/api/virtual_keys")
+async def create_virtual_key_endpoint(
+    body: dict[str, Any] = Body(...),
+) -> dict[str, Any]:
+    """Issue a new virtual key. Returns the plaintext EXACTLY ONCE.
+
+    Body fields:
+    - ``name`` (required): human-readable label shown in the dashboard.
+    - ``tenant_id`` (optional): if set, requests bearing this key
+      auto-tag the session with this tenant (REQ-VG-TENANT-004).
+    - ``issued_by`` (optional): free-form audit string.
+
+    The returned ``plaintext`` is the only place the full key appears.
+    The FE shows the "save this key" modal and discards it; subsequent
+    list responses expose only ``key_prefix``.
+    """
+    name = str(body.get("name") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="`name` is required")
+    tenant_id_raw = body.get("tenant_id")
+    tenant_id = str(tenant_id_raw).strip() if tenant_id_raw not in (None, "") else None
+    issued_by_raw = body.get("issued_by")
+    issued_by = str(issued_by_raw).strip() if issued_by_raw not in (None, "") else None
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=503, detail="Storage backend not configured")
+    db = await gw.storage._ensure_initialized()
+    created = await virtual_keys_repo.create_virtual_key(
+        db, name=name, tenant_id=tenant_id, issued_by=issued_by
+    )
+    return {
+        "id": created.id,
+        "plaintext": created.plaintext,
+        "row": dataclasses.asdict(created.row),
+    }
+
+
+@app.post("/api/virtual_keys/{key_id}/revoke")
+async def revoke_virtual_key_endpoint(key_id: int) -> dict[str, Any]:
+    """Soft-revoke a virtual key (OQ5: keeps the row for audit)."""
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=503, detail="Storage backend not configured")
+    db = await gw.storage._ensure_initialized()
+    ok = await virtual_keys_repo.revoke(db, key_id)
+    if not ok:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Virtual key {key_id} not found or already revoked",
+        )
+    row = await virtual_keys_repo.get_by_id(db, key_id)
+    if row is None:
+        # Should never happen: revoke() just returned True. Defensive.
+        raise HTTPException(status_code=404, detail=f"Virtual key {key_id} vanished")
+    return {"id": key_id, "revoked": True, "row": dataclasses.asdict(row)}
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -315,6 +315,7 @@ async def get_session_detail(session_id: str) -> dict[str, Any]:
 async def get_metrics_summary(
     project: str | None = Query(None),
     days: int = Query(7, ge=1, le=365),
+    tenant: str | None = Query(None),
 ) -> dict[str, Any]:
     """Aggregated voice-conversation metrics for the filter window.
 
@@ -349,6 +350,12 @@ async def get_metrics_summary(
         if project:
             where_clauses.append("project = ?")
             params.append(project)
+        if tenant is not None:
+            if tenant == "":
+                where_clauses.append("tenant_id IS NULL")
+            else:
+                where_clauses.append("tenant_id = ?")
+                params.append(tenant)
         where = " AND ".join(where_clauses)
         cursor = await db.execute(
             f"""SELECT id,
@@ -397,7 +404,7 @@ async def get_metrics_summary(
                 "since": since_iso,
                 "until": until_iso,
             },
-            "filter": {"project": project},
+            "filter": {"project": project, "tenant": tenant},
             "session_count": session_count,
             "measured_session_count": measured_count,
             "per_minute_cost_usd_avg": per_minute_cost_avg,

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -35,7 +35,7 @@ _LOCAL_PROVIDER_NAMES = frozenset({"ollama", "whisper", "kokoro", "piper"})
 
 app = FastAPI(
     title="VoiceGateway Dashboard",
-    version="0.3.0",
+    version="0.4.0",
 )
 
 # Set by the CLI / combined server when starting the dashboard.

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -140,7 +140,7 @@ function Sidebar({
           <span className="neo-status-dot neo-status-dot--online" />
           {providerCount} Providers · {modelCount} Models
         </div>
-        <span className="version-pill">v0.3.0</span>
+        <span className="version-pill">v0.4.0</span>
         {hasToken && (
           <button
             type="button"

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -11,21 +11,28 @@ import Sessions from './pages/Sessions';
 import Projects from './pages/Projects';
 import Providers from './pages/Providers';
 import Settings from './pages/Settings';
+import VirtualKeys from './pages/VirtualKeys';
 import Login from './pages/Login';
 import type { StatusResponse } from './lib/types';
 import { AUTH_REQUIRED_EVENT, clearToken, fetchJson, getToken } from './lib/api';
 
+// Foundry v0.4.0 nav order: Costs, Logs, Sessions, Metrics, Replay
+// (conditional, lives under /sessions/:id/replay so it is not a top-
+// level entry), Projects, Providers, Virtual Keys. Overview, Models,
+// Latency, and Settings predate that spec and are kept above /
+// below the v0.4.0 block so existing users find them where they were.
 const PAGES = [
-  { to: '/',         label: 'Overview',  id: 'overview' },
-  { to: '/models',   label: 'Models',    id: 'models'   },
-  { to: '/costs',    label: 'Costs',     id: 'costs'    },
-  { to: '/latency',  label: 'Latency',   id: 'latency'  },
-  { to: '/logs',     label: 'Logs',      id: 'logs'     },
-  { to: '/sessions', label: 'Sessions',  id: 'sessions' },
-  { to: '/metrics',  label: 'Metrics',   id: 'metrics'  },
-  { to: '/projects', label: 'Projects',  id: 'projects' },
-  { to: '/providers', label: 'Providers', id: 'providers' },
-  { to: '/settings', label: 'Settings',  id: 'settings' },
+  { to: '/',             label: 'Overview',     id: 'overview' },
+  { to: '/models',       label: 'Models',       id: 'models'   },
+  { to: '/costs',        label: 'Costs',        id: 'costs'    },
+  { to: '/latency',      label: 'Latency',      id: 'latency'  },
+  { to: '/logs',         label: 'Logs',         id: 'logs'     },
+  { to: '/sessions',     label: 'Sessions',     id: 'sessions' },
+  { to: '/metrics',      label: 'Metrics',      id: 'metrics'  },
+  { to: '/projects',     label: 'Projects',     id: 'projects' },
+  { to: '/providers',    label: 'Providers',    id: 'providers' },
+  { to: '/virtual-keys', label: 'Virtual Keys', id: 'virtual-keys' },
+  { to: '/settings',     label: 'Settings',     id: 'settings' },
 ] as const;
 
 type AuthState = 'checking' | 'needs-login' | 'ready';
@@ -91,6 +98,7 @@ export default function App() {
             <Route path="/metrics" element={<Metrics />} />
             <Route path="/projects" element={<Projects />} />
             <Route path="/providers" element={<Providers />} />
+            <Route path="/virtual-keys" element={<VirtualKeys />} />
             <Route path="/settings" element={<Settings />} />
             <Route path="/settings/audit-log" element={<Settings tab="audit" />} />
           </Routes>

--- a/dashboard/frontend/src/components/FilterBar.tsx
+++ b/dashboard/frontend/src/components/FilterBar.tsx
@@ -1,0 +1,82 @@
+import { useSearchParams } from 'react-router-dom';
+import TenantFilter from './TenantFilter';
+
+interface Props {
+  /** When true, render the tenant typeahead. Default true. */
+  showTenant?: boolean;
+  /** Optional slot for a page-specific project filter. */
+  projectSlot?: React.ReactNode;
+  /** Optional slot for a page-specific time-range filter. */
+  timeRangeSlot?: React.ReactNode;
+  /** Optional extra controls (sort, etc.). */
+  extra?: React.ReactNode;
+}
+
+/**
+ * REQ-VG-TENANT-002 AC-2: shared filter strip that syncs to the URL.
+ *
+ * The tenant value lives in the ``tenant`` URL search param:
+ *   - missing            → no tenant filter (all)
+ *   - empty string       → unattributed bucket
+ *   - any other string   → that tenant
+ *
+ * Pages read the same param to scope their data fetches. This is how
+ * the per-tenant view persists across navigation (Costs → Sessions →
+ * Metrics → Replay all see the same scope as long as the URL carries
+ * the param).
+ *
+ * Project + time-range filters are intentionally page-owned slots:
+ * the Costs page wants today/week/month/all, Sessions has a different
+ * ordering control, Metrics carries a `days` selector. Pushing them
+ * into the FilterBar would force every page to share one taxonomy,
+ * which the existing v0.2.0 / v0.3.0 pages don't agree on.
+ */
+export default function FilterBar({
+  showTenant = true,
+  projectSlot,
+  timeRangeSlot,
+  extra,
+}: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tenantParam = searchParams.get('tenant');
+  // ``null`` = no tenant filter; ``""`` = unattributed; otherwise a tenant id.
+  const tenant: string | null = tenantParam === null ? null : tenantParam;
+
+  const setTenant = (next: string | null) => {
+    const params = new URLSearchParams(searchParams);
+    if (next === null) {
+      params.delete('tenant');
+    } else {
+      params.set('tenant', next);
+    }
+    setSearchParams(params, { replace: true });
+  };
+
+  return (
+    <div
+      className="flex-row mt-md"
+      style={{
+        justifyContent: 'flex-end',
+        gap: '0.5rem',
+        flexWrap: 'wrap',
+        marginBottom: '0.75rem',
+      }}
+    >
+      {projectSlot}
+      {timeRangeSlot}
+      {extra}
+      {showTenant && <TenantFilter value={tenant} onChange={setTenant} />}
+    </div>
+  );
+}
+
+/**
+ * Helper hook for pages to read the current tenant filter without
+ * duplicating the URL-parsing logic. Returns the same convention as
+ * FilterBar: ``null`` (no filter), ``""`` (unattributed), or a tenant id.
+ */
+export function useTenantFilter(): string | null {
+  const [searchParams] = useSearchParams();
+  const v = searchParams.get('tenant');
+  return v;
+}

--- a/dashboard/frontend/src/components/TenantFilter.tsx
+++ b/dashboard/frontend/src/components/TenantFilter.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchJson } from '../lib/api';
+
+interface TenantRow {
+  tenant_id: string;
+  session_count: number;
+  total_cost_usd: number;
+  first_seen: string | null;
+  last_seen: string | null;
+}
+
+interface UnattributedAggregates {
+  session_count: number;
+  total_cost_usd: number;
+  first_seen: string | null;
+  last_seen: string | null;
+}
+
+interface TenantsResponse {
+  tenants: TenantRow[];
+  unattributed: UnattributedAggregates;
+}
+
+interface Props {
+  /** Current tenant filter: ``null`` (no filter), ``""`` (unattributed bucket), or a tenant id. */
+  value: string | null;
+  /** Called with the new selection. ``null`` clears the filter; ``""`` scopes to unattributed. */
+  onChange: (next: string | null) => void;
+}
+
+/**
+ * REQ-VG-TENANT-002 AC-1: typeahead tenant filter.
+ *
+ * Fetches `/api/tenants` with a substring query that updates as the
+ * operator types. The returned list (plus the implicit unattributed
+ * bucket) becomes the dropdown options. Selection bubbles up via
+ * ``onChange`` so the parent (typically ``FilterBar``) can sync to the
+ * URL query and re-fetch the page's data.
+ *
+ * The fetch is debounced 200ms so a busy operator doesn't fire a
+ * request per keystroke; the limit caps server cost.
+ */
+export default function TenantFilter({ value, onChange }: Props) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState<TenantsResponse | null>(null);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      const params = new URLSearchParams({ limit: '50' });
+      if (query.trim()) params.set('q', query.trim());
+      fetchJson<TenantsResponse>(`/api/tenants?${params}`)
+        .then(setData)
+        .catch(() => setData(null));
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const display = useMemo(() => {
+    if (value === null) return 'All tenants';
+    if (value === '') return 'Unattributed';
+    return value;
+  }, [value]);
+
+  const selectTenant = (next: string | null) => {
+    onChange(next);
+    setOpen(false);
+    setQuery('');
+  };
+
+  return (
+    <div className="tenant-filter" style={{ position: 'relative' }}>
+      <button
+        className="neo-btn"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        Tenant: <strong>{display}</strong>
+        <span style={{ marginLeft: '0.4rem' }}>▾</span>
+      </button>
+
+      {open && (
+        <div
+          className="neo-card"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 0.5rem)',
+            right: 0,
+            zIndex: 10,
+            minWidth: '20rem',
+            padding: '0.75rem',
+            maxHeight: '24rem',
+            overflowY: 'auto',
+          }}
+        >
+          <input
+            className="neo-input"
+            placeholder="Search tenants…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            autoFocus
+          />
+
+          <div className="mt-sm">
+            <button
+              className={`neo-btn ${value === null ? 'neo-btn--primary' : ''}`}
+              style={{ width: '100%', justifyContent: 'flex-start' }}
+              onClick={() => selectTenant(null)}
+            >
+              All tenants
+            </button>
+            <button
+              className={`neo-btn mt-sm ${value === '' ? 'neo-btn--primary' : ''}`}
+              style={{ width: '100%', justifyContent: 'flex-start', opacity: 0.85 }}
+              onClick={() => selectTenant('')}
+            >
+              Unattributed
+              {data && (
+                <span className="label" style={{ marginLeft: 'auto', fontSize: '0.75rem' }}>
+                  {data.unattributed.session_count} session(s)
+                </span>
+              )}
+            </button>
+          </div>
+
+          {data && data.tenants.length > 0 && (
+            <div className="mt-sm">
+              <div
+                className="label"
+                style={{ fontSize: '0.7rem', textTransform: 'uppercase', marginBottom: '0.25rem' }}
+              >
+                Tenants
+              </div>
+              {data.tenants.map((t) => (
+                <button
+                  key={t.tenant_id}
+                  className={`neo-btn ${value === t.tenant_id ? 'neo-btn--primary' : ''}`}
+                  style={{ width: '100%', justifyContent: 'flex-start', marginTop: '0.25rem' }}
+                  onClick={() => selectTenant(t.tenant_id)}
+                >
+                  <span>{t.tenant_id}</span>
+                  <span className="label" style={{ marginLeft: 'auto', fontSize: '0.75rem' }}>
+                    {t.session_count} · ${t.total_cost_usd.toFixed(2)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {data && data.tenants.length === 0 && query.trim() && (
+            <div className="empty-state mt-md">No tenants match "{query}".</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/TenantFilter.tsx
+++ b/dashboard/frontend/src/components/TenantFilter.tsx
@@ -1,25 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { fetchJson } from '../lib/api';
-
-interface TenantRow {
-  tenant_id: string;
-  session_count: number;
-  total_cost_usd: number;
-  first_seen: string | null;
-  last_seen: string | null;
-}
-
-interface UnattributedAggregates {
-  session_count: number;
-  total_cost_usd: number;
-  first_seen: string | null;
-  last_seen: string | null;
-}
-
-interface TenantsResponse {
-  tenants: TenantRow[];
-  unattributed: UnattributedAggregates;
-}
+import { fetchTenants } from '../lib/api';
+import type { TenantsResponse } from '../lib/types';
 
 interface Props {
   /** Current tenant filter: ``null`` (no filter), ``""`` (unattributed bucket), or a tenant id. */
@@ -47,9 +28,7 @@ export default function TenantFilter({ value, onChange }: Props) {
 
   useEffect(() => {
     const handle = setTimeout(() => {
-      const params = new URLSearchParams({ limit: '50' });
-      if (query.trim()) params.set('q', query.trim());
-      fetchJson<TenantsResponse>(`/api/tenants?${params}`)
+      fetchTenants({ limit: 50, q: query.trim() || undefined })
         .then(setData)
         .catch(() => setData(null));
     }, 200);

--- a/dashboard/frontend/src/components/TenantPill.tsx
+++ b/dashboard/frontend/src/components/TenantPill.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+
+interface Props {
+  tenantId: string | null;
+  /** When true, the pill is a link to the tenant-scoped Sessions view. */
+  asLink?: boolean;
+  /** Optional click handler instead of the link. Ignored when ``asLink`` is true. */
+  onClick?: () => void;
+}
+
+/**
+ * REQ-VG-TENANT-002 AC-3: per-session tenant indicator.
+ *
+ * Renders the tenant id as a black neo-badge, or the muted
+ * "unattributed" label when the session's tenant_id is NULL. The
+ * empty-string tenant query convention scopes the dashboard to the
+ * unattributed bucket.
+ */
+export default function TenantPill({ tenantId, asLink = false, onClick }: Props) {
+  const isAttributed = tenantId !== null && tenantId !== '';
+  const label = isAttributed ? tenantId : 'unattributed';
+  const cls = isAttributed ? 'neo-badge neo-badge--black' : 'neo-badge';
+  const style = isAttributed
+    ? undefined
+    : { background: 'transparent', color: 'var(--text-muted, #888)', opacity: 0.75 };
+
+  if (asLink) {
+    const search = new URLSearchParams({ tenant: tenantId ?? '' }).toString();
+    return (
+      <Link className={cls} style={style} to={`/sessions?${search}`}>
+        {label}
+      </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <button className={cls} style={{ ...(style ?? {}), border: 'none', cursor: 'pointer' }} onClick={onClick}>
+        {label}
+      </button>
+    );
+  }
+  return (
+    <span className={cls} style={style}>
+      {label}
+    </span>
+  );
+}

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -86,19 +86,40 @@ async function extractErrorDetail(res: Response): Promise<string | null> {
 // ----------------------------------------------------------------------
 
 import type {
+  CreatedVirtualKey,
   DeadAirEvent,
   MetricsAggregate,
   ReplayResponse,
   RetentionWindow,
+  TenantFilter,
+  TenantRow,
+  TenantsResponse,
   TurnRow,
+  VirtualKey,
 } from './types';
 
+/**
+ * Append the tenant filter to a URLSearchParams instance per the v0.4.0
+ * convention. ``null`` is "no filter" (param not set); ``""`` is the
+ * unattributed bucket (param set to empty string); any other value is
+ * that exact tenant. Matches the backend's ``tenant`` query parsing on
+ * /api/costs, /api/latency, /api/logs, /api/sessions, and /api/metrics.
+ */
+export function appendTenantParam(
+  params: URLSearchParams,
+  tenant: TenantFilter | undefined,
+): void {
+  if (tenant === null || tenant === undefined) return;
+  params.set('tenant', tenant);
+}
+
 export function fetchMetricsSummary(
-  options: { project?: string; days?: number } = {},
+  options: { project?: string; days?: number; tenant?: TenantFilter } = {},
 ): Promise<MetricsAggregate> {
   const params = new URLSearchParams();
   if (options.project) params.set('project', options.project);
   if (options.days !== undefined) params.set('days', String(options.days));
+  appendTenantParam(params, options.tenant);
   const query = params.toString();
   return fetchJson<MetricsAggregate>(
     query ? `/api/metrics?${query}` : '/api/metrics',
@@ -158,4 +179,54 @@ export function updateReplayRetention(
       body: JSON.stringify({ retention_days: retentionDays }),
     },
   );
+}
+
+// ----------------------------------------------------------------------
+// v0.4.0 multi-tenant typed fetchers (REQ-VG-TENANT-002 + -003).
+// ----------------------------------------------------------------------
+
+export function fetchTenants(
+  options: { limit?: number; q?: string } = {},
+): Promise<TenantsResponse> {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+  if (options.q !== undefined && options.q.length > 0) params.set('q', options.q);
+  const query = params.toString();
+  return fetchJson<TenantsResponse>(
+    query ? `/api/tenants?${query}` : '/api/tenants',
+  );
+}
+
+export function fetchTenant(tenantId: string): Promise<TenantRow> {
+  return fetchJson<TenantRow>(`/api/tenants/${encodeURIComponent(tenantId)}`);
+}
+
+export function fetchVirtualKeys(
+  options: { includeRevoked?: boolean } = {},
+): Promise<{ keys: VirtualKey[] }> {
+  const params = new URLSearchParams();
+  if (options.includeRevoked !== undefined) {
+    params.set('include_revoked', options.includeRevoked ? 'true' : 'false');
+  }
+  const query = params.toString();
+  return fetchJson<{ keys: VirtualKey[] }>(
+    query ? `/api/virtual_keys?${query}` : '/api/virtual_keys',
+  );
+}
+
+export function createVirtualKey(body: {
+  name: string;
+  tenant_id?: string | null;
+  issued_by?: string | null;
+}): Promise<CreatedVirtualKey> {
+  return fetchJson<CreatedVirtualKey>('/api/virtual_keys', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function revokeVirtualKey(
+  keyId: number,
+): Promise<{ id: number; revoked: true; row: VirtualKey }> {
+  return fetchJson(`/api/virtual_keys/${keyId}/revoke`, { method: 'POST' });
 }

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -184,3 +184,57 @@ export interface RetentionWindow {
   project_id: string;
   retention_days: number;
 }
+
+// ----------------------------------------------------------------------
+// v0.4.0 multi-tenant attribution (REQ-VG-TENANT-001..004).
+// ----------------------------------------------------------------------
+
+/** One row from the dashboard's tenant typeahead feed. */
+export interface TenantRow {
+  tenant_id: string;
+  session_count: number;
+  total_cost_usd: number;
+  first_seen: string | null;
+  last_seen: string | null;
+}
+
+/** Aggregates for the implicit `tenant_id IS NULL` bucket. */
+export interface UnattributedAggregates {
+  session_count: number;
+  total_cost_usd: number;
+  first_seen: string | null;
+  last_seen: string | null;
+}
+
+/** `/api/tenants` response shape. */
+export interface TenantsResponse {
+  tenants: TenantRow[];
+  unattributed: UnattributedAggregates;
+}
+
+/**
+ * Tenant filter URL convention:
+ *   - `null`: no filter (everything)
+ *   - `""`: scope to the unattributed bucket (sessions with NULL tenant_id)
+ *   - any other string: that exact tenant
+ */
+export type TenantFilter = string | null;
+
+/** One row in the Virtual Keys table; the bcrypt hash never appears. */
+export interface VirtualKey {
+  id: number;
+  key_prefix: string;
+  name: string;
+  tenant_id: string | null;
+  issued_by: string | null;
+  issued_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+/** `POST /api/virtual_keys` response: the only place plaintext appears. */
+export interface CreatedVirtualKey {
+  id: number;
+  plaintext: string;
+  row: VirtualKey;
+}

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -93,6 +93,10 @@ export interface SessionRow {
   modalities: string[];
   total_cost_usd: number;
   request_count: number;
+  // v0.4.0 (REQ-VG-TENANT-001). NULL renders as the muted
+  // "unattributed" pill. Older session rows written before v0.4.0
+  // simply omit the field; the JSON response leaves it absent.
+  tenant_id?: string | null;
 }
 
 export interface SessionDetail extends SessionRow {

--- a/dashboard/frontend/src/pages/Costs.tsx
+++ b/dashboard/frontend/src/pages/Costs.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import PageHeader from '../components/PageHeader';
 import CostChart from '../components/CostChart';
+import FilterBar, { useTenantFilter } from '../components/FilterBar';
+import PageHeader from '../components/PageHeader';
 import StalenessBanner from '../components/StalenessBanner';
 import { fetchJson } from '../lib/api';
 import { formatCost } from '../lib/ui';
@@ -8,10 +9,15 @@ import type { CostsResponse } from '../lib/types';
 
 export default function Costs() {
   const [data, setData] = useState<CostsResponse | null>(null);
+  const tenant = useTenantFilter();
 
   useEffect(() => {
-    fetchJson<CostsResponse>('/api/costs').then(setData).catch(() => setData(null));
-  }, []);
+    const params = new URLSearchParams();
+    if (tenant !== null) params.set('tenant', tenant);
+    const qs = params.toString();
+    const url = qs ? `/api/costs?${qs}` : '/api/costs';
+    fetchJson<CostsResponse>(url).then(setData).catch(() => setData(null));
+  }, [tenant]);
 
   if (!data) return <div className="empty-state">Loading costs...</div>;
 
@@ -21,6 +27,7 @@ export default function Costs() {
     <div>
       <StalenessBanner />
       <PageHeader title="Costs" subtitle={`Period: ${data.period}`} accent="green" />
+      <FilterBar />
 
       <div className="neo-card neo-card--strip-green mb-lg">
         <div className="label">Total Spend</div>

--- a/dashboard/frontend/src/pages/Metrics.tsx
+++ b/dashboard/frontend/src/pages/Metrics.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import DeadAirList from '../components/DeadAirList';
+import FilterBar, { useTenantFilter } from '../components/FilterBar';
 import PageHeader from '../components/PageHeader';
 import PerMinuteCostCard from '../components/PerMinuteCostCard';
 import ResponseSpeedChart from '../components/ResponseSpeedChart';
@@ -40,17 +41,19 @@ export default function Metrics() {
   const [days, setDays] = useState<number>(7);
   const [data, setData] = useState<MetricsAggregate | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
+  const tenant = useTenantFilter();
 
   useEffect(() => {
     const params = new URLSearchParams();
     if (project) params.set('project', project);
     params.set('days', String(days));
+    if (tenant !== null) params.set('tenant', tenant);
     setLoading(true);
     fetchJson<MetricsAggregate>(`/api/metrics?${params.toString()}`)
       .then((d) => setData(d))
       .catch(() => setData(null))
       .finally(() => setLoading(false));
-  }, [project, days]);
+  }, [project, days, tenant]);
 
   return (
     <div>
@@ -60,6 +63,8 @@ export default function Metrics() {
         subtitle="Voice-conversation cost and quality"
         accent="orange"
       />
+
+      <FilterBar />
 
       <div className="neo-card mb-lg">
         <div className="flex flex-row gap-md items-end">

--- a/dashboard/frontend/src/pages/Sessions.tsx
+++ b/dashboard/frontend/src/pages/Sessions.tsx
@@ -7,8 +7,10 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import FilterBar, { useTenantFilter } from '../components/FilterBar';
 import PageHeader from '../components/PageHeader';
 import StalenessBanner from '../components/StalenessBanner';
+import TenantPill from '../components/TenantPill';
 import { fetchJson } from '../lib/api';
 import { formatCost } from '../lib/ui';
 import type {
@@ -43,6 +45,7 @@ export default function Sessions() {
   const [detail, setDetail] = useState<SessionDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const detailAbortRef = useRef<AbortController | null>(null);
+  const tenant = useTenantFilter();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -63,6 +66,7 @@ export default function Sessions() {
     const controller = new AbortController();
     const params = new URLSearchParams({ order_by: orderBy, limit: '100' });
     if (project) params.set('project', project);
+    if (tenant !== null) params.set('tenant', tenant);
     fetchJson<SessionRow[]>(`/api/sessions?${params.toString()}`, {
       signal: controller.signal,
     })
@@ -74,7 +78,7 @@ export default function Sessions() {
         if (!controller.signal.aborted) setLoading(false);
       });
     return () => controller.abort();
-  }, [project, orderBy]);
+  }, [project, orderBy, tenant]);
 
   const handleRowClick = (id: string) => {
     detailAbortRef.current?.abort();
@@ -99,29 +103,37 @@ export default function Sessions() {
         accent="blue"
       />
 
-      <div className="filter-bar">
-        <span className="label">Project</span>
-        <select
-          className="neo-select"
-          value={project}
-          onChange={(e) => setProject(e.target.value)}
-        >
-          <option value="">All projects</option>
-          {projects.map((p) => (
-            <option key={p.id} value={p.id}>{p.name}</option>
-          ))}
-        </select>
-        <span className="label">Sort</span>
-        <select
-          className="neo-select"
-          value={orderBy}
-          onChange={(e) => setOrderBy(e.target.value as SessionOrderBy)}
-        >
-          {ORDER_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
-      </div>
+      <FilterBar
+        projectSlot={
+          <>
+            <span className="label">Project</span>
+            <select
+              className="neo-select"
+              value={project}
+              onChange={(e) => setProject(e.target.value)}
+            >
+              <option value="">All projects</option>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </>
+        }
+        extra={
+          <>
+            <span className="label">Sort</span>
+            <select
+              className="neo-select"
+              value={orderBy}
+              onChange={(e) => setOrderBy(e.target.value as SessionOrderBy)}
+            >
+              {ORDER_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </>
+        }
+      />
 
       {loading ? (
         <div className="empty-state">Loading sessions…</div>
@@ -138,6 +150,7 @@ export default function Sessions() {
               <th>Started</th>
               <th>Duration</th>
               <th>Project</th>
+              <th>Tenant</th>
               <th>Modalities</th>
               <th>Requests</th>
               <th style={{ textAlign: 'right' }}>Cost</th>
@@ -165,6 +178,9 @@ export default function Sessions() {
                   {formatDuration(row.started_at, row.ended_at)}
                 </td>
                 <td>{row.project}</td>
+                <td onClick={(e) => e.stopPropagation()}>
+                  <TenantPill tenantId={row.tenant_id ?? null} asLink />
+                </td>
                 <td>
                   <ModalityBadges modalities={row.modalities} />
                 </td>
@@ -263,6 +279,7 @@ function SessionDetailModal({
           >
             Copy
           </button>
+          <TenantPill tenantId={session.tenant_id ?? null} />
         </div>
 
         <div className="grid grid-cols-2 mt-md">

--- a/dashboard/frontend/src/pages/VirtualKeys.tsx
+++ b/dashboard/frontend/src/pages/VirtualKeys.tsx
@@ -1,23 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import PageHeader from '../components/PageHeader';
-import { fetchJson } from '../lib/api';
-
-interface VirtualKey {
-  id: number;
-  key_prefix: string;
-  name: string;
-  tenant_id: string | null;
-  issued_by: string | null;
-  issued_at: string;
-  last_used_at: string | null;
-  revoked_at: string | null;
-}
-
-interface CreateResponse {
-  id: number;
-  plaintext: string;
-  row: VirtualKey;
-}
+import {
+  createVirtualKey,
+  fetchVirtualKeys,
+  revokeVirtualKey,
+} from '../lib/api';
+import type { CreatedVirtualKey, VirtualKey } from '../lib/types';
 
 const STALE_DAYS_DEFAULT = 90;
 
@@ -47,12 +35,10 @@ export default function VirtualKeys() {
   const [keys, setKeys] = useState<VirtualKey[]>([]);
   const [includeRevoked, setIncludeRevoked] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
-  const [showKey, setShowKey] = useState<CreateResponse | null>(null);
+  const [showKey, setShowKey] = useState<CreatedVirtualKey | null>(null);
 
   const refresh = () => {
-    fetchJson<{ keys: VirtualKey[] }>(
-      `/api/virtual_keys?include_revoked=${includeRevoked}`,
-    )
+    fetchVirtualKeys({ includeRevoked })
       .then((d) => setKeys(d.keys))
       .catch(() => setKeys([]));
   };
@@ -196,7 +182,7 @@ function RevokeButton({ id, onDone }: { id: number; onDone: () => void }) {
     if (!confirm('Revoke this key? It cannot be undone.')) return;
     setBusy(true);
     try {
-      await fetchJson(`/api/virtual_keys/${id}/revoke`, { method: 'POST' });
+      await revokeVirtualKey(id);
       onDone();
     } catch (e) {
       alert((e as Error).message || 'Failed to revoke key');
@@ -217,7 +203,7 @@ function IssueKeyModal({
   onIssued,
 }: {
   onCancel: () => void;
-  onIssued: (resp: CreateResponse) => void;
+  onIssued: (resp: CreatedVirtualKey) => void;
 }) {
   const [name, setName] = useState('');
   const [tenantId, setTenantId] = useState('');
@@ -227,13 +213,10 @@ function IssueKeyModal({
   const save = async () => {
     setSaving(true);
     try {
-      const resp = await fetchJson<CreateResponse>('/api/virtual_keys', {
-        method: 'POST',
-        body: JSON.stringify({
-          name,
-          tenant_id: tenantId.trim() || null,
-          issued_by: issuedBy.trim() || null,
-        }),
+      const resp = await createVirtualKey({
+        name,
+        tenant_id: tenantId.trim() || null,
+        issued_by: issuedBy.trim() || null,
       });
       onIssued(resp);
     } catch (e) {
@@ -292,7 +275,7 @@ function ShowKeyOnceModal({
   response,
   onClose,
 }: {
-  response: CreateResponse;
+  response: CreatedVirtualKey;
   onClose: () => void;
 }) {
   const [copied, setCopied] = useState(false);

--- a/dashboard/frontend/src/pages/VirtualKeys.tsx
+++ b/dashboard/frontend/src/pages/VirtualKeys.tsx
@@ -1,0 +1,345 @@
+import { useEffect, useMemo, useState } from 'react';
+import PageHeader from '../components/PageHeader';
+import { fetchJson } from '../lib/api';
+
+interface VirtualKey {
+  id: number;
+  key_prefix: string;
+  name: string;
+  tenant_id: string | null;
+  issued_by: string | null;
+  issued_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+interface CreateResponse {
+  id: number;
+  plaintext: string;
+  row: VirtualKey;
+}
+
+const STALE_DAYS_DEFAULT = 90;
+
+function daysSince(iso: string): number {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return 0;
+  return Math.floor((Date.now() - then) / 86400000);
+}
+
+function isStale(k: VirtualKey, threshold: number): boolean {
+  if (k.revoked_at !== null) return false;
+  const last = k.last_used_at ?? k.issued_at;
+  return daysSince(last) >= threshold;
+}
+
+function formatRelative(iso: string | null): string {
+  if (iso === null) return 'never';
+  const d = daysSince(iso);
+  if (d === 0) return 'today';
+  if (d === 1) return 'yesterday';
+  if (d < 30) return `${d}d ago`;
+  if (d < 365) return `${Math.floor(d / 30)}mo ago`;
+  return `${Math.floor(d / 365)}y ago`;
+}
+
+export default function VirtualKeys() {
+  const [keys, setKeys] = useState<VirtualKey[]>([]);
+  const [includeRevoked, setIncludeRevoked] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [showKey, setShowKey] = useState<CreateResponse | null>(null);
+
+  const refresh = () => {
+    fetchJson<{ keys: VirtualKey[] }>(
+      `/api/virtual_keys?include_revoked=${includeRevoked}`,
+    )
+      .then((d) => setKeys(d.keys))
+      .catch(() => setKeys([]));
+  };
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [includeRevoked]);
+
+  const staleCount = useMemo(
+    () => keys.filter((k) => isStale(k, STALE_DAYS_DEFAULT)).length,
+    [keys],
+  );
+  const activeCount = useMemo(
+    () => keys.filter((k) => k.revoked_at === null).length,
+    [keys],
+  );
+
+  return (
+    <div>
+      <PageHeader
+        title="Virtual Keys"
+        subtitle={`${activeCount} active · ${staleCount} stale · ${keys.length} total`}
+        accent="orange"
+        actions={
+          <button
+            className="neo-btn neo-btn--primary"
+            onClick={() => setShowCreate(true)}
+          >
+            + Issue Key
+          </button>
+        }
+      />
+
+      <div className="flex-row mt-md" style={{ justifyContent: 'flex-end' }}>
+        <label className="label" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <input
+            type="checkbox"
+            checked={includeRevoked}
+            onChange={(e) => setIncludeRevoked(e.target.checked)}
+          />
+          Show revoked
+        </label>
+      </div>
+
+      <div className="neo-card mt-md">
+        {keys.length === 0 ? (
+          <div className="empty-state">No virtual keys issued yet.</div>
+        ) : (
+          <table className="neo-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Prefix</th>
+                <th>Tenant</th>
+                <th>Issued</th>
+                <th>Last used</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => {
+                const stale = isStale(k, STALE_DAYS_DEFAULT);
+                const revoked = k.revoked_at !== null;
+                return (
+                  <tr key={k.id}>
+                    <td>
+                      <strong>{k.name}</strong>
+                      {k.issued_by && (
+                        <div className="label" style={{ fontSize: '0.75rem' }}>
+                          by {k.issued_by}
+                        </div>
+                      )}
+                    </td>
+                    <td>
+                      <code>{k.key_prefix}…</code>
+                    </td>
+                    <td>
+                      {k.tenant_id ? (
+                        <span className="neo-badge neo-badge--black">
+                          {k.tenant_id}
+                        </span>
+                      ) : (
+                        <span className="label" style={{ opacity: 0.6 }}>
+                          unscoped
+                        </span>
+                      )}
+                    </td>
+                    <td className="label">{formatRelative(k.issued_at)}</td>
+                    <td className="label">{formatRelative(k.last_used_at)}</td>
+                    <td>
+                      {revoked ? (
+                        <span className="neo-badge neo-badge--black">revoked</span>
+                      ) : stale ? (
+                        <span className="neo-badge" style={{ background: '#FFD166' }}>
+                          stale
+                        </span>
+                      ) : (
+                        <span className="neo-badge" style={{ background: 'var(--accent-green)' }}>
+                          active
+                        </span>
+                      )}
+                    </td>
+                    <td>
+                      {!revoked && <RevokeButton id={k.id} onDone={refresh} />}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {showCreate && (
+        <IssueKeyModal
+          onCancel={() => setShowCreate(false)}
+          onIssued={(resp) => {
+            setShowCreate(false);
+            setShowKey(resp);
+            refresh();
+          }}
+        />
+      )}
+
+      {showKey && (
+        <ShowKeyOnceModal
+          response={showKey}
+          onClose={() => setShowKey(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function RevokeButton({ id, onDone }: { id: number; onDone: () => void }) {
+  const [busy, setBusy] = useState(false);
+
+  const revoke = async () => {
+    if (!confirm('Revoke this key? It cannot be undone.')) return;
+    setBusy(true);
+    try {
+      await fetchJson(`/api/virtual_keys/${id}/revoke`, { method: 'POST' });
+      onDone();
+    } catch (e) {
+      alert((e as Error).message || 'Failed to revoke key');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button className="neo-btn" onClick={revoke} disabled={busy}>
+      {busy ? '…' : 'Revoke'}
+    </button>
+  );
+}
+
+function IssueKeyModal({
+  onCancel,
+  onIssued,
+}: {
+  onCancel: () => void;
+  onIssued: (resp: CreateResponse) => void;
+}) {
+  const [name, setName] = useState('');
+  const [tenantId, setTenantId] = useState('');
+  const [issuedBy, setIssuedBy] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const resp = await fetchJson<CreateResponse>('/api/virtual_keys', {
+        method: 'POST',
+        body: JSON.stringify({
+          name,
+          tenant_id: tenantId.trim() || null,
+          issued_by: issuedBy.trim() || null,
+        }),
+      });
+      onIssued(resp);
+    } catch (e) {
+      alert((e as Error).message || 'Failed to issue key');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="neo-modal-backdrop" onClick={onCancel}>
+      <div className="neo-modal" onClick={(e) => e.stopPropagation()}>
+        <h3>Issue Virtual Key</h3>
+        <label className="label">Name</label>
+        <input
+          className="neo-input"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="prod-bot"
+          autoFocus
+        />
+        <label className="label mt-md">Tenant scope (optional)</label>
+        <input
+          className="neo-input"
+          value={tenantId}
+          onChange={(e) => setTenantId(e.target.value)}
+          placeholder="acme"
+        />
+        <div className="label mt-sm" style={{ fontSize: '0.75rem', opacity: 0.7 }}>
+          Scoped keys auto-tag every session with this tenant. Conflicting
+          body tenants return 403.
+        </div>
+        <label className="label mt-md">Issued by (optional)</label>
+        <input
+          className="neo-input"
+          value={issuedBy}
+          onChange={(e) => setIssuedBy(e.target.value)}
+          placeholder="ops@example.com"
+        />
+        <div className="flex-row mt-lg">
+          <button className="neo-btn" onClick={onCancel}>Cancel</button>
+          <button
+            className="neo-btn neo-btn--primary"
+            onClick={save}
+            disabled={saving || !name.trim()}
+          >
+            {saving ? 'Issuing…' : 'Issue Key'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ShowKeyOnceModal({
+  response,
+  onClose,
+}: {
+  response: CreateResponse;
+  onClose: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(response.plaintext).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="neo-modal-backdrop" onClick={onClose}>
+      <div
+        className="neo-modal"
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: '32rem' }}
+      >
+        <h3>Save this key now</h3>
+        <p className="label mt-sm">
+          The full key appears <strong>only once</strong>. Copy it into your
+          secret store before closing this modal: the dashboard cannot show it
+          again.
+        </p>
+        <div
+          className="neo-card mt-md"
+          style={{ background: '#FFF9C2', padding: '1rem' }}
+        >
+          <code style={{ wordBreak: 'break-all', fontSize: '0.95rem' }}>
+            {response.plaintext}
+          </code>
+        </div>
+        <div className="flex-row mt-md" style={{ justifyContent: 'space-between' }}>
+          <span className="label">
+            Name: <strong>{response.row.name}</strong> · Tenant:{' '}
+            <strong>{response.row.tenant_id ?? 'unscoped'}</strong>
+          </span>
+          <div className="flex-row">
+            <button className="neo-btn" onClick={copy}>
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+            <button className="neo-btn neo-btn--primary" onClick={onClose}>
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docker/voicegateway.Dockerfile
+++ b/docker/voicegateway.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY pyproject.toml README.md ./
 COPY voicegateway/ ./voicegateway/
 
-ARG VERSION=0.3.0
+ARG VERSION=0.4.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 RUN pip install --prefix=/install ".[cloud,mcp,dashboard,tui]"
@@ -36,7 +36,7 @@ RUN pip install --prefix=/install ".[cloud,mcp,dashboard,tui]"
 # -------- Stage 3: Runtime --------
 FROM python:3.12-slim AS runtime
 
-ARG VERSION=0.3.0
+ARG VERSION=0.4.0
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -60,6 +60,7 @@ export default defineConfig({
             { text: 'Your First Agent', link: '/guide/first-agent' },
             { text: 'Core Concepts', link: '/guide/core-concepts' },
             { text: 'Cost Reconciliation', link: '/guide/cost-reconciliation' },
+            { text: 'Multi-Tenant Quickstart', link: '/guide/multi-tenant-quickstart' },
           ],
         },
       ],

--- a/docs/api/python-sdk.md
+++ b/docs/api/python-sdk.md
@@ -179,6 +179,7 @@ inference.attach_session(
     agent_session,
     *,
     session_id: str | None = None,
+    tenant_id: str | None = None,   # v0.4.0
     turn_tracker: TurnTracker | None = None,
     dead_air_detector: DeadAirDetector | None = None,
     cost_tracker: CostTracker | None = None,
@@ -210,6 +211,53 @@ async def handle_call():
 The helper subscribes to five `AgentSession` events: `user_started_speaking`, `user_stopped_speaking`, `agent_started_speaking`, `agent_stopped_speaking`, `close`. The first four feed the `TurnTracker`; `close` flushes the tracker, stops the `DeadAirDetector`, and calls `CostTracker.close_session(sid)` so the v0.2.0 aggregate columns (`talk_time_seconds`, `per_minute_cost_usd`, `response_speed_p50/p95_ms`, `talk_over_rate`) land on the `sessions` row by the time the dashboard's `/api/metrics` endpoint reads it.
 
 Components default to the process-level registry the Gateway populates on startup; pass explicit kwargs to override (the unit-test path).
+
+## Tenant attribution (v0.4.0)
+
+VoiceGateway tags each session with an optional `tenant_id` so multi-tenant operators can slice costs, metrics, and replay by customer. The tenant flows through three independent surfaces; pick the one that matches your deployment.
+
+### 1. `attach_session(..., tenant_id="…")`
+
+The opt-in path. Pass `tenant_id` at the same time you wire the LiveKit `AgentSession`, and every cost row, metric row, and replay event from that session lands tagged.
+
+```python
+from voicegateway import inference
+
+async def handle_call(tenant_id: str):
+    agent_session = AgentSession(...)
+    inference.attach_session(agent_session, tenant_id=tenant_id)
+    await agent_session.start(...)
+```
+
+When `tenant_id` is omitted (default `None`) the ContextVar is left alone, so a virtual key resolved earlier in the request (see surface 3 below) or an explicit `set_tenant(...)` call still wins. Calling with `tenant_id=None` does not clear a previously-set scope.
+
+### 2. `inference.set_tenant(tenant_id)`
+
+The escape hatch for code that does not own the `AgentSession` construction. Sets the `tenant_id_ctx` ContextVar for the rest of the async context; the next `log_request` call picks it up and stamps the session row. 128-char UTF-8 cap (locked at v0.4.0 OQ2).
+
+```python
+from voicegateway import inference
+
+inference.set_tenant("acme")
+stt = inference.STT("deepgram/nova-3")
+# ... subsequent factories inherit the tenant via the ContextVar.
+```
+
+`inference.current_tenant()` reads the current scope without modifying it. `inference.reset_tenant_id()` clears the ContextVar for a new session boundary inside the same task.
+
+### 3. Virtual API keys (no code change required)
+
+When a request authenticates with a `vk_`-prefixed virtual key whose `tenant_id` is set, the HTTP API's auth middleware (in `voicegateway/server/main.py::build_app`) auto-tags the session with the key's scope. Agent code does not need to know the tenant: the dashboard's Virtual Keys page (`/virtual-keys`) issues a scoped key, the operator ships it as `Authorization: Bearer vk_…`, and every request inherits the scope.
+
+Body-level `tenant_id` is rejected with `403` when it conflicts with a scoped virtual key. Unscoped virtual keys (issued without a tenant) allow the body to declare any tenant, matching the static-key behavior.
+
+### The "unattributed" bucket
+
+Sessions where none of the three surfaces set a tenant get `tenant_id = NULL` in storage. The dashboard renders these as a muted "unattributed" pill rather than a literal tenant string. No backfill happens at migration time (OQ3 locked at v0.4.0/T01): pre-v0.4.0 rows stay NULL and the FE handles them gracefully.
+
+The first tenant-bearing request "wins" for the session's lifetime. A later unattributed request on the same `session_id` does not clear the tenant_id (the `sessions` UPSERT uses `COALESCE(tenant_id, excluded.tenant_id)`).
+
+For the operator-facing workflow (issuing keys, viewing per-tenant costs, exporting), see the [multi-tenant quickstart](/guide/multi-tenant-quickstart).
 
 ## Conversation replay capture (v0.3.0)
 

--- a/docs/guide/multi-tenant-quickstart.md
+++ b/docs/guide/multi-tenant-quickstart.md
@@ -1,0 +1,155 @@
+# Multi-tenant quickstart (v0.4.0)
+
+VoiceGateway tags every voice session with an optional `tenant_id` so a single deployment can serve many customers and account for each one separately. This guide walks an operator through the four moves the v0.4.0 release enables:
+
+1. Tag a session with a tenant at session-create.
+2. Issue a virtual API key scoped to that tenant.
+3. View per-tenant costs, metrics, and replay in the dashboard.
+4. Export per-tenant data for billing or analysis.
+
+If you only need to filter the dashboard, jump straight to [Step 3](#3-view-per-tenant-costs-and-metrics).
+
+## Prerequisites
+
+- VoiceGateway v0.4.0 or later (`voicegw --version` to confirm).
+- The dashboard running: `voicegw dashboard` (defaults to `127.0.0.1:9090`).
+- A `voicegw.yaml` with `cost_tracking.db_path` set (the dashboard reads the same SQLite database the gateway writes to).
+
+## 1. Tag a session with a tenant
+
+Three independent surfaces, listed in order of "least to most operator coupling." Pick whichever fits your deployment.
+
+### Option A: pass `tenant_id` to `attach_session`
+
+The cleanest path when your worker code knows the tenant. Refer to the [Python SDK reference](/api/python-sdk#1-attach_session-tenant_id) for the full signature.
+
+```python
+from voicegateway import inference
+
+async def handle_call(tenant_id: str):
+    agent_session = AgentSession(...)
+    inference.attach_session(agent_session, tenant_id=tenant_id)
+    await agent_session.start(...)
+```
+
+Use this when the LiveKit dispatcher hands your worker a context that already names the tenant (room metadata, a custom claim, a header passed through to the worker, etc.).
+
+### Option B: `inference.set_tenant("…")`
+
+The ContextVar escape hatch for code that does not own the `AgentSession` construction. Sets `tenant_id_ctx` for the rest of the async context; subsequent factory calls inherit the scope.
+
+```python
+from voicegateway import inference
+
+inference.set_tenant("acme")
+stt = inference.STT("deepgram/nova-3")
+llm = inference.LLM("openai/gpt-4o-mini")
+# Every request from this point in the async context tags 'acme'.
+```
+
+Tenant ids are bounded at 128 UTF-8 characters (locked at v0.4.0 OQ2). Unicode is allowed. Pass `None` to leave the ContextVar untouched (it does **not** clear a previously-set tenant). Use `inference.reset_tenant_id()` to clear it explicitly between sessions in long-lived tasks.
+
+### Option C: scoped virtual API keys
+
+When the caller is not your own agent code (a partner integration, a third-party voicebot) but you can give them a unique API key, issue a virtual key scoped to their tenant. The auth middleware auto-tags every session that arrives bearing that key. See [Step 2](#2-issue-a-virtual-api-key) for the workflow.
+
+### Sessions without a tenant: the "unattributed" bucket
+
+Sessions where none of the three surfaces set a tenant get `tenant_id = NULL` in storage. The dashboard renders these as a muted **unattributed** pill. The dashboard's tenant filter has a dedicated entry for the unattributed bucket so you can audit which sessions slipped through.
+
+There is **no** automatic backfill of pre-v0.4.0 sessions. They stay `NULL` forever unless you re-tag them via the dashboard's session-detail affordance (deferred to a v0.4.x follow-up).
+
+## 2. Issue a virtual API key
+
+The dashboard is the only surface that issues virtual keys. The CLI is read-only by design: a CLI that printed the plaintext key would leak it via shell history and scrollback.
+
+1. Open the dashboard at `http://127.0.0.1:9090/virtual-keys`.
+2. Click **+ Issue Key**.
+3. Fill in:
+    - **Name** (required): a human label, e.g. `acme-prod`.
+    - **Tenant scope** (optional): the tenant id you want auto-attached. Leave blank for an unscoped key.
+    - **Issued by** (optional): free-form audit string.
+4. Hit **Issue Key**. The next modal shows the full key **exactly once**. Copy it into your secret store before closing.
+
+The key looks like `vk_AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPP` (35 characters: `vk_` + 32 base32). The first 8 characters (`vk_AABBC`) persist as the visible prefix so you can identify a key in the list without exposing the secret; the whole key is bcrypt-hashed before storage.
+
+Ship the key to the caller as `Authorization: Bearer vk_…`. From that point:
+
+- Scoped keys auto-tag every session. A body-level `tenant_id` that disagrees with the key's scope returns `403`.
+- Unscoped keys allow the body to declare any tenant.
+- Static API keys (the v0.0.5 `auth.api_keys` block in `voicegw.yaml`) remain unchanged and never set a tenant.
+
+### Revoke
+
+The same Virtual Keys page exposes a **Revoke** action per row. Revocation is soft (OQ5 lock): the row stays for audit and the stale-key surface, but verification rejects further requests bearing the key within ~30 seconds.
+
+### Stale-key detection
+
+Keys whose `last_used_at` (or `issued_at`, for never-used keys) is older than `virtual_key_stale_days` (default 90, per-project overridable in `voicegw.yaml`) surface with a yellow **stale** badge. Hide revoked rows with the toggle at the top of the page when triaging.
+
+## 3. View per-tenant costs and metrics
+
+Every cost, log, sessions, metrics, and replay page in the dashboard now respects the `tenant` URL parameter.
+
+- Use the **Tenant** typeahead in the filter strip (top-right of each page) to scope to one tenant, or pick **Unattributed** to see only sessions without attribution.
+- The filter persists across navigation: switching from Costs to Sessions to Metrics keeps the same tenant in scope because the value lives in the URL.
+- Selecting **All tenants** clears the filter without losing project or time-range scope.
+
+### The Tenants tab
+
+`GET /api/tenants` (consumed by the typeahead) returns the index of every tenant the gateway has seen, ordered by most recent activity. Each entry carries the session count, total cost, and first/last-seen timestamps. The unattributed bucket appears as a separate entry below the list.
+
+### Per-session attribution
+
+The Sessions page has a **Tenant** column that renders the row's `tenant_id` as a clickable pill: clicking it scopes the page to that tenant immediately. The SessionDetail modal also shows the tenant pill next to the session id so you can verify attribution without leaving the row.
+
+## 4. Export per-tenant data
+
+For billing exports or third-party analysis, two paths.
+
+### CLI
+
+```bash
+voicegw tenant list --json
+voicegw tenant show acme --json
+```
+
+Both commands emit JSON with the same shape `/api/tenants` returns. `tenant show` exits 1 when the tenant has no sessions so CI scripts can branch.
+
+The `voicegw costs` command (v0.0.5) does **not** yet accept a `--tenant` flag. The dashboard's `/api/costs?tenant=…` endpoint is the canonical per-tenant cost source for v0.4.0; a CLI flag may land in v0.4.x if operators ask for it.
+
+### Direct SQL
+
+The `sessions` table carries `tenant_id` as of migration 0005. For ad-hoc analysis:
+
+```sql
+SELECT tenant_id,
+       COUNT(*) AS session_count,
+       SUM(total_cost_usd) AS total_cost
+FROM sessions
+WHERE started_at >= '2026-05-01'
+GROUP BY tenant_id
+ORDER BY total_cost DESC;
+```
+
+The `requests`, `turns`, `dead_air_events`, and `replay_*` tables all carry the column too, so any join-and-aggregate workflow you had pre-v0.4.0 can add `tenant_id` to the GROUP BY without schema gymnastics.
+
+## What v0.4.0 does not do
+
+A few operator workflows are deliberately deferred to keep v0.4.0 focused. Plan accordingly.
+
+- **No automatic backfill** of pre-v0.4.0 sessions. They stay `tenant_id = NULL` (the unattributed bucket).
+- **No CLI issuance of virtual keys.** REQ-VG-TENANT-003 AC-2 pins the plaintext surface to the dashboard's "show key once" modal. A CLI flow would leak via shell history.
+- **No `voicegw costs --tenant`.** The dashboard's `/api/costs?tenant=…` is the canonical per-tenant cost source. CLI flag follows in a later patch if asked for.
+- **No re-tag affordance for already-attributed sessions.** Once a session has a non-NULL `tenant_id`, the dashboard cannot change it; the COALESCE rule in `log_request` only fills NULL slots. A re-tag flow for unattributed sessions is on the v0.4.x roadmap.
+- **Virtual keys do not carry RBAC scopes** in v0.4.0. A verified vk grants the same access a wildcard static key would. RBAC scopes on virtual keys can layer on later.
+
+## Where the design lives
+
+- **Refinery / Foundry**: REQ-VG-TENANT-001..004 (see the Linear project for the requirements rationale).
+- **Migration**: `voicegateway/storage/migrations/0005_tenant_attribution.py`.
+- **ContextVar**: `voicegateway/inference/_session_context.py`.
+- **Auth middleware**: `voicegateway/server/main.py::build_app` + `voicegateway/core/auth.py`.
+- **Repos**: `voicegateway/storage/virtual_keys_repo.py`, `voicegateway/storage/tenants_repo.py`.
+- **Dashboard API**: `dashboard/api/main.py` (search for `/api/tenants` and `/api/virtual_keys`).
+- **Frontend primitives**: `dashboard/frontend/src/components/{FilterBar,TenantFilter,TenantPill}.tsx`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pydantic>=2.0",
     "cryptography>=43.0",
     "genai-prices>=0.0.52,<0.1",
+    "bcrypt>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/inference/test_tenant_propagation.py
+++ b/tests/inference/test_tenant_propagation.py
@@ -1,0 +1,115 @@
+"""End-to-end tenant propagation across three synthetic sessions.
+
+REQ-VG-TENANT-001 AC-1: every cost row, metric row, and replay event
+for a session is tagged with that session's tenant. This test runs
+three sessions with three different tenants through
+``log_request`` and asserts the resulting aggregates match the
+per-tenant ground truth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.inference._session_context import (
+    current_tenant,
+    reset_tenant_id,
+    set_tenant,
+)
+from voicegateway.storage import tenants_repo
+from voicegateway.storage.models import RequestRecord
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    yield SQLiteStorage(db_path=str(tmp_path / "prop.db"))
+    reset_tenant_id()
+
+
+def _req(session_id: str, *, cost: float, ts: float = 1746000000.0) -> RequestRecord:
+    return RequestRecord(
+        id=f"req-{session_id}-{ts}",
+        timestamp=ts,
+        project="default",
+        modality="stt",
+        model_id="deepgram/nova-3",
+        provider="deepgram",
+        input_units=0,
+        output_units=0,
+        cost_usd=cost,
+        pricing_source="test",
+        ttfb_ms=None,
+        total_latency_ms=None,
+        status="success",
+        fallback_from=None,
+        error_message=None,
+        metadata=None,
+        session_id=session_id,
+    )
+
+
+async def test_three_tenants_aggregate_independently(storage) -> None:
+    # Tenant A: 2 sessions, 3 requests, $0.30 total.
+    set_tenant("alpha")
+    await storage.log_request(_req("a-1", cost=0.10))
+    await storage.log_request(_req("a-1", cost=0.05, ts=1746000010.0))
+    await storage.log_request(_req("a-2", cost=0.15))
+
+    # Tenant B: 1 session, 1 request, $1.00 total.
+    set_tenant("bravo")
+    await storage.log_request(_req("b-1", cost=1.00))
+
+    # Tenant C: 1 session, 2 requests, $0.50 total.
+    set_tenant("charlie")
+    await storage.log_request(_req("c-1", cost=0.30))
+    await storage.log_request(_req("c-1", cost=0.20, ts=1746000020.0))
+
+    reset_tenant_id()
+
+    # Per-tenant cost summary.
+    alpha = await storage.get_cost_summary("all", tenant="alpha")
+    assert alpha["total"] == pytest.approx(0.30)
+    bravo = await storage.get_cost_summary("all", tenant="bravo")
+    assert bravo["total"] == pytest.approx(1.00)
+    charlie = await storage.get_cost_summary("all", tenant="charlie")
+    assert charlie["total"] == pytest.approx(0.50)
+
+    # Tenants repo index aggregates.
+    db = await storage._ensure_initialized()
+    rows = await tenants_repo.list_tenants(db)
+    by_tenant = {r.tenant_id: r for r in rows}
+    assert by_tenant["alpha"].session_count == 2
+    assert by_tenant["alpha"].total_cost_usd == pytest.approx(0.30)
+    assert by_tenant["bravo"].session_count == 1
+    assert by_tenant["charlie"].session_count == 1
+
+
+async def test_context_var_resets_between_tenants(storage) -> None:
+    """Switching tenants does not leak across sessions when set_tenant is called."""
+    set_tenant("alpha")
+    assert current_tenant() == "alpha"
+
+    set_tenant("bravo")
+    assert current_tenant() == "bravo"
+
+    reset_tenant_id()
+    assert current_tenant() is None
+
+
+async def test_unattributed_sessions_separate_from_tenant_index(storage) -> None:
+    """The list_tenants result excludes NULL-tenant sessions."""
+    set_tenant("alpha")
+    await storage.log_request(_req("a-1", cost=0.10))
+
+    reset_tenant_id()
+    await storage.log_request(_req("u-1", cost=0.05))
+    await storage.log_request(_req("u-2", cost=0.05))
+
+    db = await storage._ensure_initialized()
+    tenant_rows = await tenants_repo.list_tenants(db)
+    assert {r.tenant_id for r in tenant_rows} == {"alpha"}
+
+    unattr = await tenants_repo.get_unattributed_aggregates(db)
+    assert unattr.session_count == 2
+    assert unattr.total_cost_usd == pytest.approx(0.10)

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -31,7 +31,7 @@ async def test_health(client):
     data = resp.json()
     assert data["status"] == "ok"
     assert "uptime_seconds" in data
-    assert data["version"] == "0.3.0"
+    assert data["version"] == "0.4.0"
 
 
 async def test_v1_status(client):

--- a/tests/server/test_session_create_tenant.py
+++ b/tests/server/test_session_create_tenant.py
@@ -1,0 +1,136 @@
+"""Tests for tenant_id stamping at session-create (REQ-VG-TENANT-001).
+
+The session row's tenant_id comes from ``current_tenant()`` at the
+moment ``log_request`` fires for the session_id. Three coverage cases:
+
+- Caller explicitly sets tenant via ContextVar -> session row tagged.
+- No caller scope -> session row tenant_id is NULL.
+- Tenant set after first request -> COALESCE rule fills the slot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.inference._session_context import (
+    reset_tenant_id,
+    set_tenant,
+)
+from voicegateway.storage.models import RequestRecord
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    yield SQLiteStorage(db_path=str(tmp_path / "sct.db"))
+    reset_tenant_id()
+
+
+def _record(
+    session_id: str, *, cost: float = 0.05, ts: float = 1746000000.0
+) -> RequestRecord:
+    return RequestRecord(
+        id=f"req-{session_id}-{ts}-{cost}",
+        timestamp=ts,
+        project="default",
+        modality="stt",
+        model_id="deepgram/nova-3",
+        provider="deepgram",
+        input_units=0,
+        output_units=0,
+        cost_usd=cost,
+        pricing_source="test",
+        ttfb_ms=None,
+        total_latency_ms=None,
+        status="success",
+        fallback_from=None,
+        error_message=None,
+        metadata=None,
+        session_id=session_id,
+    )
+
+
+async def test_caller_with_tenant_tags_session(storage) -> None:
+    set_tenant("acme")
+    await storage.log_request(_record("s1"))
+
+    db = await storage._ensure_initialized()
+    cur = await db.execute("SELECT tenant_id FROM sessions WHERE id = 's1'")
+    row = await cur.fetchone()
+    assert row is not None
+    assert row[0] == "acme"
+
+
+async def test_caller_with_no_tenant_writes_null(storage) -> None:
+    reset_tenant_id()  # belt-and-suspenders; the fixture also resets on teardown
+    await storage.log_request(_record("s2"))
+
+    db = await storage._ensure_initialized()
+    cur = await db.execute("SELECT tenant_id FROM sessions WHERE id = 's2'")
+    row = await cur.fetchone()
+    assert row is not None
+    assert row[0] is None
+
+
+async def test_requests_row_also_carries_tenant(storage) -> None:
+    """T08: tenant_id propagates to the requests row as well."""
+    set_tenant("acme")
+    await storage.log_request(_record("s3"))
+
+    db = await storage._ensure_initialized()
+    cur = await db.execute("SELECT tenant_id FROM requests WHERE session_id = 's3'")
+    row = await cur.fetchone()
+    assert row is not None
+    assert row[0] == "acme"
+
+
+async def test_coalesce_keeps_first_tenant_on_conflict(storage) -> None:
+    """A second request without a scope cannot blank an already-tagged row."""
+    set_tenant("acme")
+    await storage.log_request(_record("s4"))
+
+    reset_tenant_id()
+    await storage.log_request(_record("s4", cost=0.10))
+
+    db = await storage._ensure_initialized()
+    cur = await db.execute("SELECT tenant_id FROM sessions WHERE id = 's4'")
+    row = await cur.fetchone()
+    assert row is not None
+    assert row[0] == "acme"
+
+
+async def test_deferred_attribution_fills_null_slot(storage) -> None:
+    """A first unattributed request followed by a scoped one tags the row."""
+    reset_tenant_id()
+    await storage.log_request(_record("s5"))
+
+    set_tenant("acme")
+    await storage.log_request(_record("s5", cost=0.10))
+
+    db = await storage._ensure_initialized()
+    cur = await db.execute("SELECT tenant_id FROM sessions WHERE id = 's5'")
+    row = await cur.fetchone()
+    assert row is not None
+    assert row[0] == "acme"
+
+
+async def test_attach_session_sets_tenant_via_ctx_var(storage) -> None:
+    """attach_session(tenant_id=...) flows through to the next log_request."""
+    from voicegateway.inference._session_attach import attach_session
+
+    class FakeAgent:
+        def __init__(self) -> None:
+            self.handlers: dict = {}
+
+        def on(self, name, handler):
+            self.handlers[name] = handler
+
+    fake = FakeAgent()
+    attach_session(fake, session_id="s6", tenant_id="beta")
+    await storage.log_request(_record("s6"))
+
+    db = await storage._ensure_initialized()
+    cur = await db.execute("SELECT tenant_id FROM sessions WHERE id = 's6'")
+    row = await cur.fetchone()
+    assert row is not None
+    assert row[0] == "beta"

--- a/tests/server/test_tenant_filter.py
+++ b/tests/server/test_tenant_filter.py
@@ -1,0 +1,126 @@
+"""Tests for tenant URL-parameter scoping on read endpoints (T10/T13).
+
+Exercises the storage-level tenant kwarg on the five filtered methods:
+- get_cost_summary
+- get_cost_by_project
+- get_recent_requests
+- list_sessions
+- get_latency_stats
+
+Plus the dashboard handler that parses the URL param and forwards it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.inference._session_context import (
+    reset_tenant_id,
+    set_tenant,
+)
+from voicegateway.storage.models import RequestRecord
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    yield SQLiteStorage(db_path=str(tmp_path / "tf.db"))
+    reset_tenant_id()
+
+
+def _record(
+    session_id: str, *, cost: float = 0.05, ts: float = 1746000000.0
+) -> RequestRecord:
+    return RequestRecord(
+        id=f"req-{session_id}",
+        timestamp=ts,
+        project="default",
+        modality="stt",
+        model_id="deepgram/nova-3",
+        provider="deepgram",
+        input_units=0,
+        output_units=0,
+        cost_usd=cost,
+        pricing_source="test",
+        ttfb_ms=100.0,
+        total_latency_ms=200.0,
+        status="success",
+        fallback_from=None,
+        error_message=None,
+        metadata=None,
+        session_id=session_id,
+    )
+
+
+async def _seed_two_tenants(storage):
+    set_tenant("acme")
+    await storage.log_request(_record("s-acme-1", cost=0.10))
+    await storage.log_request(_record("s-acme-2", cost=0.20))
+    set_tenant("beta")
+    await storage.log_request(_record("s-beta-1", cost=1.00))
+    reset_tenant_id()
+    await storage.log_request(_record("s-unattributed", cost=0.05))
+
+
+async def test_get_cost_summary_scopes_to_tenant(storage) -> None:
+    await _seed_two_tenants(storage)
+    acme = await storage.get_cost_summary("all", tenant="acme")
+    assert acme["total"] == pytest.approx(0.30)
+    beta = await storage.get_cost_summary("all", tenant="beta")
+    assert beta["total"] == pytest.approx(1.00)
+    every = await storage.get_cost_summary("all")
+    assert every["total"] == pytest.approx(1.35)
+
+
+async def test_get_cost_summary_empty_string_targets_unattributed(storage) -> None:
+    await _seed_two_tenants(storage)
+    u = await storage.get_cost_summary("all", tenant="")
+    assert u["total"] == pytest.approx(0.05)
+
+
+async def test_get_cost_by_project_scopes_to_tenant(storage) -> None:
+    await _seed_two_tenants(storage)
+    acme = await storage.get_cost_by_project("all", tenant="acme")
+    assert acme.get("default", {}).get("cost", 0.0) == pytest.approx(0.30)
+    beta = await storage.get_cost_by_project("all", tenant="beta")
+    assert beta.get("default", {}).get("cost", 0.0) == pytest.approx(1.00)
+
+
+async def test_list_sessions_scopes_to_tenant(storage) -> None:
+    await _seed_two_tenants(storage)
+    acme = await storage.list_sessions(tenant="acme")
+    assert {s["id"] for s in acme} == {"s-acme-1", "s-acme-2"}
+    beta = await storage.list_sessions(tenant="beta")
+    assert {s["id"] for s in beta} == {"s-beta-1"}
+
+
+async def test_list_sessions_empty_string_targets_unattributed(storage) -> None:
+    await _seed_two_tenants(storage)
+    rows = await storage.list_sessions(tenant="")
+    assert {s["id"] for s in rows} == {"s-unattributed"}
+
+
+async def test_get_recent_requests_scopes_to_tenant(storage) -> None:
+    await _seed_two_tenants(storage)
+    acme = await storage.get_recent_requests(tenant="acme")
+    assert {r["session_id"] for r in acme} == {"s-acme-1", "s-acme-2"}
+
+
+async def test_get_latency_stats_scopes_to_tenant(storage) -> None:
+    await _seed_two_tenants(storage)
+    acme = await storage.get_latency_stats("all", tenant="acme")
+    # Acme has 2 requests with latency, beta has 1; the stats should
+    # surface model_id keys for whichever tenant we scope.
+    assert isinstance(acme, dict)
+    # The model_id key carries a non-empty request_count when present.
+    if acme:
+        any_model = next(iter(acme.values()))
+        assert any_model["request_count"] == 2
+
+
+async def test_none_tenant_means_all_data(storage) -> None:
+    await _seed_two_tenants(storage)
+    all_summary = await storage.get_cost_summary("all", tenant=None)
+    assert all_summary["total"] == pytest.approx(1.35)
+    all_sessions = await storage.list_sessions(tenant=None)
+    assert len(all_sessions) == 4

--- a/tests/server/test_virtual_key_auth.py
+++ b/tests/server/test_virtual_key_auth.py
@@ -1,0 +1,204 @@
+"""Tests for the v0.4.0 virtual-key path in the HTTP API auth middleware.
+
+Covers REQ-VG-TENANT-004:
+
+- A valid virtual key resolves and the request reaches the handler.
+- A revoked virtual key returns 401.
+- A virtual key scoped to tenant A + a body that declares tenant B
+  returns 403 with a structured reason (via
+  ``check_tenant_body_conflict``).
+- An unscoped virtual key allows the body to declare any tenant.
+
+The unit-level helpers in ``voicegateway/core/auth.py`` are exercised
+directly without spinning up a FastAPI app where possible.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.auth import (
+    AuthError,
+    check_tenant_body_conflict,
+    is_virtual_key_token,
+    verify_virtual_key,
+)
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+from voicegateway.storage import virtual_keys_repo
+
+_BASE_CONFIG = {
+    "providers": {
+        "openai": {"api_key": "test-key"},
+        "deepgram": {"api_key": "test-key"},
+    },
+    "models": {
+        "stt": {"deepgram/nova-3": {"provider": "deepgram", "model": "nova-3"}},
+        "llm": {"openai/gpt-4o-mini": {"provider": "openai", "model": "gpt-4o-mini"}},
+        "tts": {},
+    },
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+
+def _write_config(tmp_path):
+    path = tmp_path / "voicegw.yaml"
+    with open(path, "w") as f:
+        yaml.dump(_BASE_CONFIG, f)
+    return str(path)
+
+
+@pytest.fixture
+def gateway(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "vk_auth.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    return Gateway(config_path=_write_config(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Unit: helpers in voicegateway/core/auth.py
+# ---------------------------------------------------------------------------
+
+
+def test_is_virtual_key_token_recognizes_vk_prefix():
+    assert is_virtual_key_token("Bearer vk_AABBCCDDEEFFGG") is True
+    assert is_virtual_key_token("Bearer sk_anything") is False
+    assert is_virtual_key_token("Bearer ") is False
+    assert is_virtual_key_token(None) is False
+    assert is_virtual_key_token("vk_AABBCCDDEEFFGG") is False  # missing Bearer
+
+
+def test_check_tenant_body_conflict_allows_when_either_none():
+    check_tenant_body_conflict(key_tenant_id=None, body_tenant_id="acme")
+    check_tenant_body_conflict(key_tenant_id="acme", body_tenant_id=None)
+    check_tenant_body_conflict(key_tenant_id=None, body_tenant_id=None)
+
+
+def test_check_tenant_body_conflict_allows_matching():
+    check_tenant_body_conflict(key_tenant_id="acme", body_tenant_id="acme")
+
+
+def test_check_tenant_body_conflict_rejects_mismatch():
+    with pytest.raises(AuthError) as ei:
+        check_tenant_body_conflict(key_tenant_id="acme", body_tenant_id="beta")
+    assert ei.value.status_code == 403
+    assert "acme" in ei.value.message
+    assert "beta" in ei.value.message
+
+
+async def test_verify_virtual_key_returns_verified_key(gateway):
+    db = await gateway.storage._ensure_initialized()
+    created = await virtual_keys_repo.create_virtual_key(
+        db, name="bot", tenant_id="acme"
+    )
+    verified = await verify_virtual_key(f"Bearer {created.plaintext}", db)
+    assert verified.id == created.id
+    assert verified.tenant_id == "acme"
+
+
+async def test_verify_virtual_key_rejects_revoked(gateway):
+    db = await gateway.storage._ensure_initialized()
+    created = await virtual_keys_repo.create_virtual_key(db, name="bot")
+    await virtual_keys_repo.revoke(db, created.id)
+
+    with pytest.raises(AuthError) as ei:
+        await verify_virtual_key(f"Bearer {created.plaintext}", db)
+    assert ei.value.status_code == 401
+
+
+async def test_verify_virtual_key_rejects_non_vk_prefix(gateway):
+    db = await gateway.storage._ensure_initialized()
+    with pytest.raises(AuthError):
+        await verify_virtual_key("Bearer sk-static", db)
+
+
+async def test_verify_virtual_key_rejects_missing_header(gateway):
+    db = await gateway.storage._ensure_initialized()
+    with pytest.raises(AuthError) as ei:
+        await verify_virtual_key(None, db)
+    assert ei.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: middleware flow against the FastAPI app
+# ---------------------------------------------------------------------------
+
+
+async def _client(gw: Gateway):
+    app = build_app(gw)
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+async def test_virtual_key_authenticates_write_request(gateway):
+    """A valid scoped virtual key satisfies the write dep."""
+    db = await gateway.storage._ensure_initialized()
+    created = await virtual_keys_repo.create_virtual_key(
+        db, name="bot", tenant_id="acme"
+    )
+
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.post(
+            "/v1/providers",
+            headers={"Authorization": f"Bearer {created.plaintext}"},
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        # /v1/providers requires the write scope. The vk_ path satisfies
+        # every scope in v0.4.0 (RBAC scopes on vk are out of scope).
+        assert resp.status_code == 200
+
+
+async def test_virtual_key_revoked_returns_401(gateway):
+    db = await gateway.storage._ensure_initialized()
+    created = await virtual_keys_repo.create_virtual_key(db, name="bot")
+    await virtual_keys_repo.revoke(db, created.id)
+
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.post(
+            "/v1/providers",
+            headers={"Authorization": f"Bearer {created.plaintext}"},
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+        # The auth block isn't enforced (no api_keys configured) so a
+        # revoked vk_ falls through? No — the middleware short-circuits
+        # on vk_ prefix detection and rejects revoked keys directly.
+        assert resp.status_code == 401
+
+
+async def test_virtual_key_marks_last_used(gateway):
+    """Successful verify bumps last_used_at via mark_used."""
+    db = await gateway.storage._ensure_initialized()
+    created = await virtual_keys_repo.create_virtual_key(db, name="bot")
+    assert created.row.last_used_at is None
+
+    client = await _client(gateway)
+    async with client as c:
+        await c.post(
+            "/v1/providers",
+            headers={"Authorization": f"Bearer {created.plaintext}"},
+            json={"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""},
+        )
+
+    # Re-read the row through a fresh connection (the middleware ran
+    # mark_used on its own connection; tests run in the same async
+    # context so the commit is visible).
+    db2 = await gateway.storage._ensure_initialized()
+    row = await virtual_keys_repo.get_by_id(db2, created.id)
+    assert row is not None
+    assert row.last_used_at is not None
+
+
+async def test_unscoped_virtual_key_does_not_force_tenant(gateway):
+    """check_tenant_body_conflict with key_tenant=None lets body pick."""
+    db = await gateway.storage._ensure_initialized()
+    await virtual_keys_repo.create_virtual_key(db, name="unscoped")
+
+    # Helper-level check; no app exercise needed because the unscoped
+    # behavior is enforced inside check_tenant_body_conflict.
+    check_tenant_body_conflict(key_tenant_id=None, body_tenant_id="anything")

--- a/tests/storage/test_sessions_table.py
+++ b/tests/storage/test_sessions_table.py
@@ -91,6 +91,8 @@ async def test_sessions_columns_match_design(tmp_path):
         "talk_over_rate",
         # v0.3.0 replay storage column (added by migration 0004).
         "replay_size_bytes",
+        # v0.4.0 tenant attribution column (added by migration 0005).
+        "tenant_id",
     }
 
     # Required keys (NOT NULL).

--- a/tests/storage/test_tenant_migration.py
+++ b/tests/storage/test_tenant_migration.py
@@ -1,0 +1,169 @@
+"""Contract tests for migration 0005 (tenant_id columns + virtual_keys table).
+
+Covers REQ-VG-TENANT-001 (tenant_id on every cost / metric / replay
+row) and REQ-VG-TENANT-003 (virtual_keys table). Two scenarios:
+
+- v0.0.5-only baseline: migrations 0003 and 0004 have not run, so the
+  ``turns`` / ``dead_air_events`` / ``replay_*`` tables don't exist
+  yet. Migration 0005 must skip the conditional ALTERs silently (OQ4
+  lock).
+- Fully-migrated baseline: every prior migration has run, so the
+  conditional ALTERs land tenant_id on the derived tables.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import aiosqlite
+
+from voicegateway.storage.sqlite import SQLiteStorage
+
+_migration = import_module("voicegateway.storage.migrations.0005_tenant_attribution")
+
+
+async def test_creates_virtual_keys_table(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='virtual_keys'"
+        )
+        assert await cur.fetchone() is not None
+
+
+async def test_virtual_keys_columns_match_design(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute("PRAGMA table_info(virtual_keys)")
+        cols = {row[1] async for row in cur}
+
+    assert cols == {
+        "id",
+        "key_prefix",
+        "key_hash",
+        "name",
+        "tenant_id",
+        "issued_by",
+        "issued_at",
+        "last_used_at",
+        "revoked_at",
+    }
+
+
+async def test_virtual_keys_indexes_present(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='virtual_keys'"
+        )
+        names = {row[0] async for row in cur}
+
+    assert "idx_virtual_keys_prefix" in names
+    assert "idx_virtual_keys_tenant_id" in names
+
+
+async def test_adds_tenant_id_to_baseline_tables(tmp_path) -> None:
+    """sessions and requests get tenant_id unconditionally (v0.0.5 baseline)."""
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        for table in ("sessions", "requests"):
+            cur = await db.execute(f"PRAGMA table_info({table})")
+            cols = {row[1] async for row in cur}
+            assert "tenant_id" in cols, f"{table}.tenant_id missing"
+
+
+async def test_adds_tenant_id_to_derived_tables(tmp_path) -> None:
+    """turns, dead_air_events, and replay_* get tenant_id when present."""
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        for table in (
+            "turns",
+            "dead_air_events",
+            "replay_stt_events",
+            "replay_llm_tokens",
+            "replay_tts_frames",
+            "replay_state_snapshots",
+        ):
+            cur = await db.execute(f"PRAGMA table_info({table})")
+            cols = {row[1] async for row in cur}
+            assert "tenant_id" in cols, f"{table}.tenant_id missing"
+
+
+async def test_is_idempotent(tmp_path) -> None:
+    """Re-running the migration on an already-migrated DB is a no-op."""
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        # Re-apply manually; should not raise on duplicate column adds.
+        await _migration.apply(db)
+        await db.commit()
+
+        # Verify the column is still exactly one column, not duplicated.
+        cur = await db.execute("PRAGMA table_info(sessions)")
+        tenant_cols = [row for row in await cur.fetchall() if row[1] == "tenant_id"]
+        assert len(tenant_cols) == 1
+
+
+async def test_v005_baseline_skips_missing_tables(tmp_path) -> None:
+    """OQ4: ALTERs on absent v0.2.0/v0.3.0 tables don't error."""
+    db_path = str(tmp_path / "v005.db")
+
+    # Build a v0.0.5-only baseline by hand: sessions + requests, no
+    # turns / dead_air / replay_* tables. Then run migration 0005
+    # directly and verify it doesn't raise.
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, project TEXT)")
+        await db.execute("CREATE TABLE requests (id TEXT PRIMARY KEY, project TEXT)")
+        await db.commit()
+
+        await _migration.apply(db)
+        await db.commit()
+
+        cur = await db.execute("PRAGMA table_info(sessions)")
+        cols = {row[1] async for row in cur}
+        assert "tenant_id" in cols
+
+        cur = await db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='turns'"
+        )
+        assert await cur.fetchone() is None  # Still absent; ALTER was skipped.
+
+
+async def test_preexisting_rows_get_null_tenant_id(tmp_path) -> None:
+    """OQ3: no backfill; pre-v0.4.0 sessions stay NULL."""
+    db_path = str(tmp_path / "with_rows.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    # Insert a row via the public API path (RequestRecord -> log_request
+    # would also stamp tenant from ContextVar; this insert simulates a
+    # pre-v0.4.0 row that pre-dates the ContextVar layer).
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO sessions (id, project, started_at, ended_at, "
+            "modalities, total_cost_usd, request_count) "
+            "VALUES ('legacy', 'default', '2026-01-01T00:00', NULL, '', 0.0, 0)"
+        )
+        await db.commit()
+        cur = await db.execute("SELECT tenant_id FROM sessions WHERE id = 'legacy'")
+        row = await cur.fetchone()
+        assert row is not None
+        assert row[0] is None

--- a/tests/storage/test_tenants_repo.py
+++ b/tests/storage/test_tenants_repo.py
@@ -1,0 +1,214 @@
+"""Tests for ``tenants_repo`` (REQ-VG-TENANT-002).
+
+Covers the tenant index aggregates, typeahead substring search with
+literal ``%`` / ``_`` escaping, count helper, and the unattributed
+bucket aggregator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.storage import tenants_repo as tr
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def db(tmp_path):
+    storage = SQLiteStorage(db_path=str(tmp_path / "tenants.db"))
+    conn = await storage._ensure_initialized()
+    yield conn
+
+
+async def _seed(db, rows):
+    """Insert pre-baked session rows."""
+    await db.executemany(
+        "INSERT INTO sessions (id, project, started_at, ended_at, "
+        "modalities, total_cost_usd, request_count, tenant_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    await db.commit()
+
+
+async def test_list_tenants_aggregates_per_tenant(db) -> None:
+    await _seed(
+        db,
+        [
+            (
+                "s1",
+                "default",
+                "2026-05-01T10:00",
+                "2026-05-01T10:05",
+                "stt",
+                0.5,
+                3,
+                "acme",
+            ),
+            (
+                "s2",
+                "default",
+                "2026-05-02T11:00",
+                "2026-05-02T11:02",
+                "tts",
+                0.1,
+                1,
+                "acme",
+            ),
+            (
+                "s3",
+                "default",
+                "2026-05-03T09:00",
+                "2026-05-03T09:30",
+                "llm",
+                1.25,
+                5,
+                "beta",
+            ),
+        ],
+    )
+    rows = await tr.list_tenants(db)
+    by_tenant = {r.tenant_id: r for r in rows}
+    assert by_tenant["acme"].session_count == 2
+    assert by_tenant["acme"].total_cost_usd == pytest.approx(0.6)
+    assert by_tenant["beta"].session_count == 1
+    assert by_tenant["beta"].total_cost_usd == pytest.approx(1.25)
+
+
+async def test_list_tenants_orders_by_last_seen_desc(db) -> None:
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", "2026-05-01T10:05", "x", 0.0, 0, "older"),
+            ("s2", "p", "2026-05-03T09:00", "2026-05-03T09:30", "x", 0.0, 0, "newest"),
+            ("s3", "p", "2026-05-02T11:00", "2026-05-02T11:02", "x", 0.0, 0, "middle"),
+        ],
+    )
+    rows = await tr.list_tenants(db)
+    assert [r.tenant_id for r in rows] == ["newest", "middle", "older"]
+
+
+async def test_list_tenants_excludes_unattributed_bucket(db) -> None:
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", None, "x", 0.0, 0, None),
+            ("s2", "p", "2026-05-02T11:00", None, "x", 0.0, 0, "acme"),
+        ],
+    )
+    rows = await tr.list_tenants(db)
+    assert [r.tenant_id for r in rows] == ["acme"]
+
+
+async def test_list_tenants_substring_query(db) -> None:
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", None, "x", 0.0, 0, "acme-prod"),
+            ("s2", "p", "2026-05-02T10:00", None, "x", 0.0, 0, "acme-staging"),
+            ("s3", "p", "2026-05-03T10:00", None, "x", 0.0, 0, "beta-prod"),
+        ],
+    )
+    acme_only = await tr.list_tenants(db, query="acme")
+    assert {r.tenant_id for r in acme_only} == {"acme-prod", "acme-staging"}
+
+    prod_only = await tr.list_tenants(db, query="prod")
+    assert {r.tenant_id for r in prod_only} == {"acme-prod", "beta-prod"}
+
+
+async def test_list_tenants_query_escapes_percent_literal(db) -> None:
+    """A user typing '%' should NOT match every tenant (no wildcard expansion)."""
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", None, "x", 0.0, 0, "acme"),
+            ("s2", "p", "2026-05-02T10:00", None, "x", 0.0, 0, "beta"),
+        ],
+    )
+    rows = await tr.list_tenants(db, query="%")
+    assert rows == []
+
+
+async def test_list_tenants_query_escapes_underscore_literal(db) -> None:
+    """'_' should NOT match any single character."""
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", None, "x", 0.0, 0, "ab"),
+            ("s2", "p", "2026-05-02T10:00", None, "x", 0.0, 0, "ac"),
+            ("s3", "p", "2026-05-03T10:00", None, "x", 0.0, 0, "a_c"),
+        ],
+    )
+    rows = await tr.list_tenants(db, query="_")
+    assert {r.tenant_id for r in rows} == {"a_c"}
+
+
+async def test_list_tenants_limit_clamped(db) -> None:
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", None, "x", 0.0, 0, "t1"),
+            ("s2", "p", "2026-05-02T10:00", None, "x", 0.0, 0, "t2"),
+            ("s3", "p", "2026-05-03T10:00", None, "x", 0.0, 0, "t3"),
+        ],
+    )
+    rows = await tr.list_tenants(db, limit=2)
+    assert len(rows) == 2
+
+    # Zero or negative clamps to 1.
+    rows = await tr.list_tenants(db, limit=0)
+    assert len(rows) == 1
+
+
+async def test_get_tenant_returns_single_row(db) -> None:
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", "2026-05-01T10:05", "x", 0.5, 3, "acme"),
+            ("s2", "p", "2026-05-02T11:00", "2026-05-02T11:02", "x", 0.1, 1, "acme"),
+        ],
+    )
+    row = await tr.get_tenant(db, "acme")
+    assert row is not None
+    assert row.session_count == 2
+    assert row.total_cost_usd == pytest.approx(0.6)
+
+
+async def test_get_tenant_returns_none_when_unseen(db) -> None:
+    assert await tr.get_tenant(db, "missing") is None
+
+
+async def test_count_tenants(db) -> None:
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", None, "x", 0.0, 0, "acme"),
+            ("s2", "p", "2026-05-02T10:00", None, "x", 0.0, 0, "beta"),
+            ("s3", "p", "2026-05-03T10:00", None, "x", 0.0, 0, "acme"),  # dup
+            ("s4", "p", "2026-05-04T10:00", None, "x", 0.0, 0, None),  # unattributed
+        ],
+    )
+    assert await tr.count_tenants(db) == 2
+
+
+async def test_get_unattributed_aggregates(db) -> None:
+    await _seed(
+        db,
+        [
+            ("s1", "p", "2026-05-01T10:00", "2026-05-01T10:05", "x", 0.05, 1, None),
+            ("s2", "p", "2026-05-02T11:00", None, "x", 0.02, 1, None),
+            ("s3", "p", "2026-05-03T11:00", None, "x", 0.10, 1, "acme"),
+        ],
+    )
+    u = await tr.get_unattributed_aggregates(db)
+    assert u.session_count == 2
+    assert u.total_cost_usd == pytest.approx(0.07)
+
+
+async def test_get_unattributed_aggregates_zero_defaults(db) -> None:
+    """Empty bucket returns sane defaults (session_count=0, cost=0.0)."""
+    u = await tr.get_unattributed_aggregates(db)
+    assert u.session_count == 0
+    assert u.total_cost_usd == 0.0
+    assert u.first_seen is None
+    assert u.last_seen is None

--- a/tests/storage/test_virtual_keys_repo.py
+++ b/tests/storage/test_virtual_keys_repo.py
@@ -1,0 +1,169 @@
+"""Tests for ``virtual_keys_repo`` (REQ-VG-TENANT-003).
+
+Covers issuance + hash-and-verify round-trip, soft revoke (OQ5), stale
+detection, and the invariant that list responses never carry the
+bcrypt hash or the plaintext key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.storage import virtual_keys_repo as vk
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def db(tmp_path):
+    storage = SQLiteStorage(db_path=str(tmp_path / "vk.db"))
+    conn = await storage._ensure_initialized()
+    yield conn
+
+
+async def test_issuance_returns_plaintext_once(db) -> None:
+    created = await vk.create_virtual_key(
+        db, name="prod-bot", tenant_id="acme", issued_by="ops@vg"
+    )
+    assert created.plaintext.startswith("vk_")
+    assert len(created.plaintext) == 35  # vk_ + 32 base32 chars
+    assert created.row.key_prefix == created.plaintext[:8]
+    assert created.row.name == "prod-bot"
+    assert created.row.tenant_id == "acme"
+    assert created.row.issued_by == "ops@vg"
+
+
+async def test_verify_round_trip_returns_id_and_tenant(db) -> None:
+    created = await vk.create_virtual_key(db, name="bot", tenant_id="acme")
+    verified = await vk.verify(db, created.plaintext)
+    assert verified is not None
+    assert verified.id == created.id
+    assert verified.tenant_id == "acme"
+    assert verified.name == "bot"
+
+
+async def test_verify_rejects_non_vk_prefix(db) -> None:
+    assert await vk.verify(db, "sk-not-a-vk") is None
+    assert await vk.verify(db, "") is None
+
+
+async def test_verify_rejects_unknown_key(db) -> None:
+    # Same prefix shape, different secret.
+    assert await vk.verify(db, "vk_BADKEY" + "A" * 28) is None
+
+
+async def test_verify_rejects_revoked_key(db) -> None:
+    created = await vk.create_virtual_key(db, name="bot")
+    assert await vk.verify(db, created.plaintext) is not None
+    assert await vk.revoke(db, created.id) is True
+    assert await vk.verify(db, created.plaintext) is None
+
+
+async def test_revoke_is_idempotent_observable(db) -> None:
+    created = await vk.create_virtual_key(db, name="bot")
+    assert await vk.revoke(db, created.id) is True
+    # Second revoke returns False because the row is already revoked.
+    assert await vk.revoke(db, created.id) is False
+
+
+async def test_revoke_keeps_row_for_audit(db) -> None:
+    """OQ5: soft revoke writes revoked_at, does not delete the row."""
+    created = await vk.create_virtual_key(db, name="bot")
+    await vk.revoke(db, created.id)
+    row = await vk.get_by_id(db, created.id)
+    assert row is not None
+    assert row.revoked_at is not None
+
+
+async def test_mark_used_updates_last_used_at(db) -> None:
+    created = await vk.create_virtual_key(db, name="bot")
+    assert created.row.last_used_at is None
+    await vk.mark_used(db, created.id)
+    refreshed = await vk.get_by_id(db, created.id)
+    assert refreshed is not None
+    assert refreshed.last_used_at is not None
+
+
+async def test_list_keys_excludes_plaintext_and_hash(db) -> None:
+    """The VirtualKeyRow dataclass intentionally drops ``key_hash``."""
+    await vk.create_virtual_key(db, name="bot1", tenant_id="acme")
+    await vk.create_virtual_key(db, name="bot2")
+    rows = await vk.list_keys(db)
+    assert len(rows) == 2
+    for row in rows:
+        # Dataclass has no ``key_hash`` field.
+        assert not hasattr(row, "key_hash")
+        # Dataclass has no ``plaintext`` field.
+        assert not hasattr(row, "plaintext")
+
+
+async def test_list_keys_filter_revoked(db) -> None:
+    active = await vk.create_virtual_key(db, name="active")
+    revoked = await vk.create_virtual_key(db, name="revoked")
+    await vk.revoke(db, revoked.id)
+
+    all_rows = await vk.list_keys(db, include_revoked=True)
+    assert {r.id for r in all_rows} == {active.id, revoked.id}
+
+    only_active = await vk.list_keys(db, include_revoked=False)
+    assert {r.id for r in only_active} == {active.id}
+
+
+async def test_unscoped_key_has_null_tenant(db) -> None:
+    created = await vk.create_virtual_key(db, name="unscoped")
+    assert created.row.tenant_id is None
+    verified = await vk.verify(db, created.plaintext)
+    assert verified is not None
+    assert verified.tenant_id is None
+
+
+async def test_list_stale_includes_never_used_keys(db) -> None:
+    """Issued-but-never-used keys past the cutoff are stale."""
+    await vk.create_virtual_key(db, name="brand-new")
+
+    # ``stale_after_days=0`` means anything issued at or before "now"
+    # is considered stale, which captures the just-created row.
+    stale = await vk.list_stale(db, stale_after_days=0)
+    assert len(stale) == 1
+    assert stale[0].name == "brand-new"
+
+
+async def test_list_stale_excludes_recently_used_keys(db) -> None:
+    created = await vk.create_virtual_key(db, name="busy")
+    await vk.mark_used(db, created.id)
+
+    # 365-day threshold means nothing should be stale yet.
+    stale = await vk.list_stale(db, stale_after_days=365)
+    assert len(stale) == 0
+
+
+async def test_list_stale_excludes_revoked_keys(db) -> None:
+    created = await vk.create_virtual_key(db, name="dead")
+    await vk.revoke(db, created.id)
+    stale = await vk.list_stale(db, stale_after_days=0)
+    assert len(stale) == 0
+
+
+async def test_list_stale_rejects_negative_threshold(db) -> None:
+    with pytest.raises(ValueError):
+        await vk.list_stale(db, stale_after_days=-1)
+
+
+async def test_create_rejects_empty_name(db) -> None:
+    with pytest.raises(ValueError):
+        await vk.create_virtual_key(db, name="")
+
+
+async def test_get_by_id_returns_none_for_missing(db) -> None:
+    assert await vk.get_by_id(db, 999999) is None
+
+
+async def test_two_keys_with_same_tenant_independent(db) -> None:
+    a = await vk.create_virtual_key(db, name="a", tenant_id="acme")
+    b = await vk.create_virtual_key(db, name="b", tenant_id="acme")
+    assert a.plaintext != b.plaintext
+    assert a.row.key_prefix != b.row.key_prefix or a.plaintext != b.plaintext
+
+    # Revoking one does not affect the other.
+    await vk.revoke(db, a.id)
+    assert await vk.verify(db, a.plaintext) is None
+    assert await vk.verify(db, b.plaintext) is not None

--- a/voicegateway/cli/__init__.py
+++ b/voicegateway/cli/__init__.py
@@ -50,6 +50,7 @@ from voicegateway.cli import rotate_secret as _rotate_secret  # noqa: F401, E402
 from voicegateway.cli import serve as _serve  # noqa: F401, E402
 from voicegateway.cli import smoke_test as _smoke_test  # noqa: F401, E402
 from voicegateway.cli import status as _status  # noqa: F401, E402
+from voicegateway.cli import tenant as _tenant  # noqa: F401, E402
 from voicegateway.cli import tui as _tui  # noqa: F401, E402
 
 # Single source of truth for both ``app`` (the Typer instance every

--- a/voicegateway/cli/tenant.py
+++ b/voicegateway/cli/tenant.py
@@ -1,0 +1,204 @@
+"""``voicegw tenant`` command group: read-only tenant index for CI scripts.
+
+Implements REQ-VG-TENANT-002 from a non-dashboard surface. Two
+subcommands:
+
+* ``voicegw tenant list`` — print the tenant index with session count,
+  total cost, and first/last-seen timestamps. Optional ``--json`` for
+  machine consumption.
+* ``voicegw tenant show <id>`` — print the aggregates for a single
+  tenant. ``--json`` available.
+
+Issuing virtual keys is intentionally NOT in scope here: the Foundry
+locks key issuance to the dashboard (REQ-VG-TENANT-003 AC-2 requires
+the "show key once" modal, which a CLI can't reproduce safely). The
+CLI exists so deployment scripts and CI checks can query attribution
+state without spinning up the dashboard.
+
+Path correction note: the Foundry's text listed
+``voicegw/cli/tenant.py`` (same typo it carried for v0.3.0/T15's
+``replay`` command). The file lives at ``voicegateway/cli/tenant.py``
+per the actual layout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import typer
+
+from voicegateway.cli._app import app, console
+from voicegateway.cli._helpers import _load_gateway
+
+# Subcommand group: ``voicegw tenant <subcommand>``.
+tenant_app = typer.Typer(
+    name="tenant",
+    help="Read-only tenant index for CI scripts. Use the dashboard to issue keys.",
+    no_args_is_help=True,
+)
+app.add_typer(tenant_app, name="tenant")
+
+
+def _format_relative(iso: str | None) -> str:
+    """Return ``iso`` verbatim or ``-`` when ``None``.
+
+    CLI consumers prefer the exact ISO timestamp over a "5 days ago"
+    rendering because they pipe the output into scripts. The
+    dashboard's relative formatting is a UI affordance, not a CLI
+    one.
+    """
+    return iso if iso else "-"
+
+
+async def _list_tenants_async(
+    storage: Any, *, limit: int, query: str | None
+) -> tuple[list[Any], Any]:
+    """Run ``tenants_repo.list_tenants`` + the unattributed aggregator."""
+    from voicegateway.storage import tenants_repo
+
+    db = await storage._ensure_initialized()
+    rows = await tenants_repo.list_tenants(db, limit=limit, query=query)
+    unattributed = await tenants_repo.get_unattributed_aggregates(db)
+    return rows, unattributed
+
+
+async def _get_tenant_async(storage: Any, tenant_id: str) -> Any:
+    from voicegateway.storage import tenants_repo
+
+    db = await storage._ensure_initialized()
+    return await tenants_repo.get_tenant(db, tenant_id)
+
+
+@tenant_app.command("list")
+def list_cmd(
+    config: str | None = typer.Option(
+        None, "--config", "-c", help="Path to voicegw.yaml."
+    ),
+    limit: int = typer.Option(
+        50, "--limit", "-n", min=1, max=1000, help="Max tenants to list."
+    ),
+    query: str | None = typer.Option(
+        None, "--query", "-q", help="Substring filter on tenant_id."
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Print one JSON object per call instead of a table."
+    ),
+) -> None:
+    """List tenants ordered by most-recently-active."""
+    gw = _load_gateway(config)
+    if gw.storage is None:
+        console.print(
+            "[red]Storage backend not configured (cost_tracking.db_path).[/red]"
+        )
+        raise typer.Exit(1)
+
+    rows, unattributed = asyncio.run(
+        _list_tenants_async(gw.storage, limit=limit, query=query),
+    )
+
+    if json_output:
+        payload = {
+            "tenants": [
+                {
+                    "tenant_id": r.tenant_id,
+                    "session_count": r.session_count,
+                    "total_cost_usd": r.total_cost_usd,
+                    "first_seen": r.first_seen,
+                    "last_seen": r.last_seen,
+                }
+                for r in rows
+            ],
+            "unattributed": {
+                "session_count": unattributed.session_count,
+                "total_cost_usd": unattributed.total_cost_usd,
+                "first_seen": unattributed.first_seen,
+                "last_seen": unattributed.last_seen,
+            },
+        }
+        # ensure_ascii=False so tenant names with unicode (the OQ2
+        # cap is 128-char UTF-8) round-trip cleanly.
+        typer.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
+
+    if not rows and unattributed.session_count == 0:
+        console.print("[dim]No tenants seen yet.[/dim]")
+        return
+
+    console.print("[bold]Tenants[/bold]")
+    if rows:
+        console.print(
+            f"{'TENANT':<32} {'SESSIONS':>10} {'COST USD':>12} {'LAST SEEN':<28}"
+        )
+        console.print("-" * 84)
+        for r in rows:
+            tenant_display = (
+                r.tenant_id if len(r.tenant_id) <= 31 else r.tenant_id[:28] + "..."
+            )
+            console.print(
+                f"{tenant_display:<32} {r.session_count:>10} "
+                f"{r.total_cost_usd:>12.4f} {_format_relative(r.last_seen):<28}"
+            )
+    else:
+        console.print("[dim](no attributed tenants in the filtered window)[/dim]")
+
+    if unattributed.session_count > 0:
+        console.print(
+            f"\n[dim]Unattributed: {unattributed.session_count} session(s), "
+            f"${unattributed.total_cost_usd:.4f} total, "
+            f"last seen {_format_relative(unattributed.last_seen)}.[/dim]"
+        )
+
+
+@tenant_app.command("show")
+def show_cmd(
+    tenant_id: str = typer.Argument(..., help="Tenant id to look up."),
+    config: str | None = typer.Option(
+        None, "--config", "-c", help="Path to voicegw.yaml."
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Print a JSON object instead of a key-value list."
+    ),
+) -> None:
+    """Print aggregates for a single tenant. Exits 1 when unseen."""
+    if not tenant_id.strip():
+        console.print("[red]tenant_id is required.[/red]")
+        raise typer.Exit(2)
+
+    gw = _load_gateway(config)
+    if gw.storage is None:
+        console.print(
+            "[red]Storage backend not configured (cost_tracking.db_path).[/red]"
+        )
+        raise typer.Exit(1)
+
+    row = asyncio.run(_get_tenant_async(gw.storage, tenant_id))
+    if row is None:
+        console.print(f"[red]Tenant {tenant_id!r} has no sessions.[/red]")
+        raise typer.Exit(1)
+
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "tenant_id": row.tenant_id,
+                    "session_count": row.session_count,
+                    "total_cost_usd": row.total_cost_usd,
+                    "first_seen": row.first_seen,
+                    "last_seen": row.last_seen,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return
+
+    console.print(f"[bold]Tenant {row.tenant_id}[/bold]")
+    console.print(f"  Sessions:   {row.session_count}")
+    console.print(f"  Total cost: ${row.total_cost_usd:.4f}")
+    console.print(f"  First seen: {_format_relative(row.first_seen)}")
+    console.print(f"  Last seen:  {_format_relative(row.last_seen)}")
+
+
+__all__ = ["list_cmd", "show_cmd", "tenant_app"]

--- a/voicegateway/core/auth.py
+++ b/voicegateway/core/auth.py
@@ -20,7 +20,13 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import aiosqlite
+
     from voicegateway.core.config import AuthConfig
+    from voicegateway.storage.virtual_keys_repo import VerifiedKey
+
+
+_VIRTUAL_KEY_PREFIX = "vk_"
 
 logger = logging.getLogger(__name__)
 
@@ -89,9 +95,7 @@ def load_api_keys(auth_config: AuthConfig | None) -> list[ApiKey]:
     if not keys:
         env_token = os.environ.get(_ENV_KEY, "").strip()
         if env_token:
-            keys.append(
-                ApiKey(token=env_token, name="env", scopes=(_WILDCARD_SCOPE,))
-            )
+            keys.append(ApiKey(token=env_token, name="env", scopes=(_WILDCARD_SCOPE,)))
 
     return keys
 
@@ -181,12 +185,91 @@ def describe_auth(keys: list[ApiKey]) -> str:
     return f"auth: enabled ({len(keys)} key(s) configured)"
 
 
+def is_virtual_key_token(authorization: str | None) -> bool:
+    """Return True if the bearer token uses the ``vk_`` prefix (REQ-VG-TENANT-004).
+
+    Detection is by prefix only; the actual hash check happens in
+    :func:`verify_virtual_key`. This helper exists so the auth middleware
+    can short-circuit the static-key path without paying the bcrypt
+    cost when a static token is presented.
+    """
+    token = _extract_bearer(authorization)
+    return token is not None and token.startswith(_VIRTUAL_KEY_PREFIX)
+
+
+async def verify_virtual_key(
+    authorization: str | None, db: aiosqlite.Connection
+) -> VerifiedKey:
+    """Validate a ``Bearer vk_…`` header against ``virtual_keys``.
+
+    Returns the :class:`VerifiedKey` on success. Raises
+    :class:`AuthError` with status 401 on any failure (missing header,
+    wrong scheme, missing/wrong prefix, revoked, hash miss). Revocation
+    is filtered inside ``virtual_keys_repo.verify`` per OQ5, so this
+    helper does not need a separate check.
+
+    The caller is responsible for bumping ``last_used_at`` via
+    :func:`voicegateway.storage.virtual_keys_repo.mark_used` once it has
+    decided the request is otherwise acceptable; this function stays
+    side-effect-free so middleware can rate-limit failures without
+    accidentally bumping the timestamp.
+    """
+    from voicegateway.storage import virtual_keys_repo
+
+    token = _extract_bearer(authorization)
+    if token is None:
+        raise AuthError("Missing bearer token", status_code=401)
+    if not token.startswith(_VIRTUAL_KEY_PREFIX):
+        # Caller should have routed to ``check_request`` for static keys.
+        raise AuthError("Invalid virtual key", status_code=401)
+    verified = await virtual_keys_repo.verify(db, token)
+    if verified is None:
+        raise AuthError("Invalid virtual key", status_code=401)
+    return verified
+
+
+def check_tenant_body_conflict(
+    *, key_tenant_id: str | None, body_tenant_id: str | None
+) -> None:
+    """Reject when the body's tenant_id contradicts the key's scope.
+
+    Rules (REQ-VG-TENANT-004 AC):
+
+    - Key has no scope (``key_tenant_id is None``): any body
+      tenant_id is allowed. Used for unscoped virtual keys and for
+      static keys.
+    - Key scoped + body absent: allow (the key sets the tenant).
+    - Key scoped + body present + matches: allow (redundant but
+      legal).
+    - Key scoped + body present + differs: 403 with a structured
+      reason.
+
+    Raises :class:`AuthError(403)` on conflict; returns ``None`` on
+    pass.
+    """
+    if key_tenant_id is None or body_tenant_id is None:
+        return
+    if key_tenant_id == body_tenant_id:
+        return
+    raise AuthError(
+        (
+            "Virtual key is scoped to tenant "
+            f"{key_tenant_id!r} but request body declared tenant "
+            f"{body_tenant_id!r}"
+        ),
+        status_code=403,
+    )
+
+
 # Re-export so callers don't need to import __all__ separately.
 __all__ = [
     "ApiKey",
     "AuthError",
     "check_request",
+    "check_tenant_body_conflict",
     "describe_auth",
+    "is_virtual_key_token",
     "load_api_keys",
     "resolve_cors_origins",
+    "verify_virtual_key",
 ]

--- a/voicegateway/core/config.py
+++ b/voicegateway/core/config.py
@@ -83,6 +83,20 @@ class ReplayConfig:
 
 
 @dataclass
+class TenantConfig:
+    """v0.4.0 multi-tenant attribution knobs.
+
+    Per-project overridable via the ``tenant:`` block in ``voicegw.yaml``.
+    ``virtual_key_stale_days`` drives the dashboard's stale-key surface
+    (REQ-VG-TENANT-003): keys whose last_used_at (or issued_at, for
+    never-used keys) is older than this threshold are flagged in the
+    Virtual Keys page. The default matches the Foundry's "90 days" lock.
+    """
+
+    virtual_key_stale_days: int = 90
+
+
+@dataclass
 class ProjectConfig:
     """Configuration for a single project."""
 
@@ -103,6 +117,8 @@ class ProjectConfig:
     metrics: MetricsConfig = field(default_factory=MetricsConfig)
     # v0.3.0: per-project replay capture knobs (REQ-VG-REPLAY-001..006).
     replay: ReplayConfig = field(default_factory=ReplayConfig)
+    # v0.4.0: per-project multi-tenant knobs (REQ-VG-TENANT-003).
+    tenant: TenantConfig = field(default_factory=TenantConfig)
 
     @property
     def accent(self) -> str:
@@ -279,6 +295,12 @@ class GatewayConfig:
                     buffer_size_events=int(replay_raw.get("buffer_size_events", 5000)),
                     flush_size_events=int(replay_raw.get("flush_size_events", 500)),
                 )
+                tenant_raw = pcfg.get("tenant") or {}
+                tenant_cfg = TenantConfig(
+                    virtual_key_stale_days=int(
+                        tenant_raw.get("virtual_key_stale_days", 90)
+                    ),
+                )
                 projects[pid] = ProjectConfig(
                     id=pid,
                     name=str(pcfg.get("name") or pid),
@@ -290,6 +312,7 @@ class GatewayConfig:
                     providers=project_providers,
                     metrics=metrics_cfg,
                     replay=replay_cfg,
+                    tenant=tenant_cfg,
                 )
 
         auth_raw = raw.get("auth", {}) or {}

--- a/voicegateway/core/schema.py
+++ b/voicegateway/core/schema.py
@@ -69,6 +69,20 @@ class ReplayConfig(_StrictBase):
     flush_size_events: int = Field(default=500, ge=1)
 
 
+class TenantConfig(_StrictBase):
+    """v0.4.0 multi-tenant attribution knobs (REQ-VG-TENANT-001..004).
+
+    Per-project overridable via the ``tenant:`` block under each
+    project entry in ``voicegw.yaml``. ``virtual_key_stale_days``
+    drives the dashboard's stale-key surface (a key whose last_used_at
+    or issued_at is older than this threshold is flagged in the
+    Virtual Keys page); the default matches the Foundry's 90-day
+    lock.
+    """
+
+    virtual_key_stale_days: int = Field(default=90, ge=1)
+
+
 class ProjectConfig(_StrictBase):
     name: str
     description: str = ""
@@ -85,6 +99,8 @@ class ProjectConfig(_StrictBase):
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
     # v0.3.0: per-project replay capture + retention knobs.
     replay: ReplayConfig = Field(default_factory=ReplayConfig)
+    # v0.4.0: per-project multi-tenant knobs.
+    tenant: TenantConfig = Field(default_factory=TenantConfig)
 
 
 class ObservabilityConfig(_StrictBase):

--- a/voicegateway/inference/_session_attach.py
+++ b/voicegateway/inference/_session_attach.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 from voicegateway.inference._session_context import (
     get_or_create_session_id,
+    set_tenant,
 )
 
 if TYPE_CHECKING:
@@ -162,6 +163,7 @@ def attach_session(
     agent_session: Any,
     *,
     session_id: str | None = None,
+    tenant_id: str | None = None,
     turn_tracker: TurnTracker | None = None,
     dead_air_detector: DeadAirDetector | None = None,
     cost_tracker: CostTracker | None = None,
@@ -179,6 +181,15 @@ def attach_session(
     ``voicegateway.inference`` ContextVar carries (creating a fresh
     ``vg-<uuid>`` if there is none). Pass an explicit id when the caller
     has its own correlation key.
+
+    ``tenant_id`` (REQ-VG-TENANT-001) attributes every cost, metric,
+    and replay row stamped for this session to a tenant. When provided
+    here, the value is pushed onto ``tenant_id_ctx`` immediately so the
+    first ``log_request`` for the session picks it up. When omitted, the
+    ContextVar is left untouched: a scoped virtual key set earlier by
+    the auth middleware (T04) still wins, and an explicit
+    ``set_tenant(...)`` from the agent code also wins. Pass an empty
+    string or ``None`` to opt into the "unattributed" bucket.
 
     Returns the bound ``session_id`` so callers can echo it into their
     own logs.
@@ -206,6 +217,8 @@ def attach_session(
     ct = cost_tracker if cost_tracker is not None else _active_cost_tracker
 
     sid = session_id if session_id is not None else get_or_create_session_id()
+    if tenant_id is not None:
+        set_tenant(tenant_id)
 
     if tracker is None:
         logger.warning(

--- a/voicegateway/inference/_session_context.py
+++ b/voicegateway/inference/_session_context.py
@@ -29,9 +29,7 @@ from contextvars import ContextVar
 
 _SESSION_ID_PREFIX = "vg-"
 
-_current_session_id: ContextVar[str | None] = ContextVar(
-    "vg_session_id", default=None
-)
+_current_session_id: ContextVar[str | None] = ContextVar("vg_session_id", default=None)
 
 
 def get_or_create_session_id() -> str:
@@ -94,3 +92,62 @@ def reset_session_id() -> None:
     round-trip.
     """
     _current_session_id.set(None)
+
+
+# ----------------------------------------------------------------------
+# v0.4.0 tenant-id ContextVar (REQ-VG-TENANT-001).
+#
+# Parallel to the session_id ContextVar above. The auth middleware
+# sets this when a tenant-scoped virtual key authenticates a request;
+# the session-create path sets it when the caller passes an explicit
+# tenant identifier. Storage repos read ``current_tenant()`` at write
+# time and stamp the row's ``tenant_id`` column. NULL is treated as
+# "unattributed" at the dashboard layer (OQ3: no backfill).
+# ----------------------------------------------------------------------
+
+_TENANT_ID_MAX_LEN = 128  # OQ2 lock: 128-char UTF-8 cap.
+
+_current_tenant_id: ContextVar[str | None] = ContextVar("vg_tenant_id", default=None)
+
+
+def set_tenant(tenant_id: str | None) -> None:
+    """Set the current tenant identifier in the active context.
+
+    ``None`` clears the value (back to the implicit "unattributed"
+    bucket). Non-string and over-length identifiers raise ``ValueError``
+    to surface misuse at the call site rather than at storage write
+    time (OQ2: 128-char UTF-8 cap, otherwise no constraints).
+    """
+    if tenant_id is None:
+        _current_tenant_id.set(None)
+        return
+    if not isinstance(tenant_id, str):
+        raise ValueError(
+            f"tenant_id must be a str or None, got {type(tenant_id).__name__}"
+        )
+    if len(tenant_id) > _TENANT_ID_MAX_LEN:
+        raise ValueError(
+            f"tenant_id length {len(tenant_id)} exceeds {_TENANT_ID_MAX_LEN} "
+            f"char cap (OQ2 lock)"
+        )
+    _current_tenant_id.set(tenant_id)
+
+
+def current_tenant() -> str | None:
+    """Return the current tenant identifier, or ``None`` when unset.
+
+    Storage repos call this at write time. NULL on the row signals
+    "unattributed" to the dashboard's tenant filter (REQ-VG-TENANT-001
+    AC-3).
+    """
+    return _current_tenant_id.get()
+
+
+def reset_tenant_id() -> None:
+    """Clear the tenant identifier in the current context.
+
+    Test-only helper; production resets happen via the
+    contextvars.Token returned by ``set_tenant`` or by spawning a
+    fresh asyncio task. Mirrors the ``reset_session_id`` shape.
+    """
+    _current_tenant_id.set(None)

--- a/voicegateway/server/main.py
+++ b/voicegateway/server/main.py
@@ -59,7 +59,7 @@ def build_app(gateway: Gateway) -> FastAPI:
     """Build a FastAPI app bound to the given Gateway instance."""
     app = FastAPI(
         title="VoiceGateway API",
-        version="0.3.0",
+        version="0.4.0",
         description="HTTP API for VoiceGateway: cost tracking and reconciliation for LiveKit voice agents.",
     )
 
@@ -148,7 +148,7 @@ def build_app(gateway: Gateway) -> FastAPI:
         return {
             "status": "ok",
             "uptime_seconds": round(time.time() - started_at, 1),
-            "version": "0.3.0",
+            "version": "0.4.0",
         }
 
     @app.get("/v1/status")

--- a/voicegateway/server/main.py
+++ b/voicegateway/server/main.py
@@ -21,10 +21,14 @@ from fastapi.responses import PlainTextResponse
 from voicegateway.core.auth import (
     AuthError,
     check_request,
+    is_virtual_key_token,
     load_api_keys,
     resolve_cors_origins,
+    verify_virtual_key,
 )
+from voicegateway.inference._session_context import set_tenant
 from voicegateway.pricing import catalog
+from voicegateway.storage import virtual_keys_repo
 from voicegateway.storage._percentiles import quantile_label
 
 if TYPE_CHECKING:
@@ -82,12 +86,49 @@ def build_app(gateway: Gateway) -> FastAPI:
     )
 
     def require_scope(scope: str):
-        """Return a FastAPI dependency enforcing ``scope`` on a request."""
+        """Return a FastAPI dependency enforcing ``scope`` on a request.
+
+        Two auth paths are supported (REQ-VG-TENANT-004):
+
+        - **Virtual keys** — bearer tokens starting with ``vk_`` are
+          resolved via :func:`virtual_keys_repo.verify`. On success the
+          row's ``tenant_id`` (if any) is stashed on
+          ``request.state.virtual_key_tenant_id`` for downstream
+          per-handler conflict checks (T05/T10), and the same value is
+          pushed onto the ``tenant_id_ctx`` ContextVar so any session
+          created inside the handler inherits the scope. ``last_used_at``
+          is bumped via :func:`virtual_keys_repo.mark_used`.
+        - **Static keys** — anything else falls through to the existing
+          :func:`check_request` path. Static keys are not associated
+          with a tenant and never set the ContextVar.
+
+        Scope enforcement for virtual keys is intentionally permissive
+        for v0.4.0: a verified virtual key satisfies every scope. The
+        scope dimension on virtual keys is out of scope for this
+        version (the Foundry's "scope" mention refers to tenant
+        scoping, not RBAC scopes).
+        """
 
         async def _dep(request: Request) -> None:
+            authorization = request.headers.get("Authorization")
+            if is_virtual_key_token(authorization) and gateway.storage is not None:
+                try:
+                    db = await gateway.storage._ensure_initialized()
+                    verified = await verify_virtual_key(authorization, db)
+                except AuthError as exc:
+                    raise HTTPException(
+                        status_code=exc.status_code, detail=exc.message
+                    ) from None
+                await virtual_keys_repo.mark_used(db, verified.id)
+                request.state.virtual_key_id = verified.id
+                request.state.virtual_key_tenant_id = verified.tenant_id
+                if verified.tenant_id is not None:
+                    set_tenant(verified.tenant_id)
+                return
+
             try:
                 check_request(
-                    request.headers.get("Authorization"),
+                    authorization,
                     scope,
                     api_keys,
                 )

--- a/voicegateway/storage/dead_air_repo.py
+++ b/voicegateway/storage/dead_air_repo.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from voicegateway.inference._session_context import current_tenant
 from voicegateway.middleware.dead_air_detector import DeadAirEvent
 
 if TYPE_CHECKING:
@@ -25,27 +26,39 @@ if TYPE_CHECKING:
 
 _INSERT_EVENT = (
     "INSERT INTO dead_air_events ("
-    "session_id, started_at_ms, duration_ms, threshold_used_ms"
-    ") VALUES (?, ?, ?, ?)"
+    "session_id, started_at_ms, duration_ms, threshold_used_ms, tenant_id"
+    ") VALUES (?, ?, ?, ?, ?)"
 )
 
 
-def _event_to_params(event: DeadAirEvent) -> tuple[object, ...]:
+def _event_to_params(event: DeadAirEvent, tenant_id: str | None) -> tuple[object, ...]:
     return (
         event.session_id,
         event.started_at_ms,
         event.duration_ms,
         event.threshold_used_ms,
+        tenant_id,
     )
 
 
-async def create_event(db: aiosqlite.Connection, event: DeadAirEvent) -> None:
+async def create_event(
+    db: aiosqlite.Connection,
+    event: DeadAirEvent,
+    *,
+    tenant_id: str | None = None,
+) -> None:
     """Insert one ``DeadAirEvent``. Commits the connection.
 
+    ``tenant_id`` defaults to ``current_tenant()`` (the v0.4.0
+    ContextVar). The dead-air watcher runs inside the session's
+    asyncio context, so the ContextVar carries the session's tenant
+    without any explicit wiring.
+
     Signature matches :data:`voicegateway.middleware.dead_air_detector.EventCallback`
-    so a partial application is the natural wiring (T08).
+    via a partial application that drops the tenant kwarg.
     """
-    await db.execute(_INSERT_EVENT, _event_to_params(event))
+    resolved = tenant_id if tenant_id is not None else current_tenant()
+    await db.execute(_INSERT_EVENT, _event_to_params(event, resolved))
     await db.commit()
 
 

--- a/voicegateway/storage/migrations/0005_tenant_attribution.py
+++ b/voicegateway/storage/migrations/0005_tenant_attribution.py
@@ -1,0 +1,119 @@
+"""Migration 0005: multi-tenant cost attribution.
+
+Introduced in v0.4.0 to back REQ-VG-TENANT-001 (tag sessions with a
+tenant dimension) and REQ-VG-TENANT-003 (issue virtual API keys).
+
+Idempotent. Re-running on an already-migrated database is a no-op:
+
+* ``CREATE TABLE IF NOT EXISTS virtual_keys`` and the index
+  ``CREATE INDEX IF NOT EXISTS`` guard themselves.
+* The ``ALTER TABLE ... ADD COLUMN tenant_id`` calls are guarded by a
+  ``PRAGMA table_info`` lookup per table.
+* The per-version-dependent ``ALTER``s (on ``turns``,
+  ``dead_air_events``, and the four ``replay_*`` tables) are
+  additionally guarded by a ``sqlite_master`` presence check, so the
+  migration is safe on any v0.0.5+ baseline (v0.0.5-only installs
+  skip the v0.2.0 and v0.3.0 table ALTERs silently). This matches the
+  Foundry's OQ4 resolution.
+
+Pre-v0.4.0 rows in every table keep ``tenant_id = NULL``. The dashboard
+renders NULL as "unattributed" with a muted style (REQ-VG-TENANT-001
+AC-3). No backfill to a literal string per OQ3.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+# Tables that get a `tenant_id TEXT NULL` column. The first two are
+# v0.0.5 baseline; the remainder are conditional on prior migrations
+# having shipped (turns/dead_air -> migration 0003; replay_* -> 0004).
+_BASELINE_TENANT_TABLES = ("sessions", "requests")
+_CONDITIONAL_TENANT_TABLES = (
+    "turns",
+    "dead_air_events",
+    "replay_stt_events",
+    "replay_llm_tokens",
+    "replay_tts_frames",
+    "replay_state_snapshots",
+)
+
+
+_VIRTUAL_KEYS_DDL = """
+CREATE TABLE IF NOT EXISTS virtual_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    key_prefix TEXT NOT NULL,
+    key_hash TEXT NOT NULL,
+    name TEXT NOT NULL,
+    tenant_id TEXT,
+    issued_by TEXT,
+    issued_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at TEXT,
+    revoked_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_virtual_keys_prefix
+    ON virtual_keys(key_prefix);
+
+CREATE INDEX IF NOT EXISTS idx_virtual_keys_tenant_id
+    ON virtual_keys(tenant_id);
+"""
+
+
+async def _table_exists(db: aiosqlite.Connection, name: str) -> bool:
+    """Return True when ``name`` is a real table in this database."""
+    cursor = await db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (name,),
+    )
+    row = await cursor.fetchone()
+    return row is not None
+
+
+async def _add_tenant_id_column(db: aiosqlite.Connection, table: str) -> None:
+    """Add ``tenant_id TEXT`` to ``table`` if the column does not exist.
+
+    Caller has already verified the table exists; this helper only
+    runs the PRAGMA + ALTER pair.
+    """
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    existing = {row[1] async for row in cursor}
+    if "tenant_id" in existing:
+        return
+    await db.execute(f"ALTER TABLE {table} ADD COLUMN tenant_id TEXT")
+
+
+async def apply(db: aiosqlite.Connection) -> None:
+    """Apply migration 0005 against the given connection.
+
+    Steps:
+
+    1. Create the ``virtual_keys`` table + two indexes
+       (``key_prefix``, ``tenant_id``) via ``CREATE ... IF NOT EXISTS``.
+    2. Add ``tenant_id`` to the two v0.0.5 baseline tables
+       (``sessions``, ``requests``) unconditionally (they exist on
+       every v0.0.5+ install).
+    3. For each conditional table (``turns``, ``dead_air_events``,
+       the four ``replay_*`` tables), check ``sqlite_master`` first
+       and skip the ALTER if the table is absent. This is the OQ4
+       guard: v0.0.5-only installs that have not migrated through
+       0003 or 0004 don't error on the missing tables.
+
+    The caller is responsible for committing the transaction; the
+    sqlite.py ensure path commits after the migration chain runs.
+    """
+    await db.executescript(_VIRTUAL_KEYS_DDL)
+
+    for table in _BASELINE_TENANT_TABLES:
+        await _add_tenant_id_column(db, table)
+
+    for table in _CONDITIONAL_TENANT_TABLES:
+        if await _table_exists(db, table):
+            await _add_tenant_id_column(db, table)
+
+
+__all__ = ["apply"]

--- a/voicegateway/storage/replay_repo.py
+++ b/voicegateway/storage/replay_repo.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+from voicegateway.inference._session_context import current_tenant
 from voicegateway.middleware.replay_capture import ReplayEvent
 
 if TYPE_CHECKING:
@@ -39,23 +40,23 @@ _TABLE_BY_MODALITY: dict[str, str] = {
 _INSERT_BY_MODALITY: dict[str, str] = {
     "stt": (
         "INSERT INTO replay_stt_events "
-        "(session_id, t_ms, payload, provider, cost_usd) "
-        "VALUES (?, ?, ?, ?, ?)"
+        "(session_id, t_ms, payload, provider, cost_usd, tenant_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)"
     ),
     "llm": (
         "INSERT INTO replay_llm_tokens "
-        "(session_id, t_ms, payload, provider, cost_usd) "
-        "VALUES (?, ?, ?, ?, ?)"
+        "(session_id, t_ms, payload, provider, cost_usd, tenant_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)"
     ),
     "tts": (
         "INSERT INTO replay_tts_frames "
-        "(session_id, t_ms, payload, provider, cost_usd) "
-        "VALUES (?, ?, ?, ?, ?)"
+        "(session_id, t_ms, payload, provider, cost_usd, tenant_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)"
     ),
     "state": (
         "INSERT INTO replay_state_snapshots "
-        "(session_id, t_ms, payload) "
-        "VALUES (?, ?, ?)"
+        "(session_id, t_ms, payload, tenant_id) "
+        "VALUES (?, ?, ?, ?)"
     ),
 }
 
@@ -65,17 +66,29 @@ def _payload_to_text(payload: dict[str, Any]) -> str:
     return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
 
 
-async def bulk_write_events(db: aiosqlite.Connection, events: list[ReplayEvent]) -> int:
+async def bulk_write_events(
+    db: aiosqlite.Connection,
+    events: list[ReplayEvent],
+    *,
+    tenant_id: str | None = None,
+) -> int:
     """Bulk-insert events into their per-modality tables.
 
     Partitions by ``event.modality`` and runs one ``executemany`` per
     partition. Empty input is a no-op (returns 0). Commits the
     connection on success.
 
+    ``tenant_id`` defaults to ``current_tenant()`` (the v0.4.0
+    ContextVar) and is applied uniformly across every row of the
+    batch. Replay flushes are session-scoped (one session per
+    ReplayCapture buffer), so the contextvar carries the session's
+    tenant without per-event wiring.
+
     Returns the total number of events inserted across the four tables.
     """
     if not events:
         return 0
+    resolved = tenant_id if tenant_id is not None else current_tenant()
 
     by_modality: dict[str, list[tuple[Any, ...]]] = {
         "stt": [],
@@ -91,7 +104,7 @@ async def bulk_write_events(db: aiosqlite.Connection, events: list[ReplayEvent])
             )
         if ev.modality == "state":
             by_modality["state"].append(
-                (ev.session_id, ev.t_ms, _payload_to_text(ev.payload))
+                (ev.session_id, ev.t_ms, _payload_to_text(ev.payload), resolved)
             )
         else:
             by_modality[ev.modality].append(
@@ -101,6 +114,7 @@ async def bulk_write_events(db: aiosqlite.Connection, events: list[ReplayEvent])
                     _payload_to_text(ev.payload),
                     ev.provider,
                     ev.cost_usd,
+                    resolved,
                 )
             )
 

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -27,6 +27,9 @@ _migration_0003 = import_module(
     "voicegateway.storage.migrations.0003_turns_and_deadair"
 )
 _migration_0004 = import_module("voicegateway.storage.migrations.0004_replay_tables")
+_migration_0005 = import_module(
+    "voicegateway.storage.migrations.0005_tenant_attribution"
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -261,6 +264,12 @@ class SQLiteStorage:
             # v0.3.0 migration 0004: replay event tables + sessions.replay_size_bytes.
             # Idempotent.
             await _migration_0004.apply(db)
+
+            # v0.4.0 migration 0005: virtual_keys table + tenant_id columns
+            # on sessions/requests (unconditionally) and on the v0.2.0/v0.3.0
+            # derived tables (conditionally via sqlite_master presence check
+            # per OQ4). Idempotent.
+            await _migration_0005.apply(db)
 
             await db.commit()
             self._initialized = True

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -397,14 +397,16 @@ class SQLiteStorage:
         same connection / commit for atomicity.
         """
         db = await self._ensure_initialized()
+        request_tenant_id = current_tenant()
         try:
             await db.execute(
                 """INSERT INTO requests
                    (id, timestamp, project, modality, model_id, provider,
                     input_units, output_units, cost_usd, pricing_source,
                     ttfb_ms, total_latency_ms, status,
-                    fallback_from, error_message, metadata, session_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    fallback_from, error_message, metadata, session_id,
+                    tenant_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     record.id,
                     record.timestamp,
@@ -423,6 +425,7 @@ class SQLiteStorage:
                     record.error_message,
                     json.dumps(record.metadata) if record.metadata else None,
                     record.session_id,
+                    request_tenant_id,
                 ),
             )
             if record.session_id:
@@ -443,16 +446,17 @@ class SQLiteStorage:
                 # earlier may finish after a faster LLM call. The MIN
                 # CASE keeps started_at at the earliest request_started
                 # timestamp regardless of completion order.
-                # ``current_tenant()`` reads the v0.4.0 tenant_id_ctx
-                # ContextVar (REQ-VG-TENANT-001). On INSERT the value
-                # stamps the session row; on CONFLICT we COALESCE so
-                # an already-set tenant_id never gets overwritten by a
-                # later request that arrived without a tenant in
-                # scope. This is the "session has one tenant for its
-                # lifetime" rule from the Refinery: the first
-                # tenant-bearing request wins, subsequent
-                # unattributed-bucket requests don't clear it.
-                session_tenant_id = current_tenant()
+                # ``request_tenant_id`` (read once at the top from the
+                # v0.4.0 tenant_id_ctx ContextVar, REQ-VG-TENANT-001) is
+                # reused for both the requests row and the sessions
+                # UPSERT. On INSERT it stamps the session row; on
+                # CONFLICT we COALESCE so an already-set tenant_id
+                # never gets overwritten by a later request that
+                # arrived without a tenant in scope. This is the
+                # "session has one tenant for its lifetime" rule from
+                # the Refinery: the first tenant-bearing request wins,
+                # subsequent unattributed-bucket requests don't clear
+                # it.
                 await db.execute(
                     """INSERT INTO sessions
                        (id, project, started_at, ended_at, modalities,
@@ -487,7 +491,7 @@ class SQLiteStorage:
                         started_at_iso,
                         record.modality,
                         record.cost_usd,
-                        session_tenant_id,
+                        request_tenant_id,
                     ),
                 )
             await db.commit()

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import aiosqlite
 
+from voicegateway.inference._session_context import current_tenant
 from voicegateway.storage import replay_repo, turns_repo
 from voicegateway.storage._percentiles import compute_percentiles
 from voicegateway.storage.models import RequestRecord
@@ -442,14 +443,25 @@ class SQLiteStorage:
                 # earlier may finish after a faster LLM call. The MIN
                 # CASE keeps started_at at the earliest request_started
                 # timestamp regardless of completion order.
+                # ``current_tenant()`` reads the v0.4.0 tenant_id_ctx
+                # ContextVar (REQ-VG-TENANT-001). On INSERT the value
+                # stamps the session row; on CONFLICT we COALESCE so
+                # an already-set tenant_id never gets overwritten by a
+                # later request that arrived without a tenant in
+                # scope. This is the "session has one tenant for its
+                # lifetime" rule from the Refinery: the first
+                # tenant-bearing request wins, subsequent
+                # unattributed-bucket requests don't clear it.
+                session_tenant_id = current_tenant()
                 await db.execute(
                     """INSERT INTO sessions
                        (id, project, started_at, ended_at, modalities,
-                        total_cost_usd, request_count)
-                       VALUES (?, ?, ?, ?, ?, ?, 1)
+                        total_cost_usd, request_count, tenant_id)
+                       VALUES (?, ?, ?, ?, ?, ?, 1, ?)
                        ON CONFLICT(id) DO UPDATE SET
                            total_cost_usd = total_cost_usd + excluded.total_cost_usd,
                            request_count = request_count + 1,
+                           tenant_id = COALESCE(tenant_id, excluded.tenant_id),
                            started_at = CASE
                                WHEN started_at IS NULL THEN excluded.started_at
                                WHEN started_at > excluded.started_at THEN excluded.started_at
@@ -475,6 +487,7 @@ class SQLiteStorage:
                         started_at_iso,
                         record.modality,
                         record.cost_usd,
+                        session_tenant_id,
                     ),
                 )
             await db.commit()

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -540,8 +540,9 @@ class SQLiteStorage:
         include_pricing_source: bool = False,
         start_ts: float | None = None,
         end_ts: float | None = None,
+        tenant: str | None = None,
     ) -> dict[str, Any]:
-        """Get cost summary for the given period, optionally filtered by project.
+        """Get cost summary for the given period, optionally filtered by project and tenant.
 
         With ``include_pricing_source=True``, each entry in ``by_model``
         gains a ``pricing_source`` field carrying the catalog (or
@@ -550,6 +551,11 @@ class SQLiteStorage:
         Pass `start_ts` and/or `end_ts` (POSIX timestamps) to override
         the named-period window. When either is set, `period` is
         ignored. `start_ts` is inclusive, `end_ts` is exclusive.
+
+        ``tenant`` (v0.4.0) scopes the aggregate to a single tenant.
+        Pass an empty string ``""`` to target the unattributed bucket
+        (sessions with NULL tenant_id). Pass ``None`` to include every
+        tenant (default).
         """
         db = await self._ensure_initialized()
         try:
@@ -563,6 +569,12 @@ class SQLiteStorage:
             if project:
                 where += " AND project = ?"
                 params.append(project)
+            if tenant is not None:
+                if tenant == "":
+                    where += " AND tenant_id IS NULL"
+                else:
+                    where += " AND tenant_id = ?"
+                    params.append(tenant)
 
             # Total cost
             cursor = await db.execute(
@@ -626,8 +638,13 @@ class SQLiteStorage:
         period: str = "today",
         start_ts: float | None = None,
         end_ts: float | None = None,
+        tenant: str | None = None,
     ) -> dict[str, Any]:
-        """Get cost summary grouped by project."""
+        """Get cost summary grouped by project.
+
+        ``tenant`` (v0.4.0) scopes the result to one tenant; ``""``
+        targets the unattributed bucket; ``None`` includes everything.
+        """
         db = await self._ensure_initialized()
         try:
             since, until = self._resolve_window(period, start_ts, end_ts)
@@ -636,6 +653,12 @@ class SQLiteStorage:
             if until is not None:
                 where += " AND timestamp < ?"
                 params.append(until)
+            if tenant is not None:
+                if tenant == "":
+                    where += " AND tenant_id IS NULL"
+                else:
+                    where += " AND tenant_id = ?"
+                    params.append(tenant)
             cursor = await db.execute(
                 f"""SELECT project, SUM(cost_usd) as cost, COUNT(*) as count
                     FROM requests {where}
@@ -690,6 +713,7 @@ class SQLiteStorage:
         period: str = "today",
         project: str | None = None,
         percentiles: list[float] | None = None,
+        tenant: str | None = None,
     ) -> dict[str, Any]:
         """Get per-model latency stats for ``period``.
 
@@ -720,6 +744,12 @@ class SQLiteStorage:
             if project:
                 where += " AND project = ?"
                 params.append(project)
+            if tenant is not None:
+                if tenant == "":
+                    where += " AND tenant_id IS NULL"
+                else:
+                    where += " AND tenant_id = ?"
+                    params.append(tenant)
 
             cursor = await db.execute(
                 f"""SELECT model_id,
@@ -867,8 +897,13 @@ class SQLiteStorage:
         limit: int = 100,
         modality: str | None = None,
         project: str | None = None,
+        tenant: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Get recent request records, optionally filtered by modality and/or project."""
+        """Get recent request records, optionally filtered by modality, project, tenant.
+
+        ``tenant`` (v0.4.0) accepts a tenant id; ``""`` targets the
+        unattributed bucket; ``None`` includes everything.
+        """
         db = await self._ensure_initialized()
         try:
             conditions: list[str] = []
@@ -879,6 +914,12 @@ class SQLiteStorage:
             if project:
                 conditions.append("project = ?")
                 params.append(project)
+            if tenant is not None:
+                if tenant == "":
+                    conditions.append("tenant_id IS NULL")
+                else:
+                    conditions.append("tenant_id = ?")
+                    params.append(tenant)
             where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
             query = f"SELECT * FROM requests {where} ORDER BY timestamp DESC LIMIT ?"
             params.append(limit)
@@ -960,6 +1001,7 @@ class SQLiteStorage:
         limit: int = 100,
         project: str | None = None,
         order_by: str = "started_at_desc",
+        tenant: str | None = None,
     ) -> list[dict[str, Any]]:
         """Return recent sessions, ordered per ``order_by``.
 
@@ -970,6 +1012,9 @@ class SQLiteStorage:
                 ``"started_at_asc"``, ``"cost_desc"``, ``"cost_asc"``.
                 Cost orderings break ties by started_at DESC so two
                 $0 sessions still surface newest first.
+            tenant: v0.4.0 tenant filter. Pass an empty string to
+                target the unattributed bucket; ``None`` lists every
+                tenant.
 
         Raises:
             ValueError: When ``order_by`` is not one of the supported
@@ -982,25 +1027,27 @@ class SQLiteStorage:
             raise ValueError(f"Unknown order_by {order_by!r}. Supported: {supported}.")
         db = await self._ensure_initialized()
         try:
+            conditions: list[str] = []
+            params: list[Any] = []
             if project:
-                cursor = await db.execute(
-                    f"""SELECT id, project, started_at, ended_at, modalities,
-                              total_cost_usd, request_count
-                       FROM sessions
-                       WHERE project = ?
-                       ORDER BY {clause}
-                       LIMIT ?""",
-                    (project, limit),
-                )
-            else:
-                cursor = await db.execute(
-                    f"""SELECT id, project, started_at, ended_at, modalities,
-                              total_cost_usd, request_count
-                       FROM sessions
-                       ORDER BY {clause}
-                       LIMIT ?""",
-                    (limit,),
-                )
+                conditions.append("project = ?")
+                params.append(project)
+            if tenant is not None:
+                if tenant == "":
+                    conditions.append("tenant_id IS NULL")
+                else:
+                    conditions.append("tenant_id = ?")
+                    params.append(tenant)
+            where = f"WHERE {' AND '.join(conditions)} " if conditions else ""
+            params.append(limit)
+            cursor = await db.execute(
+                f"""SELECT id, project, started_at, ended_at, modalities,
+                          total_cost_usd, request_count
+                   FROM sessions
+                   {where}ORDER BY {clause}
+                   LIMIT ?""",
+                tuple(params),
+            )
             return [self._row_to_session(row) async for row in cursor]
         finally:
             await db.close()

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -979,7 +979,7 @@ class SQLiteStorage:
 
     @staticmethod
     def _row_to_session(row: Any) -> dict[str, Any]:
-        return {
+        out = {
             "id": row[0],
             "project": row[1],
             "started_at": row[2],
@@ -988,6 +988,16 @@ class SQLiteStorage:
             "total_cost_usd": float(row[5] or 0.0),
             "request_count": int(row[6] or 0),
         }
+        # v0.4.0: include tenant_id when the SELECT picked it up.
+        # list_sessions and get_session both include the column on
+        # post-migration databases; the Any-typed Row may not raise on
+        # out-of-bounds, so we guard defensively.
+        try:
+            tenant_id = row[7]
+            out["tenant_id"] = None if tenant_id is None else str(tenant_id)
+        except (IndexError, KeyError):
+            pass
+        return out
 
     _SESSION_ORDER_CLAUSES: dict[str, str] = {
         "started_at_desc": "started_at DESC",
@@ -1042,7 +1052,7 @@ class SQLiteStorage:
             params.append(limit)
             cursor = await db.execute(
                 f"""SELECT id, project, started_at, ended_at, modalities,
-                          total_cost_usd, request_count
+                          total_cost_usd, request_count, tenant_id
                    FROM sessions
                    {where}ORDER BY {clause}
                    LIMIT ?""",
@@ -1064,7 +1074,7 @@ class SQLiteStorage:
         try:
             cursor = await db.execute(
                 """SELECT id, project, started_at, ended_at, modalities,
-                          total_cost_usd, request_count
+                          total_cost_usd, request_count, tenant_id
                    FROM sessions
                    WHERE id = ?""",
                 (session_id,),

--- a/voicegateway/storage/tenants_repo.py
+++ b/voicegateway/storage/tenants_repo.py
@@ -1,0 +1,188 @@
+"""Async read-side repo for the tenant index.
+
+Implements REQ-VG-TENANT-002: the dashboard's per-tenant filter and
+the Tenants overview need a typeahead-friendly list of tenants with
+aggregates. Tenants are not stored in a dedicated table; they are
+derived from ``DISTINCT sessions.tenant_id`` (migration 0005 column).
+This module owns the aggregation SQL so callers (the dashboard API
+T10, the future CLI T16) share the same definition of "what counts as
+a tenant" and "what aggregates are surfaced".
+
+Aggregates returned per tenant:
+
+- ``session_count`` — number of sessions tagged with the tenant.
+- ``total_cost_usd`` — SUM of ``sessions.total_cost_usd`` (already
+  rolled up by ``log_request``).
+- ``first_seen`` — earliest ``sessions.started_at`` (ISO string).
+- ``last_seen`` — most recent ``sessions.ended_at`` (or
+  ``started_at`` if ``ended_at`` is NULL).
+
+The "unattributed" bucket (sessions with ``tenant_id IS NULL``) is
+intentionally NOT surfaced as a tenant row: the dashboard renders it
+via a muted pill rather than via the tenant list. Callers that need
+the unattributed totals call ``get_unattributed_aggregates`` instead.
+
+Mirrors the flat-function-module pattern of ``turns_repo.py``,
+``virtual_keys_repo.py``, and ``replay_repo.py``. The caller owns the
+connection lifecycle.
+
+Schema reference:
+``voicegateway/storage/migrations/0005_tenant_attribution.py`` adds
+``tenant_id`` to ``sessions``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 1000
+
+
+@dataclass(frozen=True)
+class TenantRow:
+    """One row in the tenant index (the dashboard's tenant filter feed)."""
+
+    tenant_id: str
+    session_count: int
+    total_cost_usd: float
+    first_seen: str | None
+    last_seen: str | None
+
+
+@dataclass(frozen=True)
+class UnattributedAggregates:
+    """Aggregates for the implicit ``tenant_id IS NULL`` bucket."""
+
+    session_count: int
+    total_cost_usd: float
+    first_seen: str | None
+    last_seen: str | None
+
+
+def _row_to_tenant(row: Sequence[Any]) -> TenantRow:
+    return TenantRow(
+        tenant_id=str(row[0]),
+        session_count=int(row[1]),
+        total_cost_usd=float(row[2] or 0.0),
+        first_seen=None if row[3] is None else str(row[3]),
+        last_seen=None if row[4] is None else str(row[4]),
+    )
+
+
+_SELECT_AGGREGATES = """
+SELECT tenant_id,
+       COUNT(*) AS session_count,
+       COALESCE(SUM(total_cost_usd), 0.0) AS total_cost_usd,
+       MIN(started_at) AS first_seen,
+       MAX(COALESCE(ended_at, started_at)) AS last_seen
+FROM sessions
+WHERE tenant_id IS NOT NULL
+"""
+
+
+async def list_tenants(
+    db: aiosqlite.Connection,
+    *,
+    limit: int = _DEFAULT_LIMIT,
+    query: str | None = None,
+) -> list[TenantRow]:
+    """Return the tenant index, ordered by ``last_seen`` descending.
+
+    ``limit`` is clamped to ``[1, 1000]``. ``query`` is a substring
+    match against ``tenant_id``; case-insensitive, no escaping (callers
+    pass user-typed strings, and the query is parameterized so SQL
+    injection is impossible — but ``%`` and ``_`` are treated as
+    literal characters via SQLite's ``ESCAPE`` clause). Pass
+    ``query=None`` or ``query=""`` to list everything.
+
+    Sort order is most-recently-active first; ties broken by
+    tenant_id ASC so the feed is deterministic across page reloads.
+    """
+    if limit < 1:
+        limit = 1
+    if limit > _MAX_LIMIT:
+        limit = _MAX_LIMIT
+
+    clauses: list[str] = []
+    params: list[Any] = []
+    if query:
+        clauses.append("AND tenant_id LIKE ? ESCAPE '\\'")
+        # Treat the user-supplied substring as literal: escape % and _
+        # so they don't act as wildcards.
+        escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        params.append(f"%{escaped}%")
+
+    sql = _SELECT_AGGREGATES
+    if clauses:
+        sql += " " + " ".join(clauses) + " "
+    sql += " GROUP BY tenant_id  ORDER BY last_seen DESC, tenant_id ASC  LIMIT ?"
+    params.append(limit)
+
+    cursor = await db.execute(sql, params)
+    return [_row_to_tenant(row) async for row in cursor]
+
+
+async def get_tenant(db: aiosqlite.Connection, tenant_id: str) -> TenantRow | None:
+    """Return aggregates for a single tenant or ``None`` if not seen."""
+    cursor = await db.execute(
+        _SELECT_AGGREGATES + " AND tenant_id = ? " + "GROUP BY tenant_id",
+        (tenant_id,),
+    )
+    row = await cursor.fetchone()
+    return _row_to_tenant(row) if row is not None else None
+
+
+async def count_tenants(db: aiosqlite.Connection) -> int:
+    """Return the number of distinct attributed tenants in the index."""
+    cursor = await db.execute(
+        "SELECT COUNT(DISTINCT tenant_id) FROM sessions WHERE tenant_id IS NOT NULL"
+    )
+    row = await cursor.fetchone()
+    return int(row[0]) if row is not None else 0
+
+
+async def get_unattributed_aggregates(
+    db: aiosqlite.Connection,
+) -> UnattributedAggregates:
+    """Return aggregates for the ``tenant_id IS NULL`` bucket.
+
+    The dashboard shows this as a separate "unattributed" entry below
+    the tenant filter. Always returns a row even when zero sessions
+    are unattributed (the dataclass uses sensible empty defaults).
+    """
+    cursor = await db.execute(
+        """SELECT COUNT(*) AS session_count,
+                  COALESCE(SUM(total_cost_usd), 0.0) AS total_cost_usd,
+                  MIN(started_at) AS first_seen,
+                  MAX(COALESCE(ended_at, started_at)) AS last_seen
+           FROM sessions
+           WHERE tenant_id IS NULL"""
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return UnattributedAggregates(
+            session_count=0, total_cost_usd=0.0, first_seen=None, last_seen=None
+        )
+    return UnattributedAggregates(
+        session_count=int(row[0]),
+        total_cost_usd=float(row[1] or 0.0),
+        first_seen=None if row[2] is None else str(row[2]),
+        last_seen=None if row[3] is None else str(row[3]),
+    )
+
+
+__all__ = [
+    "TenantRow",
+    "UnattributedAggregates",
+    "count_tenants",
+    "get_tenant",
+    "get_unattributed_aggregates",
+    "list_tenants",
+]

--- a/voicegateway/storage/turns_repo.py
+++ b/voicegateway/storage/turns_repo.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import statistics
 from typing import TYPE_CHECKING
 
+from voicegateway.inference._session_context import current_tenant
 from voicegateway.middleware.turn_tracker import TurnRow
 
 if TYPE_CHECKING:
@@ -30,12 +31,12 @@ _INSERT_TURN = (
     "session_id, turn_index, "
     "caller_speak_start_ms, caller_speak_end_ms, "
     "agent_speak_start_ms, agent_speak_end_ms, "
-    "response_speed_ms"
-    ") VALUES (?, ?, ?, ?, ?, ?, ?)"
+    "response_speed_ms, tenant_id"
+    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
 )
 
 
-def _turn_to_params(turn: TurnRow) -> tuple[object, ...]:
+def _turn_to_params(turn: TurnRow, tenant_id: str | None) -> tuple[object, ...]:
     return (
         turn.session_id,
         turn.turn_index,
@@ -44,27 +45,47 @@ def _turn_to_params(turn: TurnRow) -> tuple[object, ...]:
         turn.agent_speak_start_ms,
         turn.agent_speak_end_ms,
         turn.response_speed_ms,
+        tenant_id,
     )
 
 
-async def create_turn(db: aiosqlite.Connection, turn: TurnRow) -> None:
-    """Insert one ``TurnRow``. Commits the connection."""
-    await db.execute(_INSERT_TURN, _turn_to_params(turn))
+async def create_turn(
+    db: aiosqlite.Connection,
+    turn: TurnRow,
+    *,
+    tenant_id: str | None = None,
+) -> None:
+    """Insert one ``TurnRow``. Commits the connection.
+
+    ``tenant_id`` defaults to ``current_tenant()`` (the v0.4.0
+    ContextVar). Pass it explicitly to override (e.g. backfill jobs
+    that rebuild rows for a known historical tenant).
+    """
+    resolved = tenant_id if tenant_id is not None else current_tenant()
+    await db.execute(_INSERT_TURN, _turn_to_params(turn, resolved))
     await db.commit()
 
 
-async def create_turns_bulk(db: aiosqlite.Connection, turns: list[TurnRow]) -> int:
+async def create_turns_bulk(
+    db: aiosqlite.Connection,
+    turns: list[TurnRow],
+    *,
+    tenant_id: str | None = None,
+) -> int:
     """Bulk-insert turns. Returns the number inserted.
 
     Intended target of :class:`voicegateway.middleware.turn_tracker.TurnTracker`'s
     ``flush_callback``. Empty input is a no-op (returns 0). Commits the
-    connection on success.
+    connection on success. ``tenant_id`` defaults to ``current_tenant()``
+    captured at call time and applied to every row in the batch (turns
+    are session-scoped so they share the session's tenant).
     """
     if not turns:
         return 0
+    resolved = tenant_id if tenant_id is not None else current_tenant()
     await db.executemany(
         _INSERT_TURN,
-        [_turn_to_params(t) for t in turns],
+        [_turn_to_params(t, resolved) for t in turns],
     )
     await db.commit()
     return len(turns)

--- a/voicegateway/storage/virtual_keys_repo.py
+++ b/voicegateway/storage/virtual_keys_repo.py
@@ -1,0 +1,312 @@
+"""Async repo for the ``virtual_keys`` table.
+
+Implements REQ-VG-TENANT-003 (issue virtual API keys with optional
+tenant scope, support revocation and stale-key detection).
+
+The plaintext key is returned ONCE at issuance; only a bcrypt hash and
+an 8-char visible prefix persist (OQ1 lock). Verification scans by
+prefix to keep bcrypt comparisons O(1) per request rather than O(n);
+the prefix collision space (~33M values from 5 base32 chars after
+``vk_``) is large enough to avoid practical collision but small enough
+to expose nothing about the secret.
+
+Key format (locked at v0.4.0/T01 from Foundry OQ1):
+
+* Total key handed to the user: ``vk_`` + 32 base32 random chars
+  (``vk_AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPP``) = 35 chars.
+* Visible prefix stored in ``key_prefix``: first 8 chars
+  (``vk_AABBC``) = ``vk_`` + 5 random.
+* The full key is bcrypt-hashed (cost 12) and stored in ``key_hash``.
+
+Revocation is soft (OQ5 lock): ``revoke(id)`` writes
+``revoked_at = CURRENT_TIMESTAMP`` and keeps the row for audit + the
+stale-key detector. Hard delete is out of scope for v0.4.0.
+
+Mirrors the flat-function-module pattern of ``turns_repo.py`` and
+``replay_repo.py``: each function takes an ``aiosqlite.Connection`` and
+the caller owns the connection lifecycle.
+
+Schema reference: ``voicegateway/storage/migrations/0005_tenant_attribution.py``.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final
+
+import bcrypt
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+_VK_PREFIX: Final[str] = "vk_"
+_VISIBLE_PREFIX_LEN: Final[int] = 8  # ``vk_`` + 5 random chars
+_RANDOM_SUFFIX_LEN: Final[int] = 32
+_BCRYPT_COST: Final[int] = 12
+_BASE32_ALPHABET: Final[str] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+
+@dataclass(frozen=True)
+class VirtualKeyRow:
+    """One row from the ``virtual_keys`` table (without ``key_hash``).
+
+    ``key_hash`` is omitted because callers never need it; the hash is
+    consulted only inside :func:`verify`. Exposing the plaintext key is
+    impossible: it is only ever returned from :func:`create_virtual_key`.
+    """
+
+    id: int
+    key_prefix: str
+    name: str
+    tenant_id: str | None
+    issued_by: str | None
+    issued_at: str
+    last_used_at: str | None
+    revoked_at: str | None
+
+
+@dataclass(frozen=True)
+class CreatedVirtualKey:
+    """Return value of :func:`create_virtual_key`.
+
+    The ``plaintext`` field is the one and only time the full key is
+    visible. Callers are expected to surface it to the dashboard's
+    "show key once" modal (REQ-VG-TENANT-003 AC-2) and never persist it
+    server-side beyond the bcrypt hash.
+    """
+
+    id: int
+    plaintext: str
+    row: VirtualKeyRow
+
+
+def _generate_plaintext_key() -> str:
+    suffix = "".join(
+        secrets.choice(_BASE32_ALPHABET) for _ in range(_RANDOM_SUFFIX_LEN)
+    )
+    return f"{_VK_PREFIX}{suffix}"
+
+
+def _visible_prefix(plaintext: str) -> str:
+    return plaintext[:_VISIBLE_PREFIX_LEN]
+
+
+def _hash_key(plaintext: str) -> str:
+    digest = bcrypt.hashpw(
+        plaintext.encode("utf-8"), bcrypt.gensalt(rounds=_BCRYPT_COST)
+    )
+    return digest.decode("utf-8")
+
+
+def _check_key(plaintext: str, stored_hash: str) -> bool:
+    return bcrypt.checkpw(plaintext.encode("utf-8"), stored_hash.encode("utf-8"))
+
+
+_INSERT_KEY = (
+    "INSERT INTO virtual_keys ("
+    "key_prefix, key_hash, name, tenant_id, issued_by"
+    ") VALUES (?, ?, ?, ?, ?)"
+)
+
+
+async def create_virtual_key(
+    db: aiosqlite.Connection,
+    *,
+    name: str,
+    tenant_id: str | None = None,
+    issued_by: str | None = None,
+) -> CreatedVirtualKey:
+    """Create a virtual key and return the plaintext once.
+
+    ``name`` is the human-readable label shown in the dashboard.
+    ``tenant_id`` scopes the key (REQ-VG-TENANT-004): when the auth
+    middleware presents a scoped key, it auto-tags the session with
+    this tenant. ``None`` leaves the key unscoped so the body's
+    ``tenant_id`` (if any) wins.
+    ``issued_by`` is a free-form audit string (the dashboard sets it to
+    the operator's identity).
+
+    Commits the connection.
+    """
+    if not name:
+        raise ValueError("name must be non-empty")
+    plaintext = _generate_plaintext_key()
+    prefix = _visible_prefix(plaintext)
+    digest = _hash_key(plaintext)
+    cursor = await db.execute(_INSERT_KEY, (prefix, digest, name, tenant_id, issued_by))
+    await db.commit()
+    new_id = cursor.lastrowid
+    if new_id is None:
+        # aiosqlite always reports lastrowid for INSERT; defensive only.
+        raise RuntimeError("INSERT into virtual_keys did not return a row id")
+    row = await get_by_id(db, new_id)
+    if row is None:
+        raise RuntimeError(f"virtual_keys row {new_id} disappeared after INSERT")
+    return CreatedVirtualKey(id=new_id, plaintext=plaintext, row=row)
+
+
+_SELECT_ROW_FIELDS = (
+    "id, key_prefix, name, tenant_id, issued_by, issued_at, last_used_at, revoked_at"
+)
+
+
+def _row_to_dataclass(row: Sequence[Any]) -> VirtualKeyRow:
+    return VirtualKeyRow(
+        id=int(row[0]),
+        key_prefix=str(row[1]),
+        name=str(row[2]),
+        tenant_id=None if row[3] is None else str(row[3]),
+        issued_by=None if row[4] is None else str(row[4]),
+        issued_at=str(row[5]),
+        last_used_at=None if row[6] is None else str(row[6]),
+        revoked_at=None if row[7] is None else str(row[7]),
+    )
+
+
+async def get_by_id(db: aiosqlite.Connection, key_id: int) -> VirtualKeyRow | None:
+    """Return the row for ``key_id`` or ``None`` if not found."""
+    cursor = await db.execute(
+        f"SELECT {_SELECT_ROW_FIELDS} FROM virtual_keys WHERE id = ?",
+        (key_id,),
+    )
+    row = await cursor.fetchone()
+    return _row_to_dataclass(row) if row is not None else None
+
+
+async def list_keys(
+    db: aiosqlite.Connection,
+    *,
+    include_revoked: bool = True,
+) -> list[VirtualKeyRow]:
+    """Return all virtual keys, newest first.
+
+    ``include_revoked=False`` filters out keys with a non-NULL
+    ``revoked_at`` (used by the issuance flow to avoid showing
+    tombstones unless the operator opts in).
+    """
+    where = "" if include_revoked else "WHERE revoked_at IS NULL "
+    cursor = await db.execute(
+        f"SELECT {_SELECT_ROW_FIELDS} FROM virtual_keys "
+        f"{where}ORDER BY issued_at DESC, id DESC"
+    )
+    return [_row_to_dataclass(row) async for row in cursor]
+
+
+@dataclass(frozen=True)
+class VerifiedKey:
+    """Result of a successful :func:`verify` call."""
+
+    id: int
+    tenant_id: str | None
+    name: str
+
+
+async def verify(db: aiosqlite.Connection, plaintext: str) -> VerifiedKey | None:
+    """Validate ``plaintext`` against the stored hashes.
+
+    Returns the row's ``id`` + ``tenant_id`` + ``name`` on a match,
+    ``None`` on any failure (bad prefix, no row, hash mismatch, revoked).
+    Revoked keys are rejected here so callers don't need a second check.
+
+    The caller is responsible for invoking :func:`mark_used` on success
+    if a ``last_used_at`` bump is desired; ``verify`` keeps the read
+    side pure to make it safe to call from middleware that may rate-limit
+    repeat failures.
+    """
+    if not plaintext.startswith(_VK_PREFIX):
+        return None
+    prefix = _visible_prefix(plaintext)
+    cursor = await db.execute(
+        "SELECT id, key_hash, tenant_id, name, revoked_at "
+        "FROM virtual_keys WHERE key_prefix = ?",
+        (prefix,),
+    )
+    rows = await cursor.fetchall()
+    for row in rows:
+        key_id, stored_hash, tenant_id, name, revoked_at = (
+            row[0],
+            row[1],
+            row[2],
+            row[3],
+            row[4],
+        )
+        if revoked_at is not None:
+            continue
+        if _check_key(plaintext, str(stored_hash)):
+            return VerifiedKey(
+                id=int(key_id),
+                tenant_id=None if tenant_id is None else str(tenant_id),
+                name=str(name),
+            )
+    return None
+
+
+async def mark_used(db: aiosqlite.Connection, key_id: int) -> None:
+    """Bump ``last_used_at`` to the current timestamp.
+
+    Idempotent. Commits the connection. Called by the auth middleware
+    after a successful :func:`verify`.
+    """
+    await db.execute(
+        "UPDATE virtual_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?",
+        (key_id,),
+    )
+    await db.commit()
+
+
+async def revoke(db: aiosqlite.Connection, key_id: int) -> bool:
+    """Soft-revoke the key (OQ5 lock).
+
+    Sets ``revoked_at = CURRENT_TIMESTAMP``. Returns ``True`` if a row
+    was updated, ``False`` if the row did not exist or was already
+    revoked. Commits the connection.
+    """
+    cursor = await db.execute(
+        "UPDATE virtual_keys "
+        "SET revoked_at = CURRENT_TIMESTAMP "
+        "WHERE id = ? AND revoked_at IS NULL",
+        (key_id,),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def list_stale(
+    db: aiosqlite.Connection, *, stale_after_days: int
+) -> list[VirtualKeyRow]:
+    """Return non-revoked keys whose ``last_used_at`` is older than the threshold.
+
+    Keys that have never been used (``last_used_at IS NULL``) are
+    considered stale if ``issued_at`` is older than the threshold:
+    issued-but-never-used keys past the cutoff are exactly what the
+    stale-key surface is for. The threshold is the project config's
+    ``virtual_key_stale_days`` (T09).
+    """
+    if stale_after_days < 0:
+        raise ValueError(f"stale_after_days must be >= 0, got {stale_after_days}")
+    cursor = await db.execute(
+        f"SELECT {_SELECT_ROW_FIELDS} FROM virtual_keys "
+        "WHERE revoked_at IS NULL "
+        "AND COALESCE(last_used_at, issued_at) <= "
+        "    datetime('now', ? || ' days') "
+        "ORDER BY COALESCE(last_used_at, issued_at) ASC, id ASC",
+        (f"-{stale_after_days}",),
+    )
+    return [_row_to_dataclass(row) async for row in cursor]
+
+
+__all__ = [
+    "CreatedVirtualKey",
+    "VerifiedKey",
+    "VirtualKeyRow",
+    "create_virtual_key",
+    "get_by_id",
+    "list_keys",
+    "list_stale",
+    "mark_used",
+    "revoke",
+    "verify",
+]


### PR DESCRIPTION
## v0.4.0 — Multi-tenant cost attribution

Implements: REQ-VG-TENANT-001, REQ-VG-TENANT-002, REQ-VG-TENANT-003, REQ-VG-TENANT-004

Refinery: https://linear.app/mahimailabs/document/voicegateway-v0-4-0-multi-tenant-cost-attribution
Foundry:  https://linear.app/mahimailabs/issue/MAH-VG-040

VoiceGateway now tags every voice session with an optional `tenant_id` so a single deployment can serve many customers and account for each one separately. Three independent surfaces set the tenant: an `attach_session(tenant_id=...)` kwarg for owner-of-AgentSession code, an `inference.set_tenant("…")` ContextVar API, and scoped virtual API keys that auto-attribute at the auth layer. Every cost row, metric row, and replay event for an attributed session lands tagged with the tenant; pre-v0.4.0 rows stay in the "unattributed" bucket (NULL `tenant_id`).

## What changed

- **Migration 0005** adds the `virtual_keys` table (bcrypt-hashed storage, visible-prefix index, tenant scope) and `tenant_id TEXT` to `sessions`, `requests`, `turns`, `dead_air_events`, and the four `replay_*` tables. Idempotent. The derived-table ALTERs are guarded by a `sqlite_master` presence check (OQ4) so a v0.0.5-only baseline runs cleanly.
- **`tenant_id_ctx` ContextVar** in `voicegateway/inference/_session_context.py` with `set_tenant`, `current_tenant`, `reset_tenant_id` helpers. 128-char UTF-8 cap (OQ2 lock).
- **`virtual_keys_repo`** with `create_virtual_key` (returns plaintext exactly once), `verify`, `revoke` (soft per OQ5), `mark_used`, `list_keys`, `list_stale`, `get_by_id`. Key shape: `vk_` + 32 base32 random chars (35 total); 8-char visible prefix indexed; full key bcrypt-hashed at cost 12. Adds `bcrypt>=4.0` dep.
- **`tenants_repo`** read-side derived view over `DISTINCT sessions.tenant_id`: `list_tenants` (substring typeahead with `%`/`_` literal escape), `get_tenant`, `count_tenants`, `get_unattributed_aggregates`.
- **Auth middleware** in `voicegateway/server/main.py::build_app` detects `vk_`-prefixed bearer tokens, resolves them, bumps `last_used_at`, sets `tenant_id_ctx` if scoped, stashes `virtual_key_tenant_id` on `request.state`. Static keys unchanged. New helpers: `is_virtual_key_token`, `verify_virtual_key`, `check_tenant_body_conflict` (403 on scoped-key+body mismatch).
- **`attach_session(..., tenant_id="…")`** kwarg + `log_request` writes `tenant_id` from `current_tenant()` to both `requests` and `sessions` rows. Sessions UPSERT uses `COALESCE` so the first tenant-bearing request stamps the row for its lifetime; later unattributed requests cannot blank it.
- **`turns_repo`, `dead_air_repo`, `replay_repo`** write functions accept an optional `tenant_id` kwarg defaulting to `current_tenant()` for per-batch propagation.
- **`TenantConfig`** per-project YAML knob: `tenant.virtual_key_stale_days` (default 90).
- **Five new dashboard endpoints**: `GET /api/tenants`, `GET /api/tenants/{id}`, `GET /api/virtual_keys`, `POST /api/virtual_keys`, `POST /api/virtual_keys/{id}/revoke`. Existing `/api/costs`, `/api/latency`, `/api/logs`, `/api/sessions`, `/api/metrics` accept a `tenant` query param (`null`=all, `''`=unattributed, value=that tenant).
- **Storage methods** `get_cost_summary`, `get_cost_by_project`, `get_recent_requests`, `list_sessions`, `get_latency_stats` accept the same `tenant` kwarg convention.
- **`VirtualKeys.tsx`** page with show-key-once modal (REQ-VG-TENANT-003 AC-2). **`TenantFilter` + `TenantPill` + `FilterBar`** components with URL sync via `useSearchParams`. **Costs / Sessions / Metrics** pages consume the FilterBar and forward the tenant param. Sessions table gains a Tenant column; SessionDetail modal gains a TenantPill.
- **App.tsx** registers `/virtual-keys` route + sidebar entry.
- **Typed fetchers + types** in `lib/api.ts` and `lib/types.ts` for the new endpoints.
- **`voicegw tenant list / show <id>`** read-only CLI commands with `--json` output for CI scripts. Issuance stays dashboard-only per AC-2.
- **`docs/api/python-sdk.md`** gains a "Tenant attribution (v0.4.0)" section. **`docs/guide/multi-tenant-quickstart.md`** is the operator-facing walkthrough with explicit "what v0.4.0 does NOT do" enumeration.
- **Embedded version strings** bumped 0.3.0 → 0.4.0 in `voicegateway/server/main.py`, `dashboard/api/main.py`, `tests/server/test_server.py`, `docker/voicegateway.Dockerfile`, and the dashboard sidebar pill.

## Decisions locked (Foundry Open Questions)

- **OQ1**: virtual key shape is `vk_` + 32 base32 random chars; 8-char visible prefix.
- **OQ2**: 128-char UTF-8 max for tenant identifiers.
- **OQ3**: no backfill; pre-v0.4.0 rows stay NULL.
- **OQ4**: `sqlite_master` presence check before each derived-table ALTER.
- **OQ5**: soft revoke (writes `revoked_at`, keeps row for audit).

## Test plan

- `pytest --cov=voicegateway --cov=dashboard --cov-fail-under=80` clean: **1509 passed**, 4 skipped, **coverage 87.58%** (above 80% gate).
- `ruff check .` clean.
- `mypy voicegateway` clean (127 source files).
- Frontend `npm run build` (vite) green.
- 67 new tests added across 7 files: migration contract, virtual_keys_repo round-trip + soft-revoke + stale detection, tenants_repo aggregates + typeahead escape, virtual key auth (helper + end-to-end), session-create tenant flow, tenant URL filter on storage methods, three-tenant aggregation propagation.

## Notes

Generated by Ralph fast-track. Squash-merge intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v0.4.0 Release Notes

* **New Features**
  * Multi-tenant cost attribution across dashboard analytics, costs, and metrics
  * Virtual API keys for scoped tenant authentication
  * Virtual Keys management page with issue/revoke capabilities
  * Tenant filtering on costs, latency, sessions, and metrics pages
  * New `tenant` CLI commands to query tenant aggregates and session data
  * "Unattributed" data bucket for legacy sessions

* **Documentation**
  * Added multi-tenant quickstart guide
  * Updated API docs with tenant attribution details

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mahimailabs/voicegateway/pull/18)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->