### PR TITLE
Fleet Phase 3: collector operational hardening (rate limit, retention, windowed rollup, worker wiring)

### DIFF
--- a/alembic/versions/a3f9c1d7b2e8_agent_observations.py
+++ b/alembic/versions/a3f9c1d7b2e8_agent_observations.py
@@ -1,0 +1,57 @@
+"""create agent_observations rollup table (Phase 3 fleet rollup)
+
+Revision ID: a3f9c1d7b2e8
+Revises: c4f1a9e2b8d7
+Create Date: 2026-06-04 12:00:00.000000
+
+Phase 3 operational hardening: a windowed per-agent rollup so GET /api/agents
+serves the fleet list from a pre-aggregated table instead of scanning every
+latency row (the PR #33 deferred scan). The ``agent_id IS NULL`` row is the
+unattributed bucket. The roll-up worker refreshes the whole table wholesale
+(DELETE + INSERT) every interval, so there is no UPSERT or unique constraint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401 - migrations may reference SQLModel types
+
+from alembic import op
+
+revision: str = "a3f9c1d7b2e8"
+down_revision: str | None = "c4f1a9e2b8d7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_observations",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("agent_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("request_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("total_cost_usd", sa.Float(), server_default="0", nullable=False),
+        sa.Column("error_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("p50_ms", sa.Integer(), nullable=True),
+        sa.Column("p95_ms", sa.Integer(), nullable=True),
+        sa.Column("last_seen", sa.Float(), nullable=True),
+        sa.Column("window_start", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("window_end", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column(
+            "refreshed_at",
+            sqlmodel.sql.sqltypes.AutoString(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("agent_observations", schema=None) as batch_op:
+        batch_op.create_index("idx_agent_obs_agent_id", ["agent_id"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("agent_observations", schema=None) as batch_op:
+        batch_op.drop_index("idx_agent_obs_agent_id")
+    op.drop_table("agent_observations")

--- a/alembic/versions/a3f9c1d7b2e8_agent_observations.py
+++ b/alembic/versions/a3f9c1d7b2e8_agent_observations.py
@@ -42,7 +42,7 @@ def upgrade() -> None:
         sa.Column(
             "refreshed_at",
             sqlmodel.sql.sqltypes.AutoString(),
-            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
             nullable=False,
         ),
         sa.PrimaryKeyConstraint("id"),

--- a/docs/configuration/voicegw-yaml.md
+++ b/docs/configuration/voicegw-yaml.md
@@ -21,7 +21,7 @@ variable. See [Environment variables](/docs/configuration/environment-variables)
 
 ## Top-level sections
 
-The config file has ten top-level sections. All are optional.
+The config file has thirteen top-level sections. All are optional.
 
 | Section | Purpose |
 |---|---|
@@ -34,6 +34,9 @@ The config file has ten top-level sections. All are optional.
 | `cost_tracking` | SQLite database settings for cost persistence |
 | `latency` | TTFB warning thresholds and percentile config |
 | `rate_limits` | Per-provider request rate limits |
+| `ingest` | Rate limits for the fleet collector ingest endpoint |
+| `retention` | Age-out policy for collector data |
+| `workers` | Background rollup and retention cadence |
 | `serve` | Bind host and port for the daemon |
 
 ---
@@ -265,6 +268,75 @@ rate_limits:
 
 - `requests_per_minute` (int): maximum requests per minute for the
   given provider.
+
+---
+
+## `ingest`
+
+Rate limiting for the fleet collector ingest endpoint (`POST /v1/ingest`),
+where remote agents push telemetry. Limiting is a per-caller token bucket
+keyed by virtual key (then static API key, then client IP).
+
+```yaml
+ingest:
+  enabled: true
+  requests_per_minute: 120
+  burst: 240
+  max_batch_size: 1000
+```
+
+- `enabled` (bool, default `true`): turn ingest rate limiting on or off.
+- `requests_per_minute` (int, default `120`): sustained per-caller request
+  rate. Set to `0` to disable limiting (unlimited).
+- `burst` (int, default `240`): token-bucket ceiling, the largest burst a
+  caller can send before being throttled.
+- `max_batch_size` (int, default `1000`): maximum records in one POST. A
+  larger batch is rejected with `413` before any database write.
+
+Over-limit requests get `429` with a `Retry-After` header (integer seconds).
+The library's remote sink honors `Retry-After` and retries without dropping the
+batch, so transient throttling never loses telemetry.
+
+---
+
+## `retention`
+
+Hard-delete aged rows from the collector database. A background worker prunes,
+per project, sessions and their dependent rows (replay, turns, dead-air,
+guardrail) by `ended_at`, and requests by `timestamp`, in batches.
+
+```yaml
+retention:
+  enabled: true
+  default_days: 90
+```
+
+- `enabled` (bool, default `true`): turn retention pruning on or off.
+- `default_days` (int, default `90`): age after which a project's rows are
+  deleted. Applies to every project that has data.
+
+---
+
+## `workers`
+
+Cadence for the collector's background workers: the latency and agent rollups,
+and the retention prune. Workers run in-process and are started by the server.
+In a multi-replica deployment, set `enabled: false` on every replica except the
+one chosen to run them (rollups and prunes are idempotent, but running them on
+every replica is wasteful).
+
+```yaml
+workers:
+  enabled: true
+  rollup_interval_seconds: 900
+  retention_interval_seconds: 3600
+```
+
+- `enabled` (bool, default `true`): start the background workers. When `false`,
+  no workers run (the rollup tables stay stale and retention does not prune).
+- `rollup_interval_seconds` (int, default `900`): how often the latency and
+  agent rollups refresh. The Agents dashboard list serves this 24h rollup.
+- `retention_interval_seconds` (int, default `3600`): how often retention runs.
 
 ---
 

--- a/src/dashboard/frontend/src/pages/Agents.tsx
+++ b/src/dashboard/frontend/src/pages/Agents.tsx
@@ -22,10 +22,10 @@ type SortKey =
 const COLUMNS: { key: SortKey; label: string }[] = [
   { key: 'agent_id', label: 'Agent' },
   { key: 'last_seen', label: 'Last seen' },
-  { key: 'total_cost_usd', label: 'Cost' },
-  { key: 'request_count', label: 'Requests' },
-  { key: 'p95_latency_ms', label: 'p95' },
-  { key: 'error_rate', label: 'Error rate' },
+  { key: 'total_cost_usd', label: 'Cost (24h)' },
+  { key: 'request_count', label: 'Requests (24h)' },
+  { key: 'p95_latency_ms', label: 'p95 (24h)' },
+  { key: 'error_rate', label: 'Error rate (24h)' },
 ];
 
 export default function Agents() {
@@ -73,7 +73,7 @@ export default function Agents() {
     <div>
       <PageHeader
         title="Agents"
-        subtitle={`${agents.length} agent${agents.length === 1 ? '' : 's'} in the fleet`}
+        subtitle={`${agents.length} agent${agents.length === 1 ? '' : 's'} in the fleet (metrics over the last 24h)`}
         accent="blue"
       />
 

--- a/src/dashboard/frontend/src/pages/Overview.tsx
+++ b/src/dashboard/frontend/src/pages/Overview.tsx
@@ -74,7 +74,7 @@ export default function Overview() {
                 className="label"
                 style={{ fontSize: '0.7rem', textTransform: 'uppercase', marginBottom: '0.25rem' }}
               >
-                Top by cost
+                Top by cost (24h)
               </div>
               {topAgents.map((a) => (
                 <div

--- a/src/voicegateway/core/config.py
+++ b/src/voicegateway/core/config.py
@@ -14,6 +14,7 @@ from voicegateway.schemas.config_schema import (
     IngestConfig,
     RetentionConfig,
     VoiceGatewayConfig,
+    WorkersConfig,
 )
 from voicegateway.schemas.guardrail_policy_schema import GuardrailPolicy
 
@@ -161,6 +162,7 @@ class GatewayConfig:
     )
     ingest: IngestConfig = field(default_factory=IngestConfig)
     retention: RetentionConfig = field(default_factory=RetentionConfig)
+    workers: WorkersConfig = field(default_factory=WorkersConfig)
 
     @classmethod
     def load(cls, config_path: str | Path | None = None) -> GatewayConfig:
@@ -342,6 +344,7 @@ class GatewayConfig:
             ),
             ingest=IngestConfig.model_validate(raw.get("ingest") or {}),
             retention=RetentionConfig.model_validate(raw.get("retention") or {}),
+            workers=WorkersConfig.model_validate(raw.get("workers") or {}),
         )
 
     def get_provider_config(self, provider_name: str) -> dict[str, Any]:

--- a/src/voicegateway/core/config.py
+++ b/src/voicegateway/core/config.py
@@ -10,7 +10,11 @@ from typing import Any
 
 import yaml
 
-from voicegateway.schemas.config_schema import IngestConfig, VoiceGatewayConfig
+from voicegateway.schemas.config_schema import (
+    IngestConfig,
+    RetentionConfig,
+    VoiceGatewayConfig,
+)
 from voicegateway.schemas.guardrail_policy_schema import GuardrailPolicy
 
 _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
@@ -156,6 +160,7 @@ class GatewayConfig:
         }
     )
     ingest: IngestConfig = field(default_factory=IngestConfig)
+    retention: RetentionConfig = field(default_factory=RetentionConfig)
 
     @classmethod
     def load(cls, config_path: str | Path | None = None) -> GatewayConfig:
@@ -336,6 +341,7 @@ class GatewayConfig:
                 },
             ),
             ingest=IngestConfig.model_validate(raw.get("ingest") or {}),
+            retention=RetentionConfig.model_validate(raw.get("retention") or {}),
         )
 
     def get_provider_config(self, provider_name: str) -> dict[str, Any]:

--- a/src/voicegateway/core/config.py
+++ b/src/voicegateway/core/config.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import yaml
 
-from voicegateway.schemas.config_schema import VoiceGatewayConfig
+from voicegateway.schemas.config_schema import IngestConfig, VoiceGatewayConfig
 from voicegateway.schemas.guardrail_policy_schema import GuardrailPolicy
 
 _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
@@ -155,6 +155,7 @@ class GatewayConfig:
             "request_logging": True,
         }
     )
+    ingest: IngestConfig = field(default_factory=IngestConfig)
 
     @classmethod
     def load(cls, config_path: str | Path | None = None) -> GatewayConfig:
@@ -334,6 +335,7 @@ class GatewayConfig:
                     "request_logging": True,
                 },
             ),
+            ingest=IngestConfig.model_validate(raw.get("ingest") or {}),
         )
 
     def get_provider_config(self, provider_name: str) -> dict[str, Any]:

--- a/src/voicegateway/core/events.py
+++ b/src/voicegateway/core/events.py
@@ -78,15 +78,26 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     configure_logging()
     gateway = getattr(app.state, "gateway", None)
     workers = _build_workers(gateway) if gateway is not None else []
-    for worker in workers:
-        await worker.start()
-    app.state.workers = workers
-    if workers:
-        logger.info("Started %d background worker(s)", len(workers))
+    started: list[Any] = []
+    app.state.workers = started
+    try:
+        for worker in workers:
+            await worker.start()
+            started.append(worker)
+    except Exception:
+        logger.exception(
+            "Worker startup failed; stopping %d already-started worker(s)",
+            len(started),
+        )
+        for worker in started:
+            await worker.stop()
+        raise
+    if started:
+        logger.info("Started %d background worker(s)", len(started))
 
     yield
 
-    for worker in workers:
+    for worker in started:
         await worker.stop()
-    if workers:
-        logger.info("Stopped %d background worker(s)", len(workers))
+    if started:
+        logger.info("Stopped %d background worker(s)", len(started))

--- a/src/voicegateway/core/events.py
+++ b/src/voicegateway/core/events.py
@@ -1,30 +1,92 @@
-"""FastAPI ``lifespan`` that initializes and tears down container resources."""
+"""FastAPI ``lifespan``: start and stop the collector's background workers.
+
+Reads the StorageService off ``app.state.gateway`` (set during build) and, when
+cost tracking is enabled and workers are not disabled, starts the latency and
+agent rollup workers plus the retention worker, stopping them on shutdown. The
+poll intervals come from the ``workers`` config; retention runs only when
+enabled and prunes every project that has data at ``retention.default_days``.
+"""
 
 from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI
+from sqlalchemy import text
 
 from voicegateway.core.logging_conf import configure_logging
+from voicegateway.middleware.agent_observations_worker_middleware import (
+    AgentObservationsWorker,
+)
+from voicegateway.middleware.latency_observations_worker_middleware import (
+    LatencyObservationsWorker,
+)
+from voicegateway.services.retention_service import RetentionWorker
+
+if TYPE_CHECKING:
+    from voicegateway.core.gateway import Gateway
 
 logger = logging.getLogger(__name__)
 
 
+def _build_workers(gateway: Gateway) -> list[Any]:
+    """Construct the background workers for a gateway, or [] when disabled."""
+    storage = gateway.storage
+    workers_cfg = gateway.config.workers
+    if storage is None or not workers_cfg.enabled:
+        return []
+
+    rollup_interval = workers_cfg.rollup_interval_seconds
+    workers: list[Any] = [
+        LatencyObservationsWorker(storage, poll_interval_seconds=rollup_interval),
+        AgentObservationsWorker(storage, poll_interval_seconds=rollup_interval),
+    ]
+
+    retention_cfg = gateway.config.retention
+    if retention_cfg.enabled:
+
+        async def _retention_provider() -> list[tuple[str, int]]:
+            days = retention_cfg.default_days
+            await storage._ensure_initialized()
+            async with storage._conn.session() as db:
+                result = await db.execute(
+                    text(
+                        "SELECT project FROM requests WHERE project IS NOT NULL "
+                        "UNION SELECT project FROM sessions WHERE project IS NOT NULL"
+                    )
+                )
+                projects = [str(row[0]) for row in result]
+            return [(p, days) for p in projects]
+
+        workers.append(
+            RetentionWorker(
+                storage,
+                retention_provider=_retention_provider,
+                default_retention_days=retention_cfg.default_days,
+                poll_interval_seconds=workers_cfg.retention_interval_seconds,
+            )
+        )
+    return workers
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Wire container resources at startup, dispose at shutdown."""
+    """Start the collector's background workers; stop them on shutdown."""
     configure_logging()
