### PR TITLE
feat: fleet collector Phase 1 - the wire and the on-ramp

### DIFF
--- a/alembic/versions/b2e7c4a9f1d3_agent_id.py
+++ b/alembic/versions/b2e7c4a9f1d3_agent_id.py
@@ -1,0 +1,48 @@
+"""add agent_id to requests (fleet per-agent attribution)
+
+Revision ID: b2e7c4a9f1d3
+Revises: a7c2e91f8d34
+Create Date: 2026-06-04 06:00:00.000000
+
+Phase 1 of the fleet collector integration. When N agents push telemetry
+to one collector, each request row needs to be attributable to the agent
+that produced it. ``agent_id`` is a self-reported label (env
+``VOICEGW_AGENT_ID`` or hostname), nullable so existing rows and
+non-fleet single-node writes stay valid. Indexed singly and as a
+``(agent_id, timestamp)`` composite, matching the existing project index
+convention, so per-agent fleet queries (Phase 2) are cheap.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b2e7c4a9f1d3"
+down_revision: str | None = "a7c2e91f8d34"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Direct add_column (not batch_alter_table): SQLite supports ALTER TABLE
+    # ADD COLUMN directly, and batch mode triggers a full table rename that
+    # breaks any view referencing ``requests`` (e.g. ``daily_costs``). Same
+    # rationale as the cached_input_units migration.
+    op.add_column(
+        "requests",
+        sa.Column("agent_id", sa.String(), nullable=True),
+    )
+    op.create_index("idx_requests_agent_id", "requests", ["agent_id"])
+    op.create_index(
+        "idx_requests_agent_id_timestamp", "requests", ["agent_id", "timestamp"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_requests_agent_id_timestamp", table_name="requests")
+    op.drop_index("idx_requests_agent_id", table_name="requests")
+    op.drop_column("requests", "agent_id")

--- a/alembic/versions/f1ae43d7fa98_initial_schema.py
+++ b/alembic/versions/f1ae43d7fa98_initial_schema.py
@@ -449,8 +449,43 @@ def upgrade() -> None:
     # Views (autogen does not detect them; preserved from the legacy
     # baseline. ``daily_costs`` rolls request rows up by day/modality/
     # model/provider; ``project_daily_costs`` adds the project axis.)
-    op.execute(
-        """CREATE VIEW IF NOT EXISTS daily_costs AS
+    # SQLite and Postgres differ on the day bucket
+    # (date(ts,'unixepoch') vs to_char(to_timestamp(ts))) and on view DDL
+    # (CREATE VIEW IF NOT EXISTS vs CREATE OR REPLACE VIEW), so the DDL is
+    # dialect-branched. The SQLite branch is byte-for-byte the baseline.
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            """CREATE OR REPLACE VIEW daily_costs AS
+    SELECT
+        to_char(to_timestamp(timestamp), 'YYYY-MM-DD') as day,
+        modality,
+        model_id,
+        provider,
+        COUNT(*) as request_count,
+        SUM(cost_usd) as total_cost,
+        AVG(ttfb_ms) as avg_ttfb,
+        AVG(total_latency_ms) as avg_latency
+    FROM requests
+    GROUP BY to_char(to_timestamp(timestamp), 'YYYY-MM-DD'),
+             modality, model_id, provider"""
+        )
+        op.execute(
+            """CREATE OR REPLACE VIEW project_daily_costs AS
+    SELECT
+        project,
+        to_char(to_timestamp(timestamp), 'YYYY-MM-DD') as day,
+        modality,
+        model_id,
+        COUNT(*) as request_count,
+        SUM(cost_usd) as total_cost,
+        AVG(ttfb_ms) as avg_ttfb
+    FROM requests
+    GROUP BY project, to_char(to_timestamp(timestamp), 'YYYY-MM-DD'),
+             modality, model_id"""
+        )
+    else:
+        op.execute(
+            """CREATE VIEW IF NOT EXISTS daily_costs AS
     SELECT
         date(timestamp, 'unixepoch') as day,
         modality,
@@ -462,9 +497,9 @@ def upgrade() -> None:
         AVG(total_latency_ms) as avg_latency
     FROM requests
     GROUP BY day, modality, model_id, provider"""
-    )
-    op.execute(
-        """CREATE VIEW IF NOT EXISTS project_daily_costs AS
+        )
+        op.execute(
+            """CREATE VIEW IF NOT EXISTS project_daily_costs AS
     SELECT
         project,
         date(timestamp, 'unixepoch') as day,
@@ -475,7 +510,7 @@ def upgrade() -> None:
         AVG(ttfb_ms) as avg_ttfb
     FROM requests
     GROUP BY project, day, modality, model_id"""
-    )
+        )
     # ### end Alembic commands ###
 
 

--- a/alembic/versions/f1ae43d7fa98_initial_schema.py
+++ b/alembic/versions/f1ae43d7fa98_initial_schema.py
@@ -457,7 +457,7 @@ def upgrade() -> None:
         op.execute(
             """CREATE OR REPLACE VIEW daily_costs AS
     SELECT
-        to_char(to_timestamp(timestamp), 'YYYY-MM-DD') as day,
+        to_char(to_timestamp(timestamp) AT TIME ZONE 'UTC', 'YYYY-MM-DD') as day,
         modality,
         model_id,
         provider,
@@ -466,21 +466,21 @@ def upgrade() -> None:
         AVG(ttfb_ms) as avg_ttfb,
         AVG(total_latency_ms) as avg_latency
     FROM requests
-    GROUP BY to_char(to_timestamp(timestamp), 'YYYY-MM-DD'),
+    GROUP BY to_char(to_timestamp(timestamp) AT TIME ZONE 'UTC', 'YYYY-MM-DD'),
              modality, model_id, provider"""
         )
         op.execute(
             """CREATE OR REPLACE VIEW project_daily_costs AS
     SELECT
         project,
-        to_char(to_timestamp(timestamp), 'YYYY-MM-DD') as day,
+        to_char(to_timestamp(timestamp) AT TIME ZONE 'UTC', 'YYYY-MM-DD') as day,
         modality,
         model_id,
         COUNT(*) as request_count,
         SUM(cost_usd) as total_cost,
         AVG(ttfb_ms) as avg_ttfb
     FROM requests
-    GROUP BY project, to_char(to_timestamp(timestamp), 'YYYY-MM-DD'),
+    GROUP BY project, to_char(to_timestamp(timestamp) AT TIME ZONE 'UTC', 'YYYY-MM-DD'),
              modality, model_id"""
         )
     else:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+# Codecov configuration.
+#
+# The >=80% total-coverage gate is the contract; it is enforced here (project
+# status) and by the test-coverage CI job (pytest --cov, fail_under=80). Patch
+# (diff) coverage is reported but kept informational: defensive branches in new
+# code (RuntimeError fallbacks, no-event-loop paths, retry/backoff) are not worth
+# chasing to 100% and must not block a PR.
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        informational: true
+
+comment:
+  require_changes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,11 @@ dashboard = ["voicegateway[server]"]
 # MCP server (for managing the gateway from coding agents)
 mcp = ["mcp>=1.2.0"]
 
+# Postgres collector backend (fleet mode). asyncpg is the async driver
+# resolve_database_url targets when VOICEGW_DB_URL=postgresql+asyncpg://...
+# is set; embedded single-node mode still uses bundled SQLite.
+postgres = ["asyncpg>=0.29"]
+
 # Terminal UI (`voicegw tui`, v0.1.1). Textual ships breaking changes
 # between minor versions, so the upper bound is tight per design.md
 # section 8.1; revisit at v0.1.2. httpx is already a base dependency

--- a/src/voicegateway/__init__.py
+++ b/src/voicegateway/__init__.py
@@ -2,5 +2,6 @@
 
 from voicegateway import inference
 from voicegateway._version import __version__
+from voicegateway.inference.session.attach import attach
 
-__all__ = ["inference", "__version__"]
+__all__ = ["attach", "inference", "__version__"]

--- a/src/voicegateway/core/database.py
+++ b/src/voicegateway/core/database.py
@@ -25,7 +25,16 @@ DEFAULT_DB_PATH = "~/.config/voicegateway/voicegw.db"
 
 
 def resolve_database_url(config: GatewayConfig) -> str:
-    """Compute the SQLAlchemy URL from the gateway config."""
+    """Compute the SQLAlchemy URL from the gateway config.
+
+    Precedence: a full ``VOICEGW_DB_URL`` (e.g. a Postgres collector URL)
+    wins outright; otherwise the SQLite path (``VOICEGW_DB_PATH`` > config >
+    default) is used. This is the seam that lets the same code run embedded on
+    SQLite and as a fleet collector on Postgres.
+    """
+    env_url = os.environ.get("VOICEGW_DB_URL")
+    if env_url:
+        return env_url
     cost_cfg = config.cost_tracking or {}
     env_db = os.environ.get("VOICEGW_DB_PATH")
     raw_path = env_db or cost_cfg.get("db_path") or DEFAULT_DB_PATH
@@ -60,7 +69,10 @@ class Database:
         self.config = config
         url = resolve_database_url(config)
         self._db_file_path = _resolve_db_file_path(config)
-        self._db_file_path.parent.mkdir(parents=True, exist_ok=True)
+        # Only the SQLite backend has a local file to create. A Postgres
+        # collector URL must not touch the filesystem.
+        if url.startswith("sqlite"):
+            self._db_file_path.parent.mkdir(parents=True, exist_ok=True)
         self._engine = create_async_engine(
             url,
             echo=False,

--- a/src/voicegateway/core/gateway.py
+++ b/src/voicegateway/core/gateway.py
@@ -14,6 +14,7 @@ from voicegateway.middleware.cost_tracker_middleware import CostTracker
 from voicegateway.middleware.latency_monitor_middleware import LatencyMonitor
 from voicegateway.middleware.logger_middleware import RequestLogger
 from voicegateway.middleware.rate_limiter_middleware import RateLimiter
+from voicegateway.services.sinks import LocalSqliteSink
 from voicegateway.services.storage_service import StorageService
 
 T = TypeVar("T")
@@ -63,7 +64,13 @@ class Gateway:
                     source="auto",
                 )
 
-        self._cost_tracker = CostTracker(self._storage)
+        # CostTracker writes through a Sink. In single-node mode that is the
+        # LocalSqliteSink wrapping the embedded StorageService; fleet mode
+        # swaps in a RemoteCollectorSink with no change to the producer.
+        cost_sink = (
+            LocalSqliteSink(self._storage) if self._storage is not None else None
+        )
+        self._cost_tracker = CostTracker(cost_sink)
         self._latency_monitor = LatencyMonitor(
             ttfb_warning_ms=self._config.latency.get("ttfb_warning_ms", 500.0)
         )

--- a/src/voicegateway/inference/__init__.py
+++ b/src/voicegateway/inference/__init__.py
@@ -2,7 +2,7 @@
 
 from voicegateway.core.active_project import get_active_project, set_project
 from voicegateway.inference.llm_inference import LLM
-from voicegateway.inference.session.attach import attach_session
+from voicegateway.inference.session.attach import attach, attach_session
 from voicegateway.inference.session.context import start_session
 from voicegateway.inference.stt_inference import STT
 from voicegateway.inference.tts_inference import TTS
@@ -11,6 +11,7 @@ __all__ = [
     "LLM",
     "STT",
     "TTS",
+    "attach",
     "attach_session",
     "get_active_project",
     "set_project",

--- a/src/voicegateway/inference/session/__init__.py
+++ b/src/voicegateway/inference/session/__init__.py
@@ -1,6 +1,7 @@
 """Session correlation: ContextVars and LiveKit AgentSession attach helpers."""
 
 from voicegateway.inference.session.attach import (
+    attach,
     attach_session,
     register_components,
     reset_components,
@@ -25,6 +26,7 @@ from voicegateway.inference.session.context import (
 )
 
 __all__ = [
+    "attach",
     "attach_session",
     "current_guardrail_policy_snapshot",
     "current_guardrails_bypassed",

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 from voicegateway.inference.session.context import (
@@ -17,6 +18,9 @@ if TYPE_CHECKING:
     from voicegateway.middleware.cost_tracker_middleware import CostTracker
     from voicegateway.middleware.dead_air_detector_middleware import DeadAirDetector
     from voicegateway.middleware.turn_tracker_middleware import TurnTracker
+    from voicegateway.services.sinks import Sink
+
+DEFAULT_DB_PATH = "~/.config/voicegateway/voicegw.db"
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +193,103 @@ def attach_session(
     return sid
 
 
+def _default_agent_id() -> str:
+    """Resolve the agent label: explicit env > hostname > a constant."""
+    import socket
+
+    return os.environ.get("VOICEGW_AGENT_ID") or socket.gethostname() or "agent"
+
+
+def _build_default_sink(collector_url: str | None, virtual_key: str | None) -> Sink:
+    """Build the sink for attach() from env/args.
+
+    Single-node default is a LocalSqliteSink over the embedded StorageService.
+    Fleet mode (``collector_url`` set) swaps in the RemoteCollectorSink in a
+    later build step; until then the local sink is used.
+    """
+    from voicegateway.services.sinks import LocalSqliteSink
+    from voicegateway.services.storage_service import StorageService
+
+    db_path = os.environ.get("VOICEGW_DB_PATH") or DEFAULT_DB_PATH
+    return LocalSqliteSink(StorageService(db_path))
+
+
+def attach(
+    session: Any,
+    *,
+    project: str = "default",
+    agent_id: str | None = None,
+    tenant_id: str | None = None,
+    collector_url: str | None = None,
+    virtual_key: str | None = None,
+    sink: Sink | None = None,
+) -> str:
+    """Attach VoiceGateway to an existing LiveKit ``AgentSession`` in one call.
+
+    The *observe* tier: works for ANY plugin (native LiveKit,
+    ``livekit.agents.inference``, or ``voicegateway.inference``) by subscribing
+    to the non-deprecated per-component ``metrics_collected`` events. Captures
+    per-call cost + latency + errors and writes them through a ``Sink`` (local
+    SQLite by default, or a collector when configured via ``collector_url`` /
+    ``VOICEGW_COLLECTOR_URL``).
+
+    Args:
+        session: the ``AgentSession`` to observe.
+        project: project id to tag rows with.
+        agent_id: fleet label; defaults to ``VOICEGW_AGENT_ID`` or hostname.
+        tenant_id: optional tenant attribution.
+        collector_url / virtual_key: fleet push target (env fallbacks).
+        sink: advanced/testing override; defaults to local or remote per env.
+
+    Returns:
+        The correlation session id stamped on every captured row.
+    """
+    import asyncio
+
+    from voicegateway.inference.session.capture import MetricCapture
+    from voicegateway.middleware.cost_tracker_middleware import CostTracker
+
+    resolved_agent_id = agent_id or _default_agent_id()
+    resolved_collector = collector_url or os.environ.get("VOICEGW_COLLECTOR_URL")
+    resolved_key = virtual_key or os.environ.get("VOICEGW_VIRTUAL_KEY")
+    session_id = get_or_create_session_id()
+    if tenant_id is not None:
+        set_tenant(tenant_id)
+    if sink is None:
+        sink = _build_default_sink(resolved_collector, resolved_key)
+
+    cost_tracker = CostTracker(sink)
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project=project,
+        agent_id=resolved_agent_id,
+        session_id=session_id,
+        tenant_id=tenant_id,
+    )
+    capture.bind(session)
+
+    # Expose for graceful shutdown + tests; flush in-flight writes on close.
+    try:
+        session._vg_capture = capture
+    except Exception:  # noqa: BLE001 - real session may forbid attribute set
+        logger.debug("attach: could not stash capture on session", exc_info=True)
+
+    def _on_close(*_args: Any, **_kwargs: Any) -> None:
+        try:
+            asyncio.ensure_future(capture.drain())  # noqa: RUF006
+        except RuntimeError:
+            pass
+
+    on = getattr(session, "on", None)
+    if callable(on):
+        on("close", _on_close)
+
+    return session_id
+
+
 __all__ = [
+    "attach",
     "attach_session",
     "register_components",
     "reset_components",

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -204,9 +204,14 @@ def _build_default_sink(collector_url: str | None, virtual_key: str | None) -> S
     """Build the sink for attach() from env/args.
 
     Single-node default is a LocalSqliteSink over the embedded StorageService.
-    Fleet mode (``collector_url`` set) swaps in the RemoteCollectorSink in a
-    later build step; until then the local sink is used.
+    Fleet mode (``collector_url`` set) uses the RemoteCollectorSink, which
+    batches rows and pushes them to the collector's ``/v1/ingest``.
     """
+    if collector_url:
+        from voicegateway.services.sinks import RemoteCollectorSink
+
+        return RemoteCollectorSink(collector_url, virtual_key)
+
     from voicegateway.services.sinks import LocalSqliteSink
     from voicegateway.services.storage_service import StorageService
 

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -280,9 +280,15 @@ def attach(
     except Exception:  # noqa: BLE001 - real session may forbid attribute set
         logger.debug("attach: could not stash capture on session", exc_info=True)
 
+    async def _finish() -> None:
+        # Reconcile cumulative session.usage against the per-call rows, then
+        # await any in-flight writes so a graceful shutdown loses nothing.
+        await capture.reconcile(session)
+        await capture.drain()
+
     def _on_close(*_args: Any, **_kwargs: Any) -> None:
         try:
-            asyncio.ensure_future(capture.drain())  # noqa: RUF006
+            asyncio.ensure_future(_finish())  # noqa: RUF006
         except RuntimeError:
             pass
 

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -219,6 +219,21 @@ def _build_default_sink(collector_url: str | None, virtual_key: str | None) -> S
     return LocalSqliteSink(StorageService(db_path))
 
 
+# Strong refs to in-flight session-close finalize tasks; the event loop only
+# weak-refs scheduled tasks, so without this a close-time reconcile/flush can be
+# GC'd mid-write (the hazard MetricCapture._schedule guards against for writes).
+_close_tasks: set[Any] = set()
+
+
+def _on_close_task_done(task: Any) -> None:
+    _close_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning("attach: session close finalize failed", exc_info=exc)
+
+
 def attach(
     session: Any,
     *,
@@ -281,15 +296,23 @@ def attach(
         logger.debug("attach: could not stash capture on session", exc_info=True)
 
     async def _finish() -> None:
-        # Reconcile cumulative session.usage against the per-call rows, then
-        # await any in-flight writes so a graceful shutdown loses nothing.
+        # Reconcile cumulative session.usage against the per-call rows, drain
+        # in-flight writes, then flush the sink so a buffered RemoteCollectorSink
+        # sub-batch is pushed before shutdown. A graceful close loses nothing.
         await capture.reconcile(session)
         await capture.drain()
+        await sink.flush()
 
     def _on_close(*_args: Any, **_kwargs: Any) -> None:
         try:
-            asyncio.ensure_future(_finish())  # noqa: RUF006
+            task = asyncio.ensure_future(_finish())
         except RuntimeError:
+            return
+        _close_tasks.add(task)
+        task.add_done_callback(_on_close_task_done)
+        try:
+            session._vg_close_task = task
+        except Exception:  # noqa: BLE001 - real session may forbid attribute set
             pass
 
     on = getattr(session, "on", None)

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -42,7 +42,8 @@ def _ttfb_ms(metric: object) -> float | None:
     value = getattr(metric, "ttft", None)
     if value is None:
         value = getattr(metric, "ttfb", None)
-    return float(value) * 1000.0 if value else None
+    # ``is not None`` so a genuine 0.0 latency records as 0.0, not None.
+    return float(value) * 1000.0 if value is not None else None
 
 
 def units_from_metric(
@@ -340,7 +341,11 @@ class MetricCapture:
             d_in = cum_in - recorded["input"]
             d_out = cum_out - recorded["output"]
             d_cached = cum_cached - recorded["cached"]
-            if d_in <= _RECONCILE_EPSILON and d_out <= _RECONCILE_EPSILON:
+            if (
+                d_in <= _RECONCILE_EPSILON
+                and d_out <= _RECONCILE_EPSILON
+                and d_cached <= _RECONCILE_EPSILON
+            ):
                 continue
             record = self._cost_tracker.create_record(
                 model_id=model_id,

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -1,0 +1,253 @@
+"""Per-component metric capture for ``voicegateway.attach()``.
+
+Subscribes to the NON-DEPRECATED per-component ``metrics_collected`` events on
+an ``AgentSession``'s stt/llm/tts components, maps each LiveKit metric to a
+``RequestRecord``, and writes it through a ``Sink``. This works for ANY plugin,
+because native LiveKit plugins (and ``livekit.agents.inference``) emit these
+per-component events regardless of how they were constructed.
+
+We deliberately avoid the session-level ``metrics_collected`` event, which is
+deprecated in livekit-agents 1.5+. Unit conventions mirror
+``InstrumentationMixin._extract_units``: LLM passes raw tokens, STT passes
+audio MINUTES (the cost path multiplies back by 60 to recover seconds), TTS
+passes characters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from voicegateway.models.request_model import RequestRecord
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from voicegateway.middleware.cost_tracker_middleware import CostTracker
+    from voicegateway.services.sinks import Sink
+
+logger = logging.getLogger(__name__)
+
+_MODALITIES: tuple[str, ...] = ("stt", "llm", "tts")
+
+
+def _ttfb_ms(metric: object) -> float | None:
+    """Return first-byte latency in ms from a metric's ttft/ttfb, if present."""
+    value = getattr(metric, "ttft", None)
+    if value is None:
+        value = getattr(metric, "ttfb", None)
+    return float(value) * 1000.0 if value else None
+
+
+def units_from_metric(
+    metric: object, modality: str
+) -> tuple[float, float, float, float | None]:
+    """Return ``(input_units, output_units, cached_input_units, ttfb_ms)``.
+
+    Defensive ``getattr(..., default) or default`` mirrors the middleware
+    bridge: LK emits None for fields when a stream is cancelled before any
+    tokens/audio land.
+    """
+    ttfb_ms = _ttfb_ms(metric)
+    if modality == "llm":
+        return (
+            float(getattr(metric, "prompt_tokens", 0) or 0),
+            float(getattr(metric, "completion_tokens", 0) or 0),
+            float(getattr(metric, "prompt_cached_tokens", 0) or 0),
+            ttfb_ms,
+        )
+    if modality == "stt":
+        audio = float(getattr(metric, "audio_duration", 0.0) or 0.0)
+        return (audio / 60.0, 0.0, 0.0, ttfb_ms)
+    if modality == "tts":
+        return (
+            float(getattr(metric, "characters_count", 0) or 0),
+            0.0,
+            0.0,
+            ttfb_ms,
+        )
+    return (0.0, 0.0, 0.0, ttfb_ms)
+
+
+def _provider_name(component: object) -> str:
+    """Best-effort provider id from a live plugin instance.
+
+    Prefers the ``livekit.plugins.<provider>`` module segment; falls back to a
+    ``provider``/``_provider`` attribute (useful for non-standard wrappers).
+    """
+    module = type(component).__module__ or ""
+    parts = module.split(".")
+    if "plugins" in parts:
+        idx = parts.index("plugins")
+        if idx + 1 < len(parts):
+            return parts[idx + 1]
+    for attr in ("provider", "_provider"):
+        value = getattr(component, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _model_name(component: object) -> str:
+    """Best-effort model string from a live plugin instance."""
+    for attr in ("model", "_model", "model_name"):
+        value = getattr(component, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    opts = getattr(component, "_opts", None)
+    if opts is not None:
+        for attr in ("model", "model_name"):
+            value = getattr(opts, attr, None)
+            if isinstance(value, str) and value:
+                return value
+    return ""
+
+
+def component_identity(component: object) -> tuple[str, str]:
+    """Return ``(provider, model_id)`` for a plugin instance, best-effort.
+
+    ``model_id`` is normalized to VG's ``provider/model`` form. Unknown
+    components resolve to ``("unknown", "unknown")`` and still record (cost
+    falls to 0 / unpriced, matching the catalog's existing behavior).
+    """
+    provider = _provider_name(component)
+    model = _model_name(component)
+    if provider and model:
+        return provider, f"{provider}/{model}"
+    if model:
+        return provider or "unknown", model
+    return provider or "unknown", "unknown"
+
+
+def _error_modality(source: object) -> str:
+    """Map an ErrorEvent.source to a modality string, best-effort."""
+    name = type(source).__name__.lower() if source is not None else ""
+    if "stt" in name:
+        return "stt"
+    if "tts" in name:
+        return "tts"
+    return "llm"
+
+
+def _iter_components(session: object) -> Iterator[tuple[str, object]]:
+    """Yield ``(modality, component)`` for each non-None stt/llm/tts slot."""
+    for modality in _MODALITIES:
+        component = getattr(session, modality, None)
+        if component is not None:
+            yield modality, component
+
+
+class MetricCapture:
+    """Binds per-component metric + error events to a Sink write.
+
+    Holds strong refs to the scheduled write tasks so the event loop's weak
+    refs do not GC a pending write mid-flight (the same hazard the inference
+    middleware guards against). ``drain`` awaits in-flight writes; the
+    ``attach`` close path calls it.
+    """
+
+    def __init__(
+        self,
+        *,
+        cost_tracker: CostTracker,
+        sink: Sink,
+        project: str,
+        agent_id: str | None,
+        session_id: str | None,
+        tenant_id: str | None = None,
+    ) -> None:
+        self._cost_tracker = cost_tracker
+        self._sink = sink
+        self._project = project
+        self._agent_id = agent_id
+        self._session_id = session_id
+        self._tenant_id = tenant_id
+        self._pending: set[asyncio.Task[None]] = set()
+
+    def bind(self, session: object) -> None:
+        """Subscribe to every component's metrics + the session error event."""
+        for modality, component in _iter_components(session):
+            provider, model_id = component_identity(component)
+            component.on(  # type: ignore[attr-defined]
+                "metrics_collected",
+                self._make_metric_handler(modality, provider, model_id),
+            )
+        on = getattr(session, "on", None)
+        if callable(on):
+            on("error", self._on_error)
+
+    def _make_metric_handler(self, modality: str, provider: str, model_id: str) -> Any:
+        def handler(metric: object, *_args: Any, **_kwargs: Any) -> None:
+            input_units, output_units, cached, ttfb_ms = units_from_metric(
+                metric, modality
+            )
+            status = (
+                "cancelled" if bool(getattr(metric, "cancelled", False)) else "success"
+            )
+            record = self._cost_tracker.create_record(
+                model_id=model_id,
+                modality=modality,
+                provider=provider,
+                project=self._project,
+                input_units=input_units,
+                output_units=output_units,
+                cached_input_units=cached,
+                ttfb_ms=ttfb_ms,
+                status=status,
+                session_id=self._session_id,
+                agent_id=self._agent_id,
+            )
+            self._schedule(self._sink.log_request(record))
+
+        return handler
+
+    def _on_error(self, event: object, *_args: Any, **_kwargs: Any) -> None:
+        source = getattr(event, "source", None)
+        error = getattr(event, "error", event)
+        record = RequestRecord(
+            id=str(uuid.uuid4()),
+            timestamp=time.time(),
+            modality=_error_modality(source),
+            model_id="",
+            provider="",
+            project=self._project,
+            status="error",
+            error_message=str(error),
+            session_id=self._session_id,
+            agent_id=self._agent_id,
+        )
+        self._schedule(self._sink.log_request(record))
+
+    def _schedule(self, coro: Any) -> None:
+        try:
+            task = asyncio.ensure_future(coro)
+        except RuntimeError:
+            # No running loop (sync test rig driving the binding directly).
+            coro.close()
+            return
+        self._pending.add(task)
+        task.add_done_callback(self._on_done)
+
+    def _on_done(self, task: asyncio.Task[None]) -> None:
+        self._pending.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning("attach: sink write failed", exc_info=exc)
+
+    async def drain(self) -> None:
+        """Await any in-flight sink writes scheduled by the bound handlers."""
+        if not self._pending:
+            return
+        await asyncio.gather(*list(self._pending), return_exceptions=True)
+
+
+__all__ = [
+    "MetricCapture",
+    "component_identity",
+    "units_from_metric",
+]

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 
 _MODALITIES: tuple[str, ...] = ("stt", "llm", "tts")
 
+# Below this unit delta, a reconcile correction is not worth a row.
+_RECONCILE_EPSILON = 1e-9
+
 
 def _ttfb_ms(metric: object) -> float | None:
     """Return first-byte latency in ms from a metric's ttft/ttfb, if present."""
@@ -140,6 +143,60 @@ def _iter_components(session: object) -> Iterator[tuple[str, object]]:
             yield modality, component
 
 
+def _usage_modality(entry: object) -> str:
+    """Map an AgentSessionUsage.model_usage entry to a modality, best-effort."""
+    name = type(entry).__name__.lower()
+    if "stt" in name:
+        return "stt"
+    if "tts" in name:
+        return "tts"
+    if "llm" in name or "realtime" in name:
+        return "llm"
+    return ""
+
+
+def _usage_units(entry: object, modality: str) -> tuple[float, float, float]:
+    """Cumulative ``(input, output, cached)`` from a usage entry, VG units.
+
+    STT seconds are converted to minutes to match the per-call rows. Field
+    names are read defensively across the variants LiveKit may expose.
+    """
+    if modality == "llm":
+        return (
+            float(
+                getattr(entry, "prompt_tokens", None)
+                or getattr(entry, "input_tokens", 0)
+                or 0
+            ),
+            float(
+                getattr(entry, "completion_tokens", None)
+                or getattr(entry, "output_tokens", 0)
+                or 0
+            ),
+            float(
+                getattr(entry, "prompt_cached_tokens", None)
+                or getattr(entry, "cache_read_tokens", 0)
+                or 0
+            ),
+        )
+    if modality == "stt":
+        seconds = float(
+            getattr(entry, "audio_duration", None) or getattr(entry, "duration", 0) or 0
+        )
+        return (seconds / 60.0, 0.0, 0.0)
+    if modality == "tts":
+        return (
+            float(
+                getattr(entry, "characters", None)
+                or getattr(entry, "characters_count", 0)
+                or 0
+            ),
+            0.0,
+            0.0,
+        )
+    return (0.0, 0.0, 0.0)
+
+
 class MetricCapture:
     """Binds per-component metric + error events to a Sink write.
 
@@ -166,6 +223,9 @@ class MetricCapture:
         self._session_id = session_id
         self._tenant_id = tenant_id
         self._pending: set[asyncio.Task[None]] = set()
+        # Per-(provider, model_id) running tally of captured units, so the
+        # close-time reconcile can diff against cumulative session.usage.
+        self._recorded: dict[tuple[str, str], dict[str, float]] = {}
 
     def bind(self, session: object) -> None:
         """Subscribe to every component's metrics + the session error event."""
@@ -200,6 +260,12 @@ class MetricCapture:
                 session_id=self._session_id,
                 agent_id=self._agent_id,
             )
+            tally = self._recorded.setdefault(
+                (provider, model_id), {"input": 0.0, "output": 0.0, "cached": 0.0}
+            )
+            tally["input"] += input_units
+            tally["output"] += output_units
+            tally["cached"] += cached
             self._schedule(self._sink.log_request(record))
 
         return handler
@@ -244,6 +310,51 @@ class MetricCapture:
         if not self._pending:
             return
         await asyncio.gather(*list(self._pending), return_exceptions=True)
+
+    async def reconcile(self, session: object) -> None:
+        """Diff cumulative ``session.usage`` against the per-call rows.
+
+        The hybrid safety net: when the cumulative totals exceed what the
+        per-call ``metrics_collected`` stream recorded (a dropped event, a
+        realtime model that emits no per-component metrics, a handoff gap),
+        emit one correction row per (provider, model) for the difference,
+        tagged ``metadata.reconciled``. Awaited from the session close path.
+        """
+        usage = getattr(session, "usage", None)
+        entries = getattr(usage, "model_usage", None) if usage is not None else None
+        if not entries:
+            return
+        for entry in entries:
+            modality = _usage_modality(entry)
+            if modality not in _MODALITIES:
+                continue
+            provider = str(getattr(entry, "provider", "") or "")
+            model = str(getattr(entry, "model", "") or "")
+            model_id = (
+                f"{provider}/{model}" if provider and model else (model or "unknown")
+            )
+            cum_in, cum_out, cum_cached = _usage_units(entry, modality)
+            recorded = self._recorded.get(
+                (provider, model_id), {"input": 0.0, "output": 0.0, "cached": 0.0}
+            )
+            d_in = cum_in - recorded["input"]
+            d_out = cum_out - recorded["output"]
+            d_cached = cum_cached - recorded["cached"]
+            if d_in <= _RECONCILE_EPSILON and d_out <= _RECONCILE_EPSILON:
+                continue
+            record = self._cost_tracker.create_record(
+                model_id=model_id,
+                modality=modality,
+                provider=provider,
+                project=self._project,
+                input_units=max(0.0, d_in),
+                output_units=max(0.0, d_out),
+                cached_input_units=max(0.0, d_cached),
+                session_id=self._session_id,
+                agent_id=self._agent_id,
+            )
+            record.metadata = {"reconciled": True}
+            await self._sink.log_request(record)
 
 
 __all__ = [

--- a/src/voicegateway/middleware/cost_tracker_middleware.py
+++ b/src/voicegateway/middleware/cost_tracker_middleware.py
@@ -112,6 +112,7 @@ class CostTracker:
         error_message: str | None = None,
         pricing_source: str = "",
         session_id: str | None = None,
+        agent_id: str | None = None,
     ) -> RequestRecord:
         """Create a request record with cost calculated."""
         cost, cost_dec = self._resolve_cost(
@@ -140,6 +141,7 @@ class CostTracker:
             fallback_from=fallback_from,
             error_message=error_message,
             session_id=session_id,
+            agent_id=agent_id,
         )
 
     async def log_request(self, record: RequestRecord) -> None:

--- a/src/voicegateway/models/request_model.py
+++ b/src/voicegateway/models/request_model.py
@@ -47,6 +47,7 @@ class RequestRecord:
     error_message: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     session_id: str | None = None  # ContextVar-derived session correlation
+    agent_id: str | None = None  # fleet: self-reported agent/instance label
 
 
 class Request(SQLModel, table=True):
@@ -66,6 +67,8 @@ class Request(SQLModel, table=True):
         Index("idx_requests_project", "project"),
         Index("idx_requests_project_timestamp", "project", "timestamp"),
         Index("idx_requests_session_id", "session_id"),
+        Index("idx_requests_agent_id", "agent_id"),
+        Index("idx_requests_agent_id_timestamp", "agent_id", "timestamp"),
     )
 
     id: str = Field(primary_key=True)
@@ -96,3 +99,6 @@ class Request(SQLModel, table=True):
 
     # 0005: tenant attribution
     tenant_id: str | None = None
+
+    # Phase 1 fleet: per-agent/instance attribution (self-reported label)
+    agent_id: str | None = None

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -106,6 +106,26 @@ _UPSERT_SESSION = text(
 )
 
 
+# Postgres uses STRPOS where SQLite uses INSTR (identical (haystack, needle)
+# signature and 1-based / 0-if-absent semantics); the rest of the UPSERT is
+# portable. Derive the PG statement from the SQLite one so the two never drift.
+_UPSERT_SESSION_PG = text(_UPSERT_SESSION.text.replace("INSTR(", "STRPOS("))
+
+_UPSERT_SESSION_BY_DIALECT: dict[str, Any] = {
+    "sqlite": _UPSERT_SESSION,
+    "postgresql": _UPSERT_SESSION_PG,
+}
+
+
+def _session_upsert_stmt(session: AsyncSession) -> Any:
+    """Pick the dialect-appropriate sessions UPSERT (defaults to SQLite)."""
+    try:
+        name = session.bind.dialect.name
+    except Exception:  # noqa: BLE001
+        name = "sqlite"
+    return _UPSERT_SESSION_BY_DIALECT.get(name, _UPSERT_SESSION_BY_DIALECT["sqlite"])
+
+
 async def log_request(session: AsyncSession, record: RequestRecord) -> None:
     """Insert one request row + accumulate the session row (UPSERT)."""
     request_tenant_id = current_tenant()
@@ -162,7 +182,7 @@ async def log_request(session: AsyncSession, record: RequestRecord) -> None:
             guardrails_bypassed = None
             guardrail_snapshot_json = None
         await session.execute(
-            _UPSERT_SESSION,
+            _session_upsert_stmt(session),
             {
                 "id": record.session_id,
                 "project": record.project,

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -41,12 +41,12 @@ _INSERT_REQUEST = text(
         input_units, output_units, cached_input_units, cost_usd, pricing_source,
         ttfb_ms, total_latency_ms, status,
         fallback_from, error_message, metadata, session_id,
-        tenant_id)
+        tenant_id, agent_id)
        VALUES (:id, :timestamp, :project, :modality, :model_id, :provider,
                :input_units, :output_units, :cached_input_units, :cost_usd, :pricing_source,
                :ttfb_ms, :total_latency_ms, :status,
                :fallback_from, :error_message, :metadata, :session_id,
-               :tenant_id)"""
+               :tenant_id, :agent_id)"""
 )
 
 
@@ -131,6 +131,7 @@ async def log_request(session: AsyncSession, record: RequestRecord) -> None:
             "metadata": json.dumps(record.metadata) if record.metadata else None,
             "session_id": record.session_id,
             "tenant_id": request_tenant_id,
+            "agent_id": record.agent_id,
         },
     )
     if record.session_id:
