### PR TITLE
feat: fleet dashboard Phase 2 - per-agent views, filter, and health

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ downloads/
 eggs/
 .eggs/
 lib/
-!dashboard/frontend/src/lib/
+!src/dashboard/frontend/src/lib/
 !web/src/lib/
 lib64/
 parts/

--- a/alembic/versions/c4f1a9e2b8d7_sessions_agent_id.py
+++ b/alembic/versions/c4f1a9e2b8d7_sessions_agent_id.py
@@ -1,0 +1,38 @@
+"""add agent_id to sessions (fleet per-agent session filter)
+
+Revision ID: c4f1a9e2b8d7
+Revises: b2e7c4a9f1d3
+Create Date: 2026-06-04 08:00:00.000000
+
+Phase 2 of the fleet collector. agent_id already lives on the requests table
+(Phase 1, b2e7c4a9f1d3); the sessions table needs it too so the dashboard's
+Sessions list can filter by agent the same way it filters by tenant (tenant_id
+is already on sessions). Nullable: pre-Phase-2 session rows keep NULL and simply
+do not match an agent filter. Written + COALESCE-preserved by the sessions
+UPSERT in request_log_repository.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c4f1a9e2b8d7"
+down_revision: str | None = "b2e7c4a9f1d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Direct add_column / create_index (not batch_alter_table): same
+    # view-collision rationale as the requests agent_id migration.
+    op.add_column("sessions", sa.Column("agent_id", sa.String(), nullable=True))
+    op.create_index("idx_sessions_agent_id", "sessions", ["agent_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_sessions_agent_id", table_name="sessions")
+    op.drop_column("sessions", "agent_id")

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import Logs from './pages/Logs';
 import Metrics from './pages/Metrics';
 import Replay from './pages/Replay';
 import Sessions from './pages/Sessions';
+import Agents from './pages/Agents';
 import Projects from './pages/Projects';
 import Providers from './pages/Providers';
 import Routing from './pages/Routing';
@@ -43,6 +44,7 @@ const PAGES = [
   { to: '/latency',      label: 'Latency',      id: 'latency'  },
   { to: '/logs',         label: 'Logs',         id: 'logs'     },
   { to: '/sessions',     label: 'Sessions',     id: 'sessions' },
+  { to: '/agents',       label: 'Agents',       id: 'agents'   },
   { to: '/metrics',      label: 'Metrics',      id: 'metrics'  },
   { to: '/routing',      label: 'Routing',      id: 'routing'  },
   { to: '/guardrails',   label: 'Guardrails',   id: 'guardrails' },
@@ -124,6 +126,7 @@ export default function App() {
             <Route path="/logs" element={<Logs />} />
             <Route path="/sessions" element={<Sessions />} />
             <Route path="/sessions/:sessionId/replay" element={<Replay />} />
+            <Route path="/agents" element={<Agents />} />
             <Route path="/metrics" element={<Metrics />} />
             <Route path="/projects" element={<Projects />} />
             <Route path="/providers" element={<Providers />} />

--- a/src/dashboard/frontend/src/components/AgentFilter.tsx
+++ b/src/dashboard/frontend/src/components/AgentFilter.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchAgents } from '../lib/api';
+import type { AgentsResponse } from '../lib/types';
+
+interface Props {
+  /** Current agent filter: `null` (no filter), `""` (unattributed), or an agent id. */
+  value: string | null;
+  /** Called with the new selection. `null` clears the filter; `""` scopes to unattributed. */
+  onChange: (next: string | null) => void;
+}
+
+/**
+ * Phase 2 fleet: typeahead agent filter (mirror of TenantFilter).
+ *
+ * Fetches `/api/agents` with a substring query that updates as the operator
+ * types. The returned list (plus the implicit unattributed bucket) becomes the
+ * dropdown options. Selection bubbles up via `onChange` so the parent
+ * (FilterBar) can sync to the `agent` URL query and re-fetch the page's data.
+ */
+export default function AgentFilter({ value, onChange }: Props) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState<AgentsResponse | null>(null);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      fetchAgents({ limit: 50, q: query.trim() || undefined })
+        .then(setData)
+        .catch(() => setData(null));
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const display = useMemo(() => {
+    if (value === null) return 'All agents';
+    if (value === '') return 'Unattributed';
+    return value;
+  }, [value]);
+
+  const selectAgent = (next: string | null) => {
+    onChange(next);
+    setOpen(false);
+    setQuery('');
+  };
+
+  return (
+    <div className="agent-filter" style={{ position: 'relative' }}>
+      <button className="neo-btn" onClick={() => setOpen((o) => !o)} aria-expanded={open}>
+        Agent: <strong>{display}</strong>
+        <span style={{ marginLeft: '0.4rem' }}>▾</span>
+      </button>
+
+      {open && (
+        <div
+          className="neo-card"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 0.5rem)',
+            right: 0,
+            zIndex: 10,
+            minWidth: '20rem',
+            padding: '0.75rem',
+            maxHeight: '24rem',
+            overflowY: 'auto',
+          }}
+        >
+          <input
+            className="neo-input"
+            placeholder="Search agents…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            autoFocus
+          />
+
+          <div className="mt-sm">
+            <button
+              className={`neo-btn ${value === null ? 'neo-btn--primary' : ''}`}
+              style={{ width: '100%', justifyContent: 'flex-start' }}
+              onClick={() => selectAgent(null)}
+            >
+              All agents
+            </button>
+            <button
+              className={`neo-btn mt-sm ${value === '' ? 'neo-btn--primary' : ''}`}
+              style={{ width: '100%', justifyContent: 'flex-start', opacity: 0.85 }}
+              onClick={() => selectAgent('')}
+            >
+              Unattributed
+              {data && (
+                <span className="label" style={{ marginLeft: 'auto', fontSize: '0.75rem' }}>
+                  {data.unattributed.request_count} req
+                </span>
+              )}
+            </button>
+          </div>
+
+          {data && data.agents.length > 0 && (
+            <div className="mt-sm">
+              <div
+                className="label"
+                style={{ fontSize: '0.7rem', textTransform: 'uppercase', marginBottom: '0.25rem' }}
+              >
+                Agents
+              </div>
+              {data.agents.map((a) => (
+                <button
+                  key={a.agent_id}
+                  className={`neo-btn ${value === a.agent_id ? 'neo-btn--primary' : ''}`}
+                  style={{ width: '100%', justifyContent: 'flex-start', marginTop: '0.25rem' }}
+                  onClick={() => selectAgent(a.agent_id)}
+                >
+                  <span>{a.agent_id}</span>
+                  <span className="label" style={{ marginLeft: 'auto', fontSize: '0.75rem' }}>
+                    {a.request_count} · ${a.total_cost_usd.toFixed(2)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {data && data.agents.length === 0 && query.trim() && (
+            <div className="empty-state mt-md">No agents match "{query}".</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/AgentPill.tsx
+++ b/src/dashboard/frontend/src/components/AgentPill.tsx
@@ -1,0 +1,49 @@
+import { Link } from 'react-router-dom';
+
+interface Props {
+  agentId: string | null;
+  /** When true, the pill links to the agent-scoped Sessions view. */
+  asLink?: boolean;
+  /** Optional click handler instead of the link. Ignored when `asLink` is true. */
+  onClick?: () => void;
+}
+
+/**
+ * Phase 2 fleet: per-row agent indicator (mirror of TenantPill).
+ *
+ * Renders the agent id as a neo-badge, or a muted "unattributed" label when
+ * the row's agent_id is NULL.
+ */
+export default function AgentPill({ agentId, asLink = false, onClick }: Props) {
+  const isAttributed = agentId !== null && agentId !== '';
+  const label = isAttributed ? agentId : 'unattributed';
+  const cls = isAttributed ? 'neo-badge neo-badge--black' : 'neo-badge';
+  const style = isAttributed
+    ? undefined
+    : { background: 'transparent', color: 'var(--text-muted, #888)', opacity: 0.75 };
+
+  if (asLink) {
+    const search = new URLSearchParams({ agent: agentId ?? '' }).toString();
+    return (
+      <Link className={cls} style={style} to={`/sessions?${search}`}>
+        {label}
+      </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <button
+        className={cls}
+        style={{ ...(style ?? {}), border: 'none', cursor: 'pointer' }}
+        onClick={onClick}
+      >
+        {label}
+      </button>
+    );
+  }
+  return (
+    <span className={cls} style={style}>
+      {label}
+    </span>
+  );
+}

--- a/src/dashboard/frontend/src/components/FilterBar.tsx
+++ b/src/dashboard/frontend/src/components/FilterBar.tsx
@@ -1,9 +1,12 @@
 import { useSearchParams } from 'react-router-dom';
 import TenantFilter from './TenantFilter';
+import AgentFilter from './AgentFilter';
 
 interface Props {
   /** When true, render the tenant typeahead. Default true. */
   showTenant?: boolean;
+  /** When true, render the agent typeahead. Default true. */
+  showAgent?: boolean;
   /** Optional slot for a page-specific project filter. */
   projectSlot?: React.ReactNode;
   /** Optional slot for a page-specific time-range filter. */
@@ -33,6 +36,7 @@ interface Props {
  */
 export default function FilterBar({
   showTenant = true,
+  showAgent = true,
   projectSlot,
   timeRangeSlot,
   extra,
@@ -41,16 +45,20 @@ export default function FilterBar({
   const tenantParam = searchParams.get('tenant');
   // ``null`` = no tenant filter; ``""`` = unattributed; otherwise a tenant id.
   const tenant: string | null = tenantParam === null ? null : tenantParam;
+  const agentParam = searchParams.get('agent');
+  const agent: string | null = agentParam === null ? null : agentParam;
 
-  const setTenant = (next: string | null) => {
+  const setParam = (key: string, next: string | null) => {
     const params = new URLSearchParams(searchParams);
     if (next === null) {
-      params.delete('tenant');
+      params.delete(key);
     } else {
-      params.set('tenant', next);
+      params.set(key, next);
     }
     setSearchParams(params, { replace: true });
   };
+  const setTenant = (next: string | null) => setParam('tenant', next);
+  const setAgent = (next: string | null) => setParam('agent', next);
 
   return (
     <div
@@ -65,9 +73,20 @@ export default function FilterBar({
       {projectSlot}
       {timeRangeSlot}
       {extra}
+      {showAgent && <AgentFilter value={agent} onChange={setAgent} />}
       {showTenant && <TenantFilter value={tenant} onChange={setTenant} />}
     </div>
   );
+}
+
+/**
+ * Helper hook for pages to read the current agent filter without duplicating
+ * the URL-parsing logic. Same convention as the tenant filter: `null` (no
+ * filter), `""` (unattributed), or an agent id.
+ */
+export function useAgentFilter(): string | null {
+  const [searchParams] = useSearchParams();
+  return searchParams.get('agent');
 }
 
 /**

--- a/src/dashboard/frontend/src/lib/api.ts
+++ b/src/dashboard/frontend/src/lib/api.ts
@@ -86,7 +86,6 @@ async function extractErrorDetail(res: Response): Promise<string | null> {
 // ----------------------------------------------------------------------
 
 import type {
-  AgentFilter,
   AgentRow,
   AgentsResponse,
   CreatedVirtualKey,
@@ -214,22 +213,9 @@ export function fetchTenant(tenantId: string): Promise<TenantRow> {
 }
 
 // ----------------------------------------------------------------------
-// Phase 2 fleet: per-agent typed fetchers + filter param (mirror tenant).
+// Phase 2 fleet: per-agent typed fetchers (mirror tenant). Pages set the
+// `agent` param inline via useAgentFilter(), matching how they set `tenant`.
 // ----------------------------------------------------------------------
-
-/**
- * Append the agent filter to a URLSearchParams instance. ``null`` is "no
- * filter"; ``""`` is the unattributed bucket; any other value is that exact
- * agent. Matches the backend's ``agent`` query parsing on /api/costs,
- * /api/latency, /api/logs, /api/sessions, and /api/metrics.
- */
-export function appendAgentParam(
-  params: URLSearchParams,
-  agent: AgentFilter | undefined,
-): void {
-  if (agent === null || agent === undefined) return;
-  params.set('agent', agent);
-}
 
 export function fetchAgents(
   options: { limit?: number; q?: string } = {},

--- a/src/dashboard/frontend/src/lib/api.ts
+++ b/src/dashboard/frontend/src/lib/api.ts
@@ -86,6 +86,9 @@ async function extractErrorDetail(res: Response): Promise<string | null> {
 // ----------------------------------------------------------------------
 
 import type {
+  AgentFilter,
+  AgentRow,
+  AgentsResponse,
   CreatedVirtualKey,
   DeadAirEvent,
   GuardrailAggregateResponse,
@@ -208,6 +211,38 @@ export function fetchTenants(
 
 export function fetchTenant(tenantId: string): Promise<TenantRow> {
   return fetchJson<TenantRow>(`/api/tenants/${encodeURIComponent(tenantId)}`);
+}
+
+// ----------------------------------------------------------------------
+// Phase 2 fleet: per-agent typed fetchers + filter param (mirror tenant).
+// ----------------------------------------------------------------------
+
+/**
+ * Append the agent filter to a URLSearchParams instance. ``null`` is "no
+ * filter"; ``""`` is the unattributed bucket; any other value is that exact
+ * agent. Matches the backend's ``agent`` query parsing on /api/costs,
+ * /api/latency, /api/logs, /api/sessions, and /api/metrics.
+ */
+export function appendAgentParam(
+  params: URLSearchParams,
+  agent: AgentFilter | undefined,
+): void {
+  if (agent === null || agent === undefined) return;
+  params.set('agent', agent);
+}
+
+export function fetchAgents(
+  options: { limit?: number; q?: string } = {},
+): Promise<AgentsResponse> {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+  if (options.q !== undefined && options.q.length > 0) params.set('q', options.q);
+  const query = params.toString();
+  return fetchJson<AgentsResponse>(query ? `/api/agents?${query}` : '/api/agents');
+}
+
+export function fetchAgent(agentId: string): Promise<AgentRow> {
+  return fetchJson<AgentRow>(`/api/agents/${encodeURIComponent(agentId)}`);
 }
 
 export function fetchVirtualKeys(

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -217,6 +217,44 @@ export interface TenantsResponse {
  */
 export type TenantFilter = string | null;
 
+// ---------------------------------------------------------------------------
+// Phase 2 fleet: per-agent dimension (mirrors the tenant types above).
+// ---------------------------------------------------------------------------
+
+/** One row in the agent index (the fleet table + agent-filter feed). */
+export interface AgentRow {
+  agent_id: string;
+  request_count: number;
+  total_cost_usd: number;
+  /** Epoch seconds of the agent's most recent request, or null. */
+  last_seen: number | null;
+  error_rate: number;
+  /** p95 total-latency ms, merged in by /api/agents; null when no samples. */
+  p95_latency_ms?: number | null;
+}
+
+/** Aggregates for the implicit `agent_id IS NULL` bucket. */
+export interface AgentUnattributedAggregates {
+  request_count: number;
+  total_cost_usd: number;
+  last_seen: number | null;
+  error_rate: number;
+}
+
+/** `/api/agents` response shape. */
+export interface AgentsResponse {
+  agents: AgentRow[];
+  unattributed: AgentUnattributedAggregates;
+}
+
+/**
+ * Agent filter URL convention (mirrors TenantFilter):
+ *   - `null`: no filter (everything)
+ *   - `""`: scope to the unattributed bucket (requests with NULL agent_id)
+ *   - any other string: that exact agent
+ */
+export type AgentFilter = string | null;
+
 /** One row in the Virtual Keys table; the bcrypt hash never appears. */
 export interface VirtualKey {
   id: number;

--- a/src/dashboard/frontend/src/lib/ui.ts
+++ b/src/dashboard/frontend/src/lib/ui.ts
@@ -31,3 +31,36 @@ export function statusBadgeClass(status: string | undefined): string {
   if (status === 'fallback') return 'neo-badge--yellow';
   return 'neo-badge--offline';
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2 fleet: agent telemetry-recency status (active / idle / dormant).
+// ---------------------------------------------------------------------------
+
+export type AgentStatus = 'active' | 'idle' | 'dormant';
+
+/** Telemetry-recency status from the agent's last-seen epoch seconds. */
+export function agentStatus(lastSeen: number | null | undefined): AgentStatus {
+  if (lastSeen == null) return 'dormant';
+  const ageSec = Date.now() / 1000 - lastSeen;
+  if (ageSec < 300) return 'active'; // < 5 min
+  if (ageSec < 3600) return 'idle'; // < 1 h
+  return 'dormant';
+}
+
+export function agentStatusBadgeClass(status: AgentStatus): string {
+  if (status === 'active') return 'neo-badge--online';
+  if (status === 'idle') return 'neo-badge--yellow';
+  return 'neo-badge--offline';
+}
+
+/** Compact "Ns / Nm / Nh / Nd ago" from an epoch-seconds timestamp. */
+export function formatRelativeTime(lastSeen: number | null | undefined): string {
+  if (lastSeen == null) return '—';
+  const sec = Math.max(0, Math.floor(Date.now() / 1000 - lastSeen));
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}

--- a/src/dashboard/frontend/src/pages/Agents.tsx
+++ b/src/dashboard/frontend/src/pages/Agents.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import PageHeader from '../components/PageHeader';
+import { fetchAgents } from '../lib/api';
+import type { AgentRow } from '../lib/types';
+import {
+  agentStatus,
+  agentStatusBadgeClass,
+  formatCost,
+  formatMs,
+  formatRelativeTime,
+} from '../lib/ui';
+
+type SortKey =
+  | 'agent_id'
+  | 'last_seen'
+  | 'total_cost_usd'
+  | 'request_count'
+  | 'p95_latency_ms'
+  | 'error_rate';
+
+const COLUMNS: { key: SortKey; label: string }[] = [
+  { key: 'agent_id', label: 'Agent' },
+  { key: 'last_seen', label: 'Last seen' },
+  { key: 'total_cost_usd', label: 'Cost' },
+  { key: 'request_count', label: 'Requests' },
+  { key: 'p95_latency_ms', label: 'p95' },
+  { key: 'error_rate', label: 'Error rate' },
+];
+
+export default function Agents() {
+  const [agents, setAgents] = useState<AgentRow[]>([]);
+  const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('last_seen');
+  const [sortAsc, setSortAsc] = useState(false);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      fetchAgents({ limit: 200, q: search.trim() || undefined })
+        .then((d) => setAgents(d.agents))
+        .catch(() => setAgents([]));
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [search]);
+
+  const sorted = useMemo(() => {
+    const rows = [...agents];
+    rows.sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      const cmp =
+        typeof av === 'string' || typeof bv === 'string'
+          ? String(av).localeCompare(String(bv))
+          : (av as number) - (bv as number);
+      return sortAsc ? cmp : -cmp;
+    });
+    return rows;
+  }, [agents, sortKey, sortAsc]);
+
+  const onSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortAsc((v) => !v);
+    } else {
+      setSortKey(key);
+      setSortAsc(key === 'agent_id');
+    }
+  };
+
+  return (
+    <div>
+      <PageHeader
+        title="Agents"
+        subtitle={`${agents.length} agent${agents.length === 1 ? '' : 's'} in the fleet`}
+        accent="blue"
+      />
+
+      <div className="filter-bar">
+        <span className="label">Search</span>
+        <input
+          className="neo-input"
+          placeholder="Filter by agent id…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ maxWidth: '20rem' }}
+        />
+      </div>
+
+      {sorted.length === 0 ? (
+        <div className="empty-state mt-lg">
+          No agents yet. Agents appear here once they push telemetry to the
+          collector (via <span className="mono">voicegateway.attach()</span> or a
+          remote sink).
+        </div>
+      ) : (
+        <table className="neo-table neo-table--blue mt-lg">
+          <thead>
+            <tr>
+              <th>Status</th>
+              {COLUMNS.map((c) => (
+                <th
+                  key={c.key}
+                  onClick={() => onSort(c.key)}
+                  style={{ cursor: 'pointer', userSelect: 'none' }}
+                >
+                  {c.label}
+                  {sortKey === c.key ? (sortAsc ? ' ▲' : ' ▼') : ''}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((a) => {
+              const status = agentStatus(a.last_seen);
+              return (
+                <tr key={a.agent_id}>
+                  <td>
+                    <span className={`neo-badge ${agentStatusBadgeClass(status)}`}>
+                      {status}
+                    </span>
+                  </td>
+                  <td className="mono">
+                    <Link to={`/costs?agent=${encodeURIComponent(a.agent_id)}`}>
+                      {a.agent_id}
+                    </Link>
+                  </td>
+                  <td>{formatRelativeTime(a.last_seen)}</td>
+                  <td className="mono">{formatCost(a.total_cost_usd, 4)}</td>
+                  <td>
+                    <span className="neo-badge neo-badge--black">{a.request_count}</span>
+                  </td>
+                  <td className="mono">{formatMs(a.p95_latency_ms)}</td>
+                  <td className="mono">{(a.error_rate * 100).toFixed(1)}%</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/pages/Costs.tsx
+++ b/src/dashboard/frontend/src/pages/Costs.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import CostChart from '../components/CostChart';
-import FilterBar, { useTenantFilter } from '../components/FilterBar';
+import FilterBar, { useTenantFilter, useAgentFilter } from '../components/FilterBar';
 import PageHeader from '../components/PageHeader';
 import { fetchJson } from '../lib/api';
 import { formatCost } from '../lib/ui';
@@ -9,14 +9,16 @@ import type { CostsResponse } from '../lib/types';
 export default function Costs() {
   const [data, setData] = useState<CostsResponse | null>(null);
   const tenant = useTenantFilter();
+  const agent = useAgentFilter();
 
   useEffect(() => {
     const params = new URLSearchParams();
     if (tenant !== null) params.set('tenant', tenant);
+    if (agent !== null) params.set('agent', agent);
     const qs = params.toString();
     const url = qs ? `/api/costs?${qs}` : '/api/costs';
     fetchJson<CostsResponse>(url).then(setData).catch(() => setData(null));
-  }, [tenant]);
+  }, [tenant, agent]);
 
   if (!data) return <div className="empty-state">Loading costs...</div>;
 

--- a/src/dashboard/frontend/src/pages/Guardrails.tsx
+++ b/src/dashboard/frontend/src/pages/Guardrails.tsx
@@ -94,6 +94,7 @@ export default function Guardrails() {
       />
 
       <FilterBar
+        showAgent={false}
         projectSlot={
           <>
             <span className="label">Project</span>

--- a/src/dashboard/frontend/src/pages/Latency.tsx
+++ b/src/dashboard/frontend/src/pages/Latency.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import PageHeader from '../components/PageHeader';
 import StatusCard from '../components/StatusCard';
 import LatencyChart from '../components/LatencyChart';
+import FilterBar, { useAgentFilter } from '../components/FilterBar';
 import { fetchJson } from '../lib/api';
 import { latencyBadgeClass, formatMs } from '../lib/ui';
 import type { LatencyResponse, LatencyStats } from '../lib/types';
@@ -30,10 +31,16 @@ function badgeFor(v: number | null | undefined): string {
 
 export default function Latency() {
   const [data, setData] = useState<LatencyResponse | null>(null);
+  const agent = useAgentFilter();
 
   useEffect(() => {
-    fetchJson<LatencyResponse>('/api/latency').then(setData).catch(() => setData(null));
-  }, []);
+    const params = new URLSearchParams();
+    if (agent !== null) params.set('agent', agent);
+    const qs = params.toString();
+    fetchJson<LatencyResponse>(qs ? `/api/latency?${qs}` : '/api/latency')
+      .then(setData)
+      .catch(() => setData(null));
+  }, [agent]);
 
   if (!data) return <div className="empty-state">Loading latency...</div>;
 
@@ -49,6 +56,8 @@ export default function Latency() {
         subtitle="Worst-model TTFB percentiles across today's requests"
         accent="pink"
       />
+
+      <FilterBar showTenant={false} />
 
       <div className="grid grid-cols-3 mb-lg">
         <StatusCard label="P50 TTFB" value={fmtP(p50)} accent="pink" icon="50" />

--- a/src/dashboard/frontend/src/pages/Logs.tsx
+++ b/src/dashboard/frontend/src/pages/Logs.tsx
@@ -1,21 +1,29 @@
 import { useEffect, useState } from 'react';
 import PageHeader from '../components/PageHeader';
 import LogTable from '../components/LogTable';
+import FilterBar, { useAgentFilter } from '../components/FilterBar';
 import { fetchJson } from '../lib/api';
 import type { LogRecord } from '../lib/types';
 
 export default function Logs() {
   const [logs, setLogs] = useState<LogRecord[]>([]);
   const [filter, setFilter] = useState<string>('');
+  const agent = useAgentFilter();
 
   useEffect(() => {
-    const url = filter ? `/api/logs?limit=50&modality=${filter}` : '/api/logs?limit=50';
-    fetchJson<LogRecord[]>(url).then(setLogs).catch(() => setLogs([]));
-  }, [filter]);
+    const params = new URLSearchParams({ limit: '50' });
+    if (filter) params.set('modality', filter);
+    if (agent !== null) params.set('agent', agent);
+    fetchJson<LogRecord[]>(`/api/logs?${params.toString()}`)
+      .then(setLogs)
+      .catch(() => setLogs([]));
+  }, [filter, agent]);
 
   return (
     <div>
       <PageHeader title="Logs" subtitle="Recent inference requests" accent="orange" />
+
+      <FilterBar showTenant={false} />
 
       <div className="filter-bar">
         <span className="label">Modality</span>

--- a/src/dashboard/frontend/src/pages/Metrics.tsx
+++ b/src/dashboard/frontend/src/pages/Metrics.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import DeadAirList from '../components/DeadAirList';
-import FilterBar, { useTenantFilter } from '../components/FilterBar';
+import FilterBar, { useTenantFilter, useAgentFilter } from '../components/FilterBar';
 import PageHeader from '../components/PageHeader';
 import PerMinuteCostCard from '../components/PerMinuteCostCard';
 import ResponseSpeedChart from '../components/ResponseSpeedChart';
@@ -41,18 +41,20 @@ export default function Metrics() {
   const [data, setData] = useState<MetricsAggregate | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const tenant = useTenantFilter();
+  const agent = useAgentFilter();
 
   useEffect(() => {
     const params = new URLSearchParams();
     if (project) params.set('project', project);
     params.set('days', String(days));
     if (tenant !== null) params.set('tenant', tenant);
+    if (agent !== null) params.set('agent', agent);
     setLoading(true);
     fetchJson<MetricsAggregate>(`/api/metrics?${params.toString()}`)
       .then((d) => setData(d))
       .catch(() => setData(null))
       .finally(() => setLoading(false));
-  }, [project, days, tenant]);
+  }, [project, days, tenant, agent]);
 
   return (
     <div>

--- a/src/dashboard/frontend/src/pages/Overview.tsx
+++ b/src/dashboard/frontend/src/pages/Overview.tsx
@@ -1,18 +1,31 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import StatusCard from '../components/StatusCard';
-import { fetchJson } from '../lib/api';
-import { formatCost } from '../lib/ui';
-import type { OverviewResponse } from '../lib/types';
+import { fetchJson, fetchAgents } from '../lib/api';
+import { formatCost, agentStatus } from '../lib/ui';
+import type { OverviewResponse, AgentRow } from '../lib/types';
 
 export default function Overview() {
   const [data, setData] = useState<OverviewResponse | null>(null);
+  const [agents, setAgents] = useState<AgentRow[]>([]);
 
   useEffect(() => {
     fetchJson<OverviewResponse>('/api/overview').then(setData).catch(() => setData(null));
   }, []);
 
+  useEffect(() => {
+    fetchAgents({ limit: 200 })
+      .then((d) => setAgents(d.agents))
+      .catch(() => setAgents([]));
+  }, []);
+
   if (!data) return <div className="empty-state">Loading overview...</div>;
+
+  const activeCount = agents.filter((a) => agentStatus(a.last_seen) === 'active').length;
+  const topAgents = [...agents]
+    .sort((a, b) => b.total_cost_usd - a.total_cost_usd)
+    .slice(0, 3);
 
   return (
     <div>
@@ -33,6 +46,52 @@ export default function Overview() {
         <StatusCard label="Cost (All Time)" value={formatCost(data.total_cost_all)} accent="blue" icon="Σ" />
         <StatusCard label="Active Models" value={data.active_models ?? 0} accent="pink" icon="M" />
       </div>
+
+      {agents.length > 0 && (
+        <div className="mt-lg neo-card neo-card--strip-blue">
+          <div
+            className="flex-row"
+            style={{ justifyContent: 'space-between', alignItems: 'baseline' }}
+          >
+            <div className="label">Fleet</div>
+            <Link className="neo-btn" to="/agents">
+              View all agents →
+            </Link>
+          </div>
+          <div className="flex-row flex-wrap mt-md" style={{ gap: '2.5rem' }}>
+            <div>
+              <div className="stat-value">{agents.length}</div>
+              <div className="label">Agents</div>
+            </div>
+            <div>
+              <div className="stat-value">{activeCount}</div>
+              <div className="label">Active now</div>
+            </div>
+          </div>
+          {topAgents.length > 0 && (
+            <div className="mt-md">
+              <div
+                className="label"
+                style={{ fontSize: '0.7rem', textTransform: 'uppercase', marginBottom: '0.25rem' }}
+              >
+                Top by cost
+              </div>
+              {topAgents.map((a) => (
+                <div
+                  key={a.agent_id}
+                  className="flex-row mt-sm"
+                  style={{ justifyContent: 'space-between' }}
+                >
+                  <Link className="mono" to={`/costs?agent=${encodeURIComponent(a.agent_id)}`}>
+                    {a.agent_id}
+                  </Link>
+                  <span className="mono">{formatCost(a.total_cost_usd, 4)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="mt-lg grid grid-cols-2">
         <div className="neo-card neo-card--strip-yellow">

--- a/src/dashboard/frontend/src/pages/Routing.tsx
+++ b/src/dashboard/frontend/src/pages/Routing.tsx
@@ -126,7 +126,7 @@ export default function Routing() {
         }
       />
 
-      <FilterBar showTenant={false} />
+      <FilterBar showTenant={false} showAgent={false} />
 
       <div className="neo-card mt-md">
         {refreshedAt && (

--- a/src/dashboard/frontend/src/pages/Sessions.tsx
+++ b/src/dashboard/frontend/src/pages/Sessions.tsx
@@ -7,7 +7,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import FilterBar, { useTenantFilter } from '../components/FilterBar';
+import FilterBar, { useTenantFilter, useAgentFilter } from '../components/FilterBar';
 import PageHeader from '../components/PageHeader';
 import TenantPill from '../components/TenantPill';
 import { fetchJson } from '../lib/api';
@@ -46,6 +46,7 @@ export default function Sessions() {
   const [loading, setLoading] = useState(true);
   const detailAbortRef = useRef<AbortController | null>(null);
   const tenant = useTenantFilter();
+  const agent = useAgentFilter();
 
   useEffect(() => {
     const controller = new AbortController();
@@ -67,6 +68,7 @@ export default function Sessions() {
     const params = new URLSearchParams({ order_by: orderBy, limit: '100' });
     if (project) params.set('project', project);
     if (tenant !== null) params.set('tenant', tenant);
+    if (agent !== null) params.set('agent', agent);
     fetchJson<SessionRow[]>(`/api/sessions?${params.toString()}`, {
       signal: controller.signal,
     })
@@ -78,7 +80,7 @@ export default function Sessions() {
         if (!controller.signal.aborted) setLoading(false);
       });
     return () => controller.abort();
-  }, [project, orderBy, tenant]);
+  }, [project, orderBy, tenant, agent]);
 
   const handleRowClick = (id: string) => {
     detailAbortRef.current?.abort();

--- a/src/voicegateway/models/session_model.py
+++ b/src/voicegateway/models/session_model.py
@@ -22,6 +22,7 @@ class Session(SQLModel, table=True):
     __table_args__ = (
         Index("idx_sessions_project", "project"),
         Index("idx_sessions_started_at", "started_at"),
+        Index("idx_sessions_agent_id", "agent_id"),
     )
 
     id: str = Field(primary_key=True)
@@ -44,6 +45,9 @@ class Session(SQLModel, table=True):
 
     # 0005: tenant attribution
     tenant_id: str | None = None
+
+    # Phase 2 fleet: per-agent attribution (mirror of tenant_id)
+    agent_id: str | None = None
 
     # 0006: routing + budget
     budget_ms: int | None = None

--- a/src/voicegateway/repository/agents_repository.py
+++ b/src/voicegateway/repository/agents_repository.py
@@ -1,0 +1,168 @@
+"""Async read-side repo for the agent index (fleet dashboard).
+
+Mirrors tenants_repository, but aggregates over the ``requests`` table (which
+carries ``agent_id`` from Phase 1) rather than ``sessions``: per-agent request
+count, total cost, last-seen (max request timestamp, epoch seconds), and error
+rate. Per-agent p95 latency is a separate windowed fetch, grouped and
+percentiled in Python, so the index endpoint stays O(1) queries instead of one
+percentile query per agent.
+
+The error-rate division guards against a zero denominator with
+``NULLIF(COUNT(*), 0)`` (Postgres raises on divide-by-zero; the grouped queries
+never hit it, but the unattributed bucket can when there are no NULL rows).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import text
+
+from voicegateway.utils.percentiles import compute_percentiles
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 1000
+
+
+@dataclass(frozen=True)
+class AgentRow:
+    """One row in the agent index (the fleet table + agent filter feed)."""
+
+    agent_id: str
+    request_count: int
+    total_cost_usd: float
+    last_seen: float | None  # epoch seconds of the most recent request
+    error_rate: float
+
+
+@dataclass(frozen=True)
+class UnattributedAggregates:
+    """Aggregates for the implicit ``agent_id IS NULL`` bucket."""
+
+    request_count: int
+    total_cost_usd: float
+    last_seen: float | None
+    error_rate: float
+
+
+def _row_to_agent(row: Sequence[Any]) -> AgentRow:
+    return AgentRow(
+        agent_id=str(row[0]),
+        request_count=int(row[1]),
+        total_cost_usd=float(row[2] or 0.0),
+        last_seen=None if row[3] is None else float(row[3]),
+        error_rate=float(row[4] or 0.0),
+    )
+
+
+_ERROR_RATE = (
+    "(SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) * 1.0) / NULLIF(COUNT(*), 0)"
+)
+
+_SELECT_AGGREGATES = f"""
+SELECT agent_id,
+       COUNT(*) AS request_count,
+       COALESCE(SUM(cost_usd), 0.0) AS total_cost_usd,
+       MAX(timestamp) AS last_seen,
+       {_ERROR_RATE} AS error_rate
+FROM requests
+WHERE agent_id IS NOT NULL
+"""
+
+
+async def list_agents(
+    session: AsyncSession,
+    *,
+    limit: int = _DEFAULT_LIMIT,
+    query: str | None = None,
+) -> list[AgentRow]:
+    """Return the agent index, ordered by ``last_seen`` descending."""
+    if limit < 1:
+        limit = 1
+    if limit > _MAX_LIMIT:
+        limit = _MAX_LIMIT
+
+    sql = _SELECT_AGGREGATES
+    params: dict[str, Any] = {"limit": limit}
+    if query:
+        sql += r" AND agent_id LIKE :pattern ESCAPE '\'"
+        escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        params["pattern"] = f"%{escaped}%"
+    sql += " GROUP BY agent_id ORDER BY last_seen DESC, agent_id ASC LIMIT :limit"
+
+    result = await session.execute(text(sql), params)
+    return [_row_to_agent(row) for row in result]
+
+
+async def get_agent(session: AsyncSession, agent_id: str) -> AgentRow | None:
+    """Return aggregates for a single agent or ``None`` if not seen."""
+    sql = _SELECT_AGGREGATES + " AND agent_id = :agent_id GROUP BY agent_id"
+    result = await session.execute(text(sql), {"agent_id": agent_id})
+    row = result.fetchone()
+    return _row_to_agent(row) if row is not None else None
+
+
+async def get_unattributed_aggregates(
+    session: AsyncSession,
+) -> UnattributedAggregates:
+    """Return aggregates for the ``agent_id IS NULL`` bucket."""
+    result = await session.execute(
+        text(
+            f"""SELECT COUNT(*) AS request_count,
+                       COALESCE(SUM(cost_usd), 0.0) AS total_cost_usd,
+                       MAX(timestamp) AS last_seen,
+                       {_ERROR_RATE} AS error_rate
+                FROM requests
+                WHERE agent_id IS NULL"""
+        )
+    )
+    row = result.fetchone()
+    if row is None or int(row[0]) == 0:
+        return UnattributedAggregates(
+            request_count=0, total_cost_usd=0.0, last_seen=None, error_rate=0.0
+        )
+    return UnattributedAggregates(
+        request_count=int(row[0]),
+        total_cost_usd=float(row[1] or 0.0),
+        last_seen=None if row[2] is None else float(row[2]),
+        error_rate=float(row[3] or 0.0),
+    )
+
+
+async def agent_latency_p95(
+    session: AsyncSession, *, since: float | None = None
+) -> dict[str, float]:
+    """Return ``{agent_id: p95 total-latency ms}`` via one fetch + grouping."""
+    where = "WHERE agent_id IS NOT NULL AND total_latency_ms IS NOT NULL"
+    params: dict[str, Any] = {}
+    if since is not None:
+        where += " AND timestamp >= :since"
+        params["since"] = since
+    result = await session.execute(
+        text(f"SELECT agent_id, total_latency_ms FROM requests {where}"), params
+    )
+    by_agent: dict[str, list[float]] = {}
+    for row in result:
+        by_agent.setdefault(str(row[0]), []).append(float(row[1]))
+    out: dict[str, float] = {}
+    for agent_id, samples in by_agent.items():
+        p95 = compute_percentiles(samples, [95.0]).get("p95")
+        if p95 is not None:
+            out[agent_id] = float(p95)
+    return out
+
+
+__all__ = [
+    "AgentRow",
+    "UnattributedAggregates",
+    "agent_latency_p95",
+    "get_agent",
+    "get_unattributed_aggregates",
+    "list_agents",
+]