-
-    container = getattr(app.state, "container", None)
-    if container is not None:
-        container.init_resources()
-        logger.info("Container resources initialized")
+    gateway = getattr(app.state, "gateway", None)
+    workers = _build_workers(gateway) if gateway is not None else []
+    for worker in workers:
+        await worker.start()
+    app.state.workers = workers
+    if workers:
+        logger.info("Started %d background worker(s)", len(workers))
 
     yield
 
-    if container is not None:
-        container.shutdown_resources()
-        logger.info("Container resources shutdown")
+    for worker in workers:
+        await worker.stop()
+    if workers:
+        logger.info("Stopped %d background worker(s)", len(workers))

--- a/src/voicegateway/middleware/agent_observations_worker_middleware.py
+++ b/src/voicegateway/middleware/agent_observations_worker_middleware.py
@@ -1,0 +1,112 @@
+"""15-minute roll-up worker for the ``agent_observations`` table.
+
+Mirrors ``LatencyObservationsWorker``: a background task that recomputes the
+per-agent windowed rollup so the fleet dashboard's GET /api/agents reads a
+pre-aggregated snapshot instead of scanning every request row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Final
+
+from voicegateway.middleware.base_middleware import AsyncWorker
+from voicegateway.repository import agent_observations_repository as agent_observations
+
+if TYPE_CHECKING:
+    from voicegateway.services.storage_service import StorageService
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_WINDOW_MINUTES: Final[int] = 24 * 60
+_DEFAULT_POLL_INTERVAL_SECONDS: Final[float] = 15 * 60.0
+
+
+WindowProvider = Callable[[], Awaitable[int]]
+
+
+async def _default_window_provider() -> int:
+    return _DEFAULT_WINDOW_MINUTES
+
+
+class AgentObservationsWorker(AsyncWorker):
+    """Background worker that refreshes ``agent_observations``."""
+
+    def __init__(
+        self,
+        storage: StorageService,
+        window_provider: WindowProvider | None = None,
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> None:
+        if poll_interval_seconds <= 0:
+            raise ValueError(
+                f"poll_interval_seconds must be > 0, got {poll_interval_seconds}"
+            )
+        self._storage = storage
+        self._provider: WindowProvider = window_provider or _default_window_provider
+        self._poll_interval = poll_interval_seconds
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Spawn the roll-up loop. Idempotent."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._loop(), name="agent-observations-worker")
+
+    async def stop(self) -> None:
+        """Cancel the loop and clear state."""
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def tick_now(self) -> int:
+        """Run one roll-up pass synchronously. Returns the inserted row count."""
+        return await self._tick()
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                try:
+                    await self._tick()
+                except Exception:
+                    logger.exception("AgentObservationsWorker tick raised; continuing")
+                await asyncio.sleep(self._poll_interval)
+        except asyncio.CancelledError:
+            raise
+
+    async def _tick(self) -> int:
+        window_minutes = await self._provider()
+        if window_minutes < 1:
+            logger.warning(
+                "AgentObservationsWorker: window_minutes=%d (< 1); using default %d",
+                window_minutes,
+                _DEFAULT_WINDOW_MINUTES,
+            )
+            window_minutes = _DEFAULT_WINDOW_MINUTES
+        await self._storage._ensure_initialized()
+        async with self._storage._conn.session() as db:
+            inserted = await agent_observations.roll_up(
+                db, window_minutes=window_minutes
+            )
+        logger.info(
+            "AgentObservationsWorker: rolled up %d per-agent observation(s) "
+            "over %d-minute window",
+            inserted,
+            window_minutes,
+        )
+        return inserted
+
+
+__all__ = [
+    "AgentObservationsWorker",
+    "WindowProvider",
+]

--- a/src/voicegateway/models/__init__.py
+++ b/src/voicegateway/models/__init__.py
@@ -7,6 +7,7 @@ both see them.
 
 from __future__ import annotations
 
+from voicegateway.models.agent_observation_model import AgentObservation
 from voicegateway.models.base_model import BaseModel, BaseUUIDModel
 from voicegateway.models.config_audit_log_model import ConfigAuditLog
 from voicegateway.models.dead_air_event_model import DeadAirEvent
@@ -27,6 +28,7 @@ from voicegateway.models.turn_model import Turn
 from voicegateway.models.virtual_key_model import VirtualKey
 
 __all__ = [
+    "AgentObservation",
     "BaseModel",
     "BaseUUIDModel",
     "ConfigAuditLog",

--- a/src/voicegateway/models/agent_observation_model.py
+++ b/src/voicegateway/models/agent_observation_model.py
@@ -1,0 +1,34 @@
+"""ORM model for the ``agent_observations`` table (Phase 3 fleet rollup)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sqlalchemy import Index, text
+from sqlmodel import Field, SQLModel
+
+
+class AgentObservation(SQLModel, table=True):
+    """One denormalized per-agent rollup over the trailing window.
+
+    The ``agent_id IS NULL`` row is the unattributed bucket. The table is
+    refreshed wholesale (DELETE + INSERT) by the agent-observations roll-up
+    worker, so callers read it as a fast, pre-aggregated snapshot.
+    """
+
+    __tablename__: ClassVar[str] = "agent_observations"
+    __table_args__ = (Index("idx_agent_obs_agent_id", "agent_id"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    agent_id: str | None = None
+    request_count: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
+    total_cost_usd: float = Field(default=0.0, sa_column_kwargs={"server_default": "0"})
+    error_count: int = Field(default=0, sa_column_kwargs={"server_default": "0"})
+    p50_ms: int | None = None
+    p95_ms: int | None = None
+    last_seen: float | None = None
+    window_start: str
+    window_end: str
+    refreshed_at: str = Field(
+        sa_column_kwargs={"server_default": text("CURRENT_TIMESTAMP")}
+    )

--- a/src/voicegateway/repository/agent_observations_repository.py
+++ b/src/voicegateway/repository/agent_observations_repository.py
@@ -1,0 +1,168 @@
+"""Async repo for the ``agent_observations`` rollup table (fleet dashboard).
+
+``roll_up`` mirrors ``latency_observations_repository.roll_up``: it scans the
+``requests`` table over the trailing window, groups by ``agent_id`` (None is
+the unattributed bucket), computes the per-agent aggregates in Python, and
+replaces the table wholesale (DELETE then INSERT) in a single transaction so a
+concurrent reader never sees a half-empty table. The read paths serve the
+fleet list (agent_id IS NOT NULL) and the unattributed bucket (agent_id IS
+NULL); error_rate is derived by the caller from error_count / request_count.
+
+All SQL is plain parameterized CRUD (no INSTR, date bucketing, or boolean SUM),
+so the table is portable across SQLite and Postgres with no dialect branching.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import text
+
+from voicegateway.utils.percentiles import compute_percentiles
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_DEFAULT_WINDOW_MINUTES = 24 * 60  # 24h rolling window, matching Routing.
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 1000
+
+
+@dataclass(frozen=True)
+class AgentObservationRow:
+    """One row from the agent_observations rollup snapshot."""
+
+    agent_id: str | None
+    request_count: int
+    total_cost_usd: float
+    error_count: int
+    p50_ms: int | None
+    p95_ms: int | None
+    last_seen: float | None
+    window_start: str
+    window_end: str
+    refreshed_at: str
+
+
+_SELECT_FIELDS = (
+    "agent_id, request_count, total_cost_usd, error_count, p50_ms, p95_ms, "
+    "last_seen, window_start, window_end, refreshed_at"
+)
+
+
+def _row(r: Sequence[Any]) -> AgentObservationRow:
+    return AgentObservationRow(
+        agent_id=None if r[0] is None else str(r[0]),
+        request_count=int(r[1]),
+        total_cost_usd=float(r[2] or 0.0),
+        error_count=int(r[3] or 0),
+        p50_ms=None if r[4] is None else int(r[4]),
+        p95_ms=None if r[5] is None else int(r[5]),
+        last_seen=None if r[6] is None else float(r[6]),
+        window_start=str(r[7]),
+        window_end=str(r[8]),
+        refreshed_at=str(r[9]),
+    )
+
+
+async def roll_up(
+    session: AsyncSession, *, window_minutes: int = _DEFAULT_WINDOW_MINUTES
+) -> int:
+    """Recompute the per-agent rollup over the trailing window. Returns rows."""
+    now = _dt.datetime.now(tz=_dt.UTC)
+    window_start = now - _dt.timedelta(minutes=window_minutes)
+    ws_ts = window_start.timestamp()
+    we_ts = now.timestamp()
+
+    result = await session.execute(
+        text(
+            "SELECT agent_id, cost_usd, status, total_latency_ms, timestamp "
+            "FROM requests WHERE timestamp >= :ws AND timestamp < :we"
+        ),
+        {"ws": ws_ts, "we": we_ts},
+    )
+
+    groups: dict[Any, dict[str, Any]] = {}
+    for agent_id, cost, status, latency, ts in result.fetchall():
+        g = groups.get(agent_id)
+        if g is None:
+            g = {"count": 0, "cost": 0.0, "errors": 0, "last": None, "lat": []}
+            groups[agent_id] = g
+        g["count"] += 1
+        g["cost"] += float(cost or 0.0)
+        if status == "error":
+            g["errors"] += 1
+        if ts is not None:
+            tsf = float(ts)
+            if g["last"] is None or tsf > g["last"]:
+                g["last"] = tsf
+        if latency is not None:
+            g["lat"].append(float(latency))
+
+    await session.execute(text("DELETE FROM agent_observations"))
+
+    insert = text(
+        "INSERT INTO agent_observations "
+        "(agent_id, request_count, total_cost_usd, error_count, p50_ms, p95_ms, "
+        " last_seen, window_start, window_end) "
+        "VALUES (:agent_id, :rc, :cost, :errors, :p50, :p95, :last, :ws, :we)"
+    )
+    inserted = 0
+    for agent_id, g in groups.items():
+        pcts = compute_percentiles(g["lat"], [50.0, 95.0])
+        p50 = pcts.get("p50")
+        p95 = pcts.get("p95")
+        await session.execute(
+            insert,
+            {
+                "agent_id": agent_id,
+                "rc": g["count"],
+                "cost": g["cost"],
+                "errors": g["errors"],
+                "p50": None if p50 is None else int(round(p50)),
+                "p95": None if p95 is None else int(round(p95)),
+                "last": g["last"],
+                "ws": window_start.isoformat(),
+                "we": now.isoformat(),
+            },
+        )
+        inserted += 1
+
+    await session.commit()
+    return inserted
+
+
+async def read_agents(
+    session: AsyncSession, *, limit: int = _DEFAULT_LIMIT, query: str | None = None
+) -> list[AgentObservationRow]:
+    """Return attributed agents (agent_id IS NOT NULL), newest first."""
+    limit = max(1, min(limit, _MAX_LIMIT))
+    sql = f"SELECT {_SELECT_FIELDS} FROM agent_observations WHERE agent_id IS NOT NULL"
+    params: dict[str, Any] = {"limit": limit}
+    if query:
+        sql += r" AND agent_id LIKE :pattern ESCAPE '\'"
+        escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        params["pattern"] = f"%{escaped}%"
+    sql += " ORDER BY last_seen DESC, agent_id ASC LIMIT :limit"
+    result = await session.execute(text(sql), params)
+    return [_row(r) for r in result]
+
+
+async def read_unattributed(session: AsyncSession) -> AgentObservationRow | None:
+    """Return the agent_id IS NULL bucket row, or None if it is empty."""
+    result = await session.execute(
+        text(f"SELECT {_SELECT_FIELDS} FROM agent_observations WHERE agent_id IS NULL")
+    )
+    row = result.fetchone()
+    return _row(row) if row is not None else None
+
+
+__all__ = [
+    "AgentObservationRow",
+    "read_agents",
+    "read_unattributed",
+    "roll_up",
+]

--- a/src/voicegateway/schemas/config_schema.py
+++ b/src/voicegateway/schemas/config_schema.py
@@ -93,6 +93,30 @@ class TenantConfig(_StrictBase):
     virtual_key_stale_days: int = Field(default=90, ge=1)
 
 
+class IngestConfig(_StrictBase):
+    """Rate-limit knobs for POST /v1/ingest (fleet collector)."""
+
+    enabled: bool = True
+    requests_per_minute: int = Field(default=120, ge=0)
+    burst: int = Field(default=240, ge=0)
+    max_batch_size: int = Field(default=1000, ge=1)
+
+
+class RetentionConfig(_StrictBase):
+    """Collector-wide retention default for requests and sessions."""
+
+    enabled: bool = True
+    default_days: int = Field(default=90, ge=1)
+
+
+class WorkersConfig(_StrictBase):
+    """Background-worker cadence for the collector (rollups, retention)."""
+
+    enabled: bool = True
+    rollup_interval_seconds: int = Field(default=900, ge=1)
+    retention_interval_seconds: int = Field(default=3600, ge=1)
+
+
 class ProjectConfig(_StrictBase):
     name: str
     description: str = ""
@@ -192,6 +216,9 @@ _VALID_TOP_LEVEL_KEYS = {
     "dashboard",
     "serve",
     "auth",
+    "ingest",
+    "retention",
+    "workers",
 }
 
 
@@ -213,6 +240,9 @@ class VoiceGatewayConfig(BaseModel):
     dashboard: DashboardConfig = Field(default_factory=DashboardConfig)
     serve: ServeConfig = Field(default_factory=ServeConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
+    ingest: IngestConfig = Field(default_factory=IngestConfig)
+    retention: RetentionConfig = Field(default_factory=RetentionConfig)
+    workers: WorkersConfig = Field(default_factory=WorkersConfig)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/voicegateway/server/api/dashboard/agents.py
+++ b/src/voicegateway/server/api/dashboard/agents.py
@@ -13,11 +13,15 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from voicegateway.repository import agent_observations_repository as agent_obs
 from voicegateway.repository import agents_repository as agents
 from voicegateway.server.api._deps import get_gateway
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
+    from voicegateway.repository.agent_observations_repository import (
+        AgentObservationRow,
+    )
 
 router = APIRouter(prefix="/agents", tags=["dashboard"])
 
@@ -29,31 +33,57 @@ _EMPTY_UNATTRIBUTED = {
 }
 
 
+def _error_rate(error_count: int, request_count: int) -> float:
+    """Derive error_rate from rollup counts (a stored row has request_count >=
+    1, so the divide is safe; guard a zero denominator defensively)."""
+    return (error_count / request_count) if request_count else 0.0
+
+
+def _agent_entry(row: AgentObservationRow) -> dict[str, Any]:
+    return {
+        "agent_id": row.agent_id,
+        "request_count": row.request_count,
+        "total_cost_usd": row.total_cost_usd,
+        "last_seen": row.last_seen,
+        "error_rate": _error_rate(row.error_count, row.request_count),
+        "p95_latency_ms": row.p95_ms,
+    }
+
+
+def _unattributed_entry(row: AgentObservationRow | None) -> dict[str, Any]:
+    if row is None:
+        return dict(_EMPTY_UNATTRIBUTED)
+    return {
+        "request_count": row.request_count,
+        "total_cost_usd": row.total_cost_usd,
+        "last_seen": row.last_seen,
+        "error_rate": _error_rate(row.error_count, row.request_count),
+    }
+
+
 @router.get("")
 async def list_agents_endpoint(
     limit: int = Query(50, ge=1, le=1000),
     q: str | None = Query(None, max_length=128),
     gateway: Gateway = Depends(get_gateway),
 ) -> dict[str, Any]:
-    """Return the agent index for the fleet table + filter typeahead.
+    """Return the fleet index over the last 24h, read from the rollup.
 
-    ``q`` is a substring match against agent_id. The implicit unattributed
-    bucket (NULL agent_id) is returned separately so the FE can render it as a
-    muted row. Each agent carries ``p95_latency_ms`` (null when no samples).
+    Served from the ``agent_observations`` rollup (refreshed every 15 minutes),
+    not a live requests scan, so cost / requests / p95 / error_rate all cover the
+    same window. ``q`` is a substring match against agent_id; the unattributed
+    bucket (NULL agent_id) is returned separately.
     """
     if gateway.storage is None:
         return {"agents": [], "unattributed": dict(_EMPTY_UNATTRIBUTED)}
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        rows = await agents.list_agents(db, limit=limit, query=q)
-        unattributed = await agents.get_unattributed_aggregates(db)
-        p95 = await agents.agent_latency_p95(db)
-    out: list[dict[str, Any]] = []
-    for row in rows:
-        entry = dataclasses.asdict(row)
-        entry["p95_latency_ms"] = p95.get(row.agent_id)
-        out.append(entry)
-    return {"agents": out, "unattributed": dataclasses.asdict(unattributed)}
+        rows = await agent_obs.read_agents(db, limit=limit, query=q)
+        unattributed = await agent_obs.read_unattributed(db)
+    return {
+        "agents": [_agent_entry(r) for r in rows],
+        "unattributed": _unattributed_entry(unattributed),
+    }
 
 
 @router.get("/{agent_id}")

--- a/src/voicegateway/server/api/ingest.py
+++ b/src/voicegateway/server/api/ingest.py
@@ -11,7 +11,9 @@ UUID, so a duplicate (a sink retry) is counted, not double-written.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import logging
+import math
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -42,6 +44,22 @@ def _record_from_payload(raw: dict[str, Any]) -> RequestRecord | None:
         return None
 
 
+def _rate_limit_key(request: Request) -> str:
+    """Identity for ingest rate limiting: virtual key, then API-key hash, then IP.
+
+    ``require_scope`` sets ``virtual_key_id`` only on the virtual-key path, so
+    static-key and bare callers fall through to the API-key hash or client IP.
+    """
+    vk = getattr(request.state, "virtual_key_id", None)
+    if vk is not None:
+        return f"vk:{vk}"
+    auth = request.headers.get("Authorization")
+    if auth:
+        return "ak:" + hashlib.sha256(auth.encode()).hexdigest()
+    client = request.client
+    return "ip:" + (client.host if client is not None else "unknown")
+
+
 @router.post("/ingest")
 async def ingest(
     records: list[dict[str, Any]],
@@ -55,6 +73,25 @@ async def ingest(
         raise HTTPException(
             status_code=503,
             detail="cost tracking storage is disabled on this collector",
+        )
+
+    # Rate limit (429) takes precedence over the batch-size cap (413); both run
+    # before any database write. Storage-disabled (503 above) wins over both.
+    limiter = getattr(request.app.state, "ingest_rate_limiter", None)
+    if limiter is not None:
+        retry_after = limiter.check(_rate_limit_key(request))
+        if retry_after is not None:
+            raise HTTPException(
+                status_code=429,
+                detail="ingest rate limit exceeded",
+                headers={"Retry-After": str(math.ceil(retry_after))},
+            )
+
+    max_batch = gateway.config.ingest.max_batch_size
+    if len(records) > max_batch:
+        raise HTTPException(
+            status_code=413,
+            detail=f"batch too large: {len(records)} records exceeds max {max_batch}",
         )
 
     accepted = 0

--- a/src/voicegateway/server/main.py
+++ b/src/voicegateway/server/main.py
@@ -23,6 +23,7 @@ from voicegateway.core.auth import load_api_keys, resolve_cors_origins
 from voicegateway.server.mcp.transport import mount_sse
 from voicegateway.server.routes import api_router, dashboard_router, system_router
 from voicegateway.server.static import mount_frontend
+from voicegateway.services.ingest_rate_limiter import IngestRateLimiter
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
@@ -86,6 +87,15 @@ class ApplicationBuilder:
         self.app.state.gateway = self.gateway
         self.app.state.api_keys = load_api_keys(self.gateway.config.auth)
         self.app.state.started_at = time.time()
+        ingest_cfg = self.gateway.config.ingest
+        self.app.state.ingest_rate_limiter = (
+            IngestRateLimiter(
+                requests_per_minute=ingest_cfg.requests_per_minute,
+                burst=ingest_cfg.burst,
+            )
+            if ingest_cfg.enabled and ingest_cfg.requests_per_minute > 0
+            else None
+        )
 
     def _configure_cors(self) -> None:
         cors_origins = resolve_cors_origins(self.gateway.config.auth)

--- a/src/voicegateway/server/main.py
+++ b/src/voicegateway/server/main.py
@@ -20,6 +20,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from voicegateway.core.app_wiring import attach_layered_stack
 from voicegateway.core.auth import load_api_keys, resolve_cors_origins
+from voicegateway.core.events import lifespan
 from voicegateway.server.mcp.transport import mount_sse
 from voicegateway.server.routes import api_router, dashboard_router, system_router
 from voicegateway.server.static import mount_frontend
@@ -75,6 +76,7 @@ class ApplicationBuilder:
                 "HTTP API for VoiceGateway: cost tracking and reconciliation "
                 "for LiveKit voice agents."
             ),
+            lifespan=lifespan,
         )
 
     def _configure_layered_stack(self) -> None:

--- a/src/voicegateway/services/ingest_rate_limiter.py
+++ b/src/voicegateway/services/ingest_rate_limiter.py
@@ -1,0 +1,76 @@
+"""Per-key token-bucket rate limiter for the fleet ingest endpoint.
+
+Unlike ``middleware.rate_limiter_middleware.RateLimiter`` (a per-provider
+sliding window on the gateway call path), this limits HTTP callers of
+``POST /v1/ingest`` by caller identity (virtual key, then static-API-key
+hash, then client IP). It is a plain in-process token bucket: the collector
+is a single writer, so no shared store is needed.
+
+``check`` is synchronous and does no I/O, so on the single-threaded event
+loop a call is atomic (no interleaving), which is why it needs no lock.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+__all__ = ["IngestRateLimiter"]
+
+
+class IngestRateLimiter:
+    """Token bucket keyed by caller identity.
+
+    ``requests_per_minute`` sets the refill rate and ``burst`` the bucket
+    ceiling. ``requests_per_minute <= 0`` disables limiting (every call is
+    allowed). Idle buckets that have refilled to full are reaped once the
+    map exceeds ``max_keys`` so memory stays bounded.
+    """
+
+    def __init__(
+        self,
+        *,
+        requests_per_minute: int,
+        burst: int,
+        max_keys: int = 10_000,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._rpm = requests_per_minute
+        self._rate_per_sec = requests_per_minute / 60.0
+        self._burst = float(burst)
+        self._max_keys = max_keys
+        self._monotonic = monotonic
+        # key -> (tokens, last_refill_monotonic)
+        self._buckets: dict[str, tuple[float, float]] = {}
+
+    def check(self, key: str) -> float | None:
+        """Spend one token for ``key``.
+
+        Returns ``None`` when the call is allowed, otherwise the number of
+        seconds until the next token (a Retry-After hint).
+        """
+        if self._rpm <= 0 or self._rate_per_sec <= 0:
+            return None  # limiting disabled
+        now = self._monotonic()
+        tokens, last = self._buckets.get(key, (self._burst, now))
+        tokens = min(self._burst, tokens + (now - last) * self._rate_per_sec)
+        if tokens >= 1.0:
+            self._buckets[key] = (tokens - 1.0, now)
+            self._maybe_reap(now)
+            return None
+        self._buckets[key] = (tokens, now)
+        deficit = 1.0 - tokens
+        return deficit / self._rate_per_sec
+
+    def _maybe_reap(self, now: float) -> None:
+        """Drop buckets that have refilled to full (idle) when over capacity."""
+        if len(self._buckets) <= self._max_keys:
+            return
+        stale = [
+            k
+            for k, (tokens, last) in self._buckets.items()
+            if min(self._burst, tokens + (now - last) * self._rate_per_sec)
+            >= self._burst
+        ]
+        for k in stale:
+            del self._buckets[k]

--- a/src/voicegateway/services/retention_service.py
+++ b/src/voicegateway/services/retention_service.py
@@ -1,16 +1,27 @@
-"""Hourly retention worker for replay rows."""
+"""Hourly retention worker: ages out requests, sessions, and their rows.
+
+Per project, sessions older than the cutoff (by ``ended_at``) and their
+dependent rows (replay, turns, dead-air, guardrail) are deleted child-first;
+requests are pruned independently by ``timestamp`` (a request may have no
+session). Deletes are hard and batched so a large backlog does not hold a
+long write lock, which keeps the pass friendly to both SQLite and Postgres.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator, Sequence
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Any, Final
+
+from sqlalchemy import bindparam, text
 
 from voicegateway.repository import replay_repository as replay
 
 if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
     from voicegateway.services.storage_service import StorageService
 
 logger = logging.getLogger(__name__)
@@ -18,6 +29,23 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_RETENTION_DAYS: Final[int] = 90
 _DEFAULT_POLL_INTERVAL_SECONDS: Final[float] = 3600.0  # one hour
+_DEFAULT_BATCH_SIZE: Final[int] = 500
+_SESSION_CHILD_TABLES: Final[tuple[str, ...]] = (
+    "turns",
+    "dead_air_events",
+    "guardrail_events",
+)
+
+
+def _rowcount(result: Any) -> int:
+    """A DELETE's affected-row count (CursorResult.rowcount), 0 if unknown."""
+    return result.rowcount or 0
+
+
+def _chunked(items: Sequence[Any], size: int) -> Iterator[Sequence[Any]]:
+    """Yield ``items`` in contiguous chunks of at most ``size``."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
 
 
 RetentionProvider = Callable[[], Awaitable[list[tuple[str, int]]]]
@@ -38,6 +66,7 @@ class RetentionWorker:
         retention_provider: RetentionProvider | None = None,
         default_retention_days: int = _DEFAULT_RETENTION_DAYS,
         poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+        batch_size: int = _DEFAULT_BATCH_SIZE,
     ) -> None:
         if default_retention_days < 1:
             raise ValueError(
@@ -47,10 +76,13 @@ class RetentionWorker:
             raise ValueError(
                 f"poll_interval_seconds must be > 0, got {poll_interval_seconds}"
             )
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
         self._storage = storage
         self._provider: RetentionProvider = retention_provider or _default_provider
         self._default_retention_days = default_retention_days
         self._poll_interval = poll_interval_seconds
+        self._batch_size = batch_size
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
@@ -92,7 +124,6 @@ class RetentionWorker:
         projects = await self._provider()
         if not projects:
             return {}
-        from sqlalchemy import text
 
         per_project_deletes: dict[str, int] = {}
         now = datetime.now(UTC)
@@ -108,32 +139,86 @@ class RetentionWorker:
                         self._default_retention_days,
                     )
                     retention_days = self._default_retention_days
-                cutoff_iso = (now - timedelta(days=retention_days)).isoformat()
-                result = await db.execute(
-                    text(
-                        "SELECT id FROM sessions "
-                        "WHERE project = :project AND ended_at IS NOT NULL "
-                        "  AND ended_at < :cutoff"
-                    ),
-                    {"project": project_id, "cutoff": cutoff_iso},
+                cutoff = now - timedelta(days=retention_days)
+                deleted = await self._prune_project(
+                    db, project_id, cutoff.isoformat(), cutoff.timestamp()
                 )
-                stale_ids = [row[0] for row in result]
-                if not stale_ids:
-                    per_project_deletes[project_id] = 0
-                    continue
-                deleted_rows = 0
-                for sid in stale_ids:
-                    deleted_rows += await replay.delete_replay(db, sid)
-                per_project_deletes[project_id] = deleted_rows
+                per_project_deletes[project_id] = deleted
                 logger.info(
-                    "RetentionWorker: project %s, retention %d days, "
-                    "deleted %d replay rows across %d sessions",
+                    "RetentionWorker: project %s, retention %d days, deleted %d row(s)",
                     project_id,
                     retention_days,
-                    deleted_rows,
-                    len(stale_ids),
+                    deleted,
                 )
         return per_project_deletes
+
+    async def _prune_project(
+        self,
+        db: AsyncSession,
+        project_id: str,
+        cutoff_iso: str,
+        cutoff_ts: float,
+    ) -> int:
+        """Hard-delete one project's aged rows; return the total row count.
+
+        Children first (replay, turns, dead-air, guardrail), then the session
+        rows, then requests independently by timestamp. Each chunk commits so a
+        large backlog never holds one long write lock.
+        """
+        deleted = 0
+
+        result = await db.execute(
+            text(
+                "SELECT id FROM sessions "
+                "WHERE project = :project AND ended_at IS NOT NULL "
+                "  AND ended_at < :cutoff"
+            ),
+            {"project": project_id, "cutoff": cutoff_iso},
+        )
+        stale_ids = [row[0] for row in result]
+        for chunk in _chunked(stale_ids, self._batch_size):
+            ids = list(chunk)
+            for sid in ids:
+                deleted += await replay.delete_replay(db, sid)
+            for table in _SESSION_CHILD_TABLES:
+                res = await db.execute(
+                    text(f"DELETE FROM {table} WHERE session_id IN :ids").bindparams(
+                        bindparam("ids", expanding=True)
+                    ),
+                    {"ids": ids},
+                )
+                deleted += _rowcount(res)
+            res = await db.execute(
+                text("DELETE FROM sessions WHERE id IN :ids").bindparams(
+                    bindparam("ids", expanding=True)
+                ),
+                {"ids": ids},
+            )
+            deleted += _rowcount(res)
+            await db.commit()
+
+        # Requests prune on their own clock (a request may have no session_id).
+        while True:
+            res = await db.execute(
+                text(
+                    "DELETE FROM requests WHERE id IN ("
+                    "  SELECT id FROM requests "
+                    "  WHERE project = :project AND timestamp < :cutoff "
+                    "  LIMIT :limit)"
+                ),
+                {
+                    "project": project_id,
+                    "cutoff": cutoff_ts,
+                    "limit": self._batch_size,
+                },
+            )
+            removed = _rowcount(res)
+            await db.commit()
+            deleted += removed
+            if removed == 0:
+                break
+
+        return deleted
 
 
 __all__ = [

--- a/src/voicegateway/services/retention_service.py
+++ b/src/voicegateway/services/retention_service.py
@@ -58,7 +58,12 @@ async def _default_provider() -> list[tuple[str, int]]:
 
 
 class RetentionWorker:
-    """Background worker that ages out old replay rows per project."""
+    """Background worker that hard-deletes aged rows per project.
+
+    Sessions and their dependent rows (replay, turns, dead-air, guardrail) prune
+    by ``ended_at``; requests prune independently by ``timestamp``. Deletes run
+    child-first in batches on a periodic loop.
+    """
 
     def __init__(
         self,

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
     from voicegateway.services.storage_service import StorageService
 
 logger = logging.getLogger(__name__)
+
+# Clamp Retry-After so an absurd server value cannot wedge the sink.
+_RETRY_AFTER_MAX = 60.0
 
 
 @runtime_checkable
@@ -72,8 +76,10 @@ class RemoteCollectorSink:
     Best-effort by design (cost telemetry is not billing-of-record): writes
     never block or fail the agent's hot path. Records buffer in memory and
     flush on batch size, on a periodic interval, or on ``aclose``. On a full
-    buffer the oldest rows are dropped; failed POSTs are retried with backoff
-    up to ``max_retries`` and then dropped.
+    in-memory buffer the oldest rows are dropped. A 429 is backpressure: the
+    batch is retried with a clamped Retry-After delay and is never dropped on
+    rate limiting. Other failed POSTs are retried with backoff up to
+    ``max_retries`` and then dropped.
     """
 
     def __init__(
@@ -87,6 +93,7 @@ class RemoteCollectorSink:
         max_retries: int = 2,
         backoff: float = 0.2,
         client: Any | None = None,
+        sleep: Callable[[float], Awaitable[None]] | None = None,
     ) -> None:
         self._ingest_url = url.rstrip("/") + "/v1/ingest"
         self._headers = (
@@ -99,6 +106,7 @@ class RemoteCollectorSink:
         self._backoff = backoff
         self._client = client
         self._owns_client = client is None
+        self._sleep = sleep or asyncio.sleep
         self._buffer: list[dict[str, Any]] = []
         self._flusher: asyncio.Task[None] | None = None
         self._closed = False
@@ -157,6 +165,13 @@ class RemoteCollectorSink:
                 )
                 if resp.status_code < 400:
                     return
+                if resp.status_code == 429:
+                    # Backpressure, not failure: honor Retry-After (clamped) and
+                    # retry the same batch WITHOUT counting toward max_retries,
+                    # so a 429 never drops the in-flight batch. Memory is bounded
+                    # by the log_request buffer drop-oldest, not by dropping here.
+                    await self._sleep(self._retry_after_seconds(resp))
+                    continue
                 reason = f"HTTP {resp.status_code}"
             except Exception as exc:  # noqa: BLE001 - best-effort, never propagate
                 reason = exc
@@ -168,8 +183,28 @@ class RemoteCollectorSink:
                     reason,
                 )
                 return
-            await asyncio.sleep(self._backoff * (2**attempt))
+            await self._sleep(self._backoff * (2**attempt))
             attempt += 1
+
+    def _retry_after_seconds(self, resp: Any) -> float:
+        """Parse a Retry-After header into seconds, clamped to a sane maximum.
+
+        Falls back to the configured backoff when the header is absent or not a
+        non-negative integer (we only ever emit integer-second Retry-After).
+        """
+        try:
+            raw = resp.headers.get("retry-after")
+        except Exception:  # noqa: BLE001 - a malformed response must not propagate
+            raw = None
+        if raw is None:
+            return self._backoff
+        try:
+            seconds = float(int(str(raw).strip()))
+        except (TypeError, ValueError):
+            return self._backoff
+        if seconds < 0:
+            return self._backoff
+        return min(seconds, _RETRY_AFTER_MAX)
 
     async def aclose(self) -> None:
         self._closed = True

--- a/src/voicegateway/tests/cli/tui/test_screens.py
+++ b/src/voicegateway/tests/cli/tui/test_screens.py
@@ -452,17 +452,19 @@ async def test_costs_screen_polls_for_live_refresh() -> None:
         # Simulate a fresh request landing in storage between polls.
         responses["today"]["total"] = 0.42
 
-        # Pump the event loop until the next poll tick fires.
-        for _ in range(40):
+        # Pump real time until a fresh poll fires. The stub returns the response
+        # dict by reference, so the card reflects the mutation immediately; the
+        # rising call count is what actually proves the interval is polling.
+        for _ in range(50):
+            await asyncio.sleep(0.02)
             await pilot.pause()
-            if card._costs.get("total") == 0.42:
+            if len(client.calls) > initial_calls:
                 break
 
-        assert card._costs.get("total") == 0.42, (
-            "Costs card did not pick up the synthetic change; "
+        assert len(client.calls) > initial_calls, (
             "CostsScreen.on_mount must register a polling interval."
         )
-        assert len(client.calls) > initial_calls
+        assert card._costs.get("total") == 0.42
 
 
 # ---------------------------------------------------------------------------

--- a/src/voicegateway/tests/core/test_database_run_migrations.py
+++ b/src/voicegateway/tests/core/test_database_run_migrations.py
@@ -47,6 +47,7 @@ async def test_run_migrations_on_fresh_db_builds_baseline(tmp_path: Path) -> Non
             )
         }
     expected = {
+        "agent_observations",
         "alembic_version",
         "config_audit_log",
         "dead_air_events",

--- a/src/voicegateway/tests/core/test_ingest_config.py
+++ b/src/voicegateway/tests/core/test_ingest_config.py
@@ -1,0 +1,33 @@
+"""Phase 3 config: ingest rate-limit knobs surface on GatewayConfig."""
+
+from __future__ import annotations
+
+import yaml
+
+from voicegateway.core.config import GatewayConfig
+
+
+def _write(tmp_path, cfg: dict) -> str:
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump(cfg))
+    return str(path)
+
+
+def test_ingest_defaults(tmp_path) -> None:
+    cfg = GatewayConfig.load(_write(tmp_path, {"cost_tracking": {"enabled": True}}))
+    assert cfg.ingest.enabled is True
+    assert cfg.ingest.requests_per_minute == 120
+    assert cfg.ingest.burst == 240
+    assert cfg.ingest.max_batch_size == 1000
+
+
+def test_ingest_overrides(tmp_path) -> None:
+    cfg = GatewayConfig.load(
+        _write(
+            tmp_path,
+            {"ingest": {"requests_per_minute": 30, "burst": 60, "max_batch_size": 100}},
+        )
+    )
+    assert cfg.ingest.requests_per_minute == 30
+    assert cfg.ingest.burst == 60
+    assert cfg.ingest.max_batch_size == 100