@@ -282,6 +283,7 @@ _REQUEST_COLUMNS = (
     "metadata",
     "session_id",
     "tenant_id",
+    "agent_id",
 )
 
 

--- a/src/voicegateway/server/api/ingest.py
+++ b/src/voicegateway/server/api/ingest.py
@@ -71,6 +71,11 @@ async def ingest(
         except IntegrityError:
             # Duplicate id: a sink retry re-sent an already-stored row.
             duplicates += 1
+        except Exception:  # noqa: BLE001 - one bad record must not 500 the batch
+            rejected += 1
+            logger.warning(
+                "ingest: failed to persist record %r", raw.get("id"), exc_info=True
+            )
 
     if rejected:
         logger.warning("ingest: skipped %d malformed record(s)", rejected)

--- a/src/voicegateway/server/api/ingest.py
+++ b/src/voicegateway/server/api/ingest.py
@@ -1,0 +1,80 @@
+"""POST /v1/ingest: receive batched request records from fleet agents.
+
+A self-hosted collector exposes this endpoint; the library's
+``RemoteCollectorSink`` POSTs batches here. Auth is a virtual-key bearer token
+(``require_scope`` short-circuits on the ``vk_`` prefix and sets the tenant
+ContextVar, which the request-log repository reads at write time -> the tenant
+is stamped server-side, not trusted from the payload). ``id`` is the record's
+UUID, so a duplicate (a sink retry) is counted, not double-written.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.exc import IntegrityError
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.server.api._deps import get_gateway, require_scope
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_RECORD_FIELDS: frozenset[str] = frozenset(
+    f.name for f in dataclasses.fields(RequestRecord)
+)
+
+
+def _record_from_payload(raw: dict[str, Any]) -> RequestRecord | None:
+    """Build a RequestRecord from a payload dict, ignoring unknown keys.
+
+    Returns None for a malformed record (missing required fields) so one bad
+    row in a batch does not reject the whole batch.
+    """
+    filtered = {k: v for k, v in raw.items() if k in _RECORD_FIELDS}
+    try:
+        return RequestRecord(**filtered)
+    except TypeError:
+        return None
+
+
+@router.post("/ingest")
+async def ingest(
+    records: list[dict[str, Any]],
+    request: Request,
+    _auth: None = Depends(require_scope("write")),
+) -> dict[str, int]:
+    """Persist a batch of request records pushed by a fleet agent."""
+    gateway = get_gateway(request)
+    storage = gateway.storage
+    if storage is None:
+        raise HTTPException(
+            status_code=503,
+            detail="cost tracking storage is disabled on this collector",
+        )
+
+    accepted = 0
+    duplicates = 0
+    rejected = 0
+    for raw in records:
+        record = _record_from_payload(raw)
+        if record is None:
+            rejected += 1
+            continue
+        try:
+            await storage.log_request(record)
+            accepted += 1
+        except IntegrityError:
+            # Duplicate id: a sink retry re-sent an already-stored row.
+            duplicates += 1
+
+    if rejected:
+        logger.warning("ingest: skipped %d malformed record(s)", rejected)
+    return {"accepted": accepted, "duplicates": duplicates}
+
+
+__all__ = ["router"]

--- a/src/voicegateway/server/routes.py
+++ b/src/voicegateway/server/routes.py
@@ -22,6 +22,7 @@ from voicegateway.server.api import (
     audit_log,
     costs,
     guardrails,
+    ingest,
     latency,
     logs,
     metrics,
@@ -90,6 +91,7 @@ api_router.include_router(guardrails.router)
 api_router.include_router(metrics.router)
 api_router.include_router(audit_log.router)
 api_router.include_router(virtual_keys.router)
+api_router.include_router(ingest.router)
 
 dashboard_router = APIRouter(prefix="/api")
 dashboard_router.include_router(dashboard_health.router)

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -11,11 +11,16 @@ swaps.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+import asyncio
+import logging
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from voicegateway.models.request_model import RequestRecord
     from voicegateway.services.storage_service import StorageService
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -61,4 +66,123 @@ class LocalSqliteSink:
         await self._storage.finalize_session_replay(session_id)
 
 
-__all__ = ["LocalSqliteSink", "Sink"]
+class RemoteCollectorSink:
+    """Fleet sink: batches records and pushes them to a collector's /v1/ingest.
+
+    Best-effort by design (cost telemetry is not billing-of-record): writes
+    never block or fail the agent's hot path. Records buffer in memory and
+    flush on batch size, on a periodic interval, or on ``aclose``. On a full
+    buffer the oldest rows are dropped; failed POSTs are retried with backoff
+    up to ``max_retries`` and then dropped.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        virtual_key: str | None,
+        *,
+        batch_size: int = 20,
+        flush_interval: float | None = 2.0,
+        max_buffer: int = 1000,
+        max_retries: int = 2,
+        backoff: float = 0.2,
+        client: Any | None = None,
+    ) -> None:
+        self._ingest_url = url.rstrip("/") + "/v1/ingest"
+        self._headers = (
+            {"Authorization": f"Bearer {virtual_key}"} if virtual_key else {}
+        )
+        self._batch_size = max(1, batch_size)
+        self._flush_interval = flush_interval
+        self._max_buffer = max_buffer
+        self._max_retries = max_retries
+        self._backoff = backoff
+        self._client = client
+        self._owns_client = client is None
+        self._buffer: list[dict[str, Any]] = []
+        self._flusher: asyncio.Task[None] | None = None
+        self._closed = False
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            import httpx
+
+            self._client = httpx.AsyncClient(timeout=10.0)
+        return self._client
+
+    async def log_request(self, record: RequestRecord) -> None:
+        self._buffer.append(asdict(record))
+        if len(self._buffer) > self._max_buffer:
+            overflow = len(self._buffer) - self._max_buffer
+            del self._buffer[:overflow]
+            logger.warning(
+                "RemoteCollectorSink buffer full; dropped %d oldest row(s)", overflow
+            )
+        self._maybe_start_flusher()
+        if len(self._buffer) >= self._batch_size:
+            await self.flush()
+
+    def _maybe_start_flusher(self) -> None:
+        if not self._flush_interval or self._flusher is not None or self._closed:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._flusher = loop.create_task(self._periodic_flush())
+
+    async def _periodic_flush(self) -> None:
+        try:
+            while not self._closed:
+                await asyncio.sleep(self._flush_interval or 0)
+                await self.flush()
+        except asyncio.CancelledError:
+            pass
+
+    async def flush(self) -> None:
+        if not self._buffer:
+            return
+        batch = self._buffer
+        self._buffer = []
+        await self._post(batch)
+
+    async def _post(self, batch: list[dict[str, Any]]) -> None:
+        client = self._ensure_client()
+        attempt = 0
+        while True:
+            reason: Any
+            try:
+                resp = await client.post(
+                    self._ingest_url, json=batch, headers=self._headers
+                )
+                if resp.status_code < 400:
+                    return
+                reason = f"HTTP {resp.status_code}"
+            except Exception as exc:  # noqa: BLE001 - best-effort, never propagate
+                reason = exc
+            if attempt >= self._max_retries:
+                logger.warning(
+                    "RemoteCollectorSink dropped %d row(s) after %d attempt(s): %s",
+                    len(batch),
+                    attempt + 1,
+                    reason,
+                )
+                return
+            await asyncio.sleep(self._backoff * (2**attempt))
+            attempt += 1
+
+    async def aclose(self) -> None:
+        self._closed = True
+        if self._flusher is not None:
+            self._flusher.cancel()
+            try:
+                await self._flusher
+            except asyncio.CancelledError:
+                pass
+            self._flusher = None
+        await self.flush()
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+
+
+__all__ = ["LocalSqliteSink", "RemoteCollectorSink", "Sink"]

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -1,0 +1,64 @@
+"""Write sinks: the seam between record producers and where rows land.
+
+A ``Sink`` is the narrow write interface every telemetry producer (the
+inference middleware and the ``attach()`` capture pipeline) targets. In
+single-node mode the sink is :class:`LocalSqliteSink`, which writes to the
+embedded SQLite ``StorageService``. In fleet mode it is the
+``RemoteCollectorSink`` (added in a later build step), which batches rows
+and pushes them to a collector. Producers stay identical; only the sink
+swaps.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from voicegateway.models.request_model import RequestRecord
+    from voicegateway.services.storage_service import StorageService
+
+
+@runtime_checkable
+class Sink(Protocol):
+    """Narrow write target for request records.
+
+    ``log_request`` persists one record. ``flush`` drains any buffered
+    writes (a no-op for synchronous sinks). ``aclose`` releases resources.
+    """
+
+    async def log_request(self, record: RequestRecord) -> None: ...
+
+    async def flush(self) -> None: ...
+
+    async def aclose(self) -> None: ...
+
+
+class LocalSqliteSink:
+    """Default single-node sink: writes through the embedded StorageService.
+
+    Delegates ``log_request`` and the session-finalization hooks to the
+    wrapped storage so ``CostTracker.close_session`` (which resolves
+    ``finalize_session_*`` by ``getattr``) keeps working unchanged. ``flush``
+    is a no-op because each SQLite write commits on its own.
+    """
+
+    def __init__(self, storage: StorageService) -> None:
+        self._storage = storage
+
+    async def log_request(self, record: RequestRecord) -> None:
+        await self._storage.log_request(record)
+
+    async def flush(self) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        await self._storage.aclose()
+
+    async def finalize_session_metrics(self, session_id: str) -> None:
+        await self._storage.finalize_session_metrics(session_id)
+
+    async def finalize_session_replay(self, session_id: str) -> None:
+        await self._storage.finalize_session_replay(session_id)
+
+
+__all__ = ["LocalSqliteSink", "Sink"]

--- a/src/voicegateway/tests/core/test_database_url.py
+++ b/src/voicegateway/tests/core/test_database_url.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from voicegateway.core.config import GatewayConfig
 from voicegateway.core.database import Database, resolve_database_url
 
@@ -24,7 +26,12 @@ def test_resolve_database_url_falls_back_to_sqlite_path(monkeypatch, tmp_path):
 
 
 def test_database_builds_postgres_engine_for_db_url(monkeypatch):
-    """A Postgres URL produces a postgres engine (and no filesystem mkdir)."""
+    """A Postgres URL produces a postgres engine (and no filesystem mkdir).
+
+    Building the engine imports the asyncpg driver, so this skips when the
+    optional [postgres] extra is not installed (e.g. the default CI [dev] env).
+    """
+    pytest.importorskip("asyncpg")
     monkeypatch.setenv("VOICEGW_DB_URL", "postgresql+asyncpg://u:p@localhost/vg")
     db = Database(GatewayConfig())
     assert db._engine.url.get_backend_name() == "postgresql"

--- a/src/voicegateway/tests/core/test_database_url.py
+++ b/src/voicegateway/tests/core/test_database_url.py
@@ -1,0 +1,30 @@
+"""Tests for VOICEGW_DB_URL dual-dialect resolution in core/database.py."""
+
+from __future__ import annotations
+
+from voicegateway.core.config import GatewayConfig
+from voicegateway.core.database import Database, resolve_database_url
+
+
+def test_resolve_database_url_honors_db_url_env(monkeypatch):
+    """A full VOICEGW_DB_URL takes precedence over the SQLite path."""
+    monkeypatch.setenv("VOICEGW_DB_URL", "postgresql+asyncpg://u:p@localhost/vg")
+    url = resolve_database_url(GatewayConfig(cost_tracking={"db_path": "/tmp/x.db"}))
+    assert url == "postgresql+asyncpg://u:p@localhost/vg"
+
+
+def test_resolve_database_url_falls_back_to_sqlite_path(monkeypatch, tmp_path):
+    """Without VOICEGW_DB_URL the SQLite path is used."""
+    monkeypatch.delenv("VOICEGW_DB_URL", raising=False)
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    db_path = tmp_path / "x.db"
+    url = resolve_database_url(GatewayConfig(cost_tracking={"db_path": str(db_path)}))
+    assert url.startswith("sqlite+aiosqlite:///")
+    assert str(db_path) in url
+
+
+def test_database_builds_postgres_engine_for_db_url(monkeypatch):
+    """A Postgres URL produces a postgres engine (and no filesystem mkdir)."""
+    monkeypatch.setenv("VOICEGW_DB_URL", "postgresql+asyncpg://u:p@localhost/vg")
+    db = Database(GatewayConfig())
+    assert db._engine.url.get_backend_name() == "postgresql"

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -219,3 +219,20 @@ async def test_public_attach_captures_metric_through_injected_sink(tmp_path):
     assert len(rows) == 1
     assert rows[0]["agent_id"] == "agent-x"
     assert rows[0]["session_id"] == sid
+
+
+def test_build_default_sink_uses_remote_when_collector_url_set():
+    from voicegateway.inference.session.attach import _build_default_sink
+    from voicegateway.services.sinks import RemoteCollectorSink
+
+    sink = _build_default_sink("http://collector", "vk_x")
+    assert isinstance(sink, RemoteCollectorSink)
+
+
+def test_build_default_sink_uses_local_without_collector(tmp_path, monkeypatch):
+    from voicegateway.inference.session.attach import _build_default_sink
+    from voicegateway.services.sinks import LocalSqliteSink
+
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "local.db"))
+    sink = _build_default_sink(None, None)
+    assert isinstance(sink, LocalSqliteSink)

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -348,3 +348,89 @@ async def test_reconcile_no_correction_when_totals_match(tmp_path):
         if isinstance(r.get("metadata"), dict) and r["metadata"].get("reconciled")
     ]
     assert reconciled == []
+
+
+class _ZeroTtftMetric:
+    prompt_tokens = 10
+    completion_tokens = 5
+    prompt_cached_tokens = 0
+    ttft = 0.0
+
+
+def test_units_from_metric_zero_ttft_records_zero_not_none():
+    """A genuine 0.0 first-byte latency records as 0.0, not None."""
+    _inp, _out, _cached, ttfb_ms = units_from_metric(_ZeroTtftMetric(), "llm")
+    assert ttfb_ms == 0.0
+
+
+async def test_reconcile_emits_correction_for_cached_only_delta(tmp_path):
+    """A cached-token-only divergence still produces a correction row."""
+    storage = StorageService(str(tmp_path / "recon_cached.db"))
+    sink = LocalSqliteSink(storage)
+    cost_tracker = CostTracker(sink)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    # input/output match the per-call row (1000/500); only cached differs (500 vs 200).
+    usage = _FakeUsage(
+        [
+            _FakeLLMUsage(
+                prompt_tokens=1000, completion_tokens=500, prompt_cached_tokens=500
+            )
+        ]
+    )
+    session = _FakeSessionWithUsage(usage, llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="fleet",
+        agent_id="a-c",
+        session_id="vg-c",
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())  # records cached=200
+    await capture.drain()
+
+    await capture.reconcile(session)
+
+    rows = await storage.get_recent_requests(limit=10)
+    reconciled = [
+        r
+        for r in rows
+        if isinstance(r.get("metadata"), dict) and r["metadata"].get("reconciled")
+    ]
+    assert len(reconciled) == 1
+    assert reconciled[0]["cached_input_units"] == 300.0  # 500 - 200
+
+
+class _FlushRecordingSink:
+    def __init__(self) -> None:
+        self.rows: list = []
+        self.flushes = 0
+
+    async def log_request(self, record: Any) -> None:
+        self.rows.append(record)
+
+    async def flush(self) -> None:
+        self.flushes += 1
+
+    async def aclose(self) -> None:
+        pass
+
+
+async def test_attach_close_flushes_sink(tmp_path):
+    """The session close path drains writes AND flushes the sink (and the
+    finalize task is strong-reffed: awaitable via session._vg_close_task)."""
+    import voicegateway
+
+    sink = _FlushRecordingSink()
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSessionWithUsage(_FakeUsage([]), llm=llm)
+
+    voicegateway.attach(session, project="fleet", agent_id="agent-f", sink=sink)
+    llm.emit("metrics_collected", _LLMMetric())
+    session.emit("close")
+
+    await session._vg_close_task
+
+    assert sink.flushes >= 1
+    assert len(sink.rows) >= 1

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -236,3 +236,115 @@ def test_build_default_sink_uses_local_without_collector(tmp_path, monkeypatch):
     monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "local.db"))
     sink = _build_default_sink(None, None)
     assert isinstance(sink, LocalSqliteSink)
+
+
+# --- reconcile-at-close --------------------------------------------------
+
+
+class _FakeLLMUsage:
+    """Mirror of LiveKit LLMModelUsage: cumulative per (provider, model)."""
+
+    def __init__(
+        self,
+        *,
+        prompt_tokens: float,
+        completion_tokens: float,
+        prompt_cached_tokens: float = 200,
+        provider: str = "openai",
+        model: str = "gpt-4o-mini",
+    ) -> None:
+        self.provider = provider
+        self.model = model
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.prompt_cached_tokens = prompt_cached_tokens
+
+
+class _FakeUsage:
+    def __init__(self, model_usage: list) -> None:
+        self.model_usage = model_usage
+
+
+class _FakeSessionWithUsage(_FakeSession):
+    def __init__(self, usage: Any, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.usage = usage
+
+
+async def test_reconcile_emits_correction_when_usage_exceeds_recorded(tmp_path):
+    """Cumulative session.usage above the per-call rows yields a correction."""
+    storage = StorageService(str(tmp_path / "recon.db"))
+    sink = LocalSqliteSink(storage)
+    cost_tracker = CostTracker(sink)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    usage = _FakeUsage(
+        [
+            _FakeLLMUsage(
+                prompt_tokens=1500, completion_tokens=700, prompt_cached_tokens=200
+            )
+        ]
+    )
+    session = _FakeSessionWithUsage(usage, llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="fleet",
+        agent_id="agent-r",
+        session_id="vg-rec",
+    )
+    capture.bind(session)
+
+    # Per-call captured 1000 prompt / 500 completion / 200 cached.
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    await capture.reconcile(session)
+
+    rows = await storage.get_recent_requests(limit=10)
+    reconciled = [
+        r
+        for r in rows
+        if isinstance(r.get("metadata"), dict) and r["metadata"].get("reconciled")
+    ]
+    assert len(reconciled) == 1
+    assert reconciled[0]["input_units"] == 500.0  # 1500 - 1000
+    assert reconciled[0]["output_units"] == 200.0  # 700 - 500
+    assert reconciled[0]["agent_id"] == "agent-r"
+
+
+async def test_reconcile_no_correction_when_totals_match(tmp_path):
+    """When session.usage matches the per-call rows, no correction is written."""
+    storage = StorageService(str(tmp_path / "recon2.db"))
+    sink = LocalSqliteSink(storage)
+    cost_tracker = CostTracker(sink)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    usage = _FakeUsage(
+        [
+            _FakeLLMUsage(
+                prompt_tokens=1000, completion_tokens=500, prompt_cached_tokens=200
+            )
+        ]
+    )
+    session = _FakeSessionWithUsage(usage, llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="fleet",
+        agent_id="agent-r",
+        session_id="vg-rec2",
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    await capture.reconcile(session)
+
+    rows = await storage.get_recent_requests(limit=10)
+    reconciled = [
+        r
+        for r in rows
+        if isinstance(r.get("metadata"), dict) and r["metadata"].get("reconciled")
+    ]
+    assert reconciled == []

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -1,0 +1,221 @@
+"""Tests for voicegateway.attach() per-component metric capture."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from voicegateway.inference.session.capture import MetricCapture, units_from_metric
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
+from voicegateway.services.sinks import LocalSqliteSink
+from voicegateway.services.storage_service import StorageService
+
+
+class _LLMMetric:
+    prompt_tokens = 1000
+    completion_tokens = 500
+    prompt_cached_tokens = 200
+    ttft = 0.25
+
+
+class _STTMetric:
+    audio_duration = 120.0  # seconds
+
+
+class _TTSMetric:
+    characters_count = 350
+    ttfb = 0.1
+
+
+class _FakeEmitter:
+    """Minimal stand-in for a LiveKit plugin instance (event emitter)."""
+
+    def __init__(
+        self, *, model: str | None = None, provider: str | None = None
+    ) -> None:
+        self.model = model
+        self.provider = provider
+        self._handlers: dict[str, list[Any]] = {}
+
+    def on(self, event: str, handler: Any) -> None:
+        self._handlers.setdefault(event, []).append(handler)
+
+    def emit(self, event: str, *args: Any) -> None:
+        for handler in list(self._handlers.get(event, [])):
+            handler(*args)
+
+
+class _FakeSession:
+    """Minimal stand-in for livekit.agents.AgentSession."""
+
+    def __init__(
+        self,
+        *,
+        stt: Any = None,
+        llm: Any = None,
+        tts: Any = None,
+    ) -> None:
+        self.stt = stt
+        self.llm = llm
+        self.tts = tts
+        self._handlers: dict[str, list[Any]] = {}
+
+    def on(self, event: str, handler: Any) -> None:
+        self._handlers.setdefault(event, []).append(handler)
+
+    def emit(self, event: str, *args: Any) -> None:
+        for handler in list(self._handlers.get(event, [])):
+            handler(*args)
+
+
+# --- unit mapping --------------------------------------------------------
+
+
+def test_units_from_llm_metric():
+    inp, out, cached, ttfb_ms = units_from_metric(_LLMMetric(), "llm")
+    assert inp == 1000.0
+    assert out == 500.0
+    assert cached == 200.0
+    assert ttfb_ms == 250.0
+
+
+def test_units_from_stt_metric_converts_seconds_to_minutes():
+    inp, out, cached, ttfb_ms = units_from_metric(_STTMetric(), "stt")
+    assert inp == 2.0  # 120s / 60 -> minutes (cost path multiplies back by 60)
+    assert out == 0.0
+    assert cached == 0.0
+    assert ttfb_ms is None
+
+
+def test_units_from_tts_metric():
+    inp, out, cached, ttfb_ms = units_from_metric(_TTSMetric(), "tts")
+    assert inp == 350.0
+    assert out == 0.0
+    assert ttfb_ms == 100.0
+
+
+# --- capture binding -----------------------------------------------------
+
+
+async def test_metric_capture_writes_llm_row(tmp_path):
+    """An LLM component's metric becomes a request row through the sink."""
+    storage = StorageService(str(tmp_path / "cap.db"))
+    sink = LocalSqliteSink(storage)
+    cost_tracker = CostTracker(sink)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="fleet",
+        agent_id="agent-3",
+        session_id="vg-test",
+    )
+    capture.bind(session)
+
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    rows = await storage.get_recent_requests(limit=10)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["modality"] == "llm"
+    assert row["model_id"] == "openai/gpt-4o-mini"
+    assert row["provider"] == "openai"
+    assert row["input_units"] == 1000.0
+    assert row["output_units"] == 500.0
+    assert row["cached_input_units"] == 200.0
+    assert row["agent_id"] == "agent-3"
+    assert row["session_id"] == "vg-test"
+
+
+async def test_metric_capture_handles_three_modalities(tmp_path):
+    """STT, LLM, and TTS components each produce a correctly-typed row."""
+    storage = StorageService(str(tmp_path / "cap3.db"))
+    sink = LocalSqliteSink(storage)
+    cost_tracker = CostTracker(sink)
+    stt = _FakeEmitter(model="nova-3", provider="deepgram")
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    tts = _FakeEmitter(model="sonic-3", provider="cartesia")
+    session = _FakeSession(stt=stt, llm=llm, tts=tts)
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="fleet",
+        agent_id="agent-3",
+        session_id="vg-3",
+    )
+    capture.bind(session)
+
+    stt.emit("metrics_collected", _STTMetric())
+    llm.emit("metrics_collected", _LLMMetric())
+    tts.emit("metrics_collected", _TTSMetric())
+    await capture.drain()
+
+    rows = await storage.get_recent_requests(limit=10)
+    by_modality = {r["modality"]: r for r in rows}
+    assert set(by_modality) == {"stt", "llm", "tts"}
+    assert by_modality["stt"]["model_id"] == "deepgram/nova-3"
+    assert by_modality["stt"]["input_units"] == 2.0
+    assert by_modality["tts"]["model_id"] == "cartesia/sonic-3"
+    assert by_modality["tts"]["input_units"] == 350.0
+
+
+class _LLMErrorSource:
+    """Source object whose type name marks the failing modality."""
+
+
+class _ErrorEvent:
+    def __init__(self, message: str, source: Any) -> None:
+        self.error = message
+        self.source = source
+
+
+async def test_metric_capture_records_session_error(tmp_path):
+    """A session ErrorEvent becomes an error-status request row."""
+    storage = StorageService(str(tmp_path / "caperr.db"))
+    sink = LocalSqliteSink(storage)
+    cost_tracker = CostTracker(sink)
+    session = _FakeSession(llm=_FakeEmitter(model="gpt-4o-mini", provider="openai"))
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="fleet",
+        agent_id="agent-e",
+        session_id="vg-err",
+    )
+    capture.bind(session)
+
+    session.emit("error", _ErrorEvent("upstream 500", _LLMErrorSource()))
+    await capture.drain()
+
+    rows = await storage.get_recent_requests(limit=10)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["status"] == "error"
+    assert "upstream 500" in (row["error_message"] or "")
+    assert row["modality"] == "llm"
+    assert row["agent_id"] == "agent-e"
+
+
+async def test_public_attach_captures_metric_through_injected_sink(tmp_path):
+    """voicegateway.attach() binds capture and writes through the given sink."""
+    import voicegateway
+
+    storage = StorageService(str(tmp_path / "attach.db"))
+    sink = LocalSqliteSink(storage)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    sid = voicegateway.attach(session, project="fleet", agent_id="agent-x", sink=sink)
+    assert sid is not None
+
+    llm.emit("metrics_collected", _LLMMetric())
+    await session._vg_capture.drain()
+
+    rows = await storage.get_recent_requests(limit=10)
+    assert len(rows) == 1
+    assert rows[0]["agent_id"] == "agent-x"
+    assert rows[0]["session_id"] == sid