--- a/src/voicegateway/repository/agents_repository.py
+++ b/src/voicegateway/repository/agents_repository.py
@@ -136,11 +136,22 @@ async def get_unattributed_aggregates(
 
 
 async def agent_latency_p95(
-    session: AsyncSession, *, since: float | None = None
+    session: AsyncSession,
+    *,
+    since: float | None = None,
+    agent_id: str | None = None,
 ) -> dict[str, float]:
-    """Return ``{agent_id: p95 total-latency ms}`` via one fetch + grouping."""
+    """Return ``{agent_id: p95 total-latency ms}`` via one fetch + grouping.
+
+    Pass ``agent_id`` to scope the scan to a single agent (the detail
+    endpoint), avoiding an all-fleet latency scan; omit it for the list
+    endpoint, which needs every agent's p95 in one pass.
+    """
     where = "WHERE agent_id IS NOT NULL AND total_latency_ms IS NOT NULL"
     params: dict[str, Any] = {}
+    if agent_id is not None:
+        where += " AND agent_id = :agent_id"
+        params["agent_id"] = agent_id
     if since is not None:
         where += " AND timestamp >= :since"
         params["since"] = since

--- a/src/voicegateway/repository/cost_repository.py
+++ b/src/voicegateway/repository/cost_repository.py
@@ -150,6 +150,7 @@ async def get_cost_by_project(
     start_ts: float | None = None,
     end_ts: float | None = None,
     tenant: str | None = None,
+    agent: str | None = None,
 ) -> dict[str, Any]:
     """Return cost rollup grouped by project."""
     since, until = resolve_window(period, start_ts, end_ts)
@@ -158,6 +159,7 @@ async def get_cost_by_project(
         until=until,
         project=None,
         tenant=tenant,
+        agent=agent,
         include_project=False,
     )
     result = await session.execute(

--- a/src/voicegateway/repository/cost_repository.py
+++ b/src/voicegateway/repository/cost_repository.py
@@ -47,6 +47,7 @@ def _build_where(
     until: float | None,
     project: str | None,
     tenant: str | None,
+    agent: str | None = None,
     include_project: bool = True,
 ) -> tuple[str, dict[str, Any]]:
     """Compose the WHERE clause + named params for a window-+-filter query."""
@@ -64,6 +65,12 @@ def _build_where(
         else:
             where += " AND tenant_id = :tenant"
             params["tenant"] = tenant
+    if agent is not None:
+        if agent == "":
+            where += " AND agent_id IS NULL"
+        else:
+            where += " AND agent_id = :agent"
+            params["agent"] = agent
     return where, params
 
 
@@ -75,11 +82,12 @@ async def get_cost_summary(
     start_ts: float | None = None,
     end_ts: float | None = None,
     tenant: str | None = None,
+    agent: str | None = None,
 ) -> dict[str, Any]:
     """Return total / by_provider / by_model cost rollups for the window."""
     since, until = resolve_window(period, start_ts, end_ts)
     where, params = _build_where(
-        since=since, until=until, project=project, tenant=tenant
+        since=since, until=until, project=project, tenant=tenant, agent=agent
     )
 
     result = await session.execute(

--- a/src/voicegateway/repository/latency_repository.py
+++ b/src/voicegateway/repository/latency_repository.py
@@ -29,6 +29,7 @@ async def get_latency_stats(
     project: str | None = None,
     percentiles: list[float] | None = None,
     tenant: str | None = None,
+    agent: str | None = None,
 ) -> dict[str, Any]:
     """Per-model latency rollup with avg + percentile distributions."""
     pcts = percentiles or _DEFAULT_PERCENTILES
@@ -47,6 +48,12 @@ async def get_latency_stats(
         else:
             where += " AND tenant_id = :tenant"
             params["tenant"] = tenant
+    if agent is not None:
+        if agent == "":
+            where += " AND agent_id IS NULL"
+        else:
+            where += " AND agent_id = :agent"
+            params["agent"] = agent
 
     result = await session.execute(
         text(

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -58,12 +58,12 @@ _INSERT_REQUEST = text(
 _UPSERT_SESSION = text(
     """INSERT INTO sessions
        (id, project, started_at, ended_at, modalities,
-        total_cost_usd, request_count, tenant_id,
+        total_cost_usd, request_count, tenant_id, agent_id,
         routed_llm, routed_tts, budget_ms, budget_overrun,
         guardrails_active, guardrails_bypassed,
         guardrail_policy_snapshot_json)
        VALUES (:id, :project, :started_at, :ended_at, :modalities,
-               :cost, 1, :tenant_id,
+               :cost, 1, :tenant_id, :agent_id,
                :routed_llm, :routed_tts, :budget_ms, :budget_overrun,
                :guardrails_active, :guardrails_bypassed,
                :guardrail_snapshot_json)
@@ -71,6 +71,7 @@ _UPSERT_SESSION = text(
            total_cost_usd = total_cost_usd + excluded.total_cost_usd,
            request_count = request_count + 1,
            tenant_id = COALESCE(tenant_id, excluded.tenant_id),
+           agent_id = COALESCE(agent_id, excluded.agent_id),
            routed_llm = COALESCE(routed_llm, excluded.routed_llm),
            routed_tts = COALESCE(routed_tts, excluded.routed_tts),
            budget_ms = COALESCE(budget_ms, excluded.budget_ms),
@@ -191,6 +192,7 @@ async def log_request(session: AsyncSession, record: RequestRecord) -> None:
                 "modalities": record.modality,
                 "cost": record.cost_usd,
                 "tenant_id": request_tenant_id,
+                "agent_id": record.agent_id,
                 "routed_llm": r_llm,
                 "routed_tts": r_tts,
                 "budget_ms": r_budget,

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -325,6 +325,7 @@ async def get_recent_requests(
     modality: str | None = None,
     project: str | None = None,
     tenant: str | None = None,
+    agent: str | None = None,
 ) -> list[dict[str, Any]]:
     """Return the N newest request rows, optionally filtered."""
     conditions: list[str] = []
@@ -341,6 +342,12 @@ async def get_recent_requests(
         else:
             conditions.append("tenant_id = :tenant")
             params["tenant"] = tenant
+    if agent is not None:
+        if agent == "":
+            conditions.append("agent_id IS NULL")
+        else:
+            conditions.append("agent_id = :agent")
+            params["agent"] = agent
     where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
     column_list = ", ".join(_REQUEST_COLUMNS)
     query = (

--- a/src/voicegateway/repository/session_repository.py
+++ b/src/voicegateway/repository/session_repository.py
@@ -91,6 +91,7 @@ async def list_sessions(
     project: str | None = None,
     order_by: str = "started_at_desc",
     tenant: str | None = None,
+    agent: str | None = None,
 ) -> list[dict[str, Any]]:
     """Return recent sessions, ordered per ``order_by``."""
     clause = _SESSION_ORDER_CLAUSES.get(order_by)
@@ -108,6 +109,12 @@ async def list_sessions(
         else:
             conditions.append("tenant_id = :tenant")
             params["tenant"] = tenant
+    if agent is not None:
+        if agent == "":
+            conditions.append("agent_id IS NULL")
+        else:
+            conditions.append("agent_id = :agent")
+            params["agent"] = agent
     where = f"WHERE {' AND '.join(conditions)} " if conditions else ""
     result = await session.execute(
         text(f"{_BASE_SELECT} {where}ORDER BY {clause} LIMIT :limit"),

--- a/src/voicegateway/server/api/dashboard/agents.py
+++ b/src/voicegateway/server/api/dashboard/agents.py
@@ -68,7 +68,7 @@ async def get_agent_endpoint(
         row = await agents.get_agent(db, agent_id)
         if row is None:
             raise HTTPException(status_code=404, detail=f"Agent {agent_id!r} not found")
-        p95 = await agents.agent_latency_p95(db)
+        p95 = await agents.agent_latency_p95(db, agent_id=agent_id)
     entry = dataclasses.asdict(row)
     entry["p95_latency_ms"] = p95.get(agent_id)
     return entry

--- a/src/voicegateway/server/api/dashboard/agents.py
+++ b/src/voicegateway/server/api/dashboard/agents.py
@@ -1,0 +1,74 @@
+"""Dashboard endpoints: GET /api/agents, /api/agents/{agent_id}.
+
+Phase 2 fleet dashboard. Agents are derived from DISTINCT requests.agent_id;
+this index feeds the Agents page (fleet table) and the agent-filter typeahead.
+Per-agent p95 latency is merged in from a single windowed query so the index
+stays O(1) queries.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from voicegateway.repository import agents_repository as agents
+from voicegateway.server.api._deps import get_gateway
+
+if TYPE_CHECKING:
+    from voicegateway.core.gateway import Gateway
+
+router = APIRouter(prefix="/agents", tags=["dashboard"])
+
+_EMPTY_UNATTRIBUTED = {
+    "request_count": 0,
+    "total_cost_usd": 0.0,
+    "last_seen": None,
+    "error_rate": 0.0,
+}
+
+
+@router.get("")
+async def list_agents_endpoint(
+    limit: int = Query(50, ge=1, le=1000),
+    q: str | None = Query(None, max_length=128),
+    gateway: Gateway = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Return the agent index for the fleet table + filter typeahead.
+
+    ``q`` is a substring match against agent_id. The implicit unattributed
+    bucket (NULL agent_id) is returned separately so the FE can render it as a
+    muted row. Each agent carries ``p95_latency_ms`` (null when no samples).
+    """
+    if gateway.storage is None:
+        return {"agents": [], "unattributed": dict(_EMPTY_UNATTRIBUTED)}
+    await gateway.storage._ensure_initialized()
+    async with gateway.storage._conn.session() as db:
+        rows = await agents.list_agents(db, limit=limit, query=q)
+        unattributed = await agents.get_unattributed_aggregates(db)
+        p95 = await agents.agent_latency_p95(db)
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        entry = dataclasses.asdict(row)
+        entry["p95_latency_ms"] = p95.get(row.agent_id)
+        out.append(entry)
+    return {"agents": out, "unattributed": dataclasses.asdict(unattributed)}
+
+
+@router.get("/{agent_id}")
+async def get_agent_endpoint(
+    agent_id: str, gateway: Gateway = Depends(get_gateway)
+) -> dict[str, Any]:
+    """Return aggregates for a single agent. 404 when unseen."""
+    if gateway.storage is None:
+        raise HTTPException(status_code=404, detail=f"Agent {agent_id!r} not found")
+    await gateway.storage._ensure_initialized()
+    async with gateway.storage._conn.session() as db:
+        row = await agents.get_agent(db, agent_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"Agent {agent_id!r} not found")
+        p95 = await agents.agent_latency_p95(db)
+    entry = dataclasses.asdict(row)
+    entry["p95_latency_ms"] = p95.get(agent_id)
+    return entry

--- a/src/voicegateway/server/api/dashboard/costs.py
+++ b/src/voicegateway/server/api/dashboard/costs.py
@@ -81,11 +81,12 @@ async def get_logs(
     modality: str | None = Query(None, enum=["stt", "llm", "tts"]),
     project: str | None = Query(None),
     tenant: str | None = Query(None),
+    agent: str | None = Query(None),
     gateway: Gateway = Depends(get_gateway),
 ) -> list[dict]:
-    """Get recent request logs, optionally filtered by modality, project, and tenant."""
+    """Get recent request logs, filtered by modality, project, tenant, agent."""
     if gateway.storage is None:
         return []
     return await gateway.storage.get_recent_requests(
-        limit=limit, modality=modality, project=project, tenant=tenant
+        limit=limit, modality=modality, project=project, tenant=tenant, agent=agent
     )

--- a/src/voicegateway/server/api/dashboard/costs.py
+++ b/src/voicegateway/server/api/dashboard/costs.py
@@ -51,7 +51,7 @@ async def get_costs(
     )
     if project is None:
         summary["by_project"] = await gateway.storage.get_cost_by_project(
-            period, tenant=tenant
+            period, tenant=tenant, agent=agent
         )
     else:
         summary["by_project"] = {}

--- a/src/voicegateway/server/api/dashboard/costs.py
+++ b/src/voicegateway/server/api/dashboard/costs.py
@@ -26,6 +26,7 @@ async def get_costs(
     period: str = Query("today", enum=["today", "week", "month", "all"]),
     project: str | None = Query(None),
     tenant: str | None = Query(None),
+    agent: str | None = Query(None),
     gateway: Gateway = Depends(get_gateway),
 ) -> dict:
     """Get cost summary for a period, optionally filtered by project and tenant.
@@ -46,7 +47,7 @@ async def get_costs(
             "by_project": {},
         }
     summary = await gateway.storage.get_cost_summary(
-        period, project=project, include_pricing_source=True, tenant=tenant
+        period, project=project, include_pricing_source=True, tenant=tenant, agent=agent
     )
     if project is None:
         summary["by_project"] = await gateway.storage.get_cost_by_project(
@@ -62,6 +63,7 @@ async def get_latency(
     period: str = Query("today", enum=["today", "week"]),
     project: str | None = Query(None),
     tenant: str | None = Query(None),
+    agent: str | None = Query(None),
     gateway: Gateway = Depends(get_gateway),
 ) -> dict:
     """Get latency statistics, optionally filtered by project and tenant."""
@@ -69,7 +71,7 @@ async def get_latency(
         return {}
     pcts = gateway.config.latency.get("percentiles") or [50.0, 95.0, 99.0]
     return await gateway.storage.get_latency_stats(
-        period, project=project, percentiles=pcts, tenant=tenant
+        period, project=project, percentiles=pcts, tenant=tenant, agent=agent
     )
 
 

--- a/src/voicegateway/server/api/dashboard/metrics.py
+++ b/src/voicegateway/server/api/dashboard/metrics.py
@@ -28,6 +28,7 @@ async def get_metrics_summary(
     project: str | None = Query(None),
     days: int = Query(7, ge=1, le=365),
     tenant: str | None = Query(None),
+    agent: str | None = Query(None),
     gateway: Gateway = Depends(get_gateway),
 ) -> dict[str, Any]:
     """Aggregated voice-conversation metrics for the filter window.
@@ -68,6 +69,12 @@ async def get_metrics_summary(
             else:
                 where_clauses.append("tenant_id = :tenant")
                 params["tenant"] = tenant
+        if agent is not None:
+            if agent == "":
+                where_clauses.append("agent_id IS NULL")
+            else:
+                where_clauses.append("agent_id = :agent")
+                params["agent"] = agent
         where = " AND ".join(where_clauses)
         result = await db.execute(
             text(
@@ -121,7 +128,7 @@ async def get_metrics_summary(
                 "since": since_iso,
                 "until": until_iso,
             },
-            "filter": {"project": project, "tenant": tenant},
+            "filter": {"project": project, "tenant": tenant, "agent": agent},
             "session_count": session_count,
             "measured_session_count": measured_count,
             "per_minute_cost_usd_avg": per_minute_cost_avg,

--- a/src/voicegateway/server/api/dashboard/sessions.py
+++ b/src/voicegateway/server/api/dashboard/sessions.py
@@ -36,6 +36,7 @@ async def get_sessions(
     limit: int = Query(100, ge=1, le=1000),
     project: str | None = Query(None),
     tenant: str | None = Query(None),
+    agent: str | None = Query(None),
     order_by: str = Query(
         "started_at_desc",
         pattern="^(started_at_desc|started_at_asc|cost_desc|cost_asc)$",
@@ -52,7 +53,7 @@ async def get_sessions(
     if gateway.storage is None:
         return []
     return await gateway.storage.list_sessions(
-        limit=limit, project=project, order_by=order_by, tenant=tenant
+        limit=limit, project=project, order_by=order_by, tenant=tenant, agent=agent
     )
 
 

--- a/src/voicegateway/server/api/logs.py
+++ b/src/voicegateway/server/api/logs.py
@@ -19,10 +19,11 @@ async def list_logs(
     limit: int = Query(100, ge=1, le=1000),
     modality: str | None = Query(None),
     project: str | None = Query(None),
+    agent: str | None = Query(None),
     gateway: Gateway = Depends(get_gateway),
 ) -> list[dict]:
     if gateway.storage is None:
         return []
     return await gateway.storage.get_recent_requests(
-        limit=limit, modality=modality, project=project
+        limit=limit, modality=modality, project=project, agent=agent
     )

--- a/src/voicegateway/server/routes.py
+++ b/src/voicegateway/server/routes.py
@@ -34,6 +34,9 @@ from voicegateway.server.api import (
     virtual_keys,
 )
 from voicegateway.server.api.dashboard import (
+    agents as dashboard_agents,
+)
+from voicegateway.server.api.dashboard import (
     auth_status as dashboard_auth_status,
 )
 from voicegateway.server.api.dashboard import (
@@ -105,6 +108,7 @@ dashboard_router.include_router(dashboard_guardrails.router)
 dashboard_router.include_router(dashboard_replay.router)
 dashboard_router.include_router(dashboard_providers_by_project.router)
 dashboard_router.include_router(dashboard_tenants.router)
+dashboard_router.include_router(dashboard_agents.router)
 dashboard_router.include_router(dashboard_virtual_keys.router)
 dashboard_router.include_router(dashboard_routing.router)
 dashboard_router.include_router(dashboard_branding.router)

--- a/src/voicegateway/services/cost_service.py
+++ b/src/voicegateway/services/cost_service.py
@@ -45,11 +45,17 @@ class CostService:
         start_ts: float | None = None,
         end_ts: float | None = None,
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> dict[str, Any]:
         """Return cost rollup grouped by project."""
         async with self._db.session() as s:
             return await repo.get_cost_by_project(
-                s, period=period, start_ts=start_ts, end_ts=end_ts, tenant=tenant
+                s,
+                period=period,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                tenant=tenant,
+                agent=agent,
             )
 
     async def get_by_modality(

--- a/src/voicegateway/services/cost_service.py
+++ b/src/voicegateway/services/cost_service.py
@@ -24,6 +24,7 @@ class CostService:
         start_ts: float | None = None,
         end_ts: float | None = None,
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> dict[str, Any]:
         """Return total / by_provider / by_model rollups."""
         async with self._db.session() as s:
@@ -35,6 +36,7 @@ class CostService:
                 start_ts=start_ts,
                 end_ts=end_ts,
                 tenant=tenant,
+                agent=agent,
             )
 
     async def get_by_project(

--- a/src/voicegateway/services/latency_service.py
+++ b/src/voicegateway/services/latency_service.py
@@ -22,6 +22,7 @@ class LatencyService:
         project: str | None = None,
         percentiles: list[float] | None = None,
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> dict[str, Any]:
         """Per-model latency rollup with percentiles."""
         async with self._db.session() as s:
@@ -31,6 +32,7 @@ class LatencyService:
                 project=project,
                 percentiles=percentiles,
                 tenant=tenant,
+                agent=agent,
             )
 
     async def get_samples(

--- a/src/voicegateway/services/request_log_service.py
+++ b/src/voicegateway/services/request_log_service.py
@@ -53,10 +53,13 @@ class RequestLogService:
         modality: str | None = None,
         project: str | None = None,
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> list[dict[str, Any]]:
         """Return the N newest request rows."""
         async with self._db.session() as s:
-            return await repo.get_recent_requests(s, limit, modality, project, tenant)
+            return await repo.get_recent_requests(
+                s, limit, modality, project, tenant, agent
+            )
 
     async def get_requests_in_window(
         self,

--- a/src/voicegateway/services/session_service.py
+++ b/src/voicegateway/services/session_service.py
@@ -22,10 +22,16 @@ class SessionService:
         project: str | None = None,
         order_by: str = "started_at_desc",
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> list[dict[str, Any]]:
         async with self._db.session() as s:
             return await repo.list_sessions(
-                s, limit=limit, project=project, order_by=order_by, tenant=tenant
+                s,
+                limit=limit,
+                project=project,
+                order_by=order_by,
+                tenant=tenant,
+                agent=agent,
             )
 
     async def get_session(self, session_id: str) -> dict[str, Any] | None:

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -106,6 +106,7 @@ class StorageService:
         start_ts: float | None = None,
         end_ts: float | None = None,
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> dict[str, Any]:
         """Delegate to CostService.get_summary."""
         await self._ensure_initialized()
@@ -116,6 +117,7 @@ class StorageService:
             start_ts=start_ts,
             end_ts=end_ts,
             tenant=tenant,
+            agent=agent,
         )
 
     async def get_cost_by_project(
@@ -150,6 +152,7 @@ class StorageService:
         project: str | None = None,
         percentiles: list[float] | None = None,
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> dict[str, Any]:
         """Delegate to LatencyService.get_stats."""
         await self._ensure_initialized()
@@ -158,6 +161,7 @@ class StorageService:
             project=project,
             percentiles=percentiles,
             tenant=tenant,
+            agent=agent,
         )
 
     async def get_latency_samples(
@@ -190,11 +194,12 @@ class StorageService:
         modality: str | None = None,
         project: str | None = None,
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> list[dict[str, Any]]:
         """Delegate to RequestLogService.get_recent_requests."""
         await self._ensure_initialized()
         return await self._request_log_service.get_recent_requests(
-            limit, modality, project, tenant
+            limit, modality, project, tenant, agent
         )
 
     async def get_project_stats(self, project: str) -> dict[str, Any]:

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -126,11 +126,16 @@ class StorageService:
         start_ts: float | None = None,
         end_ts: float | None = None,
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> dict[str, Any]:
         """Delegate to CostService.get_by_project."""
         await self._ensure_initialized()
         return await self._cost_service.get_by_project(
-            period=period, start_ts=start_ts, end_ts=end_ts, tenant=tenant
+            period=period,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            tenant=tenant,
+            agent=agent,
         )
 
     async def get_cost_by_modality(

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -212,11 +212,16 @@ class StorageService:
         project: str | None = None,
         order_by: str = "started_at_desc",
         tenant: str | None = None,
+        agent: str | None = None,
     ) -> list[dict[str, Any]]:
         """Delegate to SessionService.list_sessions."""
         await self._ensure_initialized()
         return await self._session_service.list_sessions(
-            limit=limit, project=project, order_by=order_by, tenant=tenant
+            limit=limit,
+            project=project,
+            order_by=order_by,
+            tenant=tenant,
+            agent=agent,
         )
 
     async def get_session(self, session_id: str) -> dict[str, Any] | None:

--- a/src/voicegateway/tests/server/test_agent_filter_api.py
+++ b/src/voicegateway/tests/server/test_agent_filter_api.py
@@ -1,0 +1,79 @@
+"""Phase 2: the agent query param on the dashboard read endpoints."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.server import build_app
+
+_CFG = {
+    "providers": {"openai": {"api_key": "k"}},
+    "models": {"stt": {}, "llm": {}, "tts": {}},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+
+def _cfg(tmp_path) -> str:
+    p = tmp_path / "voicegw.yaml"
+    p.write_text(yaml.dump(_CFG))
+    return str(p)
+
+
+@pytest.fixture
+def gateway(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "api.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    return Gateway(config_path=_cfg(tmp_path))
+
+
+async def _client(gw: Gateway) -> AsyncClient:
+    return AsyncClient(
+        transport=ASGITransport(app=build_app(gw)), base_url="http://test"
+    )
+
+
+def _rec(agent: str, cost: float) -> RequestRecord:
+    return RequestRecord(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        modality="llm",
+        model_id="openai/gpt-4o-mini",
+        provider="openai",
+        project="fleet",
+        cost_usd=cost,
+        ttfb_ms=100.0,
+        total_latency_ms=200.0,
+        agent_id=agent,
+        session_id=f"vg-{agent}-{uuid.uuid4()}",
+    )
+
+
+async def test_api_costs_filters_by_agent(gateway):
+    await gateway.storage.log_request(_rec("agent-x", 0.01))
+    await gateway.storage.log_request(_rec("agent-y", 0.05))
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.get("/api/costs?period=today&agent=agent-x")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == pytest.approx(0.01)
+
+
+async def test_api_sessions_filters_by_agent(gateway):
+    await gateway.storage.log_request(_rec("agent-x", 0.01))
+    await gateway.storage.log_request(_rec("agent-y", 0.05))
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.get("/api/sessions?agent=agent-x")
+    assert resp.status_code == 200
+    ids = [s["id"] for s in resp.json()]
+    assert ids
+    assert all(i.startswith("vg-agent-x") for i in ids)

--- a/src/voicegateway/tests/server/test_agent_filter_api.py
+++ b/src/voicegateway/tests/server/test_agent_filter_api.py
@@ -77,3 +77,19 @@ async def test_api_sessions_filters_by_agent(gateway):
     ids = [s["id"] for s in resp.json()]
     assert ids
     assert all(i.startswith("vg-agent-x") for i in ids)
+
+
+async def test_api_agents_index(gateway):
+    await gateway.storage.log_request(_rec("agent-x", 0.01))
+    await gateway.storage.log_request(_rec("agent-x", 0.02))
+    await gateway.storage.log_request(_rec("agent-y", 0.05))
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.get("/api/agents")
+    assert resp.status_code == 200
+    body = resp.json()
+    by_id = {a["agent_id"]: a for a in body["agents"]}
+    assert set(by_id) == {"agent-x", "agent-y"}
+    assert by_id["agent-x"]["request_count"] == 2
+    assert "p95_latency_ms" in by_id["agent-x"]
+    assert "unattributed" in body

--- a/src/voicegateway/tests/server/test_agent_filter_api.py
+++ b/src/voicegateway/tests/server/test_agent_filter_api.py
@@ -93,3 +93,15 @@ async def test_api_agents_index(gateway):
     assert by_id["agent-x"]["request_count"] == 2
     assert "p95_latency_ms" in by_id["agent-x"]
     assert "unattributed" in body
+
+
+async def test_api_logs_filters_by_agent(gateway):
+    await gateway.storage.log_request(_rec("agent-x", 0.01))
+    await gateway.storage.log_request(_rec("agent-y", 0.05))
+    client = await _client(gateway)
+    async with client as c:
+        resp = await c.get("/api/logs?agent=agent-x")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert rows
+    assert all(r["agent_id"] == "agent-x" for r in rows)

--- a/src/voicegateway/tests/storage/test_agent_read_filters.py
+++ b/src/voicegateway/tests/storage/test_agent_read_filters.py
@@ -51,3 +51,12 @@ async def test_latency_stats_filters_by_agent(tmp_path):
     await storage.log_request(_rec("agent-y"))
     stats = await storage.get_latency_stats(period="today", agent="agent-x")
     assert stats["openai/gpt-4o-mini"]["request_count"] == 2
+
+
+async def test_cost_by_project_filters_by_agent(tmp_path):
+    """The by_project breakdown must be agent-scoped, not all-agents."""
+    storage = StorageService(str(tmp_path / "byproj.db"))
+    await storage.log_request(_rec("agent-x", cost=0.01))
+    await storage.log_request(_rec("agent-y", cost=0.05))
+    by_project = await storage.get_cost_by_project(period="today", agent="agent-x")
+    assert by_project["fleet"]["cost"] == pytest.approx(0.01)

--- a/src/voicegateway/tests/storage/test_agent_read_filters.py
+++ b/src/voicegateway/tests/storage/test_agent_read_filters.py
@@ -1,0 +1,53 @@
+"""Phase 2: agent filter on the cost / logs / latency read paths."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.services.storage_service import StorageService
+
+
+def _rec(agent: str, *, cost: float = 0.01, ttfb: float = 100.0, total: float = 200.0):
+    return RequestRecord(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        modality="llm",
+        model_id="openai/gpt-4o-mini",
+        provider="openai",
+        project="fleet",
+        cost_usd=cost,
+        ttfb_ms=ttfb,
+        total_latency_ms=total,
+        agent_id=agent,
+        session_id=f"vg-{agent}-{uuid.uuid4()}",
+    )
+
+
+async def test_cost_summary_filters_by_agent(tmp_path):
+    storage = StorageService(str(tmp_path / "cost.db"))
+    await storage.log_request(_rec("agent-x", cost=0.01))
+    await storage.log_request(_rec("agent-y", cost=0.05))
+    summary = await storage.get_cost_summary(period="today", agent="agent-x")
+    assert summary["total"] == pytest.approx(0.01)
+
+
+async def test_recent_requests_filters_by_agent(tmp_path):
+    storage = StorageService(str(tmp_path / "logs.db"))
+    await storage.log_request(_rec("agent-x"))
+    await storage.log_request(_rec("agent-y"))
+    rows = await storage.get_recent_requests(agent="agent-x")
+    assert rows
+    assert all(r["agent_id"] == "agent-x" for r in rows)
+
+
+async def test_latency_stats_filters_by_agent(tmp_path):
+    storage = StorageService(str(tmp_path / "lat.db"))
+    await storage.log_request(_rec("agent-x"))
+    await storage.log_request(_rec("agent-x"))
+    await storage.log_request(_rec("agent-y"))
+    stats = await storage.get_latency_stats(period="today", agent="agent-x")
+    assert stats["openai/gpt-4o-mini"]["request_count"] == 2

--- a/src/voicegateway/tests/storage/test_agents_repository.py
+++ b/src/voicegateway/tests/storage/test_agents_repository.py
@@ -1,0 +1,96 @@
+"""Phase 2: agents_repository aggregates + per-agent p95."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.repository import agents_repository as agents
+from voicegateway.services.storage_service import StorageService
+
+
+def _rec(
+    agent: str | None,
+    *,
+    cost: float = 0.01,
+    status: str = "success",
+    total: float = 200.0,
+) -> RequestRecord:
+    return RequestRecord(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        modality="llm",
+        model_id="openai/gpt-4o-mini",
+        provider="openai",
+        project="fleet",
+        cost_usd=cost,
+        status=status,
+        ttfb_ms=100.0,
+        total_latency_ms=total,
+        agent_id=agent,
+        session_id=f"vg-{agent}-{uuid.uuid4()}",
+    )
+
+
+async def _populate(storage: StorageService, records: list[RequestRecord]) -> None:
+    for r in records:
+        await storage.log_request(r)
+
+
+async def test_list_agents_aggregates(tmp_path):
+    storage = StorageService(str(tmp_path / "agents.db"))
+    await _populate(
+        storage,
+        [
+            _rec("agent-x", cost=0.01, status="success"),
+            _rec("agent-x", cost=0.02, status="error"),
+            _rec("agent-y", cost=0.05),
+        ],
+    )
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        rows = await agents.list_agents(db)
+
+    by_id = {r.agent_id: r for r in rows}
+    assert set(by_id) == {"agent-x", "agent-y"}
+    assert by_id["agent-x"].request_count == 2
+    assert by_id["agent-x"].total_cost_usd == pytest.approx(0.03)
+    assert by_id["agent-x"].error_rate == pytest.approx(0.5)
+    assert by_id["agent-x"].last_seen is not None
+
+
+async def test_list_agents_excludes_null_agent(tmp_path):
+    storage = StorageService(str(tmp_path / "agents2.db"))
+    rec = _rec("agent-x")
+    rec.agent_id = None
+    await storage.log_request(rec)
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        rows = await agents.list_agents(db)
+    assert rows == []
+
+
+async def test_get_agent(tmp_path):
+    storage = StorageService(str(tmp_path / "agents3.db"))
+    await storage.log_request(_rec("agent-x"))
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        found = await agents.get_agent(db, "agent-x")
+        missing = await agents.get_agent(db, "nope")
+    assert found is not None
+    assert found.agent_id == "agent-x"
+    assert missing is None
+
+
+async def test_agent_latency_p95(tmp_path):
+    storage = StorageService(str(tmp_path / "agents4.db"))
+    for total in (100.0, 200.0, 300.0):
+        await storage.log_request(_rec("agent-x", total=total))
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        p95 = await agents.agent_latency_p95(db)
+    assert "agent-x" in p95
+    assert p95["agent-x"] >= 200.0  # p95 of [100, 200, 300]

--- a/src/voicegateway/tests/storage/test_agents_repository.py
+++ b/src/voicegateway/tests/storage/test_agents_repository.py
@@ -94,3 +94,14 @@ async def test_agent_latency_p95(tmp_path):
         p95 = await agents.agent_latency_p95(db)
     assert "agent-x" in p95
     assert p95["agent-x"] >= 200.0  # p95 of [100, 200, 300]
+
+
+async def test_agent_latency_p95_scopes_to_agent_id(tmp_path):
+    """Passing agent_id scopes the scan to that agent (detail endpoint path)."""
+    storage = StorageService(str(tmp_path / "agentsp95.db"))
+    await storage.log_request(_rec("agent-x", total=200.0))
+    await storage.log_request(_rec("agent-y", total=999.0))
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        only_x = await agents.agent_latency_p95(db, agent_id="agent-x")
+    assert set(only_x) == {"agent-x"}

--- a/src/voicegateway/tests/storage/test_sessions_agent_id.py
+++ b/src/voicegateway/tests/storage/test_sessions_agent_id.py
@@ -1,0 +1,70 @@
+"""Phase 2: agent_id on the sessions table + the list_sessions agent filter."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.services.storage_service import StorageService
+
+
+def _record(
+    session_id: str,
+    agent_id: str,
+    *,
+    project: str = "fleet",
+    modality: str = "llm",
+    cost: float = 0.01,
+) -> RequestRecord:
+    return RequestRecord(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        modality=modality,
+        model_id="openai/gpt-4o-mini",
+        provider="openai",
+        project=project,
+        cost_usd=cost,
+        session_id=session_id,
+        agent_id=agent_id,
+    )
+
+
+def _session_agent_id(db_path: str, sid: str) -> str | None:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT agent_id FROM sessions WHERE id = ?", (sid,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return None if row is None else row[0]
+
+
+async def test_session_row_carries_agent_id(tmp_path):
+    db_path = str(tmp_path / "sess_agent.db")
+    storage = StorageService(db_path)
+    await storage.log_request(_record("vg-a", "agent-x"))
+    assert _session_agent_id(db_path, "vg-a") == "agent-x"
+
+
+async def test_session_agent_id_coalesce_preserved_across_requests(tmp_path):
+    """The first request's agent_id is preserved across the session's UPSERTs."""
+    db_path = str(tmp_path / "sess_agent2.db")
+    storage = StorageService(db_path)
+    await storage.log_request(_record("vg-a", "agent-x", modality="stt"))
+    await storage.log_request(_record("vg-a", "agent-x", modality="llm"))
+    assert _session_agent_id(db_path, "vg-a") == "agent-x"
+
+
+async def test_list_sessions_filters_by_agent(tmp_path):
+    storage = StorageService(str(tmp_path / "sess_agent3.db"))
+    await storage.log_request(_record("vg-a", "agent-x"))
+    await storage.log_request(_record("vg-b", "agent-y"))
+
+    only_x = await storage.list_sessions(agent="agent-x")
+    assert {s["id"] for s in only_x} == {"vg-a"}
+
+    only_y = await storage.list_sessions(agent="agent-y")
+    assert {s["id"] for s in only_y} == {"vg-b"}

--- a/src/voicegateway/tests/storage/test_sessions_table.py
+++ b/src/voicegateway/tests/storage/test_sessions_table.py
@@ -99,6 +99,8 @@ async def test_sessions_columns_match_design(tmp_path):
         "replay_size_bytes",
         # v0.4.0 tenant attribution column (added by migration 0005).
         "tenant_id",
+        # Phase 2 fleet per-agent attribution (migration c4f1a9e2b8d7).
+        "agent_id",
         # v0.5.0 routing columns (added by migration 0006).
         "budget_ms",
         "budget_ms_used",


### PR DESCRIPTION
## Fleet dashboard, Phase 2: per-agent views, filter, and health

Phase 1 made N agents push telemetry to one collector and stamped every request with an `agent_id`, but the dashboard had no way to *see* the fleet. Phase 2 surfaces the agent dimension, mirroring the existing tenant dimension almost exactly. Read-only + UI; no agent-side or ingest-path change.

Spec: `docs/superpowers/specs/2026-06-04-fleet-dashboard-phase2-design.md`.

### What's in it (build order, one commit per step)

1. **`sessions.agent_id`** — nullable column + index (migration `c4f1a9e2b8d7`, mirrors `tenant_id`), written and `COALESCE`-preserved by the sessions UPSERT (in the dialect-templated form, so SQLite/Postgres both inherit it), plus the `list_sessions` agent filter.
2. **Agent read filter** — threaded through the cost/latency/recent-requests storage→service→repository layers (empty string → `IS NULL`, else `= :agent`) and exposed as an `agent` query param on `/api/costs`, `/api/latency`, `/api/sessions`, `/api/metrics`, and `/api/logs`.
3. **`agents_repository` + `GET /api/agents`** — per-agent `request_count`, `total_cost_usd`, `last_seen` (max request ts, epoch), and `error_rate` (NULLIF-guarded for Postgres) over `requests.agent_id`, plus the unattributed bucket and `agent_latency_p95` (one windowed fetch + Python grouping, so the index is O(1) queries).
4. **`AgentFilter` / `AgentPill`** (mirror `TenantFilter`/`TenantPill`) + FilterBar wiring + a `?agent=` URL param + `useAgentFilter()` hook; Costs/Sessions/Metrics/Logs read it and pass it through, so a per-agent view persists across navigation and deep-links.
5. **Agents fleet page** — a dense sortable table (status dot · last-seen · cost · requests · p95 · error rate) with search; each row deep-links to `/costs?agent=<id>`. Plus the nav route and the telemetry-recency status helper (active <5m / idle <1h / dormant).
6. **Overview fleet card** — agent count, active-now count, and top-3 by cost.

### The mental model

"Agent health" is **telemetry-recency**, not a real heartbeat: `last_seen` is the agent's most recent request timestamp, so an idle-but-alive agent and a crashed one look the same. This is deliberate (a real heartbeat is Phase 3); the `/api/agents` shape is built so a heartbeat can fold into `last_seen` later without an FE change.

### Testing

- Backend: **1634 passed, 5 skipped**, coverage **84.33%** (gate 80%). Backend steps were RED-first TDD; ruff + mypy clean.
- Frontend: `npm run build` (tsc typecheck + vite build) is clean. The dashboard has no FE unit-test harness, so build/typecheck is the FE gate (matches the spec's acceptance).

### Incidental fixes (called out for review)

- **`.gitignore`**: the dashboard-lib un-ignore negation was `!dashboard/frontend/src/lib/`, but the tree is `src/dashboard/...`, so the FE lib was still caught by the generic `lib/` rule. Fixed to `!src/dashboard/frontend/src/lib/`.
- **`/api/logs` agent param**: served by `get_logs` in `costs.py` (there is no `dashboard/logs` router), so it was missed in step 2's sweep and added in step 4, with a test.

### Out of scope (Phase 3)

Real heartbeat / true liveness, per-agent alerting, retention, agent grouping/tags. The bundled SPA `dist/` is rebuilt at wheel-build time, so nothing in `dist/` is committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new Agents page displaying fleet telemetry with agent status, request counts, costs, latency, and error rates.
  * Added agent filtering across the dashboard (Costs, Sessions, Logs, Metrics pages).
  * Enhanced Overview dashboard with fleet summary card showing active agents and top agents by cost.

* **Tests**
  * Added comprehensive test coverage for agent filtering across API endpoints and storage layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->