### PR TITLE
ci: publish to PyPI on tag push (fix auto-publish)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,20 @@
 name: Publish Python Package
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
 
 jobs:
   publish:
     name: Publish to PyPI
-    # Only run on releases starting with 'v'
-    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')
+    # Publish on a v* tag push (automatic), or a manual workflow_dispatch run
+    # targeting a v* tag ref. A branch dispatch is skipped so it can never
+    # upload a dev version. Triggering on the tag push (not the GitHub Release
+    # event) avoids the GITHUB_TOKEN-created-release-does-not-trigger-workflows
+    # trap that previously left PyPI unpublished.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -47,3 +52,4 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
         packages-dir: dist/
+        skip-existing: true


### PR DESCRIPTION
## Problem

Pushing a `v*` tag did not publish to PyPI. `docker-publish`'s `create-release` job authors the GitHub Release as `github-actions[bot]` (default `GITHUB_TOKEN`), and **GitHub does not fire downstream workflows for `GITHUB_TOKEN`-created events** - so `publish.yml` (which only listened for `release: published`) never ran. v0.7.0 had to be re-published manually as a real user to ship.

`publish.yml`'s `workflow_dispatch` trigger was also a dead path: the job `if` required `event_name == 'release'`, so a manual dispatch was always skipped.

## Fix

Trigger `publish.yml` **directly on the `v*.*.*` tag push** instead of the release event:

- `on: push: tags: ['v*.*.*']` (+ `workflow_dispatch` kept as a real manual fallback).
- Job guard `if: startsWith(github.ref, 'refs/tags/v')` - works for both a tag push and a `workflow_dispatch` run targeting a tag ref; a branch dispatch is skipped so it can never upload a dev version.
- `skip-existing: true` on the publish step so a re-run does not hard-fail on an already-uploaded version.

After this, a `v*` tag push auto-publishes to PyPI with no manual re-publish. The `docker-publish` Release-creation is now purely cosmetic (PyPI no longer depends on it).

No code changes; workflow-only.