--- a/src/voicegateway/tests/middleware/test_cost_tracker_middleware.py
+++ b/src/voicegateway/tests/middleware/test_cost_tracker_middleware.py
@@ -30,6 +30,18 @@ def test_tts_cost_calculation():
     assert cost == pytest.approx(0.004)
 
 
+def test_create_record_carries_agent_id():
+    """create_record threads the fleet agent_id onto the record."""
+    tracker = CostTracker()
+    record = tracker.create_record(
+        model_id="openai/gpt-4o-mini",
+        modality="llm",
+        provider="openai",
+        agent_id="agent-9",
+    )
+    assert record.agent_id == "agent-9"
+
+
 def test_local_model_is_free():
     tracker = CostTracker()
     cost = tracker.calculate_cost(

--- a/src/voicegateway/tests/server/test_ingest_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_endpoint.py
@@ -118,3 +118,51 @@ async def test_ingest_rejects_revoked_key(gateway):
             json=[_payload("x")],
         )
     assert resp.status_code == 401
+
+
+async def test_two_agents_aggregate_in_one_collector(gateway):
+    """Acceptance: two distinct agents push to one collector; /v1/costs
+    aggregates both spends and each agent is individually attributable."""
+    import time
+
+    import pytest
+
+    await gateway.storage._ensure_initialized()
+    async with gateway.storage._conn.session() as db:
+        created = await virtual_keys.create_virtual_key(db, name="fleet")
+
+    now = time.time()
+
+    def at_now(rid: str, agent: str, cost: float) -> dict:
+        row = _payload(rid, agent)
+        row["timestamp"] = now
+        row["cost_usd"] = cost
+        return row
+
+    headers = {"Authorization": f"Bearer {created.plaintext}"}
+    client = await _client(gateway)
+    async with client as c:
+        ra = await c.post(
+            "/v1/ingest",
+            headers=headers,
+            json=[at_now("a-1", "agent-a", 0.01), at_now("a-2", "agent-a", 0.02)],
+        )
+        rb = await c.post(
+            "/v1/ingest",
+            headers=headers,
+            json=[at_now("b-1", "agent-b", 0.04)],
+        )
+        assert ra.status_code == 200
+        assert rb.status_code == 200
+
+        costs = await c.get("/v1/costs?period=today", headers=headers)
+        assert costs.status_code == 200
+        assert costs.json()["total"] == pytest.approx(0.07)  # 0.01 + 0.02 + 0.04
+
+    # Per-agent attribution: each agent's rows are individually queryable.
+    rows = await gateway.storage.get_recent_requests(limit=50)
+    counts: dict = {}
+    for r in rows:
+        counts[r["agent_id"]] = counts.get(r["agent_id"], 0) + 1
+    assert counts.get("agent-a") == 2
+    assert counts.get("agent-b") == 1

