### PR TITLE
fix(web): serve install.sh at the public URL

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -7,12 +7,14 @@ on:
       - 'web/**'
       - 'docs/**'
       - 'CHANGELOG.md'
+      - 'install.sh'
       - '.github/workflows/web.yml'
   pull_request:
     paths:
       - 'web/**'
       - 'docs/**'
       - 'CHANGELOG.md'
+      - 'install.sh'
       - '.github/workflows/web.yml'
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -394,6 +394,9 @@ web/.dev.vars*
 web/.vercel
 web/next-env.d.ts
 
+# web/ assets synced from repo root at build time (do not commit)
+web/public/install.sh
+
 # web/ docs content synced from docs/ at build time (do not commit)
 web/content/docs/api/
 web/content/docs/architecture/

--- a/web/scripts/sync-docs.ts
+++ b/web/scripts/sync-docs.ts
@@ -15,7 +15,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..', '..');
 const SOURCE_DOCS = join(REPO_ROOT, 'docs');
 const SOURCE_CHANGELOG = join(REPO_ROOT, 'CHANGELOG.md');
+const SOURCE_INSTALL_SH = join(REPO_ROOT, 'install.sh');
 const TARGET = resolve(__dirname, '..', 'content', 'docs');
+const PUBLIC_INSTALL_SH = resolve(__dirname, '..', 'public', 'install.sh');
 const NATIVE_DOCS = new Set(['index.md', 'index.mdx', 'get-started.md', 'get-started.mdx']);
 // Top-level docs/ entries to skip during sync. These exist on disk but
 // must not appear on the public docs site. Pre-merge, these were
@@ -110,6 +112,15 @@ if (existsSync(SOURCE_CHANGELOG)) {
   const raw = readFileSync(SOURCE_CHANGELOG, 'utf8');
   const mdx = `---\ntitle: "Changelog"\ndescription: "VoiceGateway SDK release notes."\n---\n\n${raw}`;
   writeFileSync(join(TARGET, 'changelog.mdx'), mdx);
+}
+
+// Copy install.sh into public/ so https://voicegateway.mahimai.ca/install.sh
+// resolves. Root install.sh stays the canonical source (it is also used by
+// the Python package itself); the public copy is regenerated on every build,
+// so the two never drift.
+if (existsSync(SOURCE_INSTALL_SH)) {
+  writeFileSync(PUBLIC_INSTALL_SH, readFileSync(SOURCE_INSTALL_SH, 'utf8'));
+  console.log(`Copied install.sh into ${PUBLIC_INSTALL_SH}`);
 }
 
 console.log(`Synced docs from ${SOURCE_DOCS} into ${TARGET}`);


### PR DESCRIPTION
## Summary
- README + docs point users at `https://voicegateway.mahimai.ca/install.sh`, but the URL returns 404 since the monorepo merge: `install.sh` lives at repo root, never copied into `web/public/`.
- Extends `web/scripts/sync-docs.ts` to also copy `../install.sh` into `web/public/install.sh` at build time. Single source of truth stays at repo root; the public copy is regenerated on every build.
- Adds `web/public/install.sh` to root `.gitignore` (generated, not tracked).
- Adds `install.sh` to `.github/workflows/web.yml` path filter so installer-only edits trigger a site rebuild.

## Test plan
- [x] `cd web && pnpm sync-docs` creates a 12,351-byte `public/install.sh` matching repo root
- [x] `cd web && pnpm build` succeeds with 81 static pages
- [ ] After merge: `curl -sI https://voicegateway.mahimai.ca/install.sh | head -1` returns 200
- [ ] Vercel IBS proceeds (this PR touches `web/scripts/sync-docs.ts`, so the existing `web/**` clause already covers it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to trigger builds whenever the installation script is modified in the repository.
  * Improved build automation process to synchronize the installation script into the web application's public directory for end-user distribution.
  * Enhanced repository configuration to properly exclude automatically generated and synced build artifacts from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mahimailabs/voicegateway/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->