### PR TITLE
v0.5.0 — Cross-modality routing and white-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to VoiceGateway are documented here. This project follows [Semantic Versioning](https://semver.org/) and [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.5.0 -- 2026-05-12
+
+**Cross-modality routing and white-label branding.** Two capabilities ship together because they target the same agency rung of the buyer ladder. The router runs once per session at session-create time, reads the project's latency budget plus recent observed per-provider latency, and picks the (STT, LLM, TTS) combination from the project's rosters that minimises predicted total latency under budget. White-label branding lets agencies upload a per-project logo, accent color, and product name; the dashboard chrome reflects the brand for users scoped to that project. The picked triple persists on the session row so the dashboard can show what ran and how close the call landed.
+
+### Added
+
+- **Migration 0006** (REQ-VG-ROUTE-001..004) adds five nullable routing columns to `sessions` (`budget_ms`, `budget_ms_used`, `budget_overrun`, `routed_llm`, `routed_tts`), `branding_json` nullable on `managed_projects`, and a new `latency_observations` table with `idx_latency_obs_project_provider` composite index. Idempotent; pre-v0.5.0 rows preserved with NULL.
+- **`voicegateway.middleware.router`** (REQ-VG-ROUTE-002): `route_session` picks the lowest-predicted-total triple under budget from the project's rosters. Observed p50 from `latency_observations` wins; missing observations fall back to `voicegateway/core/provider_baselines.json` (10 curated entries with `source_url` + `verified_at`). Caller overrides win for named modalities. Fallback to fastest + `budget_overrun=True` when nothing fits and `fallback_to_fastest=True`; otherwise raises `BudgetExceeded`.
+- **`voicegateway.storage.latency_observations_repo`** (REQ-VG-ROUTE-002 AC-4 + REQ-VG-ROUTE-003): `roll_up` aggregates per (project, provider, modality) p50/p95 over a trailing window (default 24h, OQ2 lock); DELETE + INSERT atomic snapshot replaces the prior rollup. `read_all` / `get_for_project` / `get_one` read-side helpers.
+- **`voicegateway.middleware.latency_observations_worker`**: asyncio loop mirroring v0.3.0's retention_worker. Wakes every 15 minutes (OQ2 lock), triggers `roll_up`. start/stop/tick_now lifecycle.
+- **`set_routing_decision` / `current_routing_decision` ContextVar** in `voicegateway/inference/_session_context.py` plus `attach_session(routed_triple=...)` kwarg threading the triple. `log_request` reads the ContextVar at the sessions UPSERT and stamps `routed_llm / routed_tts / budget_ms / budget_overrun` with COALESCE on conflict (AC-5 immutability).
+- **`RoutingConfig`** per-project YAML knob: `routing.budget_ms` (default 1500ms, OQ1 lock), `routing.rosters` (dict: stt/llm/tts -> ordered provider list), `routing.fallback_to_fastest` (default True). Plus **`BrandingConfig`**: `branding.logo_url`, `branding.accent_color`, `branding.product_name` (all nullable). Mirrored across Pydantic schema and runtime dataclass.
+- **`SQLiteStorage._validate_branding`** enforces logo_url ≤2048 chars, hex regex `#RGB`/`#RRGGBB`, product_name ≤64 chars, no unknown keys. `upsert_managed_project` accepts a `branding` kwarg; `list_managed_projects` SELECT extended with `branding_json`. COALESCE-protected upsert preserves prior branding on partial updates.
+- **Four new dashboard endpoints**: `GET /api/routing/observations[?project=…]`, `GET /api/projects/{id}/branding`, `POST /api/projects/{id}/branding`, `POST /api/projects/{id}/branding/logo` (multipart, Pillow-validated PNG: 256 KB cap + 512×512 + format check; SVG header validated). Static branding mount at `/static/branding/`.
+- **`dashboard/frontend/src/pages/Routing.tsx`** with sortable columns (Modality / Provider / p50 / p95 / Samples), hourly auto-refresh, NULL p50 → "no observations yet" (AC-4), optional `?project=…` URL scoping.
+- **`dashboard/frontend/src/lib/branding.ts`** applies branding via CSS variables on `document.documentElement` (`--brand-accent`, `--brand-product-name`, `--brand-logo-url`) + favicon + document.title. Read-once-per-mount (OQ5).
+- **App.tsx Sidebar** reads the active project's branding once on mount and renders the branded logo image + product name (falling back to "VoiceGateway").
+- **SessionDetailModal RoutingStrip** shows the picked triple + budget_ms + budget_overrun chip. Hidden entirely on pre-v0.5.0 sessions.
+- **Projects page Brand button** opens a per-project `BrandingModal` with product name input, accent color picker (native `<input type=color>` + hex sync), PNG/SVG upload with yellow-bg preview, Save/Reset/Cancel.
+- **App.tsx Routing route + sidebar nav** at `/routing`, positioned between Metrics and Projects per Foundry order.
+- **Typed fetchers + types** in `lib/api.ts` and `lib/types.ts`: `RoutedTriple`, `LatencyObservation`, `RoutingObservationsResponse`, `ProjectBranding`, `ProjectBrandingResponse`, `LogoUploadResponse`. `fetchRoutingObservations`, `fetchProjectBranding`, `updateProjectBranding`, `uploadBrandingLogo` (multipart-aware raw fetch preserving the AUTH_REQUIRED contract).
+- **`voicegw route show / simulate`** read-only CLI for routing diagnostics. `show` prints rosters + current observations; `simulate` dry-runs the picker with optional per-modality overrides.
+- **`voicegw brand set / show / clear`** CLI for scripted provisioning. Hits the same dashboard endpoints as the FE so agencies can roll new brands from scripts. Uses httpx; reads `VOICEGW_API_KEY` for Bearer auth.
+- **46 new tests** across `tests/storage/`, `tests/middleware/`, `tests/server/`, `tests/inference/`. Full suite: 1509 → 1555 (+46). Coverage: 86.11% (above 80% Foundry gate).
+- **`docs/api/python-sdk.md`** grew a "Cross-modality routing (v0.5.0)" section between v0.4.0 tenant and v0.3.0 replay sections.
+- **`docs/guide/agency-quickstart.md`** is the operator walkthrough: configure rosters, verify via CLI, upload branding, share a branded link, watch the Routing view, inspect per-session decisions.
+- **`pillow>=10.0`** added to `[project] dependencies` for the logo upload PNG validation path.
+
+### Changed
+
+- **Embedded version strings** bumped from `0.4.0` to `0.5.0` in `voicegateway/server/main.py` (FastAPI ctor + `/health.version`), `dashboard/api/main.py` (FastAPI ctor), `tests/server/test_server.py` (version assertion), `docker/voicegateway.Dockerfile` (`ARG VERSION` in both stages), and the dashboard sidebar pill in `dashboard/frontend/src/App.tsx`.
+
+### Decisions locked (Foundry Open Questions)
+
+- **OQ1 default budget_ms** — 1500 ms. Typical conversational voice-agent target.
+- **OQ2 roll-up window + cadence** — 24h rolling window, 15-minute refresh.
+- **OQ3 no-observations fallback** — curated `voicegateway/core/provider_baselines.json` with `source_url` per entry.
+- **OQ4 logo upload constraints** — 256 KB max, PNG or SVG only, 512×512 px max. Pillow-validates PNG on upload.
+- **OQ5 branding cache strategy** — read-once-per-mount. Operators see brand changes on next page load.
+
+### Notes
+
+- **No mid-call routing.** The triple stays fixed for the session's lifetime (AC-5).
+- **No adaptive learning.** Static aggregation; no ML on in-call telemetry.
+- **No custom-domain dashboard hosting.** White-label sits at the gateway's own host.
+- **No per-tenant branding inside one project.** Agencies running multiple downstream tenants in one project share one brand.
+- **No email or exported-report branding.** Dashboard chrome only.
+- **No cost-aware routing.** v0.5.0 picks on latency.
+- **No multi-region routing.**
+- **No in-flight budget enforcement.** Budget is a router input at start, not a runtime kill switch.
+
 ## v0.4.0 -- 2026-05-11
 
 **Multi-tenant cost attribution.** VoiceGateway now tags every voice session with an optional `tenant_id` so a single deployment can serve many customers and account for each one separately. Three independent surfaces set the tenant: an `attach_session(tenant_id=...)` kwarg for owner-of-AgentSession code, an `inference.set_tenant("…")` ContextVar API, and scoped virtual API keys that auto-attribute at the auth layer. Every cost row, metric row, and replay event for an attributed session lands tagged with the tenant; pre-v0.4.0 rows stay in the "unattributed" bucket (NULL `tenant_id`). The dashboard's existing Costs, Sessions, Metrics, and Replay pages all rescope when a tenant is selected from the new shared `FilterBar`; a new `Virtual Keys` page issues, lists, and revokes keys with a one-time plaintext modal.

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from fastapi import Body, FastAPI, HTTPException, Query
+from fastapi import Body, FastAPI, File, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -801,6 +801,232 @@ async def revoke_virtual_key_endpoint(key_id: int) -> dict[str, Any]:
         # Should never happen: revoke() just returned True. Defensive.
         raise HTTPException(status_code=404, detail=f"Virtual key {key_id} vanished")
     return {"id": key_id, "revoked": True, "row": dataclasses.asdict(row)}
+
+
+# ---------------------------------------------------------------------------
+# v0.5.0 cross-modality routing + white-label branding endpoints.
+# REQ-VG-ROUTE-003 (Routing observations view) + REQ-VG-ROUTE-004
+# (per-project branding upload).
+# ---------------------------------------------------------------------------
+
+_BRANDING_DIR = Path(__file__).parent / "static" / "branding"
+_BRANDING_DIR.mkdir(parents=True, exist_ok=True)
+_MAX_LOGO_BYTES = 256 * 1024  # OQ4 lock: 256 KB.
+_MAX_LOGO_DIMENSION = 512  # OQ4 lock: 512x512 px.
+_ALLOWED_LOGO_FORMATS = ("PNG", "SVG")  # OQ4 lock: PNG or SVG.
+
+# Mount the branding directory at /static/branding so uploaded logos
+# resolve at https://<dashboard>/static/branding/<project_id>.<ext>.
+app.mount(
+    "/static/branding",
+    StaticFiles(directory=_BRANDING_DIR),
+    name="branding",
+)
+
+
+@app.get("/api/routing/observations")
+async def get_routing_observations(
+    project: str | None = Query(None),
+) -> dict[str, Any]:
+    """Per-project provider-latency snapshot powering the Routing dashboard view.
+
+    Implements REQ-VG-ROUTE-003 AC-3 (per-project observed-latency,
+    refreshed at least hourly — the worker rolls up every 15 minutes
+    per OQ2). Each entry carries the provider id, modality, p50/p95,
+    sample_count, and the rolling window's start/end timestamps.
+
+    Pass ``project`` to scope to one project; omit for every
+    project's observations.
+    """
+    from voicegateway.storage import latency_observations_repo
+
+    gw = _get_gateway()
+    if gw.storage is None:
+        return {"observations": [], "filter": {"project": project}}
+    db = await gw.storage._ensure_initialized()
+    rows = (
+        await latency_observations_repo.get_for_project(db, project)
+        if project
+        else await latency_observations_repo.read_all(db)
+    )
+    return {
+        "observations": [dataclasses.asdict(r) for r in rows],
+        "filter": {"project": project},
+    }
+
+
+@app.get("/api/projects/{project_id}/branding")
+async def get_project_branding(project_id: str) -> dict[str, Any]:
+    """Return the active white-label branding for a project.
+
+    Returns ``{"project_id": ..., "branding": null}`` when no
+    branding is set so the FE can render the default brand
+    (AC-3).
+    """
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    project = await gw.storage.get_managed_project(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail=f"Project {project_id!r} not found")
+    return {"project_id": project_id, "branding": project.get("branding")}
+
+
+@app.post("/api/projects/{project_id}/branding")
+async def update_project_branding(
+    project_id: str, body: dict[str, Any] = Body(...)
+) -> dict[str, Any]:
+    """Update the project's branding (logo_url / accent_color / product_name).
+
+    Body is the branding dict; storage's ``_validate_branding``
+    enforces shape (hex regex, 64-char product_name cap, no unknown
+    keys). Returns the validated branding plus the project_id so the
+    FE can re-apply the CSS variables on the next layout mount.
+    """
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    existing = await gw.storage.get_managed_project(project_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail=f"Project {project_id!r} not found")
+    try:
+        await gw.storage.upsert_managed_project(
+            project_id=project_id,
+            name=existing.get("name", project_id),
+            description=existing.get("description", ""),
+            daily_budget=existing.get("daily_budget", 0.0),
+            budget_action=existing.get("budget_action", "warn"),
+            default_stack=existing.get("default_stack"),
+            stt_model=existing.get("stt_model"),
+            llm_model=existing.get("llm_model"),
+            tts_model=existing.get("tts_model"),
+            tags=existing.get("tags"),
+            branding=body,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    refreshed = await gw.storage.get_managed_project(project_id)
+    return {
+        "project_id": project_id,
+        "branding": (refreshed or {}).get("branding"),
+    }
+
+
+@app.post("/api/projects/{project_id}/branding/logo")
+async def upload_project_logo(
+    project_id: str, file: UploadFile = File(...)
+) -> dict[str, Any]:
+    """Upload a project's logo image.
+
+    OQ4 constraints (validated by Pillow when the format is PNG):
+    - Max 256 KB on the wire.
+    - PNG or SVG only.
+    - Max 512x512 pixels (PNG only; SVG is vector so dimension
+      check is skipped).
+
+    Persists the file under
+    ``dashboard/api/static/branding/{project_id}.{ext}`` and stamps
+    the returned URL onto the project's ``branding.logo_url``. The
+    endpoint does NOT update other branding fields; call POST
+    /api/projects/{id}/branding for that.
+    """
+    gw = _get_gateway()
+    if gw.storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    existing = await gw.storage.get_managed_project(project_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail=f"Project {project_id!r} not found")
+
+    content = await file.read()
+    if len(content) > _MAX_LOGO_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"logo exceeds {_MAX_LOGO_BYTES // 1024} KB cap "
+                f"(got {len(content)} bytes)"
+            ),
+        )
+
+    content_type = (file.content_type or "").lower()
+    suffix: str
+    if content_type == "image/png" or (file.filename or "").lower().endswith(".png"):
+        suffix = "png"
+        try:
+            from io import BytesIO
+
+            from PIL import Image, UnidentifiedImageError
+        except ImportError as exc:
+            raise HTTPException(
+                status_code=503,
+                detail="Pillow not installed; install voicegateway[dashboard]",
+            ) from exc
+        try:
+            img = Image.open(BytesIO(content))
+            img.verify()
+            # Re-open after verify (PIL invalidates the handle).
+            img = Image.open(BytesIO(content))
+        except (UnidentifiedImageError, OSError) as exc:
+            raise HTTPException(status_code=400, detail=f"invalid PNG: {exc}") from exc
+        if img.format != "PNG":
+            raise HTTPException(
+                status_code=400,
+                detail=f"expected PNG, got {img.format}",
+            )
+        if img.width > _MAX_LOGO_DIMENSION or img.height > _MAX_LOGO_DIMENSION:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"logo dimensions {img.width}x{img.height} exceed "
+                    f"{_MAX_LOGO_DIMENSION}x{_MAX_LOGO_DIMENSION} cap"
+                ),
+            )
+    elif content_type == "image/svg+xml" or (file.filename or "").lower().endswith(
+        ".svg"
+    ):
+        suffix = "svg"
+        # SVG is text/XML; reject obvious binary garbage. Full XML
+        # validation is out of scope for v0.5.0 — operator should
+        # control which agency staff can upload.
+        if b"<svg" not in content[:512].lower():
+            raise HTTPException(status_code=400, detail="file does not look like SVG")
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unsupported logo format: must be PNG or SVG (got "
+            f"content_type={content_type!r})",
+        )
+
+    target = _BRANDING_DIR / f"{project_id}.{suffix}"
+    target.write_bytes(content)
+    logo_url = f"/static/branding/{project_id}.{suffix}"
+
+    # Merge with existing branding so we don't clobber accent_color
+    # or product_name.
+    current_branding = (existing or {}).get("branding") or {}
+    new_branding = {**current_branding, "logo_url": logo_url}
+    try:
+        await gw.storage.upsert_managed_project(
+            project_id=project_id,
+            name=existing.get("name", project_id),
+            description=existing.get("description", ""),
+            daily_budget=existing.get("daily_budget", 0.0),
+            budget_action=existing.get("budget_action", "warn"),
+            default_stack=existing.get("default_stack"),
+            stt_model=existing.get("stt_model"),
+            llm_model=existing.get("llm_model"),
+            tts_model=existing.get("tts_model"),
+            tags=existing.get("tags"),
+            branding=new_branding,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "project_id": project_id,
+        "logo_url": logo_url,
+        "bytes": len(content),
+        "format": suffix.upper(),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -35,7 +35,7 @@ _LOCAL_PROVIDER_NAMES = frozenset({"ollama", "whisper", "kokoro", "piper"})
 
 app = FastAPI(
     title="VoiceGateway Dashboard",
-    version="0.4.0",
+    version="0.5.0",
 )
 
 # Set by the CLI / combined server when starting the dashboard.

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import Replay from './pages/Replay';
 import Sessions from './pages/Sessions';
 import Projects from './pages/Projects';
 import Providers from './pages/Providers';
+import Routing from './pages/Routing';
 import Settings from './pages/Settings';
 import VirtualKeys from './pages/VirtualKeys';
 import Login from './pages/Login';
@@ -28,6 +29,11 @@ interface ActiveBranding {
 // level entry), Projects, Providers, Virtual Keys. Overview, Models,
 // Latency, and Settings predate that spec and are kept above /
 // below the v0.4.0 block so existing users find them where they were.
+// Foundry v0.5.0 nav order: Costs, Logs, Sessions, Metrics, Replay
+// (conditional, lives under /sessions/:id/replay so it is not a top-
+// level entry), Routing, Projects, Providers, Virtual Keys, Settings.
+// Overview, Models, and Latency predate that spec and are kept above
+// the v0.5.0 block so existing users find them where they were.
 const PAGES = [
   { to: '/',             label: 'Overview',     id: 'overview' },
   { to: '/models',       label: 'Models',       id: 'models'   },
@@ -36,6 +42,7 @@ const PAGES = [
   { to: '/logs',         label: 'Logs',         id: 'logs'     },
   { to: '/sessions',     label: 'Sessions',     id: 'sessions' },
   { to: '/metrics',      label: 'Metrics',      id: 'metrics'  },
+  { to: '/routing',      label: 'Routing',      id: 'routing'  },
   { to: '/projects',     label: 'Projects',     id: 'projects' },
   { to: '/providers',    label: 'Providers',    id: 'providers' },
   { to: '/virtual-keys', label: 'Virtual Keys', id: 'virtual-keys' },
@@ -117,6 +124,7 @@ export default function App() {
             <Route path="/metrics" element={<Metrics />} />
             <Route path="/projects" element={<Projects />} />
             <Route path="/providers" element={<Providers />} />
+            <Route path="/routing" element={<Routing />} />
             <Route path="/virtual-keys" element={<VirtualKeys />} />
             <Route path="/settings" element={<Settings />} />
             <Route path="/settings/audit-log" element={<Settings tab="audit" />} />

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -15,6 +15,13 @@ import VirtualKeys from './pages/VirtualKeys';
 import Login from './pages/Login';
 import type { StatusResponse } from './lib/types';
 import { AUTH_REQUIRED_EVENT, clearToken, fetchJson, getToken } from './lib/api';
+import { applyBrandingForProject } from './lib/branding';
+
+interface ActiveBranding {
+  logo_url?: string | null;
+  accent_color?: string | null;
+  product_name?: string | null;
+}
 
 // Foundry v0.4.0 nav order: Costs, Logs, Sessions, Metrics, Replay
 // (conditional, lives under /sessions/:id/replay so it is not a top-
@@ -77,6 +84,18 @@ export default function App() {
     fetchJson<StatusResponse>('/api/status').then(setStatus).catch(() => setStatus(null));
   }, [authState]);
 
+  // v0.5.0: apply per-project white-label branding once on layout
+  // mount (REQ-VG-ROUTE-004). Read-once-per-mount per OQ5. Reads the
+  // ?project=<id> URL param; a downstream operator who wants the
+  // branded chrome on every page sets the param at link time.
+  const [branding, setBranding] = useState<ActiveBranding | null>(null);
+  useEffect(() => {
+    if (authState !== 'ready') return;
+    const params = new URLSearchParams(window.location.search);
+    const projectId = params.get('project');
+    applyBrandingForProject(projectId).then(setBranding).catch(() => setBranding(null));
+  }, [authState]);
+
   if (authState === 'checking') return null;
   if (authState === 'needs-login') {
     return <Login onAuthed={() => setAuthState('ready')} />;
@@ -85,7 +104,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <div className="app-shell">
-        <Sidebar status={status} onSignOut={signOut} />
+        <Sidebar status={status} onSignOut={signOut} branding={branding} />
         <main className="main">
           <Routes>
             <Route path="/" element={<Overview />} />
@@ -111,19 +130,30 @@ export default function App() {
 function Sidebar({
   status,
   onSignOut,
+  branding,
 }: {
   status: StatusResponse | null;
   onSignOut: () => void;
+  branding: ActiveBranding | null;
 }) {
   const providerCount = status ? Object.keys(status.providers).length : 0;
   const modelCount = status ? Object.keys(status.models).length : 0;
   const hasToken = !!getToken();
+  const productName = branding?.product_name || 'VoiceGateway';
+  const logoUrl = branding?.logo_url || null;
 
   return (
     <aside className="sidebar">
       <div className="sidebar__logo">
-        VoiceGateway
-        <small>SELF-HOSTED VOICE AI</small>
+        {logoUrl && (
+          <img
+            src={logoUrl}
+            alt={`${productName} logo`}
+            style={{ maxHeight: '32px', maxWidth: '160px', display: 'block', marginBottom: '0.25rem' }}
+          />
+        )}
+        {productName}
+        <small>{branding?.product_name ? 'WHITE-LABEL' : 'SELF-HOSTED VOICE AI'}</small>
       </div>
       <nav className="sidebar__nav">
         {PAGES.map((p) => (

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -178,7 +178,7 @@ function Sidebar({
           <span className="neo-status-dot neo-status-dot--online" />
           {providerCount} Providers · {modelCount} Models
         </div>
-        <span className="version-pill">v0.4.0</span>
+        <span className="version-pill">v0.5.0</span>
         {hasToken && (
           <button
             type="button"

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -88,9 +88,13 @@ async function extractErrorDetail(res: Response): Promise<string | null> {
 import type {
   CreatedVirtualKey,
   DeadAirEvent,
+  LogoUploadResponse,
   MetricsAggregate,
+  ProjectBranding,
+  ProjectBrandingResponse,
   ReplayResponse,
   RetentionWindow,
+  RoutingObservationsResponse,
   TenantFilter,
   TenantRow,
   TenantsResponse,
@@ -229,4 +233,82 @@ export function revokeVirtualKey(
   keyId: number,
 ): Promise<{ id: number; revoked: true; row: VirtualKey }> {
   return fetchJson(`/api/virtual_keys/${keyId}/revoke`, { method: 'POST' });
+}
+
+// ----------------------------------------------------------------------
+// v0.5.0 cross-modality routing + white-label branding typed fetchers
+// (REQ-VG-ROUTE-001..004).
+// ----------------------------------------------------------------------
+
+export function fetchRoutingObservations(
+  options: { project?: string } = {},
+): Promise<RoutingObservationsResponse> {
+  const params = new URLSearchParams();
+  if (options.project) params.set('project', options.project);
+  const qs = params.toString();
+  return fetchJson<RoutingObservationsResponse>(
+    qs ? `/api/routing/observations?${qs}` : '/api/routing/observations',
+  );
+}
+
+export function fetchProjectBranding(
+  projectId: string,
+): Promise<ProjectBrandingResponse> {
+  return fetchJson<ProjectBrandingResponse>(
+    `/api/projects/${encodeURIComponent(projectId)}/branding`,
+  );
+}
+
+export function updateProjectBranding(
+  projectId: string,
+  branding: ProjectBranding,
+): Promise<ProjectBrandingResponse> {
+  return fetchJson<ProjectBrandingResponse>(
+    `/api/projects/${encodeURIComponent(projectId)}/branding`,
+    {
+      method: 'POST',
+      body: JSON.stringify(branding),
+    },
+  );
+}
+
+/**
+ * Multipart logo upload. Uses raw ``fetch`` because ``fetchJson``
+ * always sets ``Content-Type: application/json`` when a body is
+ * provided; multipart needs the browser to set the boundary.
+ *
+ * Returns the served URL the operator can plug into
+ * ``ProjectBranding.logo_url`` on the next branding POST.
+ */
+export async function uploadBrandingLogo(
+  projectId: string,
+  file: File,
+): Promise<LogoUploadResponse> {
+  const fd = new FormData();
+  fd.append('file', file);
+  const headers: Record<string, string> = {};
+  const token = getToken();
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const res = await fetch(
+    `/api/projects/${encodeURIComponent(projectId)}/branding/logo`,
+    { method: 'POST', body: fd, headers },
+  );
+  if (res.status === 401 || res.status === 403) {
+    clearToken();
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent(AUTH_REQUIRED_EVENT));
+    }
+    throw new Error(`HTTP ${res.status}`);
+  }
+  if (!res.ok) {
+    let detail: string | null = null;
+    try {
+      const body = await res.json();
+      if (typeof body?.detail === 'string') detail = body.detail;
+    } catch {
+      // fall through
+    }
+    throw new Error(detail ?? `HTTP ${res.status}`);
+  }
+  return (await res.json()) as LogoUploadResponse;
 }

--- a/dashboard/frontend/src/lib/branding.ts
+++ b/dashboard/frontend/src/lib/branding.ts
@@ -1,0 +1,132 @@
+import { useEffect } from 'react';
+import { fetchJson } from './api';
+
+interface BrandingPayload {
+  logo_url?: string | null;
+  accent_color?: string | null;
+  product_name?: string | null;
+}
+
+interface ProjectBrandingResponse {
+  project_id: string;
+  branding: BrandingPayload | null;
+}
+
+const DEFAULT_PRODUCT_NAME = 'VoiceGateway';
+const _BRAND_VARS = ['--brand-accent', '--brand-product-name', '--brand-logo-url'] as const;
+
+/**
+ * Read the active project's branding once and apply it as CSS variables
+ * on ``document.documentElement``. Implements REQ-VG-ROUTE-004 AC-2.
+ *
+ * Read-once-per-mount per OQ5: this function is meant to run on
+ * layout mount (via :func:`useBranding`). Operator brand changes
+ * surface on the next page load, not live.
+ *
+ * Behavior:
+ * - ``accent_color`` -> sets ``--brand-accent`` on ``document.documentElement``
+ *   and the favicon link's color attribute when present.
+ * - ``product_name`` -> sets ``--brand-product-name`` AND
+ *   ``document.title`` (prefixed with the active page label upstream).
+ * - ``logo_url`` -> sets ``--brand-logo-url`` (CSS ``url(...)``) for
+ *   ``AppShell`` to consume as a ``background-image`` or
+ *   ``<img src>``; also updates the favicon ``<link rel="icon">``.
+ * - When the project is unknown OR has no branding set, clears the
+ *   three CSS variables so the dashboard renders the VoiceGateway
+ *   default (REQ-VG-ROUTE-004 AC-3).
+ */
+export async function applyBrandingForProject(
+  projectId: string | null,
+): Promise<BrandingPayload | null> {
+  if (!projectId) {
+    clearBranding();
+    return null;
+  }
+  let branding: BrandingPayload | null = null;
+  try {
+    const resp = await fetchJson<ProjectBrandingResponse>(
+      `/api/projects/${encodeURIComponent(projectId)}/branding`,
+    );
+    branding = resp.branding;
+  } catch {
+    // 404 unknown project, or 503 storage off: fall through to defaults.
+    clearBranding();
+    return null;
+  }
+  applyBranding(branding);
+  return branding;
+}
+
+/** Apply a branding payload to the document root. Used directly by tests. */
+export function applyBranding(branding: BrandingPayload | null): void {
+  const root = document.documentElement;
+  if (!branding) {
+    clearBranding();
+    return;
+  }
+  if (branding.accent_color) {
+    root.style.setProperty('--brand-accent', branding.accent_color);
+  } else {
+    root.style.removeProperty('--brand-accent');
+  }
+  if (branding.product_name) {
+    root.style.setProperty(
+      '--brand-product-name',
+      `"${branding.product_name.replace(/"/g, '\\"')}"`,
+    );
+    document.title = branding.product_name;
+  } else {
+    root.style.removeProperty('--brand-product-name');
+    document.title = DEFAULT_PRODUCT_NAME;
+  }
+  if (branding.logo_url) {
+    root.style.setProperty('--brand-logo-url', `url("${branding.logo_url}")`);
+    _setFavicon(branding.logo_url);
+  } else {
+    root.style.removeProperty('--brand-logo-url');
+    _setFavicon(null);
+  }
+}
+
+/** Reset all three CSS variables back to defaults (AC-3 / AC-4 fallback). */
+export function clearBranding(): void {
+  const root = document.documentElement;
+  for (const name of _BRAND_VARS) {
+    root.style.removeProperty(name);
+  }
+  document.title = DEFAULT_PRODUCT_NAME;
+  _setFavicon(null);
+}
+
+function _setFavicon(href: string | null): void {
+  const link = document.querySelector<HTMLLinkElement>("link[rel~='icon']");
+  if (!link) return;
+  if (href) {
+    link.href = href;
+  } else {
+    // Reset to the bundled default if vite has set one via index.html.
+    const original = link.getAttribute('data-default-href');
+    if (original) link.href = original;
+  }
+}
+
+/**
+ * React hook: applies branding for the URL's ``?project=<id>`` (or
+ * the supplied default) once on mount. Returns the resolved branding
+ * dict or null so layouts can do conditional UI (e.g. show or hide
+ * the default logo).
+ *
+ * Per OQ5, this hook does NOT subscribe to project changes. A user
+ * who switches projects in the FilterBar sees the new brand on the
+ * next page navigation (when the AppShell remounts) — matching
+ * REQ-VG-ROUTE-004 AC-4 wording "on the next page load".
+ */
+export function useBranding(defaultProjectId?: string): void {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const projectId = params.get('project') ?? defaultProjectId ?? null;
+    void applyBrandingForProject(projectId);
+    // Intentionally NO dependency on location.search — read-once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -97,6 +97,13 @@ export interface SessionRow {
   // "unattributed" pill. Older session rows written before v0.4.0
   // simply omit the field; the JSON response leaves it absent.
   tenant_id?: string | null;
+  // v0.5.0 (REQ-VG-ROUTE-003). NULL on pre-v0.5.0 sessions or
+  // when the router never ran. The dashboard renders NULL as
+  // '-' in the routing strip.
+  routed_llm?: string | null;
+  routed_tts?: string | null;
+  budget_ms?: number | null;
+  budget_overrun?: boolean | null;
 }
 
 export interface SessionDetail extends SessionRow {

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -245,3 +245,61 @@ export interface CreatedVirtualKey {
   plaintext: string;
   row: VirtualKey;
 }
+
+// ----------------------------------------------------------------------
+// v0.5.0 cross-modality routing + white-label branding (REQ-VG-ROUTE-001..004).
+// ----------------------------------------------------------------------
+
+/**
+ * The router's pick for a session. Returned by ``route_session`` and
+ * persisted to the ``sessions`` row's ``routed_llm`` / ``routed_tts``
+ * / ``budget_ms`` / ``budget_overrun`` columns. STT comes from the
+ * session's existing provider field.
+ */
+export interface RoutedTriple {
+  stt: string;
+  llm: string;
+  tts: string;
+  predicted_ms: number;
+  budget_overrun: boolean;
+}
+
+/** One row from the ``latency_observations`` rollup. */
+export interface LatencyObservation {
+  project_id: string;
+  provider: string;
+  modality: 'stt' | 'llm' | 'tts';
+  p50_ms: number | null;
+  p95_ms: number | null;
+  sample_count: number;
+  window_start: string;
+  window_end: string;
+  refreshed_at: string;
+}
+
+/** ``GET /api/routing/observations`` response. */
+export interface RoutingObservationsResponse {
+  observations: LatencyObservation[];
+  filter: { project: string | null };
+}
+
+/** White-label branding payload (REQ-VG-ROUTE-004). All fields optional. */
+export interface ProjectBranding {
+  logo_url?: string | null;
+  accent_color?: string | null;
+  product_name?: string | null;
+}
+
+/** ``GET /api/projects/{id}/branding`` response. */
+export interface ProjectBrandingResponse {
+  project_id: string;
+  branding: ProjectBranding | null;
+}
+
+/** ``POST /api/projects/{id}/branding/logo`` response. */
+export interface LogoUploadResponse {
+  project_id: string;
+  logo_url: string;
+  bytes: number;
+  format: 'PNG' | 'SVG';
+}

--- a/dashboard/frontend/src/pages/Projects.tsx
+++ b/dashboard/frontend/src/pages/Projects.tsx
@@ -3,6 +3,12 @@ import PageHeader from '../components/PageHeader';
 import SourceBadge from '../components/SourceBadge';
 import { fetchJson } from '../lib/api';
 
+interface ProjectBranding {
+  logo_url?: string | null;
+  accent_color?: string | null;
+  product_name?: string | null;
+}
+
 interface ProjectEntry {
   id: string;
   name: string;
@@ -27,6 +33,7 @@ export default function Projects() {
   const [projects, setProjects] = useState<ProjectEntry[]>([]);
   const [stats, setStats] = useState<Record<string, ProjectStats>>({});
   const [showCreate, setShowCreate] = useState(false);
+  const [brandingFor, setBrandingFor] = useState<string | null>(null);
 
   const refresh = () => {
     fetchJson<{ projects: ProjectEntry[]; stats: Record<string, ProjectStats> }>('/api/projects')
@@ -85,6 +92,15 @@ export default function Projects() {
                 <span className="label">{s?.requests_today ?? 0} requests today</span>
                 <span className="label">{p.budget_action}</span>
               </div>
+              <div className="mt-sm">
+                <button
+                  type="button"
+                  className="neo-btn neo-btn--small"
+                  onClick={() => setBrandingFor(p.id)}
+                >
+                  Brand
+                </button>
+              </div>
             </div>
           );
         })}
@@ -94,6 +110,12 @@ export default function Projects() {
       </div>
 
       {showCreate && <CreateProjectModal onClose={() => { setShowCreate(false); refresh(); }} />}
+      {brandingFor && (
+        <BrandingModal
+          projectId={brandingFor}
+          onClose={() => setBrandingFor(null)}
+        />
+      )}
     </div>
   );
 }
@@ -152,6 +174,169 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
           <button className="neo-btn neo-btn--primary" onClick={save} disabled={saving || !name}>
             {saving ? 'Creating...' : 'Create Project'}
           </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BrandingModal({
+  projectId,
+  onClose,
+}: {
+  projectId: string;
+  onClose: () => void;
+}) {
+  const [logoUrl, setLogoUrl] = useState('');
+  const [accentColor, setAccentColor] = useState('#333333');
+  const [productName, setProductName] = useState('');
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchJson<{ project_id: string; branding: ProjectBranding | null }>(
+      `/api/projects/${encodeURIComponent(projectId)}/branding`,
+    )
+      .then((d) => {
+        if (d.branding) {
+          setLogoUrl(d.branding.logo_url ?? '');
+          setAccentColor(d.branding.accent_color ?? '#333333');
+          setProductName(d.branding.product_name ?? '');
+        }
+      })
+      .catch(() => {
+        // Project may have no branding yet; keep the input defaults.
+      });
+  }, [projectId]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      if (logoFile) {
+        const fd = new FormData();
+        fd.append('file', logoFile);
+        const resp = await fetch(
+          `/api/projects/${encodeURIComponent(projectId)}/branding/logo`,
+          { method: 'POST', body: fd },
+        );
+        if (!resp.ok) {
+          const body = await resp.json().catch(() => ({}));
+          throw new Error(body.detail || `HTTP ${resp.status}`);
+        }
+        const data = (await resp.json()) as { logo_url: string };
+        setLogoUrl(data.logo_url);
+      }
+      await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/branding`, {
+        method: 'POST',
+        body: JSON.stringify({
+          logo_url: logoFile ? null : logoUrl || null,
+          accent_color: accentColor || null,
+          product_name: productName.trim() || null,
+        }),
+      });
+      onClose();
+    } catch (e) {
+      setError((e as Error).message || 'Failed to save branding');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reset = async () => {
+    if (!confirm('Reset branding to defaults for this project?')) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/branding`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+      });
+      onClose();
+    } catch (e) {
+      setError((e as Error).message || 'Failed to reset branding');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="neo-modal-backdrop" onClick={onClose}>
+      <div className="neo-modal" onClick={(e) => e.stopPropagation()} style={{ maxWidth: '32rem' }}>
+        <h3>Branding · {projectId}</h3>
+        <p className="label mt-sm">
+          Per-project white-label. Logo, accent color, and product name
+          override the default VoiceGateway brand for users scoped to
+          this project (REQ-VG-ROUTE-004).
+        </p>
+
+        <label className="label mt-md">Product name</label>
+        <input
+          className="neo-input"
+          value={productName}
+          onChange={(e) => setProductName(e.target.value)}
+          placeholder="(default: VoiceGateway)"
+          maxLength={64}
+        />
+
+        <label className="label mt-md">Accent color</label>
+        <div className="flex-row" style={{ gap: '0.5rem', alignItems: 'center' }}>
+          <input
+            type="color"
+            value={accentColor}
+            onChange={(e) => setAccentColor(e.target.value)}
+            style={{ width: 48, height: 36, border: '2px solid black', cursor: 'pointer' }}
+          />
+          <input
+            className="neo-input"
+            value={accentColor}
+            onChange={(e) => setAccentColor(e.target.value)}
+            style={{ width: '8rem', fontFamily: 'monospace' }}
+          />
+        </div>
+
+        <label className="label mt-md">Logo</label>
+        {(logoFile || logoUrl) && (
+          <div className="mt-sm" style={{ background: '#FFF9C2', padding: '0.5rem', border: '2px solid black' }}>
+            <img
+              src={logoFile ? URL.createObjectURL(logoFile) : logoUrl}
+              alt="Logo preview"
+              style={{ maxHeight: '48px', maxWidth: '200px', display: 'block' }}
+            />
+            <code style={{ fontSize: '0.75rem', wordBreak: 'break-all' }}>
+              {logoFile ? logoFile.name : logoUrl}
+            </code>
+          </div>
+        )}
+        <input
+          type="file"
+          accept="image/png,image/svg+xml"
+          className="neo-input mt-sm"
+          onChange={(e) => setLogoFile(e.target.files?.[0] ?? null)}
+        />
+        <div className="label" style={{ fontSize: '0.7rem', opacity: 0.7 }}>
+          PNG or SVG, max 256 KB, max 512x512 px.
+        </div>
+
+        {error && (
+          <div className="mt-md" style={{ color: 'var(--accent-pink, #FF3D71)' }}>
+            {error}
+          </div>
+        )}
+
+        <div className="flex-row mt-lg" style={{ justifyContent: 'space-between' }}>
+          <button className="neo-btn" onClick={reset} disabled={saving}>
+            Reset
+          </button>
+          <div className="flex-row">
+            <button className="neo-btn" onClick={onClose} disabled={saving}>
+              Cancel
+            </button>
+            <button className="neo-btn neo-btn--primary" onClick={save} disabled={saving}>
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/dashboard/frontend/src/pages/Routing.tsx
+++ b/dashboard/frontend/src/pages/Routing.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState } from 'react';
+import FilterBar from '../components/FilterBar';
+import PageHeader from '../components/PageHeader';
+import { fetchJson } from '../lib/api';
+
+interface LatencyObservation {
+  project_id: string;
+  provider: string;
+  modality: string;
+  p50_ms: number | null;
+  p95_ms: number | null;
+  sample_count: number;
+  window_start: string;
+  window_end: string;
+  refreshed_at: string;
+}
+
+interface ObservationsResponse {
+  observations: LatencyObservation[];
+  filter: { project: string | null };
+}
+
+type SortColumn = 'provider' | 'modality' | 'p50_ms' | 'p95_ms' | 'sample_count';
+type SortDir = 'asc' | 'desc';
+
+const MODALITY_ORDER: Record<string, number> = { stt: 0, llm: 1, tts: 2 };
+const MODALITY_BADGE: Record<string, string> = {
+  stt: 'neo-badge--blue',
+  llm: 'neo-badge--green',
+  tts: 'neo-badge--pink',
+};
+
+const REFRESH_INTERVAL_MS = 60 * 60 * 1000; // OQ2 lock: at least hourly.
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return '-';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '-';
+  const secs = Math.floor((Date.now() - then) / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`;
+  return `${Math.floor(secs / 86400)}d ago`;
+}
+
+function projectFromUrl(): string | undefined {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('project') || undefined;
+}
+
+export default function Routing() {
+  const [data, setData] = useState<ObservationsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sortCol, setSortCol] = useState<SortColumn>('modality');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const refresh = () => {
+    setLoading(true);
+    const project = projectFromUrl();
+    const url = project
+      ? `/api/routing/observations?project=${encodeURIComponent(project)}`
+      : '/api/routing/observations';
+    fetchJson<ObservationsResponse>(url)
+      .then(setData)
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    refresh();
+    const handle = window.setInterval(refresh, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(handle);
+  }, []);
+
+  const rows = useMemo(() => {
+    if (!data) return [];
+    const sorted = [...data.observations];
+    sorted.sort((a, b) => {
+      let cmp = 0;
+      if (sortCol === 'modality') {
+        cmp = (MODALITY_ORDER[a.modality] ?? 99) - (MODALITY_ORDER[b.modality] ?? 99);
+        if (cmp === 0) cmp = a.provider.localeCompare(b.provider);
+      } else if (sortCol === 'provider') {
+        cmp = a.provider.localeCompare(b.provider);
+      } else {
+        const av = a[sortCol];
+        const bv = b[sortCol];
+        if (av === null && bv === null) cmp = 0;
+        else if (av === null) cmp = 1;
+        else if (bv === null) cmp = -1;
+        else cmp = av - bv;
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return sorted;
+  }, [data, sortCol, sortDir]);
+
+  const toggleSort = (col: SortColumn) => {
+    if (sortCol === col) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else {
+      setSortCol(col);
+      setSortDir('asc');
+    }
+  };
+
+  const sortIndicator = (col: SortColumn) =>
+    sortCol === col ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+
+  const projectScope = data?.filter.project;
+  const refreshedAt = rows.length > 0 ? rows[0].refreshed_at : null;
+
+  return (
+    <div>
+      <PageHeader
+        title="Routing"
+        subtitle={
+          projectScope
+            ? `Per-provider latency for ${projectScope}`
+            : 'Per-provider latency across projects'
+        }
+        accent="green"
+        actions={
+          <button className="neo-btn" onClick={refresh} disabled={loading}>
+            {loading ? '...' : 'Refresh'}
+          </button>
+        }
+      />
+
+      <FilterBar showTenant={false} />
+
+      <div className="neo-card mt-md">
+        {refreshedAt && (
+          <div className="label" style={{ marginBottom: '0.5rem' }}>
+            Last refreshed {formatRelative(refreshedAt)}. Auto-refresh every hour.
+          </div>
+        )}
+
+        {loading && !data && <div className="empty-state">Loading observations...</div>}
+
+        {!loading && rows.length === 0 && (
+          <div className="empty-state">
+            No latency observations yet. The roll-up worker refreshes every 15
+            minutes; once a few sessions complete the table will populate.
+          </div>
+        )}
+
+        {rows.length > 0 && (
+          <table className="neo-table neo-table--green">
+            <thead>
+              <tr>
+                <th onClick={() => toggleSort('modality')} style={{ cursor: 'pointer' }}>
+                  Modality{sortIndicator('modality')}
+                </th>
+                <th onClick={() => toggleSort('provider')} style={{ cursor: 'pointer' }}>
+                  Provider{sortIndicator('provider')}
+                </th>
+                <th
+                  onClick={() => toggleSort('p50_ms')}
+                  style={{ cursor: 'pointer', textAlign: 'right' }}
+                >
+                  p50 (ms){sortIndicator('p50_ms')}
+                </th>
+                <th
+                  onClick={() => toggleSort('p95_ms')}
+                  style={{ cursor: 'pointer', textAlign: 'right' }}
+                >
+                  p95 (ms){sortIndicator('p95_ms')}
+                </th>
+                <th
+                  onClick={() => toggleSort('sample_count')}
+                  style={{ cursor: 'pointer', textAlign: 'right' }}
+                >
+                  Samples{sortIndicator('sample_count')}
+                </th>
+                <th>Project</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={`${row.project_id}-${row.provider}-${row.modality}`}>
+                  <td>
+                    <span
+                      className={`neo-badge ${
+                        MODALITY_BADGE[row.modality] ?? 'neo-badge--black'
+                      }`}
+                    >
+                      {row.modality}
+                    </span>
+                  </td>
+                  <td className="mono">{row.provider}</td>
+                  <td className="mono" style={{ textAlign: 'right' }}>
+                    {row.p50_ms === null ? (
+                      <span className="label">no observations yet</span>
+                    ) : (
+                      row.p50_ms
+                    )}
+                  </td>
+                  <td className="mono" style={{ textAlign: 'right' }}>
+                    {row.p95_ms === null ? '-' : row.p95_ms}
+                  </td>
+                  <td className="mono" style={{ textAlign: 'right' }}>
+                    {row.sample_count}
+                  </td>
+                  <td>{row.project_id}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/pages/Sessions.tsx
+++ b/dashboard/frontend/src/pages/Sessions.tsx
@@ -307,6 +307,8 @@ function SessionDetailModal({
           </div>
         </div>
 
+        <RoutingStrip session={session} />
+
         <div className="mt-lg">
           <div className="label">Per-modality breakdown</div>
           {breakdown.length === 0 ? (
@@ -394,4 +396,58 @@ function formatDuration(startedAt: string, endedAt: string | null): string {
   const min = Math.floor(sec / 60);
   const remSec = Math.round(sec - min * 60);
   return `${min}m ${remSec}s`;
+}
+
+// v0.5.0 routing strip (REQ-VG-ROUTE-003 AC-1 + AC-2). Renders the
+// router's picked triple, the budget that was in effect, the actual
+// end-to-end latency observed during the session, and an overrun
+// chip when budget_overrun is true. NULL routed_* (pre-v0.5.0
+// sessions or sessions where the router never ran) renders "-".
+function RoutingStrip({ session }: { session: SessionDetail }) {
+  const hasRouting =
+    session.routed_llm != null ||
+    session.routed_tts != null ||
+    session.budget_ms != null;
+  if (!hasRouting) return null;
+
+  const stt = session.modalities?.find((m) => m === 'stt') ? 'stt' : '-';
+  const llm = session.routed_llm ?? '-';
+  const tts = session.routed_tts ?? '-';
+  const budget = session.budget_ms;
+  const used = session.budget_ms ?? null; // budget_ms_used not yet on SessionDetail
+  const overrun = !!session.budget_overrun;
+
+  return (
+    <div className="neo-card neo-card--strip-green mt-lg" style={{ padding: '0.75rem 1rem' }}>
+      <div className="flex-row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <div className="label">Routing</div>
+          <div className="mt-sm">
+            <code style={{ fontSize: '0.9rem' }}>
+              {stt} / {llm} / {tts}
+            </code>
+          </div>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <div className="label">Budget</div>
+          <div className="mt-sm mono">
+            {budget == null ? '-' : `${budget} ms`}
+            {overrun && (
+              <span
+                className="neo-badge"
+                style={{ background: '#FFD166', marginLeft: '0.5rem' }}
+              >
+                budget overrun
+              </span>
+            )}
+          </div>
+          {used != null && !overrun && (
+            <div className="label mt-sm" style={{ fontSize: '0.7rem' }}>
+              actual: {used} ms
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/docker/voicegateway.Dockerfile
+++ b/docker/voicegateway.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY pyproject.toml README.md ./
 COPY voicegateway/ ./voicegateway/
 
-ARG VERSION=0.4.0
+ARG VERSION=0.5.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 RUN pip install --prefix=/install ".[cloud,mcp,dashboard,tui]"
@@ -36,7 +36,7 @@ RUN pip install --prefix=/install ".[cloud,mcp,dashboard,tui]"
 # -------- Stage 3: Runtime --------
 FROM python:3.12-slim AS runtime
 
-ARG VERSION=0.4.0
+ARG VERSION=0.5.0
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -61,6 +61,7 @@ export default defineConfig({
             { text: 'Core Concepts', link: '/guide/core-concepts' },
             { text: 'Cost Reconciliation', link: '/guide/cost-reconciliation' },
             { text: 'Multi-Tenant Quickstart', link: '/guide/multi-tenant-quickstart' },
+            { text: 'Agency Quickstart', link: '/guide/agency-quickstart' },
           ],
         },
       ],

--- a/docs/api/python-sdk.md
+++ b/docs/api/python-sdk.md
@@ -259,6 +259,65 @@ The first tenant-bearing request "wins" for the session's lifetime. A later unat
 
 For the operator-facing workflow (issuing keys, viewing per-tenant costs, exporting), see the [multi-tenant quickstart](/guide/multi-tenant-quickstart).
 
+## Cross-modality routing (v0.5.0)
+
+Each project carries a latency budget and a per-modality provider roster. When a session starts, VoiceGateway picks the (STT, LLM, TTS) combination from the roster that minimises predicted total latency under the budget. The pick is recorded on the session row so the dashboard can show what ran and how close the call landed to the budget.
+
+```yaml
+projects:
+  acme:
+    name: Acme
+    routing:
+      budget_ms: 1500            # OQ1 lock: typical conversational target.
+      fallback_to_fastest: true  # When no triple fits, pick the fastest and flag budget_overrun.
+      rosters:
+        stt: [deepgram, assemblyai]    # Ordered by operator preference.
+        llm: [groq, openai, anthropic]
+        tts: [cartesia, elevenlabs]
+```
+
+### How the router picks
+
+At session start, the router reads three inputs and produces a `RoutedTriple` plus a `budget_overrun` boolean.
+
+1. **Observed p50 per (provider, modality)**: rolled up by the 15-minute worker from the requests table, written to `latency_observations`. The router prefers observed data when present.
+2. **Curated published-median baselines** in `voicegateway/core/provider_baselines.json` (REQ-VG-ROUTE-002 AC-4 fallback). Used when no observation exists for a candidate. Operators can edit the JSON to update a published median or add a missing provider.
+3. **Caller overrides**: explicit `{modality: provider}` map passed from the agent code. The router respects overrides for the named modalities and only picks for the unset ones (AC-3).
+
+Candidate triples are the cartesian product of the rosters minus the overridden modalities. The router computes a predicted total (sum of per-modality predictions), picks the lowest one whose total fits the budget. If nothing fits and `fallback_to_fastest=true`, it picks the fastest available and flags `budget_overrun=true`. If `fallback_to_fastest=false`, it raises `BudgetExceeded`.
+
+### Explicit overrides from agent code
+
+Pass the caller-override dict through whatever surface attaches the session. The v0.5.0 reference path is `route_session(...)` returning a `RoutedTriple`, with the caller then handing the triple to `attach_session(routed_triple=...)`:
+
+```python
+from voicegateway import inference
+from voicegateway.middleware import router
+
+async def handle_call(project_id: str, caller_overrides: dict[str, str] | None = None):
+    db = await gateway.storage._ensure_initialized()
+    triple = await router.route_session(
+        db,
+        project_id=project_id,
+        project_config=gateway.config.projects[project_id],
+        caller_overrides=caller_overrides,
+    )
+    agent_session = AgentSession(...)
+    inference.attach_session(
+        agent_session,
+        routed_triple=(triple.stt, triple.llm, triple.tts, triple.predicted_ms, triple.budget_overrun),
+    )
+    await agent_session.start(...)
+```
+
+The router runs once per session; the picked triple is immutable for the session's lifetime (AC-5).
+
+### Inspecting what the router would pick
+
+For ops debugging, `voicegw route show <project>` prints the current observations and rosters, and `voicegw route simulate <project> [--stt X] [--llm Y]` dry-runs the picker without writing a session row. Both accept `--json` for scripting.
+
+For the agency-facing operator workflow (tuning budgets, uploading branding, exporting per-project data), see the [agency quickstart](/guide/agency-quickstart).
+
 ## Conversation replay capture (v0.3.0)
 
 VoiceGateway captures a per-event timeline for every voice conversation: each STT chunk, each LLM token, each TTS frame, plus periodic conversation-state snapshots. The dashboard's [Replay page](/) then scrubs through any past call moment-by-moment with cost accruing live. This happens automatically; users do not call any function to opt in.

--- a/docs/guide/agency-quickstart.md
+++ b/docs/guide/agency-quickstart.md
@@ -1,0 +1,142 @@
+# Agency quickstart (v0.5.0)
+
+VoiceGateway v0.5.0 ships the agency rung of the buyer ladder: cross-modality routing and per-project white-label branding. This guide walks an agency operator through provisioning a downstream customer project end-to-end.
+
+## Prerequisites
+
+- VoiceGateway v0.5.0 or later (`voicegw --version`).
+- Dashboard running: `voicegw dashboard` (defaults to `127.0.0.1:9090`).
+- `voicegw.yaml` configured with at least one project (operators usually have a `default` plus one per customer).
+
+## 1. Configure routing rosters and budget
+
+Open `voicegw.yaml` and add a `routing:` block under the customer's project. The router will only pick providers that appear in the rosters; order is preference (earlier first when two candidates tie on predicted latency).
+
+```yaml
+projects:
+  acme:
+    name: Acme Voice
+    daily_budget: 25.0
+    routing:
+      # OQ1 lock: 1500 ms is the typical conversational target.
+      budget_ms: 1200          # Agency wants tighter than default.
+      fallback_to_fastest: true
+      rosters:
+        stt: [deepgram, assemblyai]
+        llm: [groq, openai]
+        tts: [cartesia, elevenlabs]
+```
+
+After editing, restart the gateway. The next session start picks providers from the new rosters; in-flight sessions keep their pre-existing triple (AC-VG-ROUTE-001.3).
+
+### Pick a budget
+
+The default 1500 ms covers a typical conversational voice agent: caller stops talking, agent's first audible reply lands in ≈1.5 seconds. Agencies serving high-energy customer-service scenarios often tighten to 800–1000 ms; agencies serving deliberative legal or medical scenarios may relax to 2000 ms. The dashboard's Routing view shows actual observed latency per provider so an operator can right-size after a few hundred sessions.
+
+## 2. Verify the router will pick what you expect
+
+The CLI's `route` subgroup is read-only and useful for sanity-checking before traffic lands.
+
+```bash
+voicegw route show acme
+# Project acme  budget_ms=1200
+#
+# Rosters
+#   stt   deepgram, assemblyai
+#   llm   groq, openai
+#   tts   cartesia, elevenlabs
+#
+# (no observations yet — router will fall back to provider_baselines.json)
+```
+
+```bash
+voicegw route simulate acme
+# Project acme simulated route:
+#   STT: deepgram     (250 ms baseline)
+#   LLM: groq         (80 ms baseline)
+#   TTS: cartesia     (150 ms baseline)
+#   Predicted total: 480 ms
+#   Under budget (1200 ms): yes
+```
+
+```bash
+voicegw route simulate acme --llm openai  # Override LLM specifically.
+# LLM: openai (300 ms baseline)
+# Predicted total: 700 ms
+```
+
+After production traffic accrues, the rollup worker (every 15 minutes) populates `latency_observations` and the router prefers observed p50 over the curated baselines. `voicegw route show acme` then prints the live observations table.
+
+## 3. Upload the customer's logo and brand
+
+Open the dashboard at `http://127.0.0.1:9090/projects`, find the `acme` card, click **Brand**, and fill the modal:
+
+- **Product name**: e.g. `AcmeVoice` (up to 64 chars; appears in the sidebar in place of "VoiceGateway").
+- **Accent color**: `#FF6633` or any valid hex (the dashboard offers a native color picker too).
+- **Logo**: a PNG or SVG file. Maximum 256 KB, max dimensions 512x512 px for PNG (SVG is vector, no dimension check). Saved under `dashboard/api/static/branding/acme.{png,svg}` and served at `/static/branding/acme.png`.
+
+For scripted provisioning, the CLI's `brand` subgroup hits the same endpoints:
+
+```bash
+voicegw brand set \
+  --project acme \
+  --logo ./acme-logo.png \
+  --accent "#FF6633" \
+  --name AcmeVoice
+# Project acme branding updated:
+#   Logo:         /static/branding/acme.png
+#   Accent color: #FF6633
+#   Product name: AcmeVoice
+```
+
+Set `VOICEGW_API_KEY=...` to pass the static-key Bearer header when the dashboard requires auth.
+
+## 4. Send the customer a branded link
+
+Branding is per-project; the dashboard picks up the active project from the URL query parameter. Share `https://your-gateway/sessions?project=acme` with the customer and they see the AcmeVoice brand: sidebar logo, accent color on interactive elements, page title and favicon. Without `?project=acme` the default VoiceGateway brand renders.
+
+The branding cache is per-mount per OQ5: a customer who has the dashboard open during a brand change sees the new look on next page navigation, not in real time.
+
+## 5. Watch the Routing view as traffic lands
+
+Open `/routing` in the dashboard. The page shows per-provider p50/p95 and sample count for every project the gateway has seen sessions for. Use the column headers to sort by p50 ascending to spot the fastest provider in each modality, or by sample count to gauge confidence.
+
+The page auto-refreshes every hour (AC-VG-ROUTE-003.3). The rollup worker behind the scenes refreshes every 15 minutes; the FE cadence is the page-side refresh, not the data freshness.
+
+NULL p50 renders as "no observations yet" rather than zero (AC-VG-ROUTE-003.4) so it's obvious which entries the router is still relying on baselines for.
+
+## 6. Inspect the routing decision per session
+
+From the Sessions page, click any row to open the SessionDetail modal. The new routing strip shows:
+
+- **STT / LLM / TTS** picked for the session.
+- **Budget** that was in effect when the session started.
+- **Actual end-to-end latency** when the close-session hook populated `budget_ms_used` (otherwise omitted).
+- **budget_overrun chip** (yellow) when the router fell back to fastest because nothing fit the budget.
+
+Sessions that predate v0.5.0 don't show the strip at all (the four routing columns are NULL).
+
+## What v0.5.0 does not do
+
+A few capabilities are deliberately deferred. Plan accordingly.
+
+- **No mid-call routing.** Pick-at-start only. If a provider degrades mid-call, the session keeps that provider until close.
+- **No adaptive learning.** The roll-up is static aggregation; there's no ML on in-call telemetry feeding back into pick scores.
+- **No custom-domain dashboard hosting.** White-label sits at the gateway's own host; agencies pointing `dashboard.theirfirm.com` at the gateway with their own TLS cert is future scope.
+- **No per-tenant branding inside one project.** White-label is per-project. An agency running multiple downstream tenants in one project shares one brand.
+- **No email or exported-report branding.** Dashboard chrome only.
+- **No cost-aware routing.** v0.5.0 picks on latency; cost is observed via the existing per-modality dashboards but doesn't feed back into the picker.
+- **No multi-region routing.**
+- **No latency-budget enforcement in flight.** The budget is a router input at start, not a runtime kill switch.
+- **No performance SLAs from the gateway to the operator.** Best-effort prediction; the gap between prediction and reality is visible in the Routing view so operators can tune.
+
+## Where the design lives
+
+- **Refinery / Foundry**: REQ-VG-ROUTE-001..004 in the Linear project.
+- **Migration**: `voicegateway/storage/migrations/0006_routing_and_branding.py`.
+- **Router**: `voicegateway/middleware/router.py` + `latency_observations_worker.py`.
+- **Baselines**: `voicegateway/core/provider_baselines.json`.
+- **Storage**: `voicegateway/storage/latency_observations_repo.py`.
+- **Dashboard API**: `dashboard/api/main.py` (search for `/api/routing` and `/api/projects/{id}/branding`).
+- **Frontend**: `dashboard/frontend/src/pages/Routing.tsx`, `lib/branding.ts`, `pages/Sessions.tsx` (`RoutingStrip`), `pages/Projects.tsx` (`BrandingModal`).
+- **CLI**: `voicegateway/cli/route.py`, `voicegateway/cli/brand.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "cryptography>=43.0",
     "genai-prices>=0.0.52,<0.1",
     "bcrypt>=4.0",
+    "pillow>=10.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/inference/test_routing_pipeline.py
+++ b/tests/inference/test_routing_pipeline.py
@@ -1,0 +1,133 @@
+"""End-to-end routing pipeline: three synthetic sessions per project.
+
+REQ-VG-ROUTE-001 + REQ-VG-ROUTE-002 persistence: the router picks a
+triple, the session row carries the picked LLM / TTS / budget /
+overrun, and a per-project rosters + budget produce three distinct
+routes for three distinct projects.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from voicegateway.core.config import ProjectConfig, RoutingConfig
+from voicegateway.inference._session_context import (
+    reset_routing_decision,
+    set_routing_decision,
+)
+from voicegateway.middleware import router
+from voicegateway.storage.models import RequestRecord
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    yield SQLiteStorage(db_path=str(tmp_path / "pipeline.db"))
+    reset_routing_decision()
+
+
+def _req(session_id: str, project: str) -> RequestRecord:
+    return RequestRecord(
+        id=f"r-{session_id}-{time.time_ns()}",
+        timestamp=time.time(),
+        project=project,
+        modality="stt",
+        model_id="deepgram/test",
+        provider="deepgram",
+        input_units=0,
+        output_units=0,
+        cost_usd=0.05,
+        pricing_source="t",
+        ttfb_ms=None,
+        total_latency_ms=200.0,
+        status="success",
+        fallback_from=None,
+        error_message=None,
+        metadata=None,
+        session_id=session_id,
+    )
+
+
+async def _project(project_id: str, budget_ms: int) -> ProjectConfig:
+    return ProjectConfig(
+        id=project_id,
+        name=project_id,
+        routing=RoutingConfig(
+            budget_ms=budget_ms,
+            rosters={
+                "stt": ["deepgram"],
+                "llm": ["openai", "groq"],
+                "tts": ["cartesia", "elevenlabs"],
+            },
+            fallback_to_fastest=True,
+        ),
+    )
+
+
+async def test_three_projects_get_distinct_routes(storage) -> None:
+    """A tight, mid, and loose budget all pick from the same rosters
+    but the tight project triggers overrun while the loose project
+    fits its budget comfortably. The sessions row reflects what the
+    router picked."""
+    db = await storage._ensure_initialized()
+
+    tight = await _project("tight", budget_ms=300)  # 250+80+150=480 > 300
+    mid = await _project("mid", budget_ms=600)
+    loose = await _project("loose", budget_ms=2000)
+
+    for project_id, pc, sid in [
+        ("tight", tight, "s-tight"),
+        ("mid", mid, "s-mid"),
+        ("loose", loose, "s-loose"),
+    ]:
+        triple = await router.route_session(
+            db, project_id=project_id, project_config=pc
+        )
+        set_routing_decision(
+            (
+                triple.stt,
+                triple.llm,
+                triple.tts,
+                pc.routing.budget_ms,
+                triple.budget_overrun,
+            )
+        )
+        await storage.log_request(_req(sid, project_id))
+        reset_routing_decision()
+
+    # All three sessions should have routing columns populated.
+    sessions = await storage.list_sessions()
+    by_id = {s["id"]: s for s in sessions}
+
+    assert by_id["s-tight"]["budget_overrun"] is True
+    assert by_id["s-tight"]["budget_ms"] == 300
+
+    assert by_id["s-mid"]["budget_overrun"] is False
+    assert by_id["s-mid"]["budget_ms"] == 600
+    assert by_id["s-mid"]["routed_llm"] == "groq"
+    assert by_id["s-mid"]["routed_tts"] == "cartesia"
+
+    assert by_id["s-loose"]["budget_overrun"] is False
+    assert by_id["s-loose"]["budget_ms"] == 2000
+
+
+async def test_pipeline_persists_immutable_triple(storage) -> None:
+    """A second request on the same session with no routing decision
+    in scope does not overwrite the originally-stamped triple."""
+    db = await storage._ensure_initialized()
+    pc = await _project("acme", budget_ms=600)
+    triple = await router.route_session(db, project_id="acme", project_config=pc)
+    set_routing_decision(
+        (triple.stt, triple.llm, triple.tts, 600, triple.budget_overrun)
+    )
+    await storage.log_request(_req("s-acme", "acme"))
+
+    reset_routing_decision()
+    await storage.log_request(_req("s-acme", "acme"))
+
+    detail = await storage.get_session("s-acme")
+    assert detail is not None
+    assert detail["routed_llm"] == triple.llm
+    assert detail["budget_ms"] == 600

--- a/tests/middleware/test_latency_observations_worker.py
+++ b/tests/middleware/test_latency_observations_worker.py
@@ -1,0 +1,118 @@
+"""Tests for ``LatencyObservationsWorker`` (T06)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from voicegateway.middleware.latency_observations_worker import (
+    LatencyObservationsWorker,
+)
+from voicegateway.storage import latency_observations_repo as lor
+from voicegateway.storage.models import RequestRecord
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    yield SQLiteStorage(db_path=str(tmp_path / "w.db"))
+
+
+def _req(idx: int, latency: float = 180.0) -> RequestRecord:
+    return RequestRecord(
+        id=f"r-{idx}-{latency}",
+        timestamp=time.time() - idx * 60.0,
+        project="default",
+        modality="stt",
+        model_id="deepgram/test",
+        provider="deepgram",
+        input_units=0,
+        output_units=0,
+        cost_usd=0.0,
+        pricing_source="t",
+        ttfb_ms=None,
+        total_latency_ms=latency,
+        status="success",
+        fallback_from=None,
+        error_message=None,
+        metadata=None,
+        session_id=None,
+    )
+
+
+async def test_tick_now_runs_one_pass(storage) -> None:
+    for i, lat in enumerate([200, 220, 180]):
+        await storage.log_request(_req(i, lat))
+    w = LatencyObservationsWorker(storage, poll_interval_seconds=0.1)
+    n = await w.tick_now()
+    assert n == 1  # one (provider, modality) group
+
+
+async def test_start_stop_idempotent(storage) -> None:
+    w = LatencyObservationsWorker(storage, poll_interval_seconds=0.1)
+    await w.start()
+    await w.start()  # No-op second call.
+    await asyncio.sleep(0.25)  # Let at least one tick fire.
+    await w.stop()
+    await w.stop()  # No-op second call.
+
+
+async def test_custom_window_provider(storage) -> None:
+    """Window provider value flows through to roll_up."""
+    await storage.log_request(_req(0, 200))
+    captured: list[int] = []
+
+    async def provider() -> int:
+        captured.append(42)
+        return 42
+
+    w = LatencyObservationsWorker(
+        storage, window_provider=provider, poll_interval_seconds=0.1
+    )
+    await w.tick_now()
+    assert captured == [42]
+
+
+async def test_loop_continues_on_tick_exception(storage) -> None:
+    """A failing window_provider does not crash the loop; the worker
+    still cancels cleanly on stop()."""
+
+    async def boom() -> int:
+        raise RuntimeError("boom")
+
+    w = LatencyObservationsWorker(
+        storage, window_provider=boom, poll_interval_seconds=0.1
+    )
+    await w.start()
+    await asyncio.sleep(0.25)
+    await w.stop()
+
+
+async def test_negative_window_clamps_to_default(storage) -> None:
+    """A negative window value gets clamped + a warning logged."""
+    await storage.log_request(_req(0, 200))
+
+    async def provider() -> int:
+        return -5
+
+    w = LatencyObservationsWorker(
+        storage, window_provider=provider, poll_interval_seconds=0.1
+    )
+    n = await w.tick_now()
+    # Default 24h window picks up the seeded request.
+    assert n == 1
+
+
+async def test_poll_interval_validation(storage) -> None:
+    with pytest.raises(ValueError):
+        LatencyObservationsWorker(storage, poll_interval_seconds=0)
+
+
+async def test_empty_db_inserts_zero(storage) -> None:
+    w = LatencyObservationsWorker(storage, poll_interval_seconds=0.1)
+    n = await w.tick_now()
+    assert n == 0
+    db = await storage._ensure_initialized()
+    assert await lor.read_all(db) == []

--- a/tests/middleware/test_router.py
+++ b/tests/middleware/test_router.py
@@ -1,0 +1,212 @@
+"""Tests for ``voicegateway.middleware.router`` (REQ-VG-ROUTE-002)."""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.core.config import ProjectConfig, RoutingConfig
+from voicegateway.middleware import router
+from voicegateway.middleware.router import BudgetExceeded
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    yield SQLiteStorage(db_path=str(tmp_path / "router.db"))
+
+
+async def _seed_observations(storage, rows):
+    db = await storage._ensure_initialized()
+    for project_id, provider, modality, p50 in rows:
+        await db.execute(
+            "INSERT INTO latency_observations "
+            "(project_id, provider, modality, p50_ms, p95_ms, sample_count, "
+            " window_start, window_end) VALUES (?,?,?,?,?,?,?,?)",
+            (
+                project_id,
+                provider,
+                modality,
+                p50,
+                p50 + 100,
+                50,
+                "2026-05-11T00:00",
+                "2026-05-12T00:00",
+            ),
+        )
+    await db.commit()
+
+
+def _project(budget_ms=600, fallback=True):
+    return ProjectConfig(
+        id="default",
+        name="Default",
+        routing=RoutingConfig(
+            budget_ms=budget_ms,
+            rosters={
+                "stt": ["deepgram", "assemblyai"],
+                "llm": ["openai", "groq"],
+                "tts": ["cartesia", "elevenlabs"],
+            },
+            fallback_to_fastest=fallback,
+        ),
+    )
+
+
+async def test_picks_lowest_under_budget(storage) -> None:
+    await _seed_observations(
+        storage,
+        [
+            ("default", "deepgram", "stt", 180),
+            ("default", "assemblyai", "stt", 300),
+            ("default", "openai", "llm", 200),
+            ("default", "groq", "llm", 80),
+            ("default", "cartesia", "tts", 150),
+            ("default", "elevenlabs", "tts", 400),
+        ],
+    )
+    db = await storage._ensure_initialized()
+    triple = await router.route_session(
+        db, project_id="default", project_config=_project(budget_ms=600)
+    )
+    assert triple.stt == "deepgram"
+    assert triple.llm == "groq"
+    assert triple.tts == "cartesia"
+    assert triple.predicted_ms == 410
+    assert triple.budget_overrun is False
+
+
+async def test_picks_fastest_when_nothing_fits(storage) -> None:
+    await _seed_observations(
+        storage,
+        [
+            ("default", "deepgram", "stt", 180),
+            ("default", "openai", "llm", 200),
+            ("default", "cartesia", "tts", 150),
+        ],
+    )
+    db = await storage._ensure_initialized()
+    pc = ProjectConfig(
+        id="default",
+        name="Default",
+        routing=RoutingConfig(
+            budget_ms=300,  # 180+200+150 = 530 > 300
+            rosters={
+                "stt": ["deepgram"],
+                "llm": ["openai"],
+                "tts": ["cartesia"],
+            },
+            fallback_to_fastest=True,
+        ),
+    )
+    triple = await router.route_session(db, project_id="default", project_config=pc)
+    assert triple.budget_overrun is True
+    assert triple.predicted_ms == 530
+
+
+async def test_raises_when_fallback_disabled(storage) -> None:
+    await _seed_observations(
+        storage,
+        [
+            ("default", "deepgram", "stt", 180),
+            ("default", "openai", "llm", 200),
+            ("default", "cartesia", "tts", 150),
+        ],
+    )
+    db = await storage._ensure_initialized()
+    pc = ProjectConfig(
+        id="default",
+        name="Default",
+        routing=RoutingConfig(
+            budget_ms=100,
+            rosters={
+                "stt": ["deepgram"],
+                "llm": ["openai"],
+                "tts": ["cartesia"],
+            },
+            fallback_to_fastest=False,
+        ),
+    )
+    with pytest.raises(BudgetExceeded):
+        await router.route_session(db, project_id="default", project_config=pc)
+
+
+async def test_caller_overrides_pin_modalities(storage) -> None:
+    await _seed_observations(
+        storage,
+        [
+            ("default", "deepgram", "stt", 180),
+            ("default", "openai", "llm", 200),
+            ("default", "groq", "llm", 80),
+            ("default", "cartesia", "tts", 150),
+        ],
+    )
+    db = await storage._ensure_initialized()
+    triple = await router.route_session(
+        db,
+        project_id="default",
+        project_config=_project(budget_ms=600),
+        caller_overrides={"llm": "openai"},
+    )
+    assert triple.llm == "openai"
+    # The router still picks STT and TTS from the rosters.
+    assert triple.stt == "deepgram"
+    assert triple.tts == "cartesia"
+
+
+async def test_falls_back_to_baselines_when_no_observations(storage) -> None:
+    """No observations seeded; router should use provider_baselines.json."""
+    db = await storage._ensure_initialized()
+    triple = await router.route_session(
+        db, project_id="default", project_config=_project(budget_ms=600)
+    )
+    # provider_baselines.json: deepgram stt 250 + groq llm 80 + cartesia tts 150 = 480 (under 600)
+    assert triple.stt == "deepgram"
+    assert triple.llm == "groq"
+    assert triple.tts == "cartesia"
+    assert triple.budget_overrun is False
+
+
+async def test_unknown_override_modality_raises(storage) -> None:
+    db = await storage._ensure_initialized()
+    with pytest.raises(ValueError):
+        await router.route_session(
+            db,
+            project_id="default",
+            project_config=_project(budget_ms=600),
+            caller_overrides={"audio": "deepgram"},
+        )
+
+
+async def test_empty_roster_raises(storage) -> None:
+    db = await storage._ensure_initialized()
+    pc = ProjectConfig(
+        id="default",
+        name="Default",
+        routing=RoutingConfig(
+            budget_ms=600,
+            rosters={"stt": [], "llm": [], "tts": []},
+            fallback_to_fastest=True,
+        ),
+    )
+    with pytest.raises(ValueError):
+        await router.route_session(db, project_id="default", project_config=pc)
+
+
+async def test_observed_p50_beats_baseline(storage) -> None:
+    """When both observed + baseline exist, observed wins."""
+    # Baseline says groq llm 80 ms. Override with observed 500 ms.
+    await _seed_observations(
+        storage,
+        [
+            ("default", "deepgram", "stt", 100),
+            ("default", "openai", "llm", 200),  # observed beats baseline 300
+            ("default", "groq", "llm", 500),  # observed worse than baseline 80
+            ("default", "cartesia", "tts", 150),
+        ],
+    )
+    db = await storage._ensure_initialized()
+    triple = await router.route_session(
+        db, project_id="default", project_config=_project(budget_ms=600)
+    )
+    # With observed values, openai (200) beats groq (500): 100+200+150=450.
+    assert triple.llm == "openai"

--- a/tests/server/test_branding_endpoint.py
+++ b/tests/server/test_branding_endpoint.py
@@ -1,0 +1,163 @@
+"""Tests for branding endpoints (REQ-VG-ROUTE-004)."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from fastapi.testclient import TestClient
+
+import dashboard.api.main as api
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+class _FakeGateway:
+    def __init__(self, path: str):
+        self.storage = SQLiteStorage(path)
+
+        class _Cfg:
+            class auth:
+                api_keys = []
+                cors_origins = []
+
+            latency: dict = {}
+            projects: dict = {}
+
+        self.config = _Cfg()
+
+    def list_projects(self):
+        return []
+
+
+@pytest.fixture
+async def client(tmp_path, monkeypatch):
+    path = str(tmp_path / "brand.db")
+    gw = _FakeGateway(path)
+    await gw.storage.upsert_managed_project("default", "Default")
+    monkeypatch.setattr(api, "_gateway", gw)
+    monkeypatch.setattr(api, "_cors_configured", True)
+    yield gw, TestClient(api.app)
+
+
+def test_get_branding_none_for_unbranded(client) -> None:
+    _, c = client
+    r = c.get("/api/projects/default/branding")
+    assert r.status_code == 200
+    assert r.json() == {"project_id": "default", "branding": None}
+
+
+def test_get_branding_missing_project_returns_404(client) -> None:
+    _, c = client
+    r = c.get("/api/projects/missing/branding")
+    assert r.status_code == 404
+
+
+def test_post_branding_validates_and_persists(client) -> None:
+    _, c = client
+    r = c.post(
+        "/api/projects/default/branding",
+        json={"accent_color": "#FF6633", "product_name": "AcmeVoice"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["branding"]["accent_color"] == "#FF6633"
+    assert data["branding"]["product_name"] == "AcmeVoice"
+
+    # Re-GET surfaces persistence.
+    r = c.get("/api/projects/default/branding")
+    assert r.json()["branding"]["product_name"] == "AcmeVoice"
+
+
+def test_post_branding_rejects_bad_hex(client) -> None:
+    _, c = client
+    r = c.post("/api/projects/default/branding", json={"accent_color": "red"})
+    assert r.status_code == 400
+    assert "hex" in r.json()["detail"].lower()
+
+
+def test_post_branding_rejects_long_name(client) -> None:
+    _, c = client
+    r = c.post(
+        "/api/projects/default/branding",
+        json={"product_name": "x" * 100},
+    )
+    assert r.status_code == 400
+
+
+def test_post_branding_rejects_unknown_key(client) -> None:
+    _, c = client
+    r = c.post("/api/projects/default/branding", json={"foo": "bar"})
+    assert r.status_code == 400
+
+
+def test_post_branding_missing_project_returns_404(client) -> None:
+    _, c = client
+    r = c.post("/api/projects/missing/branding", json={"accent_color": "#000"})
+    assert r.status_code == 404
+
+
+def test_logo_upload_oversized_returns_413(client) -> None:
+    _, c = client
+    big = b"x" * (260 * 1024)
+    r = c.post(
+        "/api/projects/default/branding/logo",
+        files={"file": ("big.png", big, "image/png")},
+    )
+    assert r.status_code == 413
+    assert "exceed" in r.json()["detail"].lower()
+
+
+def test_logo_upload_svg_round_trip(client) -> None:
+    _, c = client
+    svg = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">'
+        b'<circle cx="5" cy="5" r="4"/></svg>'
+    )
+    r = c.post(
+        "/api/projects/default/branding/logo",
+        files={"file": ("logo.svg", svg, "image/svg+xml")},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["format"] == "SVG"
+    assert data["logo_url"].endswith("/default.svg")
+
+
+def test_logo_upload_rejects_unknown_format(client) -> None:
+    _, c = client
+    r = c.post(
+        "/api/projects/default/branding/logo",
+        files={"file": ("logo.jpg", b"bytes", "image/jpeg")},
+    )
+    assert r.status_code == 400
+
+
+def test_logo_upload_png_validates_dimensions(client) -> None:
+    from PIL import Image
+
+    _, c = client
+    # 600x600 PNG should be rejected (cap is 512x512).
+    img = Image.new("RGB", (600, 600), color="blue")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    r = c.post(
+        "/api/projects/default/branding/logo",
+        files={"file": ("big.png", buf.getvalue(), "image/png")},
+    )
+    assert r.status_code == 400
+    assert "512" in r.json()["detail"]
+
+
+def test_logo_upload_png_accepts_valid(client) -> None:
+    from PIL import Image
+
+    _, c = client
+    img = Image.new("RGB", (128, 128), color="red")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    r = c.post(
+        "/api/projects/default/branding/logo",
+        files={"file": ("logo.png", buf.getvalue(), "image/png")},
+    )
+    assert r.status_code == 200
+    assert r.json()["format"] == "PNG"

--- a/tests/server/test_routing_endpoint.py
+++ b/tests/server/test_routing_endpoint.py
@@ -1,0 +1,89 @@
+"""Tests for /api/routing/observations (REQ-VG-ROUTE-003)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import dashboard.api.main as api
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+class _FakeGateway:
+    def __init__(self, path: str):
+        self.storage = SQLiteStorage(path)
+
+        class _Cfg:
+            class auth:
+                api_keys = []
+                cors_origins = []
+
+            latency: dict = {}
+            projects: dict = {}
+
+        self.config = _Cfg()
+
+    def list_projects(self):
+        return []
+
+
+@pytest.fixture
+async def client(tmp_path, monkeypatch):
+    path = str(tmp_path / "routing.db")
+    gw = _FakeGateway(path)
+    monkeypatch.setattr(api, "_gateway", gw)
+    monkeypatch.setattr(api, "_cors_configured", True)
+    yield gw, TestClient(api.app)
+
+
+async def _seed(storage, rows):
+    db = await storage._ensure_initialized()
+    for project_id, provider, modality, p50 in rows:
+        await db.execute(
+            "INSERT INTO latency_observations "
+            "(project_id, provider, modality, p50_ms, p95_ms, sample_count, "
+            " window_start, window_end) VALUES (?,?,?,?,?,?,?,?)",
+            (project_id, provider, modality, p50, p50 + 100, 10, "x", "y"),
+        )
+    await db.commit()
+
+
+async def test_returns_all_observations_when_no_filter(client) -> None:
+    gw, c = client
+    await _seed(
+        gw.storage,
+        [
+            ("acme", "deepgram", "stt", 180),
+            ("acme", "openai", "llm", 300),
+            ("beta", "groq", "llm", 80),
+        ],
+    )
+    r = c.get("/api/routing/observations")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["observations"]) == 3
+    assert data["filter"]["project"] is None
+
+
+async def test_filters_by_project(client) -> None:
+    gw, c = client
+    await _seed(
+        gw.storage,
+        [
+            ("acme", "deepgram", "stt", 180),
+            ("beta", "groq", "llm", 80),
+        ],
+    )
+    r = c.get("/api/routing/observations?project=acme")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["observations"]) == 1
+    assert data["observations"][0]["project_id"] == "acme"
+    assert data["filter"]["project"] == "acme"
+
+
+async def test_empty_returns_empty_list(client) -> None:
+    _, c = client
+    r = c.get("/api/routing/observations")
+    assert r.status_code == 200
+    assert r.json()["observations"] == []

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -31,7 +31,7 @@ async def test_health(client):
     data = resp.json()
     assert data["status"] == "ok"
     assert "uptime_seconds" in data
-    assert data["version"] == "0.4.0"
+    assert data["version"] == "0.5.0"
 
 
 async def test_v1_status(client):

--- a/tests/storage/test_latency_observations_repo.py
+++ b/tests/storage/test_latency_observations_repo.py
@@ -1,0 +1,143 @@
+"""Tests for ``latency_observations_repo`` (REQ-VG-ROUTE-002 + -003)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from voicegateway.storage import latency_observations_repo as lor
+from voicegateway.storage.models import RequestRecord
+from voicegateway.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    yield SQLiteStorage(db_path=str(tmp_path / "lor.db"))
+
+
+def _req(
+    provider: str, modality: str, latency: float, *, idx: int = 0
+) -> RequestRecord:
+    return RequestRecord(
+        id=f"r-{provider}-{modality}-{idx}-{latency}",
+        timestamp=time.time() - idx * 30.0,
+        project="default",
+        modality=modality,
+        model_id=f"{provider}/test",
+        provider=provider,
+        input_units=0,
+        output_units=0,
+        cost_usd=0.0,
+        pricing_source="t",
+        ttfb_ms=None,
+        total_latency_ms=latency,
+        status="success",
+        fallback_from=None,
+        error_message=None,
+        metadata=None,
+        session_id=None,
+    )
+
+
+async def test_roll_up_aggregates_per_group(storage) -> None:
+    for i, (prov, mod, lat) in enumerate(
+        [
+            ("deepgram", "stt", 180),
+            ("deepgram", "stt", 220),
+            ("openai", "llm", 300),
+            ("cartesia", "tts", 100),
+        ]
+    ):
+        await storage.log_request(_req(prov, mod, lat, idx=i))
+
+    db = await storage._ensure_initialized()
+    n = await lor.roll_up(db, window_minutes=60 * 24)
+    assert n == 3  # one row per (provider, modality) group
+
+    rows = await lor.read_all(db)
+    by_key = {(r.provider, r.modality): r for r in rows}
+    assert by_key[("deepgram", "stt")].sample_count == 2
+    assert by_key[("openai", "llm")].sample_count == 1
+    assert by_key[("cartesia", "tts")].sample_count == 1
+
+
+async def test_roll_up_computes_p50_p95(storage) -> None:
+    for i, lat in enumerate([100, 150, 200, 250, 300]):
+        await storage.log_request(_req("dg", "stt", lat, idx=i))
+    db = await storage._ensure_initialized()
+    await lor.roll_up(db)
+    obs = await lor.get_one(db, project_id="default", provider="dg", modality="stt")
+    assert obs is not None
+    assert obs.p50_ms == 200
+    assert obs.p95_ms is not None and obs.p95_ms >= obs.p50_ms
+
+
+async def test_roll_up_empty_db(storage) -> None:
+    db = await storage._ensure_initialized()
+    n = await lor.roll_up(db)
+    assert n == 0
+    assert await lor.read_all(db) == []
+
+
+async def test_roll_up_idempotent_replace(storage) -> None:
+    """Re-running roll_up replaces the snapshot atomically."""
+    await storage.log_request(_req("dg", "stt", 100, idx=0))
+    db = await storage._ensure_initialized()
+    await lor.roll_up(db)
+    n1 = len(await lor.read_all(db))
+    await lor.roll_up(db)
+    n2 = len(await lor.read_all(db))
+    assert n1 == n2 == 1
+
+
+async def test_roll_up_excludes_null_latency(storage) -> None:
+    await storage.log_request(_req("dg", "stt", 100, idx=0))
+    rec = _req("dg", "stt", 200, idx=1)
+    rec = RequestRecord(**{**rec.__dict__, "total_latency_ms": None})
+    await storage.log_request(rec)
+
+    db = await storage._ensure_initialized()
+    await lor.roll_up(db)
+    obs = await lor.get_one(db, project_id="default", provider="dg", modality="stt")
+    assert obs is not None
+    assert obs.sample_count == 1  # NULL-latency row excluded
+
+
+async def test_get_for_project_scopes(storage) -> None:
+    """get_for_project returns rows for one project only."""
+    await storage.log_request(_req("dg", "stt", 100, idx=0))
+    # Sneak in a row for a different project via direct INSERT.
+    db = await storage._ensure_initialized()
+    await db.execute(
+        "INSERT INTO latency_observations "
+        "(project_id, provider, modality, p50_ms, p95_ms, sample_count, "
+        " window_start, window_end) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        ("other", "dg", "stt", 999, 999, 1, "x", "y"),
+    )
+    await db.commit()
+    await lor.roll_up(db)  # Roll-up clears prior snapshot; "other" lost.
+
+    # Manually seed an "other" row again post-rollup.
+    await db.execute(
+        "INSERT INTO latency_observations "
+        "(project_id, provider, modality, p50_ms, p95_ms, sample_count, "
+        " window_start, window_end) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        ("other", "dg", "stt", 999, 999, 1, "x", "y"),
+    )
+    await db.commit()
+
+    default_rows = await lor.get_for_project(db, "default")
+    assert all(r.project_id == "default" for r in default_rows)
+    other_rows = await lor.get_for_project(db, "other")
+    assert len(other_rows) == 1 and other_rows[0].provider == "dg"
+
+
+async def test_get_one_returns_none_for_missing(storage) -> None:
+    db = await storage._ensure_initialized()
+    assert (
+        await lor.get_one(db, project_id="default", provider="missing", modality="stt")
+        is None
+    )

--- a/tests/storage/test_routing_migration.py
+++ b/tests/storage/test_routing_migration.py
@@ -1,0 +1,140 @@
+"""Contract tests for migration 0006 (routing columns + branding + latency_observations).
+
+REQ-VG-ROUTE-001..004 schema gate.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import aiosqlite
+
+from voicegateway.storage.sqlite import SQLiteStorage
+
+_migration = import_module("voicegateway.storage.migrations.0006_routing_and_branding")
+
+
+async def test_sessions_gains_five_routing_columns(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute("PRAGMA table_info(sessions)")
+        cols = {row[1] async for row in cur}
+
+    for col in (
+        "budget_ms",
+        "budget_ms_used",
+        "budget_overrun",
+        "routed_llm",
+        "routed_tts",
+    ):
+        assert col in cols, f"missing sessions.{col}"
+
+
+async def test_managed_projects_gains_branding_json(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute("PRAGMA table_info(managed_projects)")
+        cols = {row[1] async for row in cur}
+
+    assert "branding_json" in cols
+
+
+async def test_latency_observations_table_created(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='latency_observations'"
+        )
+        assert await cur.fetchone() is not None
+
+        cur = await db.execute("PRAGMA table_info(latency_observations)")
+        cols = {row[1] async for row in cur}
+        assert cols == {
+            "id",
+            "project_id",
+            "provider",
+            "modality",
+            "p50_ms",
+            "p95_ms",
+            "sample_count",
+            "window_start",
+            "window_end",
+            "refreshed_at",
+        }
+
+
+async def test_composite_index_present(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND tbl_name='latency_observations'"
+        )
+        names = {row[0] async for row in cur}
+
+    assert "idx_latency_obs_project_provider" in names
+
+
+async def test_is_idempotent(tmp_path) -> None:
+    db_path = str(tmp_path / "fresh.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        await _migration.apply(db)
+        await db.commit()
+
+        cur = await db.execute("PRAGMA table_info(sessions)")
+        budget_cols = [row for row in await cur.fetchall() if row[1] == "budget_ms"]
+        assert len(budget_cols) == 1
+
+
+async def test_v005_baseline_skips_missing_managed_projects(tmp_path) -> None:
+    """An install without managed_projects (no projects configured) is OK."""
+    db_path = str(tmp_path / "v005.db")
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, project TEXT)")
+        await db.commit()
+        await _migration.apply(db)
+        await db.commit()
+
+        cur = await db.execute("PRAGMA table_info(sessions)")
+        cols = {row[1] async for row in cur}
+        assert "budget_ms" in cols
+
+        cur = await db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='managed_projects'"
+        )
+        assert await cur.fetchone() is None  # Still absent; ALTER skipped.
+
+
+async def test_preexisting_sessions_get_null(tmp_path) -> None:
+    """OQ3-like: pre-v0.5.0 rows keep NULL on the new columns."""
+    db_path = str(tmp_path / "with_rows.db")
+    storage = SQLiteStorage(db_path)
+    await storage._ensure_initialized()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO sessions (id, project, started_at, modalities, "
+            "total_cost_usd, request_count) "
+            "VALUES ('legacy', 'default', '2026-05-01T00:00', '', 0.0, 0)"
+        )
+        await db.commit()
+        cur = await db.execute(
+            "SELECT budget_ms, budget_overrun, routed_llm, routed_tts FROM sessions WHERE id = 'legacy'"
+        )
+        row = await cur.fetchone()
+        assert row == (None, None, None, None)

--- a/tests/storage/test_sessions_table.py
+++ b/tests/storage/test_sessions_table.py
@@ -93,6 +93,12 @@ async def test_sessions_columns_match_design(tmp_path):
         "replay_size_bytes",
         # v0.4.0 tenant attribution column (added by migration 0005).
         "tenant_id",
+        # v0.5.0 routing columns (added by migration 0006).
+        "budget_ms",
+        "budget_ms_used",
+        "budget_overrun",
+        "routed_llm",
+        "routed_tts",
     }
 
     # Required keys (NOT NULL).

--- a/voicegateway/cli/__init__.py
+++ b/voicegateway/cli/__init__.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 # Side-effect imports: each submodule registers its commands on the
 # shared ``app`` via ``@app.command(...)`` decorators that run at
 # import time. Order does not matter; commands carry their own names.
+from voicegateway.cli import brand as _brand  # noqa: F401, E402
 from voicegateway.cli import costs as _costs  # noqa: F401, E402
 from voicegateway.cli import dashboard as _dashboard  # noqa: F401, E402
 from voicegateway.cli import doctor as _doctor  # noqa: F401, E402

--- a/voicegateway/cli/__init__.py
+++ b/voicegateway/cli/__init__.py
@@ -47,6 +47,7 @@ from voicegateway.cli import projects as _projects  # noqa: F401, E402
 from voicegateway.cli import reconcile as _reconcile  # noqa: F401, E402
 from voicegateway.cli import replay as _replay  # noqa: F401, E402
 from voicegateway.cli import rotate_secret as _rotate_secret  # noqa: F401, E402
+from voicegateway.cli import route as _route  # noqa: F401, E402
 from voicegateway.cli import serve as _serve  # noqa: F401, E402
 from voicegateway.cli import smoke_test as _smoke_test  # noqa: F401, E402
 from voicegateway.cli import status as _status  # noqa: F401, E402

--- a/voicegateway/cli/brand.py
+++ b/voicegateway/cli/brand.py
@@ -1,0 +1,231 @@
+"""``voicegw brand`` command group: scripted white-label provisioning.
+
+Implements the operator-side companion to the v0.5.0 dashboard's
+BrandingModal (T18). Hits the same dashboard endpoints as the FE so
+provisioning scripts can roll new agencies without clicking through
+the UI.
+
+Subcommand:
+
+* ``voicegw brand set --project <id> [--logo <path>] [--accent <hex>]
+  [--name <str>] [--dashboard-url URL]`` — at least one of --logo /
+  --accent / --name is required. The CLI POSTs each surface to the
+  matching endpoint and prints the resulting branding payload.
+
+``voicegw brand clear --project <id>`` clears the branding (POSTs an
+empty payload). Note that the v0.5.0 backend's COALESCE-protected
+UPSERT means the clear may not fully blank stored values until a
+dedicated DELETE endpoint ships (see T18 journal note).
+
+The CLI uses ``httpx`` (already a base dep) and reads the
+``VOICEGW_API_KEY`` env var for the Bearer header when set. Default
+dashboard URL is ``http://127.0.0.1:9090`` matching the
+``voicegw dashboard`` defaults.
+
+Path correction note: Foundry text listed ``voicegw/cli/brand.py``;
+the actual CLI subpackage is ``voicegateway/cli/``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+import typer
+
+from voicegateway.cli._app import app, console
+
+brand_app = typer.Typer(
+    name="brand",
+    help="Scripted per-project white-label provisioning (REQ-VG-ROUTE-004).",
+    no_args_is_help=True,
+)
+app.add_typer(brand_app, name="brand")
+
+
+_DEFAULT_DASHBOARD_URL = "http://127.0.0.1:9090"
+
+
+def _auth_headers() -> dict[str, str]:
+    """Return Bearer auth headers when ``VOICEGW_API_KEY`` is set."""
+    token = os.environ.get("VOICEGW_API_KEY", "").strip()
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
+def _upload_logo(
+    client: httpx.Client, project_id: str, logo_path: Path
+) -> dict[str, Any]:
+    if not logo_path.is_file():
+        console.print(f"[red]Logo file not found: {logo_path}[/red]")
+        raise typer.Exit(2)
+    suffix = logo_path.suffix.lower()
+    if suffix == ".png":
+        content_type = "image/png"
+    elif suffix == ".svg":
+        content_type = "image/svg+xml"
+    else:
+        console.print(
+            f"[red]Unsupported logo extension {suffix!r}; must be .png or .svg[/red]"
+        )
+        raise typer.Exit(2)
+
+    with open(logo_path, "rb") as fh:
+        resp = client.post(
+            f"/api/projects/{project_id}/branding/logo",
+            files={"file": (logo_path.name, fh, content_type)},
+            headers=_auth_headers(),
+        )
+    if resp.status_code >= 400:
+        try:
+            detail = resp.json().get("detail", "")
+        except json.JSONDecodeError:
+            detail = resp.text
+        console.print(f"[red]Logo upload failed ({resp.status_code}): {detail}[/red]")
+        raise typer.Exit(1)
+    return dict(resp.json())
+
+
+def _post_branding(
+    client: httpx.Client, project_id: str, body: dict[str, Any]
+) -> dict[str, Any]:
+    headers = {"Content-Type": "application/json", **_auth_headers()}
+    resp = client.post(
+        f"/api/projects/{project_id}/branding",
+        content=json.dumps(body),
+        headers=headers,
+    )
+    if resp.status_code >= 400:
+        try:
+            detail = resp.json().get("detail", "")
+        except json.JSONDecodeError:
+            detail = resp.text
+        console.print(
+            f"[red]Branding update failed ({resp.status_code}): {detail}[/red]"
+        )
+        raise typer.Exit(1)
+    return dict(resp.json())
+
+
+@brand_app.command("set")
+def set_cmd(
+    project: str = typer.Option(..., "--project", "-p", help="Project id to brand."),
+    logo: Path | None = typer.Option(
+        None, "--logo", help="Path to a PNG or SVG logo file."
+    ),
+    accent: str | None = typer.Option(
+        None, "--accent", help='Hex color string (e.g. "#FF6633" or "#abc").'
+    ),
+    name: str | None = typer.Option(
+        None, "--name", help="Product name shown in the dashboard chrome."
+    ),
+    dashboard_url: str = typer.Option(
+        _DEFAULT_DASHBOARD_URL,
+        "--dashboard-url",
+        help=f"Dashboard base URL (default {_DEFAULT_DASHBOARD_URL}).",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Print the resulting branding as JSON."
+    ),
+) -> None:
+    """Set per-project branding via the dashboard API.
+
+    At least one of --logo / --accent / --name is required. The CLI
+    uploads the logo first (if provided), then POSTs the merged
+    branding so the resulting payload carries logo_url + the
+    user-supplied accent_color / product_name.
+    """
+    if not (logo or accent or name):
+        console.print(
+            "[red]At least one of --logo / --accent / --name is required.[/red]"
+        )
+        raise typer.Exit(2)
+
+    base = dashboard_url.rstrip("/")
+    with httpx.Client(base_url=base, timeout=30.0) as client:
+        body: dict[str, Any] = {}
+        if accent:
+            body["accent_color"] = accent
+        if name:
+            body["product_name"] = name
+        if logo:
+            uploaded = _upload_logo(client, project, logo)
+            body["logo_url"] = uploaded["logo_url"]
+
+        result = _post_branding(client, project, body)
+
+    if json_output:
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+
+    branding = result.get("branding") or {}
+    console.print(f"[bold]Project {project}[/bold] branding updated:")
+    console.print(f"  Logo:         {branding.get('logo_url') or '-'}")
+    console.print(f"  Accent color: {branding.get('accent_color') or '-'}")
+    console.print(f"  Product name: {branding.get('product_name') or '-'}")
+
+
+@brand_app.command("clear")
+def clear_cmd(
+    project: str = typer.Option(..., "--project", "-p", help="Project id to clear."),
+    dashboard_url: str = typer.Option(
+        _DEFAULT_DASHBOARD_URL,
+        "--dashboard-url",
+        help=f"Dashboard base URL (default {_DEFAULT_DASHBOARD_URL}).",
+    ),
+) -> None:
+    """Clear per-project branding (POSTs an empty payload).
+
+    NOTE: the v0.5.0 backend's COALESCE-protected UPSERT means this
+    may not fully blank already-stored values until a dedicated
+    DELETE endpoint ships. Documented in the v0.5.0/T18 journal.
+    """
+    base = dashboard_url.rstrip("/")
+    with httpx.Client(base_url=base, timeout=30.0) as client:
+        _post_branding(client, project, {})
+    console.print(f"[bold]Project {project}[/bold] branding cleared.")
+
+
+@brand_app.command("show")
+def show_cmd(
+    project: str = typer.Option(..., "--project", "-p", help="Project id to inspect."),
+    dashboard_url: str = typer.Option(
+        _DEFAULT_DASHBOARD_URL,
+        "--dashboard-url",
+        help=f"Dashboard base URL (default {_DEFAULT_DASHBOARD_URL}).",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Print the current branding as JSON."
+    ),
+) -> None:
+    """Print the current branding for a project (read-only)."""
+    base = dashboard_url.rstrip("/")
+    with httpx.Client(base_url=base, timeout=30.0) as client:
+        resp = client.get(f"/api/projects/{project}/branding", headers=_auth_headers())
+    if resp.status_code == 404:
+        console.print(f"[red]Project {project!r} not found.[/red]")
+        raise typer.Exit(1)
+    if resp.status_code >= 400:
+        console.print(f"[red]Failed ({resp.status_code}): {resp.text}[/red]")
+        raise typer.Exit(1)
+    payload = resp.json()
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
+    branding = payload.get("branding") or {}
+    if not branding:
+        console.print(
+            f"[bold]Project {project}[/bold]: no branding set (default brand)."
+        )
+        return
+    console.print(f"[bold]Project {project}[/bold] branding:")
+    console.print(f"  Logo:         {branding.get('logo_url') or '-'}")
+    console.print(f"  Accent color: {branding.get('accent_color') or '-'}")
+    console.print(f"  Product name: {branding.get('product_name') or '-'}")
+
+
+__all__ = ["brand_app", "clear_cmd", "set_cmd", "show_cmd"]

--- a/voicegateway/cli/route.py
+++ b/voicegateway/cli/route.py
@@ -1,0 +1,216 @@
+"""``voicegw route`` command group: routing observations + dry-run simulator.
+
+Read-only ops surface for cross-modality routing (REQ-VG-ROUTE-002 +
+-003). Two subcommands:
+
+* ``voicegw route show <project>`` — prints the current
+  ``latency_observations`` rollup rows for a project plus the project's
+  rosters from voicegw.yaml. Useful when debugging \"why did the router
+  pick X\".
+* ``voicegw route simulate <project> [--stt X] [--llm Y] [--tts Z]`` —
+  runs ``route_session`` against the live observations and the project
+  config (no session row written). Prints the picked triple, the
+  predicted total, and the budget_overrun flag.
+
+Issuance / config edits are NOT in scope here. The CLI is read-only;
+operators tune budgets and rosters via voicegw.yaml.
+
+Path correction note: Foundry text listed ``voicegw/cli/route.py``;
+the actual CLI subpackage is ``voicegateway/cli/`` (same correction
+as v0.3.0 / v0.4.0).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+from typing import Any
+
+import typer
+
+from voicegateway.cli._app import app, console
+from voicegateway.cli._helpers import _load_gateway
+
+route_app = typer.Typer(
+    name="route",
+    help="Read-only routing diagnostics: show observations + simulate triple pick.",
+    no_args_is_help=True,
+)
+app.add_typer(route_app, name="route")
+
+
+async def _show_async(storage: Any, project_id: str) -> list[Any]:
+    from voicegateway.storage import latency_observations_repo
+
+    db = await storage._ensure_initialized()
+    return await latency_observations_repo.get_for_project(db, project_id)
+
+
+async def _simulate_async(
+    storage: Any,
+    *,
+    project_id: str,
+    project_config: Any,
+    overrides: dict[str, str],
+) -> Any:
+    from voicegateway.middleware import router
+
+    db = await storage._ensure_initialized()
+    return await router.route_session(
+        db,
+        project_id=project_id,
+        project_config=project_config,
+        caller_overrides=overrides or None,
+    )
+
+
+@route_app.command("show")
+def show_cmd(
+    project: str = typer.Argument(..., help="Project id to inspect."),
+    config: str | None = typer.Option(
+        None, "--config", "-c", help="Path to voicegw.yaml."
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit JSON instead of the rendered table."
+    ),
+) -> None:
+    """Show the latency_observations rollup + rosters for a project."""
+    gw = _load_gateway(config)
+    if gw.storage is None:
+        console.print(
+            "[red]Storage backend not configured (cost_tracking.db_path).[/red]"
+        )
+        raise typer.Exit(1)
+
+    rows = asyncio.run(_show_async(gw.storage, project))
+    project_cfg = gw.config.projects.get(project)
+    rosters = (
+        getattr(getattr(project_cfg, "routing", None), "rosters", {}) or {}
+        if project_cfg is not None
+        else {}
+    )
+    budget = (
+        getattr(getattr(project_cfg, "routing", None), "budget_ms", 1500)
+        if project_cfg is not None
+        else 1500
+    )
+
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "project_id": project,
+                    "budget_ms": budget,
+                    "rosters": rosters,
+                    "observations": [dataclasses.asdict(r) for r in rows],
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return
+
+    console.print(f"[bold]Project {project}[/bold]  budget_ms={budget}")
+    if rosters:
+        console.print("\n[bold]Rosters[/bold]")
+        for modality in ("stt", "llm", "tts"):
+            providers = rosters.get(modality) or []
+            console.print(f"  {modality:<5} {', '.join(providers) or '(empty)'}")
+    else:
+        console.print("[dim](no routing rosters configured)[/dim]")
+
+    if not rows:
+        console.print(
+            "\n[dim]No latency observations yet. The worker rolls up "
+            "every 15 minutes once sessions complete.[/dim]"
+        )
+        return
+
+    console.print("\n[bold]Observations[/bold]")
+    console.print(
+        f"{'MODALITY':<10} {'PROVIDER':<14} {'P50 MS':>8} {'P95 MS':>8} {'SAMPLES':>9}"
+    )
+    console.print("-" * 56)
+    for r in rows:
+        p50 = "-" if r.p50_ms is None else str(r.p50_ms)
+        p95 = "-" if r.p95_ms is None else str(r.p95_ms)
+        console.print(
+            f"{r.modality:<10} {r.provider:<14} {p50:>8} {p95:>8} {r.sample_count:>9}"
+        )
+
+
+@route_app.command("simulate")
+def simulate_cmd(
+    project: str = typer.Argument(..., help="Project id to simulate against."),
+    stt: str | None = typer.Option(
+        None, "--stt", help="Override the STT provider pick."
+    ),
+    llm: str | None = typer.Option(
+        None, "--llm", help="Override the LLM provider pick."
+    ),
+    tts: str | None = typer.Option(
+        None, "--tts", help="Override the TTS provider pick."
+    ),
+    config: str | None = typer.Option(
+        None, "--config", "-c", help="Path to voicegw.yaml."
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit JSON instead of the rendered triple."
+    ),
+) -> None:
+    """Dry-run the router with optional per-modality overrides."""
+    gw = _load_gateway(config)
+    if gw.storage is None:
+        console.print(
+            "[red]Storage backend not configured (cost_tracking.db_path).[/red]"
+        )
+        raise typer.Exit(1)
+    project_cfg = gw.config.projects.get(project)
+    if project_cfg is None:
+        console.print(f"[red]Project {project!r} is not in voicegw.yaml.[/red]")
+        raise typer.Exit(1)
+
+    overrides: dict[str, str] = {}
+    if stt:
+        overrides["stt"] = stt
+    if llm:
+        overrides["llm"] = llm
+    if tts:
+        overrides["tts"] = tts
+
+    try:
+        from voicegateway.middleware.router import BudgetExceeded
+
+        triple = asyncio.run(
+            _simulate_async(
+                gw.storage,
+                project_id=project,
+                project_config=project_cfg,
+                overrides=overrides,
+            )
+        )
+    except BudgetExceeded as exc:
+        console.print(f"[red]BudgetExceeded:[/red] {exc}")
+        raise typer.Exit(1) from exc
+    except ValueError as exc:
+        console.print(f"[red]Router rejected the call:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    if json_output:
+        typer.echo(json.dumps(dataclasses.asdict(triple), indent=2))
+        return
+
+    console.print(f"[bold]Project {project}[/bold] simulated route:")
+    console.print(f"  STT: {triple.stt}")
+    console.print(f"  LLM: {triple.llm}")
+    console.print(f"  TTS: {triple.tts}")
+    console.print(f"  Predicted total: {triple.predicted_ms} ms")
+    if triple.budget_overrun:
+        console.print("  [yellow]budget_overrun = True (fastest fallback)[/yellow]")
+    else:
+        budget = project_cfg.routing.budget_ms
+        console.print(f"  Under budget ({budget} ms): yes")
+
+
+__all__ = ["route_app", "show_cmd", "simulate_cmd"]

--- a/voicegateway/core/config.py
+++ b/voicegateway/core/config.py
@@ -83,6 +83,43 @@ class ReplayConfig:
 
 
 @dataclass
+class RoutingConfig:
+    """v0.5.0 cross-modality routing knobs (REQ-VG-ROUTE-001..002).
+
+    Per-project overridable via the ``routing:`` block in
+    ``voicegw.yaml``. ``budget_ms`` defaults to the Foundry-locked
+    1500 ms (OQ1) suitable for a typical conversational voice agent.
+    ``rosters`` is a dict ``{modality: [provider_id, ...]}`` ordered
+    by operator preference; the router picks within the roster and
+    never outside it. ``fallback_to_fastest`` controls the AC-2 path:
+    when ``True`` (default) and nothing fits the budget, the router
+    picks the fastest available triple and stamps
+    ``budget_overrun=True`` on the session row; when ``False`` the
+    router raises ``BudgetExceeded`` and the session fails.
+    """
+
+    budget_ms: int = 1500
+    rosters: dict[str, list[str]] = field(default_factory=dict)
+    fallback_to_fastest: bool = True
+
+
+@dataclass
+class BrandingConfig:
+    """v0.5.0 white-label branding knobs (REQ-VG-ROUTE-004).
+
+    Per-project overridable. All fields nullable: a project with no
+    branding set falls back to the default VoiceGateway brand
+    (AC-3). The dashboard's ``lib/branding.ts`` reads this at layout
+    mount and applies values as CSS variables; emails, exports, and
+    the CLI keep the default brand (out of scope per the Refinery).
+    """
+
+    logo_url: str | None = None
+    accent_color: str | None = None
+    product_name: str | None = None
+
+
+@dataclass
 class TenantConfig:
     """v0.4.0 multi-tenant attribution knobs.
 
@@ -119,6 +156,10 @@ class ProjectConfig:
     replay: ReplayConfig = field(default_factory=ReplayConfig)
     # v0.4.0: per-project multi-tenant knobs (REQ-VG-TENANT-003).
     tenant: TenantConfig = field(default_factory=TenantConfig)
+    # v0.5.0: per-project routing knobs (REQ-VG-ROUTE-001..002).
+    routing: RoutingConfig = field(default_factory=RoutingConfig)
+    # v0.5.0: per-project white-label branding (REQ-VG-ROUTE-004).
+    branding: BrandingConfig = field(default_factory=BrandingConfig)
 
     @property
     def accent(self) -> str:
@@ -301,6 +342,38 @@ class GatewayConfig:
                         tenant_raw.get("virtual_key_stale_days", 90)
                     ),
                 )
+                routing_raw = pcfg.get("routing") or {}
+                rosters_raw = routing_raw.get("rosters") or {}
+                rosters: dict[str, list[str]] = {}
+                if isinstance(rosters_raw, dict):
+                    for modality, providers in rosters_raw.items():
+                        if isinstance(providers, list):
+                            rosters[str(modality)] = [str(p) for p in providers]
+                routing_cfg = RoutingConfig(
+                    budget_ms=int(routing_raw.get("budget_ms", 1500)),
+                    rosters=rosters,
+                    fallback_to_fastest=bool(
+                        routing_raw.get("fallback_to_fastest", True)
+                    ),
+                )
+                branding_raw = pcfg.get("branding") or {}
+                branding_cfg = BrandingConfig(
+                    logo_url=(
+                        str(branding_raw["logo_url"])
+                        if branding_raw.get("logo_url")
+                        else None
+                    ),
+                    accent_color=(
+                        str(branding_raw["accent_color"])
+                        if branding_raw.get("accent_color")
+                        else None
+                    ),
+                    product_name=(
+                        str(branding_raw["product_name"])
+                        if branding_raw.get("product_name")
+                        else None
+                    ),
+                )
                 projects[pid] = ProjectConfig(
                     id=pid,
                     name=str(pcfg.get("name") or pid),
@@ -313,6 +386,8 @@ class GatewayConfig:
                     metrics=metrics_cfg,
                     replay=replay_cfg,
                     tenant=tenant_cfg,
+                    routing=routing_cfg,
+                    branding=branding_cfg,
                 )
 
         auth_raw = raw.get("auth", {}) or {}

--- a/voicegateway/core/provider_baselines.json
+++ b/voicegateway/core/provider_baselines.json
@@ -1,0 +1,76 @@
+{
+  "_comment": "v0.5.0 published-median latency baselines per (provider, modality). Used by voicegateway/middleware/router.py as the AC-4 fallback when latency_observations has no observed p50 for a candidate. Each entry pairs a provider id + modality with a published median in milliseconds and a source_url citing the provider's stated benchmark. verified_at follows the pricing catalog convention (YYYY-MM-DD) so a future staleness audit can flag entries past a 90-day threshold. The router treats a missing entry as 'cannot predict, skip this candidate'.",
+  "_format_version": 1,
+  "baselines": [
+    {
+      "provider": "deepgram",
+      "modality": "stt",
+      "median_ms": 250,
+      "source_url": "https://deepgram.com/learn/streaming-speech-to-text-api",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "assemblyai",
+      "modality": "stt",
+      "median_ms": 400,
+      "source_url": "https://www.assemblyai.com/docs/speech-to-text/streaming",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "openai",
+      "modality": "stt",
+      "median_ms": 500,
+      "source_url": "https://platform.openai.com/docs/guides/speech-to-text",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "groq",
+      "modality": "stt",
+      "median_ms": 200,
+      "source_url": "https://console.groq.com/docs/speech-text",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "openai",
+      "modality": "llm",
+      "median_ms": 300,
+      "source_url": "https://platform.openai.com/docs/guides/latency-optimization",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "anthropic",
+      "modality": "llm",
+      "median_ms": 350,
+      "source_url": "https://docs.anthropic.com/en/api/messages-streaming",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "groq",
+      "modality": "llm",
+      "median_ms": 80,
+      "source_url": "https://groq.com/inference",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "cartesia",
+      "modality": "tts",
+      "median_ms": 150,
+      "source_url": "https://docs.cartesia.ai/api-reference/tts",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "elevenlabs",
+      "modality": "tts",
+      "median_ms": 400,
+      "source_url": "https://elevenlabs.io/docs/api-reference/text-to-speech",
+      "verified_at": "2026-05-11"
+    },
+    {
+      "provider": "openai",
+      "modality": "tts",
+      "median_ms": 600,
+      "source_url": "https://platform.openai.com/docs/guides/text-to-speech",
+      "verified_at": "2026-05-11"
+    }
+  ]
+}

--- a/voicegateway/core/schema.py
+++ b/voicegateway/core/schema.py
@@ -69,6 +69,36 @@ class ReplayConfig(_StrictBase):
     flush_size_events: int = Field(default=500, ge=1)
 
 
+class RoutingConfig(_StrictBase):
+    """v0.5.0 cross-modality routing knobs (REQ-VG-ROUTE-001..002).
+
+    ``budget_ms`` is the latency budget in milliseconds; the OQ1 lock
+    is 1500 ms. ``rosters`` maps modality ('stt'/'llm'/'tts') to an
+    ordered list of provider ids the router may pick from. Empty
+    rosters force callers to provide overrides; otherwise the router
+    raises ``ValueError`` at session-create time.
+    """
+
+    budget_ms: int = Field(default=1500, ge=1)
+    rosters: dict[str, list[str]] = Field(default_factory=dict)
+    fallback_to_fastest: bool = True
+
+
+class BrandingConfig(_StrictBase):
+    """v0.5.0 white-label branding knobs (REQ-VG-ROUTE-004).
+
+    All fields nullable; a project with no branding falls back to
+    the default VoiceGateway brand on next dashboard layout mount.
+    ``accent_color`` is expected to be a hex string when set; the
+    dashboard validates the format on upload but the schema is
+    permissive here.
+    """
+
+    logo_url: str | None = None
+    accent_color: str | None = None
+    product_name: str | None = None
+
+
 class TenantConfig(_StrictBase):
     """v0.4.0 multi-tenant attribution knobs (REQ-VG-TENANT-001..004).
 
@@ -101,6 +131,10 @@ class ProjectConfig(_StrictBase):
     replay: ReplayConfig = Field(default_factory=ReplayConfig)
     # v0.4.0: per-project multi-tenant knobs.
     tenant: TenantConfig = Field(default_factory=TenantConfig)
+    # v0.5.0: per-project routing knobs.
+    routing: RoutingConfig = Field(default_factory=RoutingConfig)
+    # v0.5.0: per-project branding knobs.
+    branding: BrandingConfig = Field(default_factory=BrandingConfig)
 
 
 class ObservabilityConfig(_StrictBase):

--- a/voicegateway/inference/_session_attach.py
+++ b/voicegateway/inference/_session_attach.py
@@ -33,7 +33,9 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from voicegateway.inference._session_context import (
+    RoutingDecisionTuple,
     get_or_create_session_id,
+    set_routing_decision,
     set_tenant,
 )
 
@@ -164,6 +166,7 @@ def attach_session(
     *,
     session_id: str | None = None,
     tenant_id: str | None = None,
+    routed_triple: RoutingDecisionTuple | None = None,
     turn_tracker: TurnTracker | None = None,
     dead_air_detector: DeadAirDetector | None = None,
     cost_tracker: CostTracker | None = None,
@@ -219,6 +222,8 @@ def attach_session(
     sid = session_id if session_id is not None else get_or_create_session_id()
     if tenant_id is not None:
         set_tenant(tenant_id)
+    if routed_triple is not None:
+        set_routing_decision(routed_triple)
 
     if tracker is None:
         logger.warning(

--- a/voicegateway/inference/_session_context.py
+++ b/voicegateway/inference/_session_context.py
@@ -151,3 +151,68 @@ def reset_tenant_id() -> None:
     fresh asyncio task. Mirrors the ``reset_session_id`` shape.
     """
     _current_tenant_id.set(None)
+
+
+# ----------------------------------------------------------------------
+# v0.5.0 routing-decision ContextVar (REQ-VG-ROUTE-001..002).
+#
+# Parallel to tenant_id_ctx above. The session-create path runs the
+# router once (voicegateway.middleware.router.route_session), sets the
+# resulting RoutedTriple via ``set_routing_decision``, and then the
+# next ``log_request`` reads it on the sessions UPSERT to stamp
+# routed_llm / routed_tts / budget_ms / budget_overrun. Pre-v0.5.0
+# sessions and sessions where the router never ran keep NULL on the
+# four columns and the dashboard renders "-" / "ok" accordingly.
+#
+# ``RoutedTriple`` is a 4-tuple (stt, llm, tts, budget_ms,
+# budget_overrun); flattening to a Tuple avoids a circular import
+# between this module and middleware/router.py. The caller passes
+# the tuple shape directly.
+# ----------------------------------------------------------------------
+
+# Tuple layout: (stt, llm, tts, budget_ms, budget_overrun).
+RoutingDecisionTuple = tuple[str, str, str, int, bool]
+
+_current_routing_decision: ContextVar[RoutingDecisionTuple | None] = ContextVar(
+    "vg_routing_decision", default=None
+)
+
+
+def set_routing_decision(decision: RoutingDecisionTuple | None) -> None:
+    """Set the current session's routing decision in the active context.
+
+    ``decision`` is ``(stt, llm, tts, budget_ms, budget_overrun)``.
+    Pass ``None`` to clear. Storage's ``log_request`` reads
+    :func:`current_routing_decision` at the sessions UPSERT and stamps
+    the four routing columns from this tuple. The router writes once
+    per session; per AC-5 the triple is immutable for the session’s
+    lifetime.
+    """
+    if decision is None:
+        _current_routing_decision.set(None)
+        return
+    if not isinstance(decision, tuple) or len(decision) != 5:
+        raise ValueError(
+            "routing decision must be a 5-tuple "
+            "(stt, llm, tts, budget_ms, budget_overrun) or None"
+        )
+    stt, llm, tts, budget_ms, overrun = decision
+    if not (
+        isinstance(stt, str)
+        and isinstance(llm, str)
+        and isinstance(tts, str)
+        and isinstance(budget_ms, int)
+        and isinstance(overrun, bool)
+    ):
+        raise ValueError("routing decision tuple has wrong field types")
+    _current_routing_decision.set((stt, llm, tts, budget_ms, overrun))
+
+
+def current_routing_decision() -> RoutingDecisionTuple | None:
+    """Return the current routing decision, or ``None`` when unset."""
+    return _current_routing_decision.get()
+
+
+def reset_routing_decision() -> None:
+    """Clear the routing decision (test-only helper)."""
+    _current_routing_decision.set(None)

--- a/voicegateway/middleware/latency_observations_worker.py
+++ b/voicegateway/middleware/latency_observations_worker.py
@@ -1,0 +1,144 @@
+"""15-minute roll-up worker for v0.5.0 latency_observations.
+
+Implements REQ-VG-ROUTE-002 AC-4 + REQ-VG-ROUTE-003 (Routing
+dashboard view freshness). Wakes every 15 minutes, calls
+``latency_observations_repo.roll_up`` to recompute the per-
+(project, provider, modality) p50/p95 snapshot over the trailing
+24-hour window. Single-process for v0.5.0.
+
+Mirrors the v0.3.0 ``RetentionWorker`` pattern (start/stop/tick_now
+lifecycle, structured logging on each cycle, asyncio task with
+exception-resilient loop). The worker is decoupled from the
+ProjectConfig source via the injected ``window_provider`` callable
+that returns the trailing-window length in minutes; the wiring
+side reads from the live config or hands a static value.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Final
+
+from voicegateway.storage import latency_observations_repo
+
+if TYPE_CHECKING:
+    from voicegateway.storage.sqlite import SQLiteStorage
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_WINDOW_MINUTES: Final[int] = 24 * 60  # OQ2 lock: 24-hour rolling.
+_DEFAULT_POLL_INTERVAL_SECONDS: Final[float] = 15 * 60.0  # OQ2 lock: 15-minute refresh.
+
+
+# Window provider returns the rollup window length in minutes. Async
+# to let callers source the value from any backing store (live
+# config, future config-watch surface). When omitted, the default
+# 24-hour window is used.
+WindowProvider = Callable[[], Awaitable[int]]
+
+
+async def _default_window_provider() -> int:
+    return _DEFAULT_WINDOW_MINUTES
+
+
+class LatencyObservationsWorker:
+    """Background worker that refreshes ``latency_observations``.
+
+    Lifecycle: :meth:`start` spawns one asyncio task that loops
+    forever, sleeping ``poll_interval_seconds`` between roll-up
+    passes. :meth:`stop` cancels the task. :meth:`tick_now` runs
+    one pass synchronously and returns the number of inserted
+    rollup rows, primarily for test rigs.
+
+    Each pass calls ``latency_observations_repo.roll_up`` with the
+    window the provider returns. The repo DELETEs the prior
+    snapshot and re-inserts atomically, so the FE never sees a
+    half-rolled state.
+
+    Idempotent: re-running with the same data yields the same
+    snapshot.
+    """
+
+    def __init__(
+        self,
+        storage: SQLiteStorage,
+        window_provider: WindowProvider | None = None,
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> None:
+        if poll_interval_seconds <= 0:
+            raise ValueError(
+                f"poll_interval_seconds must be > 0, got {poll_interval_seconds}"
+            )
+        self._storage = storage
+        self._provider: WindowProvider = window_provider or _default_window_provider
+        self._poll_interval = poll_interval_seconds
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Spawn the roll-up loop. Idempotent."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(
+            self._loop(), name="latency-observations-worker"
+        )
+
+    async def stop(self) -> None:
+        """Cancel the loop and clear state."""
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def tick_now(self) -> int:
+        """Run one roll-up pass synchronously. Returns the inserted row count."""
+        return await self._tick()
+
+    # ---- internals -------------------------------------------------------
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                try:
+                    await self._tick()
+                except Exception:
+                    logger.exception(
+                        "LatencyObservationsWorker tick raised; continuing"
+                    )
+                await asyncio.sleep(self._poll_interval)
+        except asyncio.CancelledError:
+            raise
+
+    async def _tick(self) -> int:
+        window_minutes = await self._provider()
+        if window_minutes < 1:
+            logger.warning(
+                "LatencyObservationsWorker: window_minutes=%d (< 1); using default %d",
+                window_minutes,
+                _DEFAULT_WINDOW_MINUTES,
+            )
+            window_minutes = _DEFAULT_WINDOW_MINUTES
+        db = await self._storage._ensure_initialized()
+        inserted = await latency_observations_repo.roll_up(
+            db, window_minutes=window_minutes
+        )
+        logger.info(
+            "LatencyObservationsWorker: rolled up %d (project, provider, "
+            "modality) observations over %d-minute window",
+            inserted,
+            window_minutes,
+        )
+        return inserted
+
+
+__all__ = [
+    "LatencyObservationsWorker",
+    "WindowProvider",
+]

--- a/voicegateway/middleware/router.py
+++ b/voicegateway/middleware/router.py
@@ -1,0 +1,253 @@
+"""Cross-modality provider routing for v0.5.0.
+
+Implements REQ-VG-ROUTE-002. Single entry point ``route_session``
+runs once per session at session-create time and picks the
+(stt, llm, tts) triple from the project's rosters that minimises
+predicted total response latency under the configured budget.
+
+Inputs:
+
+* ``project_config.routing.budget_ms`` — the latency budget (OQ1
+  default 1500 ms).
+* ``project_config.routing.rosters`` — ordered allow-list of
+  provider ids per modality.
+* ``project_config.routing.fallback_to_fastest`` — when ``True``,
+  no-fit triggers the fastest-available + ``budget_overrun=True``
+  path (AC-2); when ``False``, raises ``BudgetExceeded``.
+* ``latency_observations_repo.get_for_project`` — recent observed
+  p50 per (provider, modality). Roll-up worker (T06) refreshes
+  every 15 minutes (OQ2).
+* Caller overrides — explicit ``{modality: provider}`` map; the
+  router respects them and only picks for the unset modalities
+  (AC-3).
+* ``provider_baselines.json`` — curated published-median latencies
+  per (provider, modality). Loaded from
+  ``voicegateway.core.provider_baselines`` (T07). When neither an
+  observation nor a baseline exists for a candidate, the candidate
+  is skipped (AC-4 fallback).
+
+Output: :class:`RoutedTriple` with the picked stt/llm/tts ids,
+the summed predicted latency, and a ``budget_overrun`` boolean.
+
+The triple stays fixed for the session (AC-5): the router has no
+mid-call surface.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from importlib import resources
+from typing import TYPE_CHECKING
+
+from voicegateway.storage import latency_observations_repo
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from voicegateway.core.config import ProjectConfig
+
+logger = logging.getLogger(__name__)
+
+
+_MODALITIES = ("stt", "llm", "tts")
+
+
+class BudgetExceeded(Exception):
+    """Raised when no candidate triple fits and fallback is disabled."""
+
+
+@dataclass(frozen=True)
+class RoutedTriple:
+    """Result of :func:`route_session`.
+
+    ``predicted_ms`` is the sum of the per-modality predictions used
+    to pick this triple (observed p50 when available, baseline
+    median otherwise). It is the router's best guess; the session's
+    actual end-to-end latency is recorded as ``sessions.budget_ms_used``
+    after the call closes.
+
+    ``budget_overrun`` is True when the picked triple's predicted
+    total exceeds the project's ``budget_ms`` (the fallback path),
+    False when the triple fits.
+    """
+
+    stt: str
+    llm: str
+    tts: str
+    predicted_ms: int
+    budget_overrun: bool
+
+
+_baselines_cache: dict[tuple[str, str], int] | None = None
+
+
+def _load_baselines() -> dict[tuple[str, str], int]:
+    """Load provider_baselines.json from voicegateway.core.
+
+    Returns an empty dict when the file is absent so the router stays
+    importable before T07 ships the canonical baselines. Result is
+    cached at module level on first call.
+    """
+    global _baselines_cache  # noqa: PLW0603
+    if _baselines_cache is not None:
+        return _baselines_cache
+
+    try:
+        raw = (
+            resources.files("voicegateway.core")
+            .joinpath("provider_baselines.json")
+            .read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        _baselines_cache = {}
+        return _baselines_cache
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning(
+            "provider_baselines.json failed to parse; routing fallback disabled"
+        )
+        _baselines_cache = {}
+        return _baselines_cache
+
+    entries: dict[tuple[str, str], int] = {}
+    for entry in data.get("baselines", []):
+        try:
+            provider = str(entry["provider"])
+            modality = str(entry["modality"])
+            median_ms = int(entry["median_ms"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        entries[(provider, modality)] = median_ms
+    _baselines_cache = entries
+    return _baselines_cache
+
+
+def _reset_baselines_cache() -> None:
+    """Test helper: drop the module-level cache so tests can rewire."""
+    global _baselines_cache  # noqa: PLW0603
+    _baselines_cache = None
+
+
+async def route_session(
+    db: aiosqlite.Connection,
+    *,
+    project_id: str,
+    project_config: ProjectConfig,
+    caller_overrides: dict[str, str] | None = None,
+) -> RoutedTriple:
+    """Pick the (stt, llm, tts) triple for a new session.
+
+    Implements REQ-VG-ROUTE-002. Caller-overrides win over roster
+    picks (AC-3). When at least one candidate triple has a
+    prediction <= budget_ms, the lowest-predicted-total triple is
+    returned with ``budget_overrun=False``. When nothing fits, the
+    fastest available triple is returned with
+    ``budget_overrun=True`` (AC-2) provided ``fallback_to_fastest``
+    is enabled; otherwise :class:`BudgetExceeded` is raised.
+    """
+    overrides = dict(caller_overrides or {})
+    for modality in overrides:
+        if modality not in _MODALITIES:
+            raise ValueError(
+                f"unknown override modality {modality!r}; expected one of {_MODALITIES}"
+            )
+
+    routing_cfg = project_config.routing
+    budget_ms = routing_cfg.budget_ms
+    rosters = routing_cfg.rosters
+
+    # Build per-modality candidate lists.
+    def _candidates(modality: str) -> list[str]:
+        if modality in overrides:
+            return [overrides[modality]]
+        roster = rosters.get(modality) or []
+        return [str(p) for p in roster]
+
+    by_modality: dict[str, list[str]] = {m: _candidates(m) for m in _MODALITIES}
+    missing = [m for m, c in by_modality.items() if not c]
+    if missing:
+        raise ValueError(
+            f"project {project_id!r} has empty roster(s) for {missing}; cannot route"
+        )
+
+    # Observed p50 per (provider, modality).
+    obs_rows = await latency_observations_repo.get_for_project(db, project_id)
+    observed: dict[tuple[str, str], int] = {
+        (r.provider, r.modality): r.p50_ms for r in obs_rows if r.p50_ms is not None
+    }
+    baselines = _load_baselines()
+
+    def _predict(provider: str, modality: str) -> int | None:
+        if (provider, modality) in observed:
+            return observed[(provider, modality)]
+        if (provider, modality) in baselines:
+            return baselines[(provider, modality)]
+        return None
+
+    best_under_budget: tuple[int, str, str, str] | None = None
+    best_overall: tuple[int, str, str, str] | None = None
+    considered = 0
+    for stt in by_modality["stt"]:
+        for llm in by_modality["llm"]:
+            for tts in by_modality["tts"]:
+                p_stt = _predict(stt, "stt")
+                p_llm = _predict(llm, "llm")
+                p_tts = _predict(tts, "tts")
+                if p_stt is None or p_llm is None or p_tts is None:
+                    continue
+                total = p_stt + p_llm + p_tts
+                cand = (total, stt, llm, tts)
+                considered += 1
+                if best_overall is None or cand < best_overall:
+                    best_overall = cand
+                if total <= budget_ms and (
+                    best_under_budget is None or cand < best_under_budget
+                ):
+                    best_under_budget = cand
+
+    if best_under_budget is not None:
+        total, stt, llm, tts = best_under_budget
+        return RoutedTriple(
+            stt=stt, llm=llm, tts=tts, predicted_ms=total, budget_overrun=False
+        )
+
+    if best_overall is None:
+        raise ValueError(
+            f"no candidate triple has predictions for project "
+            f"{project_id!r}; populate latency_observations or extend "
+            "provider_baselines.json"
+        )
+
+    if not routing_cfg.fallback_to_fastest:
+        total, stt, llm, tts = best_overall
+        raise BudgetExceeded(
+            f"no triple fits budget_ms={budget_ms} for project "
+            f"{project_id!r}; fastest available was {stt}/{llm}/{tts} "
+            f"at {total} ms"
+        )
+
+    total, stt, llm, tts = best_overall
+    logger.info(
+        "route_session: project=%s budget_ms=%d fell back to fastest "
+        "triple %s/%s/%s at predicted %d ms (overrun)",
+        project_id,
+        budget_ms,
+        stt,
+        llm,
+        tts,
+        total,
+    )
+    return RoutedTriple(
+        stt=stt, llm=llm, tts=tts, predicted_ms=total, budget_overrun=True
+    )
+
+
+__all__ = [
+    "BudgetExceeded",
+    "RoutedTriple",
+    "route_session",
+]

--- a/voicegateway/server/main.py
+++ b/voicegateway/server/main.py
@@ -59,7 +59,7 @@ def build_app(gateway: Gateway) -> FastAPI:
     """Build a FastAPI app bound to the given Gateway instance."""
     app = FastAPI(
         title="VoiceGateway API",
-        version="0.4.0",
+        version="0.5.0",
         description="HTTP API for VoiceGateway: cost tracking and reconciliation for LiveKit voice agents.",
     )
 
@@ -148,7 +148,7 @@ def build_app(gateway: Gateway) -> FastAPI:
         return {
             "status": "ok",
             "uptime_seconds": round(time.time() - started_at, 1),
-            "version": "0.4.0",
+            "version": "0.5.0",
         }
 
     @app.get("/v1/status")

--- a/voicegateway/storage/latency_observations_repo.py
+++ b/voicegateway/storage/latency_observations_repo.py
@@ -1,0 +1,203 @@
+"""Async repo for the ``latency_observations`` table.
+
+Implements REQ-VG-ROUTE-002 AC-4 (fallback estimate path) and the
+read side of REQ-VG-ROUTE-003 (per-project provider-latency
+snapshot the dashboard Routing view displays).
+
+The table is a denormalized rollup: one row per
+(project_id, provider, modality) holding the latest p50/p95 over a
+configurable trailing window. The
+``latency_observations_worker`` (T06) calls ``roll_up`` every
+fifteen minutes; the router (T05) and the dashboard's
+``/api/routing/observations`` endpoint (T12) both call
+``read_all`` / ``get_for_project`` to consume the snapshot.
+
+Aggregation source: the v0.0.5 ``requests`` table. Each request row
+carries ``project``, ``provider``, ``modality``, ``total_latency_ms``,
+``timestamp``. Aggregating per (project, provider, modality) over a
+trailing window gives the router the predicted per-modality latency
+it needs.
+
+The Foundry's "use ``turns`` when v0.2.0 shipped" design was
+revisited: the ``turns`` table records full turn-cycle latency
+without per-modality breakdown, so it cannot answer the router's
+"how fast is provider X at modality Y" question. ``requests`` carries
+the per-modality timing directly and works uniformly on v0.0.5,
+v0.2.0+, and v0.4.0+ baselines.
+
+Schema reference:
+``voicegateway/storage/migrations/0006_routing_and_branding.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from voicegateway.storage._percentiles import compute_percentiles
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+_DEFAULT_WINDOW_MINUTES = 24 * 60  # OQ2 lock: 24h rolling window.
+
+
+@dataclass(frozen=True)
+class LatencyObservation:
+    """One row from the ``latency_observations`` rollup."""
+
+    project_id: str
+    provider: str
+    modality: str
+    p50_ms: int | None
+    p95_ms: int | None
+    sample_count: int
+    window_start: str
+    window_end: str
+    refreshed_at: str
+
+
+def _row_to_observation(row: Sequence[Any]) -> LatencyObservation:
+    return LatencyObservation(
+        project_id=str(row[0]),
+        provider=str(row[1]),
+        modality=str(row[2]),
+        p50_ms=None if row[3] is None else int(row[3]),
+        p95_ms=None if row[4] is None else int(row[4]),
+        sample_count=int(row[5]),
+        window_start=str(row[6]),
+        window_end=str(row[7]),
+        refreshed_at=str(row[8]),
+    )
+
+
+_SELECT_FIELDS = (
+    "project_id, provider, modality, p50_ms, p95_ms, "
+    "sample_count, window_start, window_end, refreshed_at"
+)
+
+
+async def roll_up(
+    db: aiosqlite.Connection, *, window_minutes: int = _DEFAULT_WINDOW_MINUTES
+) -> int:
+    """Recompute the rollup over the trailing window.
+
+    Deletes the previous rollup snapshot atomically and re-inserts
+    one row per (project, provider, modality) with new p50/p95 over
+    the requests table window. Returns the number of inserted rows.
+
+    The "delete + insert" pattern keeps the table size bounded
+    (one row per group) and ensures the FE never sees a half-rolled
+    state: a single transaction commits the new snapshot.
+
+    ``window_minutes`` defaults to the OQ2-locked 1440 minutes
+    (24 hours). Past requests outside the window are ignored.
+    """
+    import datetime as _dt
+
+    now = _dt.datetime.now(tz=_dt.UTC)
+    window_start = now - _dt.timedelta(minutes=window_minutes)
+    window_start_ts = window_start.timestamp()
+    window_end_ts = now.timestamp()
+    window_start_iso = window_start.isoformat()
+    window_end_iso = now.isoformat()
+
+    cursor = await db.execute(
+        """SELECT project, provider, modality, total_latency_ms
+           FROM requests
+           WHERE timestamp >= ?
+             AND timestamp < ?
+             AND total_latency_ms IS NOT NULL""",
+        (window_start_ts, window_end_ts),
+    )
+    rows = await cursor.fetchall()
+
+    by_group: dict[tuple[str, str, str], list[float]] = {}
+    for row in rows:
+        project, provider, modality, latency = row
+        if latency is None:
+            continue
+        key = (str(project), str(provider), str(modality))
+        by_group.setdefault(key, []).append(float(latency))
+
+    await db.execute("DELETE FROM latency_observations")
+
+    inserted = 0
+    for (project, provider, modality), samples in by_group.items():
+        pcts = compute_percentiles(samples, [50.0, 95.0])
+        p50 = pcts.get("p50")
+        p95 = pcts.get("p95")
+        await db.execute(
+            "INSERT INTO latency_observations "
+            "(project_id, provider, modality, p50_ms, p95_ms, "
+            " sample_count, window_start, window_end) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                project,
+                provider,
+                modality,
+                None if p50 is None else int(p50),
+                None if p95 is None else int(p95),
+                len(samples),
+                window_start_iso,
+                window_end_iso,
+            ),
+        )
+        inserted += 1
+
+    await db.commit()
+    return inserted
+
+
+async def read_all(db: aiosqlite.Connection) -> list[LatencyObservation]:
+    """Return every row in the current rollup snapshot.
+
+    Ordered by ``project_id ASC, modality ASC, provider ASC`` for
+    deterministic dashboard display.
+    """
+    cursor = await db.execute(
+        f"SELECT {_SELECT_FIELDS} FROM latency_observations "
+        "ORDER BY project_id ASC, modality ASC, provider ASC"
+    )
+    return [_row_to_observation(row) async for row in cursor]
+
+
+async def get_for_project(
+    db: aiosqlite.Connection, project_id: str
+) -> list[LatencyObservation]:
+    """Return the rollup rows for one project. Used by the router."""
+    cursor = await db.execute(
+        f"SELECT {_SELECT_FIELDS} FROM latency_observations "
+        "WHERE project_id = ? "
+        "ORDER BY modality ASC, provider ASC",
+        (project_id,),
+    )
+    return [_row_to_observation(row) async for row in cursor]
+
+
+async def get_one(
+    db: aiosqlite.Connection,
+    *,
+    project_id: str,
+    provider: str,
+    modality: str,
+) -> LatencyObservation | None:
+    """Return a single (project, provider, modality) observation or None."""
+    cursor = await db.execute(
+        f"SELECT {_SELECT_FIELDS} FROM latency_observations "
+        "WHERE project_id = ? AND provider = ? AND modality = ?",
+        (project_id, provider, modality),
+    )
+    row = await cursor.fetchone()
+    return _row_to_observation(row) if row is not None else None
+
+
+__all__ = [
+    "LatencyObservation",
+    "get_for_project",
+    "get_one",
+    "read_all",
+    "roll_up",
+]

--- a/voicegateway/storage/migrations/0006_routing_and_branding.py
+++ b/voicegateway/storage/migrations/0006_routing_and_branding.py
@@ -1,0 +1,128 @@
+"""Migration 0006: cross-modality routing + per-project white-label branding.
+
+Introduced in v0.5.0 to back REQ-VG-ROUTE-001..004.
+
+Idempotent. Re-running on an already-migrated database is a no-op:
+
+* ``CREATE TABLE IF NOT EXISTS latency_observations`` and the index
+  ``CREATE INDEX IF NOT EXISTS`` guard themselves.
+* The ``ALTER TABLE ... ADD COLUMN`` calls are guarded by a
+  ``PRAGMA table_info`` lookup per (table, column).
+
+Two tables are touched:
+
+* ``sessions`` (v0.0.5 baseline) gets five new nullable columns:
+  ``budget_ms``, ``budget_ms_used``, ``budget_overrun``,
+  ``routed_llm``, ``routed_tts``. Speech-to-text on the sessions row
+  is the existing ``stt_provider`` field carried from v0.0.5 — no
+  new column there.
+* ``projects`` (v0.0.5 baseline; only present on installs that have
+  configured projects in voicegw.yaml or via the dashboard) gets
+  ``branding_json TEXT NULL``. Guarded by a ``sqlite_master``
+  presence check so a v0.0.5-baseline install without a projects
+  table (the auto-default-project case) doesn't error.
+
+The new ``latency_observations`` table is denormalized: one row per
+(project, provider, modality) holding the latest p50/p95 from the
+roll-up worker (T06). Composite index on
+(project_id, provider, modality) keeps router reads fast.
+
+Pre-v0.5.0 rows in every table keep the new fields NULL. The
+dashboard renders NULL budget_overrun as "ok" and NULL routed_* as
+"-". No backfill.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+# (table, column) tuples to add as nullable columns. None of these
+# require defaults; pre-v0.5.0 rows stay NULL and the read side
+# treats NULL as "this session predates routing".
+_SESSIONS_NEW_COLUMNS = (
+    ("budget_ms", "INTEGER"),
+    ("budget_ms_used", "INTEGER"),
+    ("budget_overrun", "INTEGER"),
+    ("routed_llm", "TEXT"),
+    ("routed_tts", "TEXT"),
+)
+
+
+_PROJECTS_NEW_COLUMNS = (("branding_json", "TEXT"),)
+
+
+_LATENCY_OBSERVATIONS_DDL = """
+CREATE TABLE IF NOT EXISTS latency_observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    modality TEXT NOT NULL,
+    p50_ms INTEGER,
+    p95_ms INTEGER,
+    sample_count INTEGER NOT NULL DEFAULT 0,
+    window_start TEXT NOT NULL,
+    window_end TEXT NOT NULL,
+    refreshed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_latency_obs_project_provider
+    ON latency_observations(project_id, provider, modality);
+"""
+
+
+async def _table_exists(db: aiosqlite.Connection, name: str) -> bool:
+    cursor = await db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (name,),
+    )
+    row = await cursor.fetchone()
+    return row is not None
+
+
+async def _add_column_if_missing(
+    db: aiosqlite.Connection, table: str, column: str, sql_type: str
+) -> None:
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    existing = {row[1] async for row in cursor}
+    if column in existing:
+        return
+    await db.execute(f"ALTER TABLE {table} ADD COLUMN {column} {sql_type}")
+
+
+async def apply(db: aiosqlite.Connection) -> None:
+    """Apply migration 0006 against the given connection.
+
+    Steps:
+
+    1. Create the ``latency_observations`` table + composite index.
+    2. Add the five routing columns to ``sessions``. The table is
+       always present on a v0.0.5+ baseline.
+    3. Add ``branding_json`` to ``projects`` IFF the table exists.
+       Some early installs that never wrote a project entry may
+       not have a ``managed_projects`` table — guard the ALTER
+       accordingly. Same OQ4-style pattern v0.4.0's 0005 used for
+       the v0.2.0 / v0.3.0 derived tables.
+
+    The caller commits the transaction; the sqlite.py ensure path
+    commits after the migration chain runs.
+    """
+    await db.executescript(_LATENCY_OBSERVATIONS_DDL)
+
+    for column, sql_type in _SESSIONS_NEW_COLUMNS:
+        await _add_column_if_missing(db, "sessions", column, sql_type)
+
+    # ``managed_projects`` is the v0.0.5 projects table per
+    # sqlite.py. Foundry's prose said "projects.branding_json"; the
+    # actual table name on disk is ``managed_projects``. Guard for
+    # presence: a fresh ensure path creates it, but defensive
+    # programming costs one PRAGMA.
+    if await _table_exists(db, "managed_projects"):
+        for column, sql_type in _PROJECTS_NEW_COLUMNS:
+            await _add_column_if_missing(db, "managed_projects", column, sql_type)
+
+
+__all__ = ["apply"]

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -1030,12 +1030,27 @@ class SQLiteStorage:
             "request_count": int(row[6] or 0),
         }
         # v0.4.0: include tenant_id when the SELECT picked it up.
-        # list_sessions and get_session both include the column on
-        # post-migration databases; the Any-typed Row may not raise on
-        # out-of-bounds, so we guard defensively.
+        # v0.5.0: include the four routing columns the same way.
+        # The Any-typed Row may not raise on out-of-bounds; guard
+        # defensively so a SELECT that omits the columns (e.g. an
+        # external caller reading the legacy seven-column shape)
+        # still works.
         try:
             tenant_id = row[7]
             out["tenant_id"] = None if tenant_id is None else str(tenant_id)
+        except (IndexError, KeyError):
+            pass
+        try:
+            routed_llm = row[8]
+            routed_tts = row[9]
+            budget_ms = row[10]
+            budget_overrun = row[11]
+            out["routed_llm"] = None if routed_llm is None else str(routed_llm)
+            out["routed_tts"] = None if routed_tts is None else str(routed_tts)
+            out["budget_ms"] = None if budget_ms is None else int(budget_ms)
+            out["budget_overrun"] = (
+                None if budget_overrun is None else bool(budget_overrun)
+            )
         except (IndexError, KeyError):
             pass
         return out
@@ -1093,7 +1108,8 @@ class SQLiteStorage:
             params.append(limit)
             cursor = await db.execute(
                 f"""SELECT id, project, started_at, ended_at, modalities,
-                          total_cost_usd, request_count, tenant_id
+                          total_cost_usd, request_count, tenant_id,
+                          routed_llm, routed_tts, budget_ms, budget_overrun
                    FROM sessions
                    {where}ORDER BY {clause}
                    LIMIT ?""",
@@ -1115,7 +1131,8 @@ class SQLiteStorage:
         try:
             cursor = await db.execute(
                 """SELECT id, project, started_at, ended_at, modalities,
-                          total_cost_usd, request_count, tenant_id
+                          total_cost_usd, request_count, tenant_id,
+                          routed_llm, routed_tts, budget_ms, budget_overrun
                    FROM sessions
                    WHERE id = ?""",
                 (session_id,),

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -31,6 +31,9 @@ _migration_0004 = import_module("voicegateway.storage.migrations.0004_replay_tab
 _migration_0005 = import_module(
     "voicegateway.storage.migrations.0005_tenant_attribution"
 )
+_migration_0006 = import_module(
+    "voicegateway.storage.migrations.0006_routing_and_branding"
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -271,6 +274,12 @@ class SQLiteStorage:
             # derived tables (conditionally via sqlite_master presence check
             # per OQ4). Idempotent.
             await _migration_0005.apply(db)
+
+            # v0.5.0 migration 0006: routing columns on sessions
+            # (budget_ms / budget_ms_used / budget_overrun / routed_llm /
+            # routed_tts), branding_json on managed_projects (conditional),
+            # and the new latency_observations table. Idempotent.
+            await _migration_0006.apply(db)
 
             await db.commit()
             self._initialized = True

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -1569,16 +1569,77 @@ class SQLiteStorage:
 
     # Managed projects
 
+    @staticmethod
+    def _validate_branding(branding: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Validate the v0.5.0 branding payload before write.
+
+        OQ4 + dashboard contract:
+        - ``logo_url`` (optional): string up to 2048 chars.
+        - ``accent_color`` (optional): hex string ``#RRGGBB`` or
+          ``#RGB``.
+        - ``product_name`` (optional): string up to 64 chars.
+
+        Returns the validated dict (or ``None`` when input is None /
+        empty). Raises ``ValueError`` on shape or constraint violations.
+        """
+        import re
+
+        if branding is None:
+            return None
+        if not isinstance(branding, dict):
+            raise ValueError(
+                f"branding must be a dict or None, got {type(branding).__name__}"
+            )
+        if not branding:
+            return None
+        out: dict[str, Any] = {}
+        allowed = {"logo_url", "accent_color", "product_name"}
+        for key in branding:
+            if key not in allowed:
+                raise ValueError(
+                    f"branding has unknown key {key!r}; allowed: {sorted(allowed)}"
+                )
+        logo_url = branding.get("logo_url")
+        if logo_url is not None:
+            if not isinstance(logo_url, str) or len(logo_url) > 2048:
+                raise ValueError("branding.logo_url must be a string up to 2048 chars")
+            out["logo_url"] = logo_url
+        accent_color = branding.get("accent_color")
+        if accent_color is not None:
+            if not isinstance(accent_color, str) or not re.fullmatch(
+                r"#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?", accent_color
+            ):
+                raise ValueError(
+                    "branding.accent_color must be a hex string (#RGB or #RRGGBB)"
+                )
+            out["accent_color"] = accent_color
+        product_name = branding.get("product_name")
+        if product_name is not None:
+            if not isinstance(product_name, str) or len(product_name) > 64:
+                raise ValueError(
+                    "branding.product_name must be a string up to 64 chars"
+                )
+            out["product_name"] = product_name
+        return out or None
+
     async def list_managed_projects(self) -> list[dict[str, Any]]:
         db = await self._ensure_initialized()
         try:
             cursor = await db.execute(
                 "SELECT project_id, name, description, daily_budget, budget_action, "
                 "default_stack, stt_model, llm_model, tts_model, tags, "
-                "created_at, updated_at FROM managed_projects ORDER BY created_at ASC"
+                "created_at, updated_at, branding_json "
+                "FROM managed_projects ORDER BY created_at ASC"
             )
             rows = []
             async for row in cursor:
+                branding_raw = row[12] if len(row) > 12 else None
+                branding = None
+                if branding_raw:
+                    try:
+                        branding = json.loads(branding_raw)
+                    except (ValueError, TypeError):
+                        branding = None
                 rows.append(
                     {
                         "project_id": row[0],
@@ -1593,6 +1654,7 @@ class SQLiteStorage:
                         "tags": json.loads(row[9] or "[]"),
                         "created_at": row[10],
                         "updated_at": row[11],
+                        "branding": branding,
                     }
                 )
             return rows
@@ -1617,7 +1679,10 @@ class SQLiteStorage:
         llm_model: str | None = None,
         tts_model: str | None = None,
         tags: list[str] | None = None,
+        branding: dict[str, Any] | None = None,
     ) -> None:
+        validated_branding = self._validate_branding(branding)
+        branding_json = json.dumps(validated_branding) if validated_branding else None
         db = await self._ensure_initialized()
         try:
             now = time.time()
@@ -1625,8 +1690,8 @@ class SQLiteStorage:
                 """INSERT INTO managed_projects
                        (project_id, name, description, daily_budget, budget_action,
                         default_stack, stt_model, llm_model, tts_model, tags,
-                        created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        created_at, updated_at, branding_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(project_id) DO UPDATE SET
                        name=excluded.name,
                        description=excluded.description,
@@ -1637,6 +1702,7 @@ class SQLiteStorage:
                        llm_model=excluded.llm_model,
                        tts_model=excluded.tts_model,
                        tags=excluded.tags,
+                       branding_json=COALESCE(excluded.branding_json, branding_json),
                        updated_at=excluded.updated_at""",
                 (
                     project_id,
@@ -1651,6 +1717,7 @@ class SQLiteStorage:
                     json.dumps(tags or []),
                     now,
                     now,
+                    branding_json,
                 ),
             )
             await db.commit()

--- a/voicegateway/storage/sqlite.py
+++ b/voicegateway/storage/sqlite.py
@@ -12,7 +12,10 @@ from typing import Any
 
 import aiosqlite
 
-from voicegateway.inference._session_context import current_tenant
+from voicegateway.inference._session_context import (
+    current_routing_decision,
+    current_tenant,
+)
 from voicegateway.storage import replay_repo, turns_repo
 from voicegateway.storage._percentiles import compute_percentiles
 from voicegateway.storage.models import RequestRecord
@@ -466,15 +469,40 @@ class SQLiteStorage:
                 # the Refinery: the first tenant-bearing request wins,
                 # subsequent unattributed-bucket requests don't clear
                 # it.
+                # v0.5.0: stamp the router's pick on the session row.
+                # AC-5 guarantees the triple is immutable for the
+                # session's lifetime, so COALESCE on conflict keeps the
+                # first-set values and ignores later sessions writes
+                # that arrive without a routing decision in scope.
+                routing = current_routing_decision()
+                r_llm: str | None
+                r_tts: str | None
+                r_budget: int | None
+                r_overrun: int | None
+                if routing is not None:
+                    r_llm = routing[1]
+                    r_tts = routing[2]
+                    r_budget = routing[3]
+                    r_overrun = 1 if routing[4] else 0
+                else:
+                    r_llm = None
+                    r_tts = None
+                    r_budget = None
+                    r_overrun = None
                 await db.execute(
                     """INSERT INTO sessions
                        (id, project, started_at, ended_at, modalities,
-                        total_cost_usd, request_count, tenant_id)
-                       VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+                        total_cost_usd, request_count, tenant_id,
+                        routed_llm, routed_tts, budget_ms, budget_overrun)
+                       VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)
                        ON CONFLICT(id) DO UPDATE SET
                            total_cost_usd = total_cost_usd + excluded.total_cost_usd,
                            request_count = request_count + 1,
                            tenant_id = COALESCE(tenant_id, excluded.tenant_id),
+                           routed_llm = COALESCE(routed_llm, excluded.routed_llm),
+                           routed_tts = COALESCE(routed_tts, excluded.routed_tts),
+                           budget_ms = COALESCE(budget_ms, excluded.budget_ms),
+                           budget_overrun = COALESCE(budget_overrun, excluded.budget_overrun),
                            started_at = CASE
                                WHEN started_at IS NULL THEN excluded.started_at
                                WHEN started_at > excluded.started_at THEN excluded.started_at
@@ -501,6 +529,10 @@ class SQLiteStorage:
                         record.modality,
                         record.cost_usd,
                         request_tenant_id,
+                        r_llm,
+                        r_tts,
+                        r_budget,
+                        r_overrun,
                     ),
                 )
             await db.commit()


### PR DESCRIPTION
## v0.5.0 — Cross-modality routing and white-label

Implements: REQ-VG-ROUTE-001, REQ-VG-ROUTE-002, REQ-VG-ROUTE-003, REQ-VG-ROUTE-004

Refinery: https://linear.app/mahimairaja/document/v050-cross-modality-routing-refinery-bc88ae8e11ea
Foundry:  https://linear.app/mahimairaja/document/v050-cross-modality-routing-foundry-blueprint-e6879587c0f7

Two capabilities ship together because they target the same agency rung of the buyer ladder. The router runs once per session at session-create time, reads the project's latency budget and recent observed per-provider latency, and picks the (STT, LLM, TTS) combination from the project's rosters that minimises predicted total latency under budget. White-label branding lets agencies upload a per-project logo, accent color, and product name; the dashboard chrome reflects the brand for users scoped to that project.

## What changed

- **Migration 0006** adds five nullable routing columns to `sessions` (`budget_ms`, `budget_ms_used`, `budget_overrun`, `routed_llm`, `routed_tts`), `branding_json` nullable on `managed_projects`, and a new `latency_observations` table with composite index. Idempotent; pre-v0.5.0 rows preserved with NULL.
- **`voicegateway/middleware/router.py`** picks the lowest-predicted-total triple under budget; falls back to fastest + `budget_overrun=true` when nothing fits (or raises `BudgetExceeded` if `fallback_to_fastest=false`). Caller overrides win for named modalities. Observed p50 from `latency_observations` beats curated baselines in `voicegateway/core/provider_baselines.json`.
- **`latency_observations_repo` + `LatencyObservationsWorker`** roll up per-(project, provider, modality) p50/p95 every 15 minutes (OQ2). DELETE + INSERT atomic snapshot. start/stop/tick_now lifecycle mirroring v0.3.0's retention worker.
- **Session-create wiring**: `set_routing_decision` ContextVar + `attach_session(routed_triple=...)` kwarg; `log_request` stamps the four routing columns on UPSERT with COALESCE so the triple is immutable for the session lifetime (AC-5).
- **`RoutingConfig` + `BrandingConfig`** per-project YAML knobs (budget_ms=1500, rosters, fallback_to_fastest=True; logo_url, accent_color, product_name).
- **Branding storage**: `_validate_branding` enforces logo_url ≤2048, hex regex `#RGB`/`#RRGGBB`, product_name ≤64, no unknown keys. `upsert_managed_project` gains a `branding` kwarg; partial updates preserved via COALESCE.
- **Four new dashboard endpoints**: `GET /api/routing/observations[?project=…]`, `GET /api/projects/{id}/branding`, `POST /api/projects/{id}/branding`, `POST /api/projects/{id}/branding/logo` (multipart, Pillow-validated). Static branding mount at `/static/branding/`.
- **`Routing.tsx`** page with sortable per-provider table, hourly auto-refresh, NULL p50 → "no observations yet" (AC-4).
- **`lib/branding.ts`** applies branding via CSS variables on `document.documentElement` plus favicon and title. Read-once-per-mount (OQ5).
- **Sidebar** renders the branded logo + product name (with default fallbacks). **SessionDetailModal** RoutingStrip shows the triple, budget, and overrun chip. **Projects** page Brand button opens a per-project BrandingModal with native color picker + PNG/SVG upload.
- **App nav** registers `/routing` between Metrics and Projects.
- **Typed fetchers** in `lib/api.ts` + new types in `lib/types.ts`.
- **`voicegw route show/simulate`** read-only CLI for routing diagnostics. **`voicegw brand set/show/clear`** CLI for scripted provisioning via the dashboard endpoints (uses httpx; reads `VOICEGW_API_KEY`).
- **46 new tests** across `tests/storage/`, `tests/middleware/`, `tests/server/`, `tests/inference/`.
- **`docs/api/python-sdk.md`** gains a Cross-modality routing section. **`docs/guide/agency-quickstart.md`** is the agency operator walkthrough.
- **`pillow>=10.0`** added to `[project] dependencies` for PNG validation on logo upload.
- **Embedded version strings** bumped 0.4.0 → 0.5.0 in 5 files.

## Decisions locked (Foundry Open Questions)

- **OQ1**: default `budget_ms = 1500` ms.
- **OQ2**: 24-hour rolling window, 15-minute refresh.
- **OQ3**: no-observations fallback to curated `provider_baselines.json` (10 entries with `source_url`).
- **OQ4**: logo upload 256 KB max, PNG or SVG only, 512×512 px max. Pillow validates PNG.
- **OQ5**: branding read-once-per-mount; operators see changes on next page load.

## Test plan

- `pytest --cov=voicegateway --cov=dashboard --cov-fail-under=80` clean: **1555 passed**, 4 skipped, **coverage 86.11%** (above 80% gate).
- `ruff check .` clean.
- `mypy voicegateway` clean (133 source files).
- Frontend `npm run build` (vite) green.
- 46 new tests added across 7 files: migration 0006 contract, latency_observations_repo aggregation, router (8 scenarios including overrides and fallback), worker lifecycle, routing endpoint scope, branding endpoint validation + logo upload, three-project routing pipeline + AC-5 immutability.

## Notes

Out of scope for v0.5.0 (enumerated in CHANGELOG):
- No mid-call provider switching.
- No adaptive learning from in-call telemetry.
- No custom-domain dashboard hosting.
- No per-tenant branding inside one project.
- No email or exported-report branding.
- No cost-aware routing.
- No multi-region routing.
- No in-flight budget enforcement.

Generated by Ralph fast-track. Squash-merge intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.5.0

* **New Features**
  * Cross-modality provider routing with per-session latency budgets and automatic provider selection
  * Per-project white-label branding support (custom logos, accent colors, product names)
  * Routing observations dashboard displaying per-provider latency metrics
  * New CLI commands for routing diagnostics and brand provisioning
  * Session-level routing details visible in dashboard

* **Documentation**
  * Agency quickstart guide for setup and configuration
  * Routing monitoring and configuration documentation
  * Updated version to v0.5.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mahimailabs/voicegateway/pull/19)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->