--- a/src/voicegateway/tests/core/test_retention_config.py
+++ b/src/voicegateway/tests/core/test_retention_config.py
@@ -1,0 +1,24 @@
+"""Phase 3 config: retention default surfaces on GatewayConfig."""
+
+from __future__ import annotations
+
+import yaml
+
+from voicegateway.core.config import GatewayConfig
+
+
+def _write(tmp_path, cfg: dict) -> str:
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump(cfg))
+    return str(path)
+
+
+def test_retention_defaults(tmp_path) -> None:
+    cfg = GatewayConfig.load(_write(tmp_path, {"cost_tracking": {"enabled": True}}))
+    assert cfg.retention.enabled is True
+    assert cfg.retention.default_days == 90
+
+
+def test_retention_override(tmp_path) -> None:
+    cfg = GatewayConfig.load(_write(tmp_path, {"retention": {"default_days": 30}}))
+    assert cfg.retention.default_days == 30

--- a/src/voicegateway/tests/core/test_workers_config.py
+++ b/src/voicegateway/tests/core/test_workers_config.py
@@ -1,0 +1,31 @@
+"""Phase 3 config: worker cadence surfaces on GatewayConfig."""
+
+from __future__ import annotations
+
+import yaml
+
+from voicegateway.core.config import GatewayConfig
+
+
+def _write(tmp_path, cfg: dict) -> str:
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump(cfg))
+    return str(path)
+
+
+def test_workers_defaults(tmp_path) -> None:
+    cfg = GatewayConfig.load(_write(tmp_path, {"cost_tracking": {"enabled": True}}))
+    assert cfg.workers.enabled is True
+    assert cfg.workers.rollup_interval_seconds == 900
+    assert cfg.workers.retention_interval_seconds == 3600
+
+
+def test_workers_override(tmp_path) -> None:
+    cfg = GatewayConfig.load(
+        _write(
+            tmp_path,
+            {"workers": {"enabled": False, "rollup_interval_seconds": 111}},
+        )
+    )
+    assert cfg.workers.enabled is False
+    assert cfg.workers.rollup_interval_seconds == 111