--- a/src/voicegateway/tests/server/test_ingest_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_endpoint.py
@@ -1,0 +1,120 @@
+"""Tests for POST /v1/ingest (fleet collector ingest endpoint)."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.repository import virtual_keys_repository as virtual_keys
+from voicegateway.server import build_app
+
+_BASE_CONFIG = {
+    "providers": {"openai": {"api_key": "test-key"}},
+    "models": {"stt": {}, "llm": {}, "tts": {}},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+
+def _write_config(tmp_path):
+    path = tmp_path / "voicegw.yaml"
+    with open(path, "w") as f:
+        yaml.dump(_BASE_CONFIG, f)
+    return str(path)
+
+
+@pytest.fixture
+def gateway(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "ingest.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    return Gateway(config_path=_write_config(tmp_path))
+
+
+async def _client(gw: Gateway):
+    app = build_app(gw)
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+def _payload(rid: str, agent_id: str = "agent-1") -> dict:
+    return {
+        "id": rid,
+        "timestamp": 1_000_000.0,
+        "modality": "llm",
+        "model_id": "openai/gpt-4o-mini",
+        "provider": "openai",
+        "project": "fleet",
+        "input_units": 100.0,
+        "output_units": 50.0,
+        "cost_usd": 0.001,
+        "agent_id": agent_id,
+    }
+
+
+async def test_ingest_accepts_batch_and_stamps_tenant(gateway):
+    await gateway.storage._ensure_initialized()
+    async with gateway.storage._conn.session() as db:
+        created = await virtual_keys.create_virtual_key(
+            db, name="bot", tenant_id="acme"
+        )
+
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.post(
+            "/v1/ingest",
+            headers={"Authorization": f"Bearer {created.plaintext}"},
+            json=[_payload("ing-1", "agent-a"), _payload("ing-2", "agent-b")],
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"accepted": 2, "duplicates": 0}
+
+    rows = await gateway.storage.get_recent_requests(limit=10)
+    assert len(rows) == 2
+    assert {r["agent_id"] for r in rows} == {"agent-a", "agent-b"}
+    # tenant stamped server-side from the verified key, not the payload.
+    assert all(r["tenant_id"] == "acme" for r in rows)
+
+
+async def test_ingest_is_idempotent_on_id(gateway):
+    await gateway.storage._ensure_initialized()
+    async with gateway.storage._conn.session() as db:
+        created = await virtual_keys.create_virtual_key(db, name="bot")
+
+    client = await _client(gateway)
+    async with client as c:
+        first = await c.post(
+            "/v1/ingest",
+            headers={"Authorization": f"Bearer {created.plaintext}"},
+            json=[_payload("dup-1")],
+        )
+        second = await c.post(
+            "/v1/ingest",
+            headers={"Authorization": f"Bearer {created.plaintext}"},
+            json=[_payload("dup-1")],
+        )
+
+    assert first.json() == {"accepted": 1, "duplicates": 0}
+    assert second.json() == {"accepted": 0, "duplicates": 1}
+
+    rows = await gateway.storage.get_recent_requests(limit=10)
+    assert len([r for r in rows if r["id"] == "dup-1"]) == 1
+
+
+async def test_ingest_rejects_revoked_key(gateway):
+    await gateway.storage._ensure_initialized()
+    async with gateway.storage._conn.session() as db:
+        created = await virtual_keys.create_virtual_key(db, name="bot")
+        await virtual_keys.revoke(db, created.id)
+
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.post(
+            "/v1/ingest",
+            headers={"Authorization": f"Bearer {created.plaintext}"},
+            json=[_payload("x")],
+        )
+    assert resp.status_code == 401

--- a/src/voicegateway/tests/server/test_ingest_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_endpoint.py
@@ -166,3 +166,30 @@ async def test_two_agents_aggregate_in_one_collector(gateway):
         counts[r["agent_id"]] = counts.get(r["agent_id"], 0) + 1
     assert counts.get("agent-a") == 2
     assert counts.get("agent-b") == 1
+
+
+async def test_ingest_one_failing_record_does_not_fail_batch(gateway, monkeypatch):
+    """A record that fails to persist (e.g. a dialect type error on Postgres)
+    is skipped, not allowed to 500 the whole batch."""
+    await gateway.storage._ensure_initialized()
+    async with gateway.storage._conn.session() as db:
+        created = await virtual_keys.create_virtual_key(db, name="bot")
+
+    real_log = gateway.storage.log_request
+
+    async def flaky_log(record):
+        if record.id == "bad-1":
+            raise RuntimeError("simulated persistence failure")
+        return await real_log(record)
+
+    monkeypatch.setattr(gateway.storage, "log_request", flaky_log)
+
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.post(
+            "/v1/ingest",
+            headers={"Authorization": f"Bearer {created.plaintext}"},
+            json=[_payload("good-1"), _payload("bad-1")],
+        )
+    assert resp.status_code == 200
+    assert resp.json()["accepted"] == 1

--- a/src/voicegateway/tests/services/test_sinks.py
+++ b/src/voicegateway/tests/services/test_sinks.py
@@ -156,3 +156,54 @@ async def test_remote_sink_omits_auth_header_without_key():
     )
     await sink.log_request(_record(id="r1"))
     assert "Authorization" not in client.calls[0]["headers"]
+
+
+class _FlakyClient:
+    """Returns the next queued status code per POST, then 200 once drained."""
+
+    def __init__(self, statuses: list[int]) -> None:
+        self.statuses = list(statuses)
+        self.calls = 0
+
+    async def post(self, url, json=None, headers=None):
+        self.calls += 1
+        code = self.statuses.pop(0) if self.statuses else 200
+        return _FakeResponse(code)
+
+    async def aclose(self) -> None:
+        pass
+
+
+async def test_remote_sink_retries_then_succeeds():
+    client = _FlakyClient([500, 200])  # fail once, then succeed
+    sink = RemoteCollectorSink(
+        "http://c",
+        "vk",
+        batch_size=1,
+        flush_interval=None,
+        max_retries=2,
+        backoff=0.001,
+        client=client,
+    )
+    await sink.log_request(_record(id="r1"))  # flush -> 500 -> retry -> 200
+    assert client.calls == 2
+
+
+async def test_remote_sink_creates_default_httpx_client():
+    import httpx
+
+    sink = RemoteCollectorSink("http://c", "vk", flush_interval=None)
+    created = sink._ensure_client()
+    assert isinstance(created, httpx.AsyncClient)
+    await created.aclose()
+
+
+async def test_remote_sink_starts_periodic_flusher_and_aclose_cancels_it():
+    client = _RecordingClient()
+    sink = RemoteCollectorSink(
+        "http://c", "vk", batch_size=100, flush_interval=0.01, client=client
+    )
+    await sink.log_request(_record(id="r1"))  # never hits batch_size
+    assert sink._flusher is not None  # periodic flusher started
+    await sink.aclose()  # cancels the flusher and flushes the buffer
+    assert len(client.calls) >= 1

--- a/src/voicegateway/tests/services/test_sinks.py
+++ b/src/voicegateway/tests/services/test_sinks.py
@@ -1,0 +1,53 @@
+"""Tests for voicegateway/services/sinks.py (the write-sink seam)."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.services.sinks import LocalSqliteSink
+from voicegateway.services.storage_service import StorageService
+
+
+def _record(**overrides) -> RequestRecord:
+    base: dict = {
+        "id": str(uuid.uuid4()),
+        "timestamp": time.time(),
+        "modality": "llm",
+        "model_id": "openai/gpt-4o-mini",
+        "provider": "openai",
+        "project": "fleet",
+        "cost_usd": 0.01,
+        "agent_id": "agent-7",
+    }
+    base.update(overrides)
+    return RequestRecord(**base)
+
+
+async def test_local_sqlite_sink_round_trips_record(tmp_path):
+    """LocalSqliteSink.log_request writes through to the wrapped storage."""
+    storage = StorageService(str(tmp_path / "sink.db"))
+    sink = LocalSqliteSink(storage)
+    await sink.log_request(_record())
+    rows = await storage.get_recent_requests(limit=10)
+    assert len(rows) == 1
+    assert rows[0]["agent_id"] == "agent-7"
+
+
+async def test_local_sqlite_sink_flush_is_noop(tmp_path):
+    """flush() succeeds without touching storage (SQLite commits per write)."""
+    storage = StorageService(str(tmp_path / "sink.db"))
+    sink = LocalSqliteSink(storage)
+    await sink.flush()  # must not raise
+
+
+async def test_local_sqlite_sink_finalize_delegates(tmp_path):
+    """finalize_* hooks delegate so CostTracker.close_session still resolves."""
+    storage = StorageService(str(tmp_path / "sink.db"))
+    sink = LocalSqliteSink(storage)
+    rec = _record(session_id="sess-1")
+    await sink.log_request(rec)
+    # Delegated finalize must run without error on a real session row.
+    await sink.finalize_session_metrics("sess-1")
+    await sink.finalize_session_replay("sess-1")

