### PR TITLE
fix(packaging): ship Alembic migrations inside the wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.8.3: ship migrations in the wheel
+
+### Fixed
+
+- **The PyPI wheel now ships the Alembic migrations.** `alembic/` and
+  `alembic.ini` live at the repo root, outside the `src/` packages, so the
+  published wheel carried no migrations and `run_migrations()` failed at runtime
+  with `alembic.ini not found` whenever storage initialized (hit by
+  `voicegw serve`, `voicegw dashboard`, and `voicegateway.attach()`'s local
+  SQLite sink). They are now force-included under the package, so a
+  `pip install voicegateway` can build its schema on first run.
+
 ## v0.8.2: importable base install
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,17 @@ exclude = [
     "src/dashboard/frontend/index.html",
 ]
 
+[tool.hatch.build.targets.wheel.force-include]
+# Ship the Alembic migrations inside the installed package. alembic/ and
+# alembic.ini live at the repo root (outside the src/ packages), so without
+# this the wheel carries no migrations and run_migrations() fails at runtime
+# with "alembic.ini not found". Placed under the package dir so that
+# _find_alembic_ini (which walks up from voicegateway/core/database.py) resolves
+# voicegateway/alembic.ini, whose `script_location = %(here)s/alembic` then
+# points at the sibling voicegateway/alembic/ tree.
+"alembic.ini" = "voicegateway/alembic.ini"
+"alembic" = "voicegateway/alembic"
+
 # Note on shipping the React bundle: the wheel published to PyPI
 # carries the dashboard SPA inside the voicegateway package itself,
 # at voicegateway/_dashboard_dist/. scripts/build_wheel.sh runs the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,9 @@ exclude = [
     "src/dashboard/frontend/vite.config.ts",
     "src/dashboard/frontend/vite.config.d.ts",
     "src/dashboard/frontend/index.html",
+    # Keep compiled migration bytecode out of the force-included alembic tree.
+    "alembic/__pycache__",
+    "alembic/versions/__pycache__",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]


### PR DESCRIPTION
The published wheel never shipped the Alembic migrations, so storage is broken on a pip-installed VoiceGateway:

```
voicegw serve → ... → run_migrations() → _find_alembic_ini()
FileNotFoundError: alembic.ini not found above .../site-packages/voicegateway/core/database.py
```

`alembic/` and `alembic.ini` live at the **repo root**, outside the `src/` packages, and the wheel only packages `src/voicegateway` + `src/dashboard`. So the wheel carried no migrations, and `run_migrations()` (called by `voicegw serve`, `voicegw dashboard`, and `voicegateway.attach()`'s local SQLite sink) fails the moment storage initializes. Surfaced while dogfooding.

### Fix
`force-include` `alembic.ini` + `alembic/` under the package in the wheel:
```toml
[tool.hatch.build.targets.wheel.force-include]
"alembic.ini" = "voicegateway/alembic.ini"
"alembic" = "voicegateway/alembic"
```
`_find_alembic_ini` walks up from `voicegateway/core/database.py` and finds `voicegateway/alembic.ini`, whose `script_location = %(here)s/alembic` then resolves the sibling `voicegateway/alembic/` tree.

### Validation
- Built the wheel from this branch and confirmed it contains `voicegateway/alembic.ini` + `voicegateway/alembic/versions/*.py` (all five migrations).
- Fresh-installed the wheel into a clean venv; `_find_alembic_ini()` resolves to the packaged `alembic.ini`, and running migrations against a fresh DB produces the full schema (17 tables, head `a3f9c1d7b2e8`).
- Editable/dev installs are unaffected (force-include only changes the built wheel), so CI stays green. The wheel's contents aren't exercised by CI, so that part is validated locally as above.

Ships as v0.8.3.