--- a/src/voicegateway/tests/middleware/test_agent_observations_worker_middleware.py
+++ b/src/voicegateway/tests/middleware/test_agent_observations_worker_middleware.py
@@ -1,0 +1,97 @@
+"""Phase 3, Step 6: AgentObservationsWorker (mirrors LatencyObservationsWorker)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from voicegateway.middleware.agent_observations_worker_middleware import (
+    AgentObservationsWorker,
+)
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.services.retention_service import RetentionWorker
+from voicegateway.services.storage_service import StorageService
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    yield StorageService(db_path=str(tmp_path / "w.db"))
+
+
+def _req(rid: str, agent_id: str | None, latency: float = 180.0) -> RequestRecord:
+    return RequestRecord(
+        id=rid,
+        timestamp=time.time(),
+        project="default",
+        modality="llm",
+        model_id="openai/gpt-4o-mini",
+        provider="openai",
+        cost_usd=0.0,
+        total_latency_ms=latency,
+        status="success",
+        agent_id=agent_id,
+    )
+
+
+async def test_tick_now_runs_one_pass(storage) -> None:
+    await storage.log_request(_req("a1", "agent-a"))
+    await storage.log_request(_req("b1", "agent-b"))
+    await storage.log_request(_req("u1", None))
+    w = AgentObservationsWorker(storage, poll_interval_seconds=0.1)
+    n = await w.tick_now()
+    assert n == 3  # agent-a, agent-b, unattributed
+
+
+async def test_default_poll_interval_is_900(storage) -> None:
+    w = AgentObservationsWorker(storage)
+    assert w._poll_interval == 900
+    # Companion assertion for the retention cadence (spec decision 8).
+    assert RetentionWorker(storage)._poll_interval == 3600
+
+
+async def test_start_stop_idempotent(storage) -> None:
+    w = AgentObservationsWorker(storage, poll_interval_seconds=0.1)
+    await w.start()
+    await w.start()
+    await asyncio.sleep(0.25)
+    await w.stop()
+    await w.stop()
+
+
+async def test_custom_window_provider_flows_through(storage) -> None:
+    await storage.log_request(_req("a1", "agent-a"))
+    captured: list[int] = []
+
+    async def provider() -> int:
+        captured.append(42)
+        return 42
+
+    w = AgentObservationsWorker(
+        storage, window_provider=provider, poll_interval_seconds=0.1
+    )
+    await w.tick_now()
+    assert captured == [42]
+
+
+async def test_loop_continues_on_tick_exception(storage) -> None:
+    async def boom() -> int:
+        raise RuntimeError("boom")
+
+    w = AgentObservationsWorker(
+        storage, window_provider=boom, poll_interval_seconds=0.1
+    )
+    await w.start()
+    await asyncio.sleep(0.25)
+    await w.stop()
+
+
+async def test_poll_interval_validation(storage) -> None:
+    with pytest.raises(ValueError):
+        AgentObservationsWorker(storage, poll_interval_seconds=0)
+
+
+async def test_empty_db_inserts_zero(storage) -> None:
+    w = AgentObservationsWorker(storage, poll_interval_seconds=0.1)
+    assert await w.tick_now() == 0

--- a/src/voicegateway/tests/repository/test_agent_observations_repository.py
+++ b/src/voicegateway/tests/repository/test_agent_observations_repository.py
@@ -1,0 +1,146 @@
+"""Phase 3, Step 5: agent_observations roll_up + read paths."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.repository import agent_observations_repository as agent_obs
+from voicegateway.services.storage_service import StorageService
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    s = StorageService(str(tmp_path / "agentobs.db"))
+    await s._ensure_initialized()
+    return s
+
+
+async def _seed(
+    storage,
+    rid: str,
+    agent_id: str | None,
+    *,
+    cost: float = 0.0,
+    status: str = "success",
+    latency: float | None = None,
+    days_ago: float = 0.0,
+) -> None:
+    ts = (datetime.now(UTC) - timedelta(days=days_ago)).timestamp()
+    await storage.log_request(
+        RequestRecord(
+            id=rid,
+            timestamp=ts,
+            modality="llm",
+            model_id="openai/gpt-4o-mini",
+            provider="openai",
+            project="acme",
+            cost_usd=cost,
+            status=status,
+            total_latency_ms=latency,
+            agent_id=agent_id,
+        )
+    )
+
+
+async def _rollup(storage, **kw) -> int:
+    async with storage._conn.session() as db:
+        return await agent_obs.roll_up(db, **kw)
+
+
+async def _read_agents(storage, **kw):
+    async with storage._conn.session() as db:
+        return await agent_obs.read_agents(db, **kw)
+
+
+async def _read_unattr(storage):
+    async with storage._conn.session() as db:
+        return await agent_obs.read_unattributed(db)
+
+
+async def test_roll_up_groups_by_agent(storage) -> None:
+    await _seed(storage, "a1", "agent-a", cost=0.01, latency=100)
+    await _seed(storage, "a2", "agent-a", cost=0.01, latency=200, status="error")
+    await _seed(storage, "a3", "agent-a", cost=0.01, latency=300)
+    await _seed(storage, "b1", "agent-b", cost=0.05, latency=50)
+    await _seed(storage, "u1", None, cost=0.02)
+    await _seed(storage, "u2", None, cost=0.02)
+
+    assert await _rollup(storage) == 3  # agent-a, agent-b, unattributed
+
+    agents = {r.agent_id: r for r in await _read_agents(storage)}
+    assert agents["agent-a"].request_count == 3
+    assert agents["agent-a"].error_count == 1
+    assert agents["agent-a"].total_cost_usd == pytest.approx(0.03)
+    assert agents["agent-a"].p95_ms is not None
+    assert agents["agent-a"].p50_ms is not None
+    assert agents["agent-a"].p95_ms >= agents["agent-a"].p50_ms
+    assert agents["agent-b"].request_count == 1
+
+    unattr = await _read_unattr(storage)
+    assert unattr is not None
+    assert unattr.agent_id is None
+    assert unattr.request_count == 2
+    assert unattr.total_cost_usd == pytest.approx(0.04)
+
+
+async def test_window_excludes_out_of_range_rows(storage) -> None:
+    await _seed(storage, "in", "agent-a", days_ago=0.04)  # ~1h ago
+    await _seed(storage, "out", "agent-a", days_ago=1.25)  # ~30h ago
+    await _seed(storage, "u-in", None, days_ago=0.04)
+    await _seed(storage, "u-out", None, days_ago=1.25)
+
+    await _rollup(storage, window_minutes=24 * 60)
+
+    agents = {r.agent_id: r for r in await _read_agents(storage)}
+    assert agents["agent-a"].request_count == 1  # the out-of-window row is excluded
+    unattr = await _read_unattr(storage)
+    assert unattr is not None and unattr.request_count == 1
+
+
+async def test_null_latency_group_has_null_percentiles(storage) -> None:
+    await _seed(storage, "c1", "agent-c", latency=None)
+    await _rollup(storage)
+    agents = {r.agent_id: r for r in await _read_agents(storage)}
+    assert agents["agent-c"].p50_ms is None
+    assert agents["agent-c"].p95_ms is None
+
+
+async def test_roll_up_replaces_table_no_duplicates(storage) -> None:
+    await _seed(storage, "a1", "agent-a", latency=100)
+    await _rollup(storage)
+    await _rollup(storage)  # second pass must replace, not append
+    agents = await _read_agents(storage)
+    assert len([r for r in agents if r.agent_id == "agent-a"]) == 1
+
+
+async def test_roll_up_commits_exactly_once(storage) -> None:
+    await _seed(storage, "a1", "agent-a", latency=100)
+    async with storage._conn.session() as db:
+        calls = {"n": 0}
+        original = db.commit
+
+        async def counting(*args, **kwargs):
+            calls["n"] += 1
+            await original()
+
+        db.commit = counting  # type: ignore[method-assign]
+        await agent_obs.roll_up(db)
+        assert calls["n"] == 1
+
+
+async def test_read_agents_limit_and_query(storage) -> None:
+    await _seed(storage, "a1", "agent-a", days_ago=0.03)
+    await _seed(storage, "b1", "agent-b", days_ago=0.02)
+    await _seed(storage, "c1", "other-c", days_ago=0.01)
+    await _rollup(storage)
+
+    limited = await _read_agents(storage, limit=2)
+    assert len(limited) == 2
+    # last_seen DESC: other-c is most recent.
+    assert limited[0].agent_id == "other-c"
+
+    filtered = await _read_agents(storage, query="agent")
+    assert {r.agent_id for r in filtered} == {"agent-a", "agent-b"}