--- a/src/voicegateway/tests/services/test_sinks.py
+++ b/src/voicegateway/tests/services/test_sinks.py
@@ -6,8 +6,29 @@ import time
 import uuid
 
 from voicegateway.models.request_model import RequestRecord
-from voicegateway.services.sinks import LocalSqliteSink
+from voicegateway.services.sinks import LocalSqliteSink, RemoteCollectorSink
 from voicegateway.services.storage_service import StorageService
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+
+
+class _RecordingClient:
+    """Stand-in for httpx.AsyncClient that records POST calls."""
+
+    def __init__(self, status_code: int = 200) -> None:
+        self.calls: list[dict] = []
+        self._status = status_code
+        self.closed = False
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        return _FakeResponse(self._status)
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 def _record(**overrides) -> RequestRecord:
@@ -51,3 +72,60 @@ async def test_local_sqlite_sink_finalize_delegates(tmp_path):
     # Delegated finalize must run without error on a real session row.
     await sink.finalize_session_metrics("sess-1")
     await sink.finalize_session_replay("sess-1")
+
+
+# --- RemoteCollectorSink -------------------------------------------------
+
+
+async def test_remote_sink_batches_until_size_then_posts():
+    client = _RecordingClient()
+    sink = RemoteCollectorSink(
+        "http://collector", "vk_abc", batch_size=2, flush_interval=None, client=client
+    )
+    await sink.log_request(_record(id="r1"))
+    assert client.calls == []  # buffered, not yet at batch_size
+    await sink.log_request(_record(id="r2"))
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call["url"] == "http://collector/v1/ingest"
+    assert call["headers"]["Authorization"] == "Bearer vk_abc"
+    assert [r["id"] for r in call["json"]] == ["r1", "r2"]
+    assert call["json"][0]["agent_id"] == "agent-7"
+
+
+async def test_remote_sink_flush_sends_partial_batch():
+    client = _RecordingClient()
+    sink = RemoteCollectorSink(
+        "http://collector/", "vk_x", batch_size=10, flush_interval=None, client=client
+    )
+    await sink.log_request(_record(id="r1"))
+    assert client.calls == []
+    await sink.flush()
+    assert len(client.calls) == 1
+    assert [r["id"] for r in client.calls[0]["json"]] == ["r1"]
+
+
+async def test_remote_sink_never_raises_on_error_status():
+    client = _RecordingClient(status_code=500)
+    sink = RemoteCollectorSink(
+        "http://collector",
+        "vk_x",
+        batch_size=1,
+        flush_interval=None,
+        max_retries=0,
+        client=client,
+    )
+    # batch_size=1 -> flush on first append; a 500 must be swallowed.
+    await sink.log_request(_record(id="r1"))
+    assert len(client.calls) == 1
+
+
+async def test_remote_sink_aclose_flushes_without_closing_injected_client():
+    client = _RecordingClient()
+    sink = RemoteCollectorSink(
+        "http://c", "vk", batch_size=10, flush_interval=None, client=client
+    )
+    await sink.log_request(_record(id="r1"))
+    await sink.aclose()
+    assert len(client.calls) == 1  # flushed on close
+    assert client.closed is False  # injected client is not owned -> not closed

--- a/src/voicegateway/tests/services/test_sinks.py
+++ b/src/voicegateway/tests/services/test_sinks.py
@@ -129,3 +129,30 @@ async def test_remote_sink_aclose_flushes_without_closing_injected_client():
     await sink.aclose()
     assert len(client.calls) == 1  # flushed on close
     assert client.closed is False  # injected client is not owned -> not closed
+
+
+async def test_remote_sink_drops_oldest_past_max_buffer():
+    client = _RecordingClient()
+    sink = RemoteCollectorSink(
+        "http://c",
+        "vk",
+        batch_size=100,  # never auto-flushes during this test
+        flush_interval=None,
+        max_buffer=2,
+        client=client,
+    )
+    await sink.log_request(_record(id="r1"))
+    await sink.log_request(_record(id="r2"))
+    await sink.log_request(_record(id="r3"))  # overflow -> drop oldest (r1)
+    await sink.flush()
+    assert len(client.calls) == 1
+    assert [r["id"] for r in client.calls[0]["json"]] == ["r2", "r3"]
+
+
+async def test_remote_sink_omits_auth_header_without_key():
+    client = _RecordingClient()
+    sink = RemoteCollectorSink(
+        "http://c", None, batch_size=1, flush_interval=None, client=client
+    )
+    await sink.log_request(_record(id="r1"))
+    assert "Authorization" not in client.calls[0]["headers"]

