### PR TITLE
fix(packaging): make a base pip install voicegateway importable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.8.2: importable base install
+
+### Fixed
+
+- **`pip install voicegateway` is importable again.** SQLAlchemy and SQLModel
+  are pulled in at import time by `voicegateway.models`, and the embedded
+  storage that `voicegateway.attach()` writes through needs Alembic, but all
+  three lived only in the `server` extra. They are now core dependencies, so a
+  base install (the agent SDK use case) no longer fails with
+  `ModuleNotFoundError: No module named 'sqlalchemy'`.
+- **The `server` extra installs `python-multipart`.** FastAPI's dashboard logo
+  upload (an `UploadFile` route) requires it; it was missing, so `voicegw serve`
+  warned and the upload endpoint would have failed.
+
 ## v0.8.1: Docker fleet collector support
 
 The official Docker image can now run as the Postgres-backed fleet collector.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,13 @@ dependencies = [
     "voice-prices>=0.0.8,<0.1",
     "bcrypt>=4.0",
     "pillow>=10.0",
+    # ORM + migration stack. Required at import time (voicegateway.models pulls
+    # in SQLAlchemy/SQLModel) and at runtime for the embedded storage that
+    # voicegateway.attach() writes through, so these are core, not optional:
+    # a base `pip install voicegateway` must be importable.
+    "sqlalchemy[asyncio]>=2.0,<3.0",
+    "sqlmodel>=0.0.22",
+    "alembic>=1.13",
 ]
 
 [project.optional-dependencies]
@@ -69,10 +76,9 @@ all = ["voicegateway[cloud,local]"]
 server = [
     "fastapi>=0.115.0",
     "uvicorn>=0.32.0",
-    "sqlalchemy[asyncio]>=2.0,<3.0",
-    "sqlmodel>=0.0.22",
+    # python-multipart backs the dashboard logo upload (UploadFile/File route).
+    "python-multipart>=0.0.9",
     "dependency-injector>=4.43",
-    "alembic>=1.13",
     "pydantic-settings>=2.0",
     "asgi-correlation-id>=4.3",
     "loguru>=0.7",
@@ -113,12 +119,11 @@ dev = [
     "platformdirs>=4.0",
     "textual>=0.85,<0.90",
     # Server stack so tests covering core/container, repository/, etc. can
-    # import them without `pip install -e .[server]` first.
+    # import them without `pip install -e .[server]` first. SQLAlchemy,
+    # SQLModel, and Alembic are core dependencies now, so they are not relisted.
     "fastapi>=0.115.0",
-    "sqlalchemy[asyncio]>=2.0,<3.0",
-    "sqlmodel>=0.0.22",
+    "python-multipart>=0.0.9",
     "dependency-injector>=4.43",
-    "alembic>=1.13",
     "pydantic-settings>=2.0",
     "asgi-correlation-id>=4.3",
     "loguru>=0.7",


### PR DESCRIPTION
A base `pip install voicegateway` (the agent SDK use case) is **not importable** on the published 0.8.x package:

```
import voicegateway → inference → ... → gateway → models → sqlalchemy + sqlmodel
ModuleNotFoundError: No module named 'sqlalchemy'
```

`voicegateway.models` pulls in SQLAlchemy/SQLModel at import time, and the embedded storage that `voicegateway.attach()` writes through needs Alembic, but all three lived only in the `server` extra. So anyone installing `voicegateway` to use `attach()` / `voicegateway.inference` in a LiveKit agent hits this on first import (which is exactly what surfaced while dogfooding the multi-agent example).

### Fix
- Move `sqlalchemy[asyncio]`, `sqlmodel`, and `alembic` into core `dependencies` (removed from the `server` and `dev` extras, which now get them transitively).
- Add `python-multipart` to the `server` extra — FastAPI's dashboard logo upload (`branding.py`, an `UploadFile` route) needs it, and it was missing, so `voicegw serve` warned and the upload route would fail.

### Validation
- Created a fresh venv, installed `voicegateway` with **core deps only** (no extras) from this branch, and `import voicegateway; from voicegateway import attach, inference` now succeeds. Before this change the same import raises `ModuleNotFoundError: sqlalchemy`.
- No code changed (pyproject + CHANGELOG only); CI runs the full suite against the new dependency layout.

Ships as v0.8.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed base installation importability to prevent import failures
  * Resolved missing dependency warnings for FastAPI upload functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->