### PR TITLE
fix(docker): make the image run as the Postgres fleet collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.8.1: Docker fleet collector support
+
+The official Docker image can now run as the Postgres-backed fleet collector.
+
+### Fixed
+
+- **The image ships the migrations.** `alembic.ini` and the `alembic/` tree are
+  now copied into the image, so the server builds its schema on first start. It
+  could not before (neither was copied in), which left storage broken on a fresh
+  container for both SQLite and Postgres.
+- **`VOICEGW_DB_URL` enables storage.** Pointing the collector at Postgres with
+  `VOICEGW_DB_URL` alone now turns storage on. Previously it also required
+  `cost_tracking.enabled` or `VOICEGW_DB_PATH`, so `POST /v1/ingest` returned
+  503 and the collector persisted nothing.
+
+### Added
+
+- The Docker image includes the `postgres` extra (asyncpg), so it can run
+  against a Postgres collector backend out of the box.
+- `docker-compose.collector.yml`: a ready-to-run Postgres + collector stack,
+  with a deployment guide in the docs.
+
 ## v0.8.0: fleet collector operational hardening
 
 The self-hosted fleet collector becomes safe to run unattended: ingest rate

--- a/docker-compose.collector.yml
+++ b/docker-compose.collector.yml
@@ -1,0 +1,66 @@
+# Fleet collector stack: the VoiceGateway server backed by Postgres, for the
+# self-hosted collector that many LiveKit agents push telemetry to. The same
+# container serves POST /v1/ingest, the dashboard API (/api), and the SPA on
+# port 8080.
+#
+#   docker compose -f docker-compose.collector.yml up -d
+#
+# Provide a voicegw.yaml next to this file (even a minimal one is enough; the
+# collector mainly needs auth.api_keys for the agents' virtual keys). Storage is
+# enabled automatically because VOICEGW_DB_URL is set, so cost_tracking does not
+# need to be turned on by hand. Set VOICEGW_PG_PASSWORD in the environment or a
+# .env file for anything beyond a local trial.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: voicegw-postgres
+    environment:
+      POSTGRES_USER: voicegw
+      POSTGRES_PASSWORD: ${VOICEGW_PG_PASSWORD:-voicegw}
+      POSTGRES_DB: voicegw
+    volumes:
+      - voicegw-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U voicegw -d voicegw"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+    networks:
+      - voicegw-net
+
+  collector:
+    image: mahimairaja/voicegateway:latest
+    container_name: voicegw-collector
+    ports:
+      - "8080:8080"
+    environment:
+      # The Postgres collector backend. Setting this enables storage and takes
+      # precedence over the embedded SQLite default.
+      VOICEGW_DB_URL: postgresql+asyncpg://voicegw:${VOICEGW_PG_PASSWORD:-voicegw}@postgres:5432/voicegw
+      VOICEGW_CONFIG: /app/voicegw.yaml
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      DEEPGRAM_API_KEY: ${DEEPGRAM_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    volumes:
+      - ./voicegw.yaml:/app/voicegw.yaml:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - voicegw-net
+
+volumes:
+  voicegw-pgdata:
+    driver: local
+
+networks:
+  voicegw-net:
+    driver: bridge

--- a/docs/examples/docker-deployment.md
+++ b/docs/examples/docker-deployment.md
@@ -216,6 +216,34 @@ providers:
     base_url: http://ollama:11434
 ```
 
+### Fleet collector (Postgres)
+
+To run the self-hosted collector that many LiveKit agents push telemetry to,
+use the Postgres-backed stack. The same container serves `POST /v1/ingest`, the
+dashboard API, and the SPA on port 8080.
+
+```bash
+docker compose -f docker-compose.collector.yml up -d
+```
+
+This starts a `postgres` service and a `collector` service. The collector reads
+its database from `VOICEGW_DB_URL`; setting that enables storage automatically,
+so `cost_tracking` does not need to be turned on by hand. The image ships the
+`postgres` extra (asyncpg) and the migrations, so it builds its schema on first
+start. Provide a `voicegw.yaml` next to the compose file (the collector mainly
+needs `auth.api_keys` for the agents' virtual keys), and set
+`VOICEGW_PG_PASSWORD` for anything beyond a local trial.
+
+Point the official image at any Postgres directly without compose:
+
+```bash
+docker run -p 8080:8080 \
+  -e VOICEGW_DB_URL="postgresql+asyncpg://user:pass@host:5432/voicegw" \
+  -v $(pwd)/voicegw.yaml:/app/voicegw.yaml:ro \
+  -e VOICEGW_CONFIG=/app/voicegw.yaml \
+  mahimairaja/voicegateway:latest
+```
+
 ## Verifying the Deployment
 
 ### Health Check

--- a/src/voicegateway/Dockerfile
+++ b/src/voicegateway/Dockerfile
@@ -37,7 +37,9 @@ COPY src/dashboard/ ./src/dashboard/
 ARG VERSION=0.5.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
-RUN pip install --prefix=/install ".[cloud,mcp,dashboard,tui]"
+# Include the `postgres` extra (asyncpg) so the image can run as a Postgres
+# fleet collector via VOICEGW_DB_URL, not just embedded SQLite.
+RUN pip install --prefix=/install ".[cloud,mcp,dashboard,tui,postgres]"
 
 # -------- Stage 3: Runtime --------
 FROM python:3.12-slim AS runtime
@@ -75,6 +77,14 @@ COPY --chown=voicegw:voicegw src/voicegateway/ /app/voicegateway/
 COPY --chown=voicegw:voicegw src/dashboard/__init__.py /app/dashboard/
 COPY --chown=voicegw:voicegw src/dashboard/api/static/ /app/dashboard/api/static/
 COPY --from=frontend-builder --chown=voicegw:voicegw /build/frontend/dist /app/dashboard/frontend/dist
+
+# Ship the migrations. On first DB access the runtime runs `alembic upgrade
+# head`; Database._find_alembic_ini walks up from /app/voicegateway to /app, and
+# alembic.ini's script_location is %(here)s/alembic, so both the ini and the
+# versions tree must live at /app. Without this the server cannot build its
+# schema (SQLite or a Postgres collector backend).
+COPY --chown=voicegw:voicegw alembic.ini /app/alembic.ini
+COPY --chown=voicegw:voicegw alembic/ /app/alembic/
 
 USER voicegw
 WORKDIR /app

--- a/src/voicegateway/core/gateway.py
+++ b/src/voicegateway/core/gateway.py
@@ -33,7 +33,11 @@ class Gateway:
         # Resolve DB path: env var > config > default
         cost_cfg = self._config.cost_tracking
         env_db = os.environ.get("VOICEGW_DB_PATH")
-        enabled = cost_cfg.get("enabled", False) or bool(env_db)
+        # A Postgres collector points at its DB with VOICEGW_DB_URL alone, so
+        # that must enable storage too (resolve_database_url gives it precedence
+        # over the sqlite db_path below).
+        env_url = os.environ.get("VOICEGW_DB_URL")
+        enabled = cost_cfg.get("enabled", False) or bool(env_db) or bool(env_url)
         self._storage: StorageService | None
         if enabled:
             db_path = env_db or cost_cfg.get("db_path", DEFAULT_DB_PATH)

--- a/src/voicegateway/tests/core/test_gateway_db_url_storage.py
+++ b/src/voicegateway/tests/core/test_gateway_db_url_storage.py
@@ -1,0 +1,32 @@
+"""VOICEGW_DB_URL (the Postgres collector backend) enables storage.
+
+A Docker fleet collector points at its database with VOICEGW_DB_URL alone; that
+must turn storage on, otherwise POST /v1/ingest returns 503 and the collector
+persists nothing. A sqlite URL stands in for Postgres so the test needs no PG.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from voicegateway.core.gateway import Gateway
+
+
+def _cfg(tmp_path) -> str:
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump({"cost_tracking": {"enabled": False}}))
+    return str(path)
+
+
+def test_db_url_enables_storage(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.setenv("VOICEGW_DB_URL", f"sqlite+aiosqlite:///{tmp_path}/collector.db")
+    gw = Gateway(config_path=_cfg(tmp_path))
+    assert gw.storage is not None
+
+
+def test_no_db_url_no_path_keeps_storage_disabled(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.delenv("VOICEGW_DB_URL", raising=False)
+    gw = Gateway(config_path=_cfg(tmp_path))
+    assert gw.storage is None


### PR DESCRIPTION
The published Docker image could not actually run as the self-hosted fleet collector that Phase 1-3 built. Three gaps, all fixed here:

1. **No migrations in the image.** `alembic.ini` and `alembic/` were never copied in (and the wheel excludes them), so `run_migrations()` raised `alembic.ini not found` the moment storage was touched. `_ensure_initialized` has no `create_all` fallback, so a fresh container had no schema (SQLite or Postgres). Fixed by copying both to `/app` (where `_find_alembic_ini` walks to, and where `script_location = %(here)s/alembic` resolves).
2. **No `postgres` extra.** The image installed `.[cloud,mcp,dashboard,tui]` (no asyncpg), so a `VOICEGW_DB_URL=postgresql+asyncpg://...` collector hit `ModuleNotFoundError`. Now installs the `postgres` extra too.
3. **`VOICEGW_DB_URL` did not enable storage.** Only `cost_tracking.enabled` or `VOICEGW_DB_PATH` did, so a collector pointed at Postgres via `VOICEGW_DB_URL` alone returned 503 from `/v1/ingest`. Now `VOICEGW_DB_URL` enables storage (resolve_database_url already gives it precedence over the sqlite path).

Also adds `docker-compose.collector.yml` (Postgres + collector stack) and a deployment guide.

### Validation
- Migration bundling validated by copying `alembic.ini` + `alembic/` to a temp dir and running `alembic upgrade head` through it: all migrations applied, including `agent_observations`.
- `VOICEGW_DB_URL`-enables-storage covered by a new test (a sqlite URL stands in for Postgres).
- ruff + mypy clean; `tests/core` 85 passed.

Caveat: the Docker image build is not run on PRs (`docker-publish.yml` triggers on tag push), and Docker was unavailable locally, so the full multi-arch image build is validated only on the release tag. The migration + storage logic is validated as above. Ships as v0.8.1.