--- a/src/voicegateway/tests/storage/test_migration_agent_id.py
+++ b/src/voicegateway/tests/storage/test_migration_agent_id.py
@@ -1,0 +1,73 @@
+"""Alembic migration b2e7c4a9f1d3: add agent_id to requests.
+
+Verifies the migration adds a nullable ``agent_id`` column plus its single
+and composite indexes, runs idempotently, and that downgrade reverses it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine, text
+
+from voicegateway.core.config import GatewayConfig
+from voicegateway.core.database import Database
+
+
+def _column_exists(engine: sa.Engine, table: str, column: str) -> bool:
+    with engine.connect() as conn:
+        info = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    return any(row[1] == column for row in info)
+
+
+def _index_names(engine: sa.Engine, table: str) -> set[str]:
+    with engine.connect() as conn:
+        rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    return {row[1] for row in rows}
+
+
+async def _build_db(tmp_path: Path) -> Database:
+    db_path = tmp_path / "agent-id-migration.db"
+    db = Database(GatewayConfig(cost_tracking={"db_path": str(db_path)}))
+    await db.run_migrations()
+    return db
+
+
+async def test_migration_adds_agent_id_column_and_indexes(tmp_path: Path) -> None:
+    """After upgrade head the column and both indexes are present."""
+    db = await _build_db(tmp_path)
+    sync_engine = create_engine(f"sqlite:///{db.db_file_path}")
+    try:
+        assert _column_exists(sync_engine, "requests", "agent_id"), (
+            "migration did not add agent_id column to requests"
+        )
+        indexes = _index_names(sync_engine, "requests")
+        assert "idx_requests_agent_id" in indexes
+        assert "idx_requests_agent_id_timestamp" in indexes
+    finally:
+        sync_engine.dispose()
+        await db.dispose()
+
+
+async def test_agent_id_is_nullable(tmp_path: Path) -> None:
+    """A row inserted without agent_id is valid and reads back NULL."""
+    db = await _build_db(tmp_path)
+    sync_engine = create_engine(f"sqlite:///{db.db_file_path}")
+    try:
+        with sync_engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO requests (id, timestamp, project, modality, "
+                    "model_id, provider) VALUES "
+                    "('agent-null-1', 1000000.0, 'p', 'llm', 'fake/m', 'fake')"
+                )
+            )
+            row = conn.execute(
+                text("SELECT agent_id FROM requests WHERE id = 'agent-null-1'")
+            ).first()
+        assert row is not None
+        assert row[0] is None
+    finally:
+        sync_engine.dispose()
+        await db.dispose()

--- a/src/voicegateway/tests/storage/test_postgres_dialect.py
+++ b/src/voicegateway/tests/storage/test_postgres_dialect.py
@@ -1,0 +1,63 @@
+"""Postgres dual-dialect collector round-trip.
+
+Guarded: runs only when VOICEGW_TEST_PG_URL points at a reachable Postgres
+(e.g. ``postgresql+asyncpg://user:pw@localhost:5433/vgtest``). It exercises the
+dialect-branched paths a SQLite run can never reach: the Postgres ``daily_costs``
+view DDL and the STRPOS variant of the sessions UPSERT. Skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.services.storage_service import StorageService
+
+_PG_URL = os.environ.get("VOICEGW_TEST_PG_URL")
+
+pytestmark = pytest.mark.skipif(
+    not _PG_URL,
+    reason="set VOICEGW_TEST_PG_URL to a reachable Postgres to run dialect tests",
+)
+
+
+async def test_collector_round_trip_on_postgres(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_URL", _PG_URL)
+    storage = StorageService(str(tmp_path / "unused.db"))
+    rid = f"pg-{uuid.uuid4()}"
+    sid = f"vg-{uuid.uuid4()}"
+    try:
+        # Runs alembic head on Postgres -> exercises the PG view DDL branch.
+        await storage._ensure_initialized()
+
+        # log_request exercises the requests INSERT + the STRPOS sessions UPSERT.
+        await storage.log_request(
+            RequestRecord(
+                id=rid,
+                timestamp=time.time(),
+                modality="llm",
+                model_id="openai/gpt-4o-mini",
+                provider="openai",
+                project="fleet",
+                cost_usd=0.01,
+                agent_id="agent-pg",
+                session_id=sid,
+            )
+        )
+
+        rows = await storage.get_recent_requests(limit=50)
+        match = [r for r in rows if r["id"] == rid]
+        assert len(match) == 1
+        assert match[0]["agent_id"] == "agent-pg"
+
+        # The Postgres daily_costs view must be queryable.
+        async with storage._conn.session() as s:
+            res = await s.execute(text("SELECT day, total_cost FROM daily_costs"))
+            assert res.first() is not None
+    finally:
+        await storage.aclose()

--- a/src/voicegateway/tests/storage/test_storage.py
+++ b/src/voicegateway/tests/storage/test_storage.py
@@ -47,6 +47,24 @@ async def test_log_request(storage):
     assert rows[0]["model_id"] == "deepgram/nova-3"
 
 
+async def test_log_request_preserves_agent_id(storage):
+    """A record's agent_id round-trips through storage to the read API."""
+    record = RequestRecord(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        modality="llm",
+        model_id="openai/gpt-4o-mini",
+        provider="openai",
+        project="fleet",
+        cost_usd=0.01,
+        agent_id="agent-7",
+    )
+    await storage.log_request(record)
+    rows = await storage.get_recent_requests(limit=10)
+    assert len(rows) == 1
+    assert rows[0]["agent_id"] == "agent-7"
+
+
 async def test_get_recent_requests_with_project_filter(storage):
     now = time.time()
     for project in ["alpha", "beta"]:


### PR DESCRIPTION
## Fleet collector, Phase 1: the wire and the on-ramp

Evolves VoiceGateway from single-node embedded (each agent writes a local SQLite that `serve`/the dashboard read) toward a fleet model: **many LiveKit agents → one self-hosted collector → one dashboard**. This PR delivers the minimum that makes that real, plus the frictionless adoption path.

Spec: `docs/superpowers/specs/2026-06-04-fleet-collector-integration-design.md` (local/gitignored).

### What's in it (build order, one commit per step)

1. **`agent_id` dimension** — nullable column on `requests` + single/composite indexes + migration `b2e7c4a9f1d3`, threaded through the `RequestRecord` dataclass and the request-log repository.
2. **`Sink` seam** — narrow `log_request`/`flush`/`aclose` protocol; `LocalSqliteSink` adapter over `StorageService`; the gateway's `CostTracker` writes through it (behavior-preserving).
3. **`voicegateway.attach(session, ...)`** — the one-line *observe* tier. Instruments **any** existing agent (native LiveKit plugins, `livekit.agents.inference`, or `voicegateway.inference`) by subscribing to the **non-deprecated per-component** `metrics_collected` event (the session-level one is deprecated in livekit-agents 1.5+), mapping each metric to a cost row, plus error rows. Writes through a `Sink`.
4. **`RemoteCollectorSink` + `POST /v1/ingest`** — the wire. The sink batches and pushes records over httpx, best-effort (never blocks/raises the agent), with drop-oldest overflow and bounded retry. The endpoint authenticates with a virtual key (tenant stamped **server-side** via the existing ContextVar the repo reads), persists each record, and is **idempotent on the record id** (a sink retry counts as a duplicate, not a double-write).
5. **Dual-dialect / Postgres** — `resolve_database_url` honors a full `VOICEGW_DB_URL` (e.g. `postgresql+asyncpg://...`); `[postgres]` extra (asyncpg). The two cost-rollup views and the sessions UPSERT are dialect-branched; the **SQLite branch is byte-for-byte the baseline** and the PG branch uses `CREATE OR REPLACE VIEW` + `to_char(to_timestamp())` and `STRPOS` (derived from the SQLite UPSERT so they never drift).
6. **Reconcile-at-close** — `MetricCapture` tallies captured units per `(provider, model)` and, at session close, diffs them against cumulative `session.usage`, emitting one correction row per `(provider, model)` for any positive delta (dropped event, realtime model, handoff gap). Plus the **two-agent acceptance test**: distinct `agent_id`s push to one collector, `/v1/costs` aggregates both spends, each agent stays individually attributable.

### Mental model

`voicegateway.attach()` = **observe** (one line, any agent). `voicegateway.inference.*` = **control** (construction-time; guardrails, routing, hard budget, frame replay). Same pipeline underneath, different capture surface.

### Testing

- Full suite: **1611 passed, 5 skipped**. Coverage **84.25%** (gate 80%).
- Every step was written test-first (RED → minimal GREEN), ruff + mypy clean.

### Caveats / reviewer notes

- **Postgres was not run live in the build environment** (no reachable PG/Docker). The PG path is covered by the dialect code (SQLite path kept byte-for-byte and fully green) plus a **guarded** round-trip test. Run it against a real PG before trusting the collector on Postgres:
  `VOICEGW_TEST_PG_URL=postgresql+asyncpg://user:pw@host:5432/db pytest src/voicegateway/tests/storage/test_postgres_dialect.py`
- Server-side stamping covers **tenant** (virtual keys carry a tenant, not a project); `project` stays as the agent declares it. Per-key project scoping is a later enhancement.

### Out of scope (later phases)

Per-agent dashboard UI/filters and agent health (Phase 2); ingest rate-limiting, retention, tighter tenant isolation (Phase 3); durable spool; OTel export. The `agent_id` column ships now; Phase-2 read filters consume it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fleet collector mode with per-agent telemetry attribution and batch ingest endpoint.
  * Introduced `attach()` helper for simplified LiveKit AgentSession integration.
  * Added support for PostgreSQL database backend alongside SQLite.
  * Implemented per-component metric capture with automatic reconciliation across LLM, STT, and TTS services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->