--- a/src/voicegateway/tests/server/test_agent_filter_api.py
+++ b/src/voicegateway/tests/server/test_agent_filter_api.py
@@ -11,6 +11,7 @@ from httpx import ASGITransport, AsyncClient
 
 from voicegateway.core.gateway import Gateway
 from voicegateway.models.request_model import RequestRecord
+from voicegateway.repository import agent_observations_repository as agent_obs
 from voicegateway.server import build_app
 
 _CFG = {
@@ -83,6 +84,9 @@ async def test_api_agents_index(gateway):
     await gateway.storage.log_request(_rec("agent-x", 0.01))
     await gateway.storage.log_request(_rec("agent-x", 0.02))
     await gateway.storage.log_request(_rec("agent-y", 0.05))
+    # The fleet index now reads the rollup, so refresh it after seeding.
+    async with gateway.storage._conn.session() as db:
+        await agent_obs.roll_up(db)
     client = await _client(gateway)
     async with client as c:
         resp = await c.get("/api/agents")

--- a/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
+++ b/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
@@ -1,0 +1,130 @@
+"""Phase 3, Step 7: GET /api/agents LIST serves the windowed rollup.
+
+The LIST endpoint reads agent_observations (not a live requests scan); error_rate
+is derived from error_count / request_count; the unattributed bucket is windowed.
+The DETAIL endpoint stays all-time (reads requests).
+"""
+
+from __future__ import annotations
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.server import build_app
+
+
+def _gateway(tmp_path, monkeypatch) -> Gateway:
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "agents.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump({"cost_tracking": {"enabled": True}}))
+    return Gateway(config_path=str(path))
+
+
+def _client(gw: Gateway) -> AsyncClient:
+    return AsyncClient(
+        transport=ASGITransport(app=build_app(gw)), base_url="http://test"
+    )
+
+
+async def _insert_obs(gw: Gateway, **cols) -> None:
+    await gw.storage._ensure_initialized()
+    keys = ", ".join(cols)
+    vals = ", ".join(f":{k}" for k in cols)
+    async with gw.storage._conn.session() as db:
+        await db.execute(
+            text(f"INSERT INTO agent_observations ({keys}) VALUES ({vals})"), cols
+        )
+        await db.commit()
+
+
+async def test_list_reads_from_rollup_not_requests(tmp_path, monkeypatch) -> None:
+    gw = _gateway(tmp_path, monkeypatch)
+    # A rollup row with NO matching requests rows: the LIST can only return it
+    # if it reads the rollup table rather than scanning requests.
+    await _insert_obs(
+        gw,
+        agent_id="ghost",
+        request_count=7,
+        total_cost_usd=0.5,
+        error_count=0,
+        p95_ms=300,
+        last_seen=1000.0,
+        window_start="ws",
+        window_end="we",
+    )
+    async with _client(gw) as c:
+        resp = await c.get("/api/agents")
+    assert resp.status_code == 200
+    ghost = [a for a in resp.json()["agents"] if a["agent_id"] == "ghost"]
+    assert len(ghost) == 1
+    assert ghost[0]["request_count"] == 7
+    assert ghost[0]["p95_latency_ms"] == 300
+
+
+async def test_list_derives_error_rate(tmp_path, monkeypatch) -> None:
+    gw = _gateway(tmp_path, monkeypatch)
+    await _insert_obs(
+        gw,
+        agent_id="a",
+        request_count=4,
+        total_cost_usd=0.0,
+        error_count=1,
+        last_seen=1.0,
+        window_start="ws",
+        window_end="we",
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "a")
+    assert entry["error_rate"] == 0.25
+
+
+async def test_list_unattributed_is_windowed(tmp_path, monkeypatch) -> None:
+    gw = _gateway(tmp_path, monkeypatch)
+    await _insert_obs(
+        gw,
+        agent_id=None,
+        request_count=3,
+        total_cost_usd=0.1,
+        error_count=0,
+        last_seen=1.0,
+        window_start="ws",
+        window_end="we",
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    assert data["unattributed"]["request_count"] == 3
+
+
+async def test_detail_is_all_time_from_requests(tmp_path, monkeypatch) -> None:
+    gw = _gateway(tmp_path, monkeypatch)
+    for i in range(2):
+        await gw.storage.log_request(
+            RequestRecord(
+                id=f"r{i}",
+                timestamp=1000.0 + i,
+                modality="llm",
+                model_id="openai/gpt-4o-mini",
+                provider="openai",
+                project="default",
+                agent_id="agent-a",
+            )
+        )
+    # A divergent rollup row the DETAIL endpoint must ignore (it is all-time).
+    await _insert_obs(
+        gw,
+        agent_id="agent-a",
+        request_count=99,
+        total_cost_usd=0.0,
+        error_count=0,
+        last_seen=1.0,
+        window_start="ws",
+        window_end="we",
+    )
+    async with _client(gw) as c:
+        detail = (await c.get("/api/agents/agent-a")).json()
+    assert detail["request_count"] == 2  # from requests, not the rollup's 99

--- a/src/voicegateway/tests/server/test_ingest_rate_limit_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_rate_limit_endpoint.py
@@ -1,0 +1,122 @@
+"""Phase 3: rate limiting (429), batch cap (413), storage-off (503) on /v1/ingest."""
+
+from __future__ import annotations
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.repository import virtual_keys_repository as virtual_keys
+from voicegateway.server import build_app
+
+
+def _gateway(tmp_path, monkeypatch, config: dict, *, db: bool = True) -> Gateway:
+    if db:
+        monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "rl.db"))
+    else:
+        # Storage is enabled by env-var OR cost_tracking.enabled; clear the env
+        # var so a cost_tracking-disabled config truly yields storage=None.
+        monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump(config))
+    return Gateway(config_path=str(path))
+
+
+def _client(gw: Gateway) -> AsyncClient:
+    transport = ASGITransport(app=build_app(gw))
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+def _payload(rid: str) -> dict:
+    return {
+        "id": rid,
+        "timestamp": 1_000_000.0,
+        "modality": "llm",
+        "model_id": "openai/gpt-4o-mini",
+        "provider": "openai",
+        "project": "fleet",
+        "input_units": 100.0,
+        "output_units": 50.0,
+        "cost_usd": 0.001,
+        "agent_id": "a",
+    }
+
+
+async def _vk(gw: Gateway) -> str:
+    await gw.storage._ensure_initialized()
+    async with gw.storage._conn.session() as db:
+        created = await virtual_keys.create_virtual_key(db, name="bot")
+    return created.plaintext
+
+
+async def test_ingest_429_when_over_rate(tmp_path, monkeypatch) -> None:
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {
+            "cost_tracking": {"enabled": True},
+            "ingest": {"requests_per_minute": 1, "burst": 1},
+        },
+    )
+    headers = {"Authorization": f"Bearer {await _vk(gw)}"}
+    async with _client(gw) as c:
+        first = await c.post("/v1/ingest", headers=headers, json=[_payload("r1")])
+        second = await c.post("/v1/ingest", headers=headers, json=[_payload("r2")])
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert int(second.headers["retry-after"]) >= 1
+
+
+async def test_ingest_413_when_batch_too_large(tmp_path, monkeypatch) -> None:
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {"cost_tracking": {"enabled": True}, "ingest": {"max_batch_size": 2}},
+    )
+    headers = {"Authorization": f"Bearer {await _vk(gw)}"}
+    async with _client(gw) as c:
+        resp = await c.post(
+            "/v1/ingest",
+            headers=headers,
+            json=[_payload("a"), _payload("b"), _payload("c")],
+        )
+    assert resp.status_code == 413
+
+
+async def test_ingest_429_precedes_413(tmp_path, monkeypatch) -> None:
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {
+            "cost_tracking": {"enabled": True},
+            "ingest": {"requests_per_minute": 1, "burst": 1, "max_batch_size": 2},
+        },
+    )
+    headers = {"Authorization": f"Bearer {await _vk(gw)}"}
+    async with _client(gw) as c:
+        first = await c.post("/v1/ingest", headers=headers, json=[_payload("r1")])
+        # The second request is both over-rate and oversized; 429 must win.
+        second = await c.post(
+            "/v1/ingest",
+            headers=headers,
+            json=[_payload("a"), _payload("b"), _payload("c")],
+        )
+    assert first.status_code == 200
+    assert second.status_code == 429
+
+
+async def test_ingest_503_when_storage_disabled(tmp_path, monkeypatch) -> None:
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {
+            "cost_tracking": {"enabled": False},
+            "auth": {"api_keys": [{"token": "static-key", "scopes": ["*"]}]},
+        },
+        db=False,
+    )
+    headers = {"Authorization": "Bearer static-key"}
+    async with _client(gw) as c:
+        resp = await c.post("/v1/ingest", headers=headers, json=[_payload("x")])
+    assert resp.status_code == 503

--- a/src/voicegateway/tests/server/test_lifespan_workers.py
+++ b/src/voicegateway/tests/server/test_lifespan_workers.py
@@ -1,0 +1,78 @@
+"""Phase 3, Step 8: the lifespan starts and stops the background workers."""
+
+from __future__ import annotations
+
+import yaml
+from starlette.testclient import TestClient
+
+from voicegateway.core.events import lifespan
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+
+
+def _gateway(tmp_path, monkeypatch, config: dict, *, db: bool = True) -> Gateway:
+    if db:
+        monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "ls.db"))
+    else:
+        monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump(config))
+    return Gateway(config_path=str(path))
+
+
+async def test_starts_three_workers_when_enabled(tmp_path, monkeypatch) -> None:
+    gw = _gateway(tmp_path, monkeypatch, {"cost_tracking": {"enabled": True}})
+    app = build_app(gw)
+    async with lifespan(app):
+        workers = app.state.workers
+        assert len(workers) == 3
+        assert all(w._task is not None for w in workers)
+    assert all(w._task is None for w in workers)  # stopped on shutdown
+
+
+async def test_starts_none_when_storage_disabled(tmp_path, monkeypatch) -> None:
+    gw = _gateway(
+        tmp_path, monkeypatch, {"cost_tracking": {"enabled": False}}, db=False
+    )
+    app = build_app(gw)
+    async with lifespan(app):
+        assert app.state.workers == []
+
+
+async def test_starts_none_when_workers_disabled(tmp_path, monkeypatch) -> None:
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {"cost_tracking": {"enabled": True}, "workers": {"enabled": False}},
+    )
+    app = build_app(gw)
+    async with lifespan(app):
+        assert app.state.workers == []
+
+
+async def test_configured_intervals_are_applied(tmp_path, monkeypatch) -> None:
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {
+            "cost_tracking": {"enabled": True},
+            "workers": {
+                "rollup_interval_seconds": 111,
+                "retention_interval_seconds": 222,
+            },
+        },
+    )
+    app = build_app(gw)
+    async with lifespan(app):
+        intervals = sorted(w._poll_interval for w in app.state.workers)
+    # Two rollup workers at 111, the retention worker at 222.
+    assert intervals == [111, 111, 222]
+
+
+def test_lifespan_is_attached_to_the_app(tmp_path, monkeypatch) -> None:
+    # TestClient drives the ASGI lifespan, proving _make_app wired it.
+    gw = _gateway(tmp_path, monkeypatch, {"cost_tracking": {"enabled": True}})
+    app = build_app(gw)
+    with TestClient(app):
+        assert len(app.state.workers) == 3

--- a/src/voicegateway/tests/server/test_lifespan_workers.py
+++ b/src/voicegateway/tests/server/test_lifespan_workers.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
 import yaml
 from starlette.testclient import TestClient
 
+from voicegateway.core import events
 from voicegateway.core.events import lifespan
 from voicegateway.core.gateway import Gateway
 from voicegateway.server import build_app
@@ -76,3 +78,32 @@ def test_lifespan_is_attached_to_the_app(tmp_path, monkeypatch) -> None:
     app = build_app(gw)
     with TestClient(app):
         assert len(app.state.workers) == 3
+
+
+class _FakeWorker:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.started = False
+        self.stopped = False
+        self._fail = fail
+
+    async def start(self) -> None:
+        if self._fail:
+            raise RuntimeError("boom")
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+async def test_partial_start_failure_stops_started_workers(
+    tmp_path, monkeypatch
+) -> None:
+    good = _FakeWorker()
+    bad = _FakeWorker(fail=True)
+    monkeypatch.setattr(events, "_build_workers", lambda gateway: [good, bad])
+    gw = _gateway(tmp_path, monkeypatch, {"cost_tracking": {"enabled": True}})
+    app = build_app(gw)
+    with pytest.raises(RuntimeError):
+        async with lifespan(app):
+            pass
+    assert good.started and good.stopped  # the started worker was cleaned up

--- a/src/voicegateway/tests/services/test_ingest_rate_limiter.py
+++ b/src/voicegateway/tests/services/test_ingest_rate_limiter.py
@@ -1,0 +1,73 @@
+"""Tests for IngestRateLimiter (Phase 3, Step 1)."""
+
+from __future__ import annotations
+
+from voicegateway.services.ingest_rate_limiter import IngestRateLimiter
+
+
+class _Clock:
+    """Mutable monotonic clock for deterministic token-bucket tests."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_allows_up_to_burst_then_blocks() -> None:
+    clock = _Clock()
+    rl = IngestRateLimiter(requests_per_minute=60, burst=5, monotonic=clock)
+    # Five tokens are available at t0; the sixth in the same instant is blocked.
+    assert [rl.check("k") for _ in range(5)] == [None, None, None, None, None]
+    retry = rl.check("k")
+    assert retry is not None
+    assert retry > 0
+
+
+def test_retry_after_seconds_is_deficit_over_rate() -> None:
+    clock = _Clock()
+    # 60 rpm is one token per second; burst 1 means a full-token deficit -> 1.0s.
+    rl = IngestRateLimiter(requests_per_minute=60, burst=1, monotonic=clock)
+    assert rl.check("k") is None
+    assert rl.check("k") == 1.0
+    # 120 rpm is two tokens per second -> 0.5s for the same deficit.
+    rl2 = IngestRateLimiter(requests_per_minute=120, burst=1, monotonic=clock)
+    assert rl2.check("k") is None
+    assert rl2.check("k") == 0.5
+
+
+def test_refills_over_time() -> None:
+    clock = _Clock()
+    rl = IngestRateLimiter(requests_per_minute=60, burst=1, monotonic=clock)
+    assert rl.check("k") is None
+    assert rl.check("k") is not None  # exhausted
+    clock.advance(1.0)  # one token per second refills exactly one token
+    assert rl.check("k") is None
+
+
+def test_keys_are_isolated() -> None:
+    clock = _Clock()
+    rl = IngestRateLimiter(requests_per_minute=60, burst=1, monotonic=clock)
+    assert rl.check("a") is None
+    assert rl.check("a") is not None  # a exhausted
+    assert rl.check("b") is None  # b is unaffected
+
+
+def test_zero_rpm_is_unlimited() -> None:
+    clock = _Clock()
+    rl = IngestRateLimiter(requests_per_minute=0, burst=0, monotonic=clock)
+    assert all(rl.check("k") is None for _ in range(100))
+
+
+def test_idle_full_buckets_are_reaped() -> None:
+    clock = _Clock()
+    rl = IngestRateLimiter(requests_per_minute=60, burst=1, max_keys=1, monotonic=clock)
+    assert rl.check("a") is None  # a now holds zero tokens
+    clock.advance(5.0)  # a would refill to full (burst 1) while idle
+    assert rl.check("b") is None  # size 2 > max_keys 1 triggers a reap of full buckets
+    assert "a" not in rl._buckets
+    assert "b" in rl._buckets

--- a/src/voicegateway/tests/services/test_retention_extended.py
+++ b/src/voicegateway/tests/services/test_retention_extended.py
@@ -1,0 +1,150 @@
+"""Phase 3, Step 3: retention prunes requests, sessions, and dependents.
+
+Extends the replay-only RetentionWorker: aged sessions and their dependent
+rows (replay, turns, dead-air, guardrail) prune by ``ended_at``; requests
+prune independently by ``timestamp`` (a request may have no session).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.services.retention_service import RetentionWorker
+from voicegateway.services.storage_service import StorageService
+
+_INSERT_SESSION = text(
+    "INSERT INTO sessions "
+    "(id, project, started_at, ended_at, total_cost_usd, request_count) "
+    "VALUES (:id, :project, :started_at, :ended_at, :cost, :rc)"
+)
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    s = StorageService(str(tmp_path / "retention.db"))
+    await s._ensure_initialized()
+    return s
+
+
+def _provider(project: str, days: int):
+    async def provider():
+        return [(project, days)]
+
+    return provider
+
+
+async def _seed_session(storage, sid: str, project: str, ended_days_ago: float) -> None:
+    ended = (datetime.now(UTC) - timedelta(days=ended_days_ago)).isoformat()
+    async with storage._conn.session() as db:
+        await db.execute(
+            _INSERT_SESSION,
+            {
+                "id": sid,
+                "project": project,
+                "started_at": ended,
+                "ended_at": ended,
+                "cost": 0.0,
+                "rc": 0,
+            },
+        )
+        await db.commit()
+
+
+async def _seed_request(
+    storage, rid: str, project: str, days_ago: float, session_id: str | None
+) -> None:
+    ts = (datetime.now(UTC) - timedelta(days=days_ago)).timestamp()
+    await storage.log_request(
+        RequestRecord(
+            id=rid,
+            timestamp=ts,
+            modality="llm",
+            model_id="openai/gpt-4o-mini",
+            provider="openai",
+            project=project,
+            session_id=session_id,
+        )
+    )
+
+
+async def _count(storage, table: str, where: str, params: dict) -> int:
+    async with storage._conn.session() as db:
+        result = await db.execute(
+            text(f"SELECT COUNT(*) FROM {table} WHERE {where}"), params
+        )
+        return int(result.scalar() or 0)
+
+
+async def test_prune_deletes_aged_session_rows(storage) -> None:
+    await _seed_session(storage, "old", "acme", ended_days_ago=10)
+    await _seed_session(storage, "young", "acme", ended_days_ago=1)
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+    assert await _count(storage, "sessions", "id = :i", {"i": "old"}) == 0
+    assert await _count(storage, "sessions", "id = :i", {"i": "young"}) == 1
+
+
+async def test_session_less_request_pruned_by_timestamp(storage) -> None:
+    await _seed_request(storage, "r-old", "acme", days_ago=10, session_id=None)
+    await _seed_request(storage, "r-new", "acme", days_ago=1, session_id=None)
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+    assert await _count(storage, "requests", "id = :i", {"i": "r-old"}) == 0
+    assert await _count(storage, "requests", "id = :i", {"i": "r-new"}) == 1
+
+
+async def test_recent_request_survives_even_when_its_session_is_aged(storage) -> None:
+    # Independent clocks: the session is aged (pruned) but the request is recent.
+    # The request creates the session via upsert, so age the session afterward.
+    await _seed_request(storage, "r-recent", "acme", days_ago=1, session_id="s-aged")
+    aged = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+    async with storage._conn.session() as db:
+        await db.execute(
+            text("UPDATE sessions SET ended_at = :e, project = 'acme' WHERE id = :i"),
+            {"e": aged, "i": "s-aged"},
+        )
+        await db.commit()
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+    assert await _count(storage, "sessions", "id = :i", {"i": "s-aged"}) == 0
+    assert await _count(storage, "requests", "id = :i", {"i": "r-recent"}) == 1
+
+
+async def test_prune_deletes_session_dependents(storage) -> None:
+    await _seed_session(storage, "s-old", "acme", ended_days_ago=10)
+    async with storage._conn.session() as db:
+        await db.execute(
+            text(
+                "INSERT INTO turns "
+                "(session_id, turn_index, caller_speak_start_ms, caller_speak_end_ms) "
+                "VALUES ('s-old', 0, 0, 100)"
+            )
+        )
+        await db.execute(
+            text(
+                "INSERT INTO dead_air_events "
+                "(session_id, started_at_ms, duration_ms, threshold_used_ms) "
+                "VALUES ('s-old', 0, 100, 3000)"
+            )
+        )
+        await db.execute(
+            text(
+                "INSERT INTO guardrail_events (event_type, session_id) "
+                "VALUES ('fired', 's-old')"
+            )
+        )
+        await db.commit()
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+    for table in ("turns", "dead_air_events", "guardrail_events"):
+        assert await _count(storage, table, "session_id = :s", {"s": "s-old"}) == 0
+
+
+async def test_request_prune_is_batched(storage) -> None:
+    for i in range(120):
+        await _seed_request(storage, f"r{i}", "acme", days_ago=10, session_id=None)
+    worker = RetentionWorker(
+        storage, retention_provider=_provider("acme", 5), batch_size=50
+    )
+    await worker.tick_now()
+    assert await _count(storage, "requests", "project = :p", {"p": "acme"}) == 0

--- a/src/voicegateway/tests/services/test_sink_429.py
+++ b/src/voicegateway/tests/services/test_sink_429.py
@@ -1,0 +1,88 @@
+"""Phase 3, Step 2: RemoteCollectorSink treats 429 as backpressure.
+
+A 429 is retried (honoring a clamped Retry-After) without counting toward
+``max_retries``, so the in-flight batch is never dropped on rate limiting.
+Non-429 errors keep the existing drop-after-max_retries behavior.
+"""
+
+from __future__ import annotations
+
+from voicegateway.services.sinks import RemoteCollectorSink
+
+
+class _Resp:
+    def __init__(self, status_code: int, headers: dict | None = None) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+
+
+class _Client:
+    def __init__(self, responses: list[_Resp]) -> None:
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def post(self, url, json, headers):  # noqa: ANN001
+        self.calls += 1
+        return self._responses.pop(0) if self._responses else _Resp(200)
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _sink(client, sleeps: list[float], **kw) -> RemoteCollectorSink:
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    return RemoteCollectorSink(
+        "http://collector",
+        "vk_test",
+        client=client,
+        sleep=fake_sleep,
+        flush_interval=None,
+        **kw,
+    )
+
+
+async def test_429_then_200_delivers_and_honors_retry_after() -> None:
+    sleeps: list[float] = []
+    client = _Client([_Resp(429, {"retry-after": "5"}), _Resp(200)])
+    sink = _sink(client, sleeps)
+    await sink._post([{"id": "1"}])
+    assert client.calls == 2
+    assert sleeps == [5.0]
+
+
+async def test_retry_after_clamped_to_60() -> None:
+    sleeps: list[float] = []
+    client = _Client([_Resp(429, {"retry-after": "120"}), _Resp(200)])
+    sink = _sink(client, sleeps)
+    await sink._post([{"id": "1"}])
+    assert sleeps == [60.0]
+
+
+async def test_429_without_header_falls_back_to_backoff() -> None:
+    sleeps: list[float] = []
+    client = _Client([_Resp(429), _Resp(200)])
+    sink = _sink(client, sleeps, backoff=0.2)
+    await sink._post([{"id": "1"}])
+    assert sleeps == [0.2]
+
+
+async def test_429_not_counted_toward_max_retries() -> None:
+    # Three consecutive 429s with max_retries=2 would drop if counted; instead
+    # the batch is delivered on the fourth call (never dropped).
+    sleeps: list[float] = []
+    client = _Client([_Resp(429), _Resp(429), _Resp(429), _Resp(200)])
+    sink = _sink(client, sleeps, max_retries=2, backoff=0.2)
+    await sink._post([{"id": "1"}])
+    assert client.calls == 4
+
+
+async def test_non_429_error_still_drops_after_max_retries() -> None:
+    sleeps: list[float] = []
+    client = _Client([_Resp(500), _Resp(500), _Resp(500), _Resp(500)])
+    sink = _sink(client, sleeps, max_retries=2, backoff=0.2)
+    await sink._post([{"id": "1"}])
+    # attempts 0,1,2 then drop: 3 calls, backoff sleeps 0.2 and 0.4.
+    assert client.calls == 3
+    assert sleeps == [0.2, 0.4]

--- a/src/voicegateway/tests/storage/test_agent_observations_schema.py
+++ b/src/voicegateway/tests/storage/test_agent_observations_schema.py
@@ -1,0 +1,65 @@
+"""Phase 3, Step 4: the agent_observations rollup table and its columns."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from voicegateway.services.storage_service import StorageService
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    s = StorageService(str(tmp_path / "agentobs.db"))
+    await s._ensure_initialized()
+    return s
+
+
+async def test_table_exists(storage) -> None:
+    async with storage._conn.session() as db:
+        result = await db.execute(
+            text(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='agent_observations'"
+            )
+        )
+        assert result.scalar() == "agent_observations"
+
+
+async def test_roundtrip_typed_columns(storage) -> None:
+    async with storage._conn.session() as db:
+        await db.execute(
+            text(
+                "INSERT INTO agent_observations "
+                "(agent_id, request_count, total_cost_usd, error_count, "
+                " p50_ms, p95_ms, last_seen, window_start, window_end) "
+                "VALUES ('a1', 5, 0.25, 1, 100, 200, 1000.0, 'ws', 'we')"
+            )
+        )
+        await db.commit()
+        row = await db.execute(
+            text(
+                "SELECT agent_id, request_count, total_cost_usd, error_count, "
+                "p50_ms, p95_ms, last_seen FROM agent_observations "
+                "WHERE agent_id = 'a1'"
+            )
+        )
+        r = row.fetchone()
+    assert r == ("a1", 5, 0.25, 1, 100, 200, 1000.0)
+
+
+async def test_null_agent_id_is_the_unattributed_bucket(storage) -> None:
+    async with storage._conn.session() as db:
+        await db.execute(
+            text(
+                "INSERT INTO agent_observations "
+                "(agent_id, request_count, total_cost_usd, error_count, "
+                " window_start, window_end) "
+                "VALUES (NULL, 3, 0.1, 0, 'ws', 'we')"
+            )
+        )
+        await db.commit()
+        result = await db.execute(
+            text("SELECT request_count FROM agent_observations WHERE agent_id IS NULL")
+        )
+        assert result.scalar() == 3


### PR DESCRIPTION
## Fleet Phase 3: collector operational hardening

Makes the fleet collector safe to run unattended. Backend-only apart from two dashboard label changes. Spec: `docs/superpowers/specs/2026-06-04-fleet-phase3-operational-hardening-design.md` (local-only).

### What it does

1. **Ingest rate limiting** on `POST /v1/ingest`: a per-caller in-process token bucket (virtual key, then static-API-key hash, then client IP). Over-limit returns `429` with a `Retry-After` header; oversized batches return `413` before any write. Rate (`429`) takes precedence over batch cap (`413`), and storage-disabled (`503`) over both.
2. **Sink backpressure**: `RemoteCollectorSink` now treats `429` as backpressure: it parses `Retry-After` (clamped to 60s), sleeps, and retries the same batch without counting toward `max_retries`, so rate limiting never drops the in-flight batch. Memory stays bounded by the existing buffer drop-oldest.
3. **Retention** extended from replay-only to prune aged `requests` + `sessions` and their dependent rows (replay, turns, dead-air, guardrail), per project, in FK-safe batched order. Requests prune by `timestamp`, sessions by `ended_at` (independent clocks).
4. **Windowed agent rollup**: a new `agent_observations` table + 15-minute worker. `GET /api/agents` (LIST) now serves a consistent 24h window from the rollup instead of scanning every latency row (the scan the previous PR deferred). The DETAIL endpoint stays all-time. Agents page and the Overview fleet card are relabeled "last 24h".

### Two latent bugs fixed

- **The sink silently dropped batches on `429`** (fixed exponential backoff, drop after ~0.6s, no `Retry-After`), so rate limiting as designed would have lost telemetry.
- **The FastAPI lifespan was never attached to the app** (`_make_app` passed no `lifespan`, and the old body read a no-op `app.state.container`), so the rollup and retention workers never ran in production. This PR attaches it and starts the three workers, guarded by storage and `workers.enabled`, with configurable intervals.

### Config

New `voicegw.yaml` blocks (documented in the config reference): `ingest`, `retention`, `workers`.

### Validation

- `ruff` + `ruff format`: clean across `src/`
- `mypy`: clean (242 files)
- `pytest`: 1687 passed, 5 skipped
- coverage: 85.18% (gate 80%)
- dashboard build (`tsc` + `vite`): clean

The Postgres path uses dialect-neutral SQL + the guarded `VOICEGW_TEST_PG_URL` test (not run live), consistent with Phases 1 and 2.

### Out of scope (Phase 4)

Real heartbeat/liveness, per-agent alerting, agent grouping/tags, multi-tenant write isolation, fleet-wide reconcile UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-process ingest rate limiting with retry-after responses.
  * Configurable background workers for periodic rollups and retention.
  * Windowed per-agent metrics surfaced as 24h rollups.

* **Configuration**
  * Added top-level ingest, retention, and workers blocks to configuration.

* **UI Updates**
  * Dashboard labels and subtitles now show metrics as “(24h)”.

* **Reliability**
  * Improved retention pruning and resilient remote-sink retry handling (honors Retry-After).

* **Tests**
  * Extensive tests covering rate limiting, rollups, workers, retention, and sink 429 behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->