### PR TITLE
docs(changelog): voice-prices migration ships as v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.7.0: voice-prices pricing backend
+
+Pricing moves from `pydantic/genai-prices` to
+[`voice-prices`](https://github.com/mahimailabs/voice-prices), a fork that
+prices all three modalities (LLM, STT, and TTS) from one source.
+
+### Changed
+
+- **Single pricing backend.** LLM, STT, and TTS costs now all resolve
+  through `voice-prices`. The hand-maintained local STT/TTS rate catalogs
+  are retired; `voice-prices` owns rates and freshness (each entry carries
+  `prices_checked` and `pricing_source_url`).
+- **Pricing-source attribution.** Cloud-priced records are tagged
+  `voice-prices@<version>`; self-hosted (`local/*`, `ollama/*`) models are
+  tagged `voicegateway-local`; unknown models stay unpriced. The catalog-only
+  `oldest_entry_date` field is dropped from the `/v1/status` and `/api/status`
+  responses (`voice-prices` owns freshness).
+- **STT and TTS rates** now follow `voice-prices` and may differ from the
+  previous local-catalog estimates. Reconcile against your provider invoices.
+
+### Dependencies
+
+- `genai-prices` replaced by `voice-prices>=0.0.8,<0.1`.
+
 ## v0.6.0: first public release
 
 The first public release of VoiceGateway. A self-hosted gateway for
@@ -17,13 +41,12 @@ against provider invoices.
   import line and your agent code keeps running:
   `from voicegateway.inference import STT, LLM, TTS`. Cost tracking,
   latency monitoring, and per-session correlation happen transparently.
-- **Cost tracking per modality.** LLM cost per 1k tokens, STT cost per
-  audio-minute, and TTS cost per character: prices for all three modalities
-  come from `voice-prices` (a fork of `pydantic/genai-prices` that covers
-  LLM, STT, and TTS). Cached LLM input tokens are billed at the provider's
-  cache-read discount rate (OpenAI 50%, Anthropic ~10%) by surfacing
-  LiveKit's `prompt_cached_tokens` through to `voice-prices`'
-  `cache_read_tokens`.
+- **Cost tracking per modality.** LLM cost per 1k tokens (prices from
+  `pydantic/genai-prices`, 1100+ models). STT cost per audio-minute and
+  TTS cost per character (catalog with source-date metadata). Cached
+  LLM input tokens are billed at the provider's cache-read discount
+  rate (OpenAI 50%, Anthropic ~10%) by surfacing LiveKit's
+  `prompt_cached_tokens` through to `genai-prices.cache_read_tokens`.
 - **Background daemon.** `voicegw onboard` runs a five-question wizard,
   writes `voicegw.yaml`, registers a user-scoped service (LaunchAgent on
   macOS, `systemd --user` unit on Linux, Scheduled Task on Windows),


### PR DESCRIPTION
## Why

The voice-prices migration was merged in #28 intending to ship as `v0.6.0`. But `v0.6.0` was already released on 2026-05-12 (it depends on `genai-prices` and is permanent on PyPI). So the migration ships as **v0.7.0** instead.

## Changes

- Add a `v0.7.0: voice-prices pricing backend` CHANGELOG section describing the migration (single backend for LLM/STT/TTS, `voice-prices@<version>` / `voicegateway-local` source tags, retired local catalogs, dropped `oldest_entry_date`).
- Restore the `v0.6.0` section to its as-released text (it shipped on `genai-prices`); #28 had incorrectly rewritten it to claim voice-prices.

No code changes. The migration code is already on `main` from #28.

## Next

Tag `v0.7.0` at `main` HEAD after merge to trigger the PyPI publish of the voice-prices build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Consolidated pricing to a single unified backend across voice and LLM services
  * Removed `oldest_entry_date` field from status responses
  * Enhanced cost tracking for cached and standard operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mahimailabs/voicegateway/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->