### PR TITLE
fix: quieter agents, live dashboard version, minimal init (v0.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.8.4: quieter agents, live dashboard version, friendlier init
+
+Polish from dogfooding the agent SDK. Embedded telemetry no longer floods a
+host agent's debug logs, the dashboard reports the real version, the model list
+only shows models you can actually call, and `voicegw init` starts minimal.
+
+### Fixed
+
+- **Embedded storage no longer floods agent DEBUG logs.** `voicegateway.attach()`
+  runs SQLite storage in-process. Under a LiveKit `console`/`dev` run (root
+  logger at DEBUG) the `aiosqlite` and `alembic` loggers emitted a line per
+  query, burying the agent's own output. `StorageService` now quiets those two
+  dependency loggers to WARNING, and only when the caller has not set a level of
+  their own (an explicit `aiosqlite=DEBUG` still wins).
+- **The dashboard and `/health` report the real version.** The footer pill and
+  the `/health` endpoint were hardcoded to `0.5.0`. Both now read the installed
+  `__version__` (PEP 440 local build segment stripped), exposed via `/health`
+  and the dashboard `/api/status`.
+
+### Changed
+
+- **The dashboard lists only callable models.** `/api/status` now returns models
+  whose provider is configured (a cloud API key is set, or it is a local
+  provider). The sidebar count and the Models page stop advertising models the
+  operator cannot reach.
+- **`voicegw init` writes a minimal config by default.** First run gets a short
+  STT + LLM + TTS starter (about 35 lines) instead of the 269-line reference.
+  Run `voicegw init --full` for the complete annotated config.
+
 ## v0.8.3: ship migrations in the wheel
 
 ### Fixed

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -185,7 +185,7 @@ function Sidebar({
           <span className="neo-status-dot neo-status-dot--online" />
           {providerCount} Providers · {modelCount} Models
         </div>
-        <span className="version-pill">v0.5.0</span>
+        {status?.version && <span className="version-pill">v{status.version}</span>}
         {hasToken && (
           <button
             type="button"

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -1,4 +1,6 @@
 export interface StatusResponse {
+  // Live server version (footer pill). Optional so older servers still type-check.
+  version?: string;
   providers: Record<string, { configured: boolean; type: string }>;
   models: Record<string, { modality: string; provider: string }>;
   fallbacks: Record<string, string[]>;

--- a/src/voicegateway/cli/init_cli.py
+++ b/src/voicegateway/cli/init_cli.py
@@ -8,7 +8,7 @@ import typer
 
 from voicegateway.cli._app import app
 from voicegateway.cli.base_cli import BaseCli
-from voicegateway.utils.cli.init import _read_example_config
+from voicegateway.utils.cli.init import _read_example_config, _read_minimal_config
 
 _cli = BaseCli()
 
@@ -18,6 +18,11 @@ def init(
     output: str = typer.Option(
         "./voicegw.yaml", "--output", "-o", help="Output path for config file"
     ),
+    full: bool = typer.Option(
+        False,
+        "--full",
+        help="Write the full annotated reference config instead of the minimal starter.",
+    ),
 ) -> None:
     """Create a voicegw.yaml configuration file."""
     dest = Path(output)
@@ -26,6 +31,10 @@ def init(
         if not overwrite:
             raise typer.Abort()
 
-    dest.write_text(_read_example_config(), encoding="utf-8")
+    dest.write_text(
+        _read_example_config() if full else _read_minimal_config(), encoding="utf-8"
+    )
     _cli.success(f"Created {dest}")
     _cli.console.print("Edit it with your API keys, models, and projects.")
+    if not full:
+        _cli.console.print("For every option, run: voicegw init --full")

--- a/src/voicegateway/data/voicegw.minimal.yaml
+++ b/src/voicegateway/data/voicegw.minimal.yaml
@@ -1,0 +1,34 @@
+# VoiceGateway — minimal config (voicegw.yaml)
+# A starter STT + LLM + TTS voice stack. Set the API keys via environment
+# variables (e.g. DEEPGRAM_API_KEY) or paste them inline below.
+#
+# This is the short template. For every option (fallbacks, routing, budgets,
+# auth, retention, guardrails, ...) generate the annotated reference with:
+#     voicegw init --full
+# Docs: https://voicegateway.mahimai.ca/docs
+
+providers:
+  deepgram:
+    api_key: ${DEEPGRAM_API_KEY}
+  openai:
+    api_key: ${OPENAI_API_KEY}
+  cartesia:
+    api_key: ${CARTESIA_API_KEY}
+
+models:
+  stt:
+    deepgram/nova-3:
+      provider: deepgram
+      model: nova-3
+  llm:
+    openai/gpt-4o-mini:
+      provider: openai
+      model: gpt-4o-mini
+  tts:
+    cartesia/sonic-3:
+      provider: cartesia
+      model: sonic-3
+
+projects:
+  default:
+    name: "My Voice Agent"

--- a/src/voicegateway/data/voicegw.minimal.yaml
+++ b/src/voicegateway/data/voicegw.minimal.yaml
@@ -1,4 +1,4 @@
-# VoiceGateway — minimal config (voicegw.yaml)
+# VoiceGateway minimal config (voicegw.yaml)
 # A starter STT + LLM + TTS voice stack. Set the API keys via environment
 # variables (e.g. DEEPGRAM_API_KEY) or paste them inline below.
 #

--- a/src/voicegateway/server/api/dashboard/status.py
+++ b/src/voicegateway/server/api/dashboard/status.py
@@ -24,16 +24,27 @@ _LOCAL_PROVIDER_NAMES = frozenset({"ollama", "whisper", "kokoro", "piper"})
 # Public version for the dashboard footer (local git segment stripped).
 _PUBLIC_VERSION = __version__.split("+", 1)[0]
 
+
+def _configured_provider_names(config) -> set[str]:
+    """Providers the operator can actually call: a cloud key is set, or local."""
+    return {
+        name
+        for name, cfg in config.providers.items()
+        if bool(cfg.get("api_key")) or name in _LOCAL_PROVIDER_NAMES
+    }
+
+
 router = APIRouter(tags=["dashboard"])
 
 
 @router.get("/status")
 async def get_status(gateway: Gateway = Depends(get_gateway)) -> dict:
-    """Get status of all configured providers and models.
+    """Status of configured providers and the models the operator can call.
 
-    Mirrors the pricing-freshness subtree from /v1/status (Q7) so
-    the dashboard StalenessBanner can render without hitting a
-    second origin.
+    Models are filtered to providers that are usable (a cloud key is set, or
+    the provider is local), so the count and the Models page stay honest. Also
+    mirrors the pricing-freshness subtree from /v1/status so the dashboard can
+    render it without hitting a second origin.
     """
     config = gateway.config
 
@@ -45,10 +56,10 @@ async def get_status(gateway: Gateway = Depends(get_gateway)) -> dict:
             "type": "local" if is_local else "cloud",
         }
 
-    # Only surface models whose provider is actually usable (a cloud key is
-    # set, or it's a local provider). A roster full of models the operator
-    # can't call is noise; this keeps the count and the Models list honest.
-    configured_providers = {name for name, p in providers.items() if p["configured"]}
+    # Only surface models whose provider is actually usable (see
+    # _configured_provider_names); a roster full of models the operator can't
+    # call is noise.
+    configured_providers = _configured_provider_names(config)
     models: dict[str, dict[str, Any]] = {}
     for modality, modality_models in config.models.items():
         if isinstance(modality_models, dict):
@@ -84,10 +95,17 @@ async def get_overview(
     """Get dashboard overview stats, optionally filtered by project."""
     config = gateway.config
 
+    # Count only callable models, so "Active Models" matches the filtered
+    # /api/status list the sidebar renders.
+    configured_providers = _configured_provider_names(config)
     model_count = 0
     for modality_models in config.models.values():
         if isinstance(modality_models, dict):
-            model_count += len(modality_models)
+            model_count += sum(
+                1
+                for m in modality_models.values()
+                if isinstance(m, dict) and m.get("provider", "") in configured_providers
+            )
 
     if gateway.storage is None:
         return {

--- a/src/voicegateway/server/api/dashboard/status.py
+++ b/src/voicegateway/server/api/dashboard/status.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, Query
 
+from voicegateway._version import __version__
 from voicegateway.inference.pricing import llm as _llm_pricing
 from voicegateway.inference.pricing import stt as _stt_pricing
 from voicegateway.inference.pricing import tts as _tts_pricing
@@ -19,6 +20,9 @@ if TYPE_CHECKING:
 # (whisper / kokoro / piper). Drives the "configured" + "type" fields
 # in /api/status so the dashboard can colour the StatusCard correctly.
 _LOCAL_PROVIDER_NAMES = frozenset({"ollama", "whisper", "kokoro", "piper"})
+
+# Public version for the dashboard footer (local git segment stripped).
+_PUBLIC_VERSION = __version__.split("+", 1)[0]
 
 router = APIRouter(tags=["dashboard"])
 
@@ -41,15 +45,21 @@ async def get_status(gateway: Gateway = Depends(get_gateway)) -> dict:
             "type": "local" if is_local else "cloud",
         }
 
+    # Only surface models whose provider is actually usable (a cloud key is
+    # set, or it's a local provider). A roster full of models the operator
+    # can't call is noise; this keeps the count and the Models list honest.
+    configured_providers = {name for name, p in providers.items() if p["configured"]}
     models: dict[str, dict[str, Any]] = {}
     for modality, modality_models in config.models.items():
         if isinstance(modality_models, dict):
             for model_id, model_cfg in modality_models.items():
                 if isinstance(model_cfg, dict):
-                    models[model_id] = {
-                        "modality": modality,
-                        "provider": model_cfg.get("provider", ""),
-                    }
+                    provider = model_cfg.get("provider", "")
+                    if provider in configured_providers:
+                        models[model_id] = {
+                            "modality": modality,
+                            "provider": provider,
+                        }
 
     pricing = {
         "llm": {"source": _llm_pricing.PRICING_SOURCE},
@@ -58,6 +68,7 @@ async def get_status(gateway: Gateway = Depends(get_gateway)) -> dict:
     }
 
     return {
+        "version": _PUBLIC_VERSION,
         "providers": providers,
         "models": models,
         "fallbacks": config.fallbacks,

--- a/src/voicegateway/server/api/system.py
+++ b/src/voicegateway/server/api/system.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, Request
 
+from voicegateway._version import __version__
 from voicegateway.inference.pricing import llm as _llm_pricing
 from voicegateway.inference.pricing import stt as _stt_pricing
 from voicegateway.inference.pricing import tts as _tts_pricing
@@ -17,6 +18,10 @@ if TYPE_CHECKING:
 
 router = APIRouter(tags=["system"])
 
+# Drop the PEP 440 local segment (the +g<sha>.d<date> git metadata an
+# editable install carries) so health/status report a clean public version.
+_PUBLIC_VERSION = __version__.split("+", 1)[0]
+
 
 @router.get("/health")
 async def health(request: Request) -> dict:
@@ -24,7 +29,7 @@ async def health(request: Request) -> dict:
     return {
         "status": "ok",
         "uptime_seconds": round(time.time() - started_at, 1),
-        "version": "0.5.0",
+        "version": _PUBLIC_VERSION,
     }
 
 

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -30,6 +30,7 @@ _NOISY_EMBEDDED_LOGGERS = ("aiosqlite", "alembic")
 
 
 def _quiet_embedded_dependency_loggers() -> None:
+    """Raise the noisy aiosqlite/alembic loggers to WARNING, unless set already."""
     for name in _NOISY_EMBEDDED_LOGGERS:
         logger = logging.getLogger(name)
         if logger.level == logging.NOTSET:

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -21,11 +21,26 @@ _DEFAULT_PERCENTILES: list[float] = [50.0, 95.0, 99.0]
 
 _logger = logging.getLogger(__name__)
 
+# aiosqlite and alembic both log every operation at DEBUG. Embedded in a
+# LiveKit agent (voicegateway.attach), a ``console``/``dev`` run sets the root
+# logger to DEBUG, so that per-query chatter floods the host's terminal. Quiet
+# the two noisy dependency loggers, but only when the caller has not picked a
+# level themselves (NOTSET = "inherit", which is what produces the flood).
+_NOISY_EMBEDDED_LOGGERS = ("aiosqlite", "alembic")
+
+
+def _quiet_embedded_dependency_loggers() -> None:
+    for name in _NOISY_EMBEDDED_LOGGERS:
+        logger = logging.getLogger(name)
+        if logger.level == logging.NOTSET:
+            logger.setLevel(logging.WARNING)
+
 
 class StorageService:
     """Aggregates per-domain services over one SQLite database."""
 
     def __init__(self, db_path: str | Path) -> None:
+        _quiet_embedded_dependency_loggers()
         self._db_path = Path(db_path).expanduser()
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         cfg = GatewayConfig(cost_tracking={"db_path": str(self._db_path)})

--- a/src/voicegateway/tests/cli/test_cli.py
+++ b/src/voicegateway/tests/cli/test_cli.py
@@ -35,6 +35,39 @@ def test_init_custom_output(tmp_path):
     assert os.path.exists(out)
 
 
+def test_init_writes_minimal_template_by_default(tmp_path, monkeypatch):
+    """`voicegw init` gives first-timers a short, valid config, not a 269-line dump."""
+    from voicegateway.core.config import GatewayConfig
+
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+
+    content = (tmp_path / "voicegw.yaml").read_text()
+    # Small enough to read at a glance, and free of advanced blocks.
+    assert content.count("\n") < 50
+    assert "stacks:" not in content
+    assert "guardrails:" not in content
+    # Still a working voice stack: provider + model blocks present.
+    assert "providers:" in content
+    assert "models:" in content
+    # And it actually parses through the real loader (defaults fill the rest).
+    GatewayConfig.load(tmp_path / "voicegw.yaml")
+    # Points the user at the exhaustive template.
+    assert "--full" in result.output
+
+
+def test_init_full_flag_writes_exhaustive_template(tmp_path, monkeypatch):
+    """`voicegw init --full` writes the complete annotated reference config."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--full"])
+    assert result.exit_code == 0
+
+    content = (tmp_path / "voicegw.yaml").read_text()
+    assert "stacks:" in content
+    assert content.count("\n") > 200
+
+
 def test_status(temp_config, tmp_path, monkeypatch):
     monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "cli-status.db"))
     result = runner.invoke(app, ["status", "--config", temp_config])

--- a/src/voicegateway/tests/server/test_dashboard_api.py
+++ b/src/voicegateway/tests/server/test_dashboard_api.py
@@ -46,6 +46,59 @@ async def test_api_status_includes_pricing_sources(client):
         assert data["pricing"][modality]["source"].startswith("voice-prices@")
 
 
+async def test_api_status_includes_version(client):
+    """The dashboard footer reads the live version from here."""
+    from voicegateway import __version__
+
+    resp = await client.get("/api/status")
+    data = resp.json()
+    assert data["version"] == __version__.split("+", 1)[0]
+
+
+async def test_api_status_lists_only_models_with_a_configured_provider(
+    tmp_path, monkeypatch
+):
+    """Models whose cloud provider has no API key are hidden; local ones stay."""
+    import yaml as _yaml
+
+    cfg = {
+        "providers": {
+            "openai": {"api_key": "test-key"},
+            "elevenlabs": {},  # cloud provider, no key -> not configured
+            "ollama": {"base_url": "http://localhost:11434"},  # local -> configured
+        },
+        "models": {
+            "llm": {
+                "openai/gpt-4o-mini": {"provider": "openai", "model": "gpt-4o-mini"},
+                "ollama/qwen2.5:3b": {"provider": "ollama", "model": "qwen2.5:3b"},
+            },
+            "tts": {
+                "elevenlabs/eleven_turbo_v2_5": {
+                    "provider": "elevenlabs",
+                    "model": "eleven_turbo_v2_5",
+                },
+            },
+        },
+    }
+    config_path = tmp_path / "voicegw.yaml"
+    config_path.write_text(_yaml.safe_dump(cfg))
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "filter-test.db"))
+
+    gateway = Gateway(config_path=str(config_path))
+    app = build_app(gateway, enable_mcp_sse=False, enable_dashboard=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        data = (await c.get("/api/status")).json()
+
+    # Keyed cloud model and keyless local model are listed.
+    assert "openai/gpt-4o-mini" in data["models"]
+    assert "ollama/qwen2.5:3b" in data["models"]
+    # Keyless cloud model is filtered out.
+    assert "elevenlabs/eleven_turbo_v2_5" not in data["models"]
+    # The unconfigured provider still appears so the UI can flag it.
+    assert data["providers"]["elevenlabs"]["configured"] is False
+
+
 async def test_api_costs(client):
     resp = await client.get("/api/costs")
     assert resp.status_code == 200

--- a/src/voicegateway/tests/server/test_dashboard_api.py
+++ b/src/voicegateway/tests/server/test_dashboard_api.py
@@ -99,6 +99,43 @@ async def test_api_status_lists_only_models_with_a_configured_provider(
     assert data["providers"]["elevenlabs"]["configured"] is False
 
 
+async def test_api_overview_active_models_matches_status_filter(tmp_path, monkeypatch):
+    """`active_models` counts only callable models, matching /api/status."""
+    import yaml as _yaml
+
+    cfg = {
+        "providers": {
+            "openai": {"api_key": "test-key"},
+            "elevenlabs": {},  # no key -> its model must not be counted
+        },
+        "models": {
+            "llm": {
+                "openai/gpt-4o-mini": {"provider": "openai", "model": "gpt-4o-mini"},
+            },
+            "tts": {
+                "elevenlabs/eleven_turbo_v2_5": {
+                    "provider": "elevenlabs",
+                    "model": "eleven_turbo_v2_5",
+                },
+            },
+        },
+    }
+    config_path = tmp_path / "voicegw.yaml"
+    config_path.write_text(_yaml.safe_dump(cfg))
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "overview-filter.db"))
+
+    gateway = Gateway(config_path=str(config_path))
+    app = build_app(gateway, enable_mcp_sse=False, enable_dashboard=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        overview = (await c.get("/api/overview")).json()
+        status = (await c.get("/api/status")).json()
+
+    # Only the openai model is callable; the keyless elevenlabs one is excluded.
+    assert overview["active_models"] == 1
+    assert overview["active_models"] == len(status["models"])
+
+
 async def test_api_costs(client):
     resp = await client.get("/api/costs")
     assert resp.status_code == 200

--- a/src/voicegateway/tests/server/test_server.py
+++ b/src/voicegateway/tests/server/test_server.py
@@ -26,12 +26,16 @@ async def client(app):
 
 
 async def test_health(client):
+    from voicegateway import __version__
+
     resp = await client.get("/health")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "ok"
     assert "uptime_seconds" in data
-    assert data["version"] == "0.5.0"
+    # Reports the real installed version (local build segment stripped),
+    # not a hand-edited string that drifts every release.
+    assert data["version"] == __version__.split("+", 1)[0]
 
 
 async def test_v1_status(client):
@@ -319,8 +323,7 @@ async def test_v1_costs_combined_query_params(client, gateway):
     assert data["by_modality"].keys() == {"llm", "stt", "tts"}
     assert data["by_modality"]["llm"]["cost"] == pytest.approx(0.10, abs=0.001)
     assert (
-        data["by_model"]["openai/gpt-4o-mini"]["pricing_source"]
-        == "voice-prices@0.0.8"
+        data["by_model"]["openai/gpt-4o-mini"]["pricing_source"] == "voice-prices@0.0.8"
     )
     assert (
         data["by_model"]["deepgram/nova-3"]["pricing_source"] == "local-stt@2026-05-04"

--- a/src/voicegateway/tests/services/test_storage_service_logging.py
+++ b/src/voicegateway/tests/services/test_storage_service_logging.py
@@ -1,0 +1,46 @@
+"""Embedded storage must not flood a host agent's DEBUG logs.
+
+``voicegateway.attach()`` runs StorageService in-process inside a LiveKit
+agent. The aiosqlite driver and alembic both log every operation at DEBUG,
+which a LiveKit ``console``/``dev`` run (root logger at DEBUG) would surface
+as a wall of per-query noise. StorageService quiets those two noisy
+dependency loggers, but only when the caller has not set a level of their
+own.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from voicegateway.services.storage_service import StorageService
+
+
+def test_embedded_storage_quiets_unconfigured_aiosqlite_logger(tmp_path):
+    lg = logging.getLogger("aiosqlite")
+    lg.setLevel(logging.NOTSET)  # default: inherits root (DEBUG under console mode)
+    try:
+        StorageService(tmp_path / "x.db")
+        assert lg.level == logging.WARNING
+    finally:
+        lg.setLevel(logging.NOTSET)
+
+
+def test_embedded_storage_quiets_unconfigured_alembic_logger(tmp_path):
+    lg = logging.getLogger("alembic")
+    lg.setLevel(logging.NOTSET)
+    try:
+        StorageService(tmp_path / "y.db")
+        assert lg.level == logging.WARNING
+    finally:
+        lg.setLevel(logging.NOTSET)
+
+
+def test_embedded_storage_respects_an_explicit_aiosqlite_level(tmp_path):
+    """A developer who deliberately turns aiosqlite up keeps their setting."""
+    lg = logging.getLogger("aiosqlite")
+    lg.setLevel(logging.DEBUG)
+    try:
+        StorageService(tmp_path / "z.db")
+        assert lg.level == logging.DEBUG
+    finally:
+        lg.setLevel(logging.NOTSET)

--- a/src/voicegateway/utils/cli/init.py
+++ b/src/voicegateway/utils/cli/init.py
@@ -6,9 +6,18 @@ from importlib import resources
 
 
 def _read_example_config() -> str:
-    """Return the canonical example config shipped with the wheel."""
+    """Return the full annotated example config shipped with the wheel."""
     return (
         resources.files("voicegateway.data")
         .joinpath("voicegw.example.yaml")
+        .read_text(encoding="utf-8")
+    )
+
+
+def _read_minimal_config() -> str:
+    """Return the short, beginner-friendly starter config shipped with the wheel."""
+    return (
+        resources.files("voicegateway.data")
+        .joinpath("voicegw.minimal.yaml")
         .read_text(encoding="utf-8")
     )


### PR DESCRIPTION
Polish surfaced while dogfooding the agent SDK against a live LiveKit agent. Four small, independent fixes; ships as v0.8.4.

## 1. Embedded storage no longer floods agent DEBUG logs
`voicegateway.attach()` runs SQLite storage in-process. Under a LiveKit `console`/`dev` run (root logger at DEBUG), `aiosqlite` and `alembic` log a line per query, burying the agent's own output (a multi-thousand-line wall for a 20s conversation).

`StorageService` now quiets those two dependency loggers to WARNING, but only when the caller has not set a level of their own (an explicit `aiosqlite=DEBUG` still wins). `src/voicegateway/services/storage_service.py`.

## 2. Dashboard and `/health` report the real version
The footer pill (`App.tsx`) and the `/health` endpoint (`system.py`) were both hardcoded to `0.5.0`. They now read the installed `__version__` (PEP 440 local build segment stripped), served via `/health` and `/api/status`, and the footer renders it dynamically.

## 3. Dashboard lists only callable models
`/api/status` now returns models whose provider is configured (a cloud API key is set, or it is a local provider), so the sidebar count and the Models page stop advertising models the operator cannot reach. `src/voicegateway/server/api/dashboard/status.py`.

## 4. `voicegw init` is minimal by default
First run gets a short STT + LLM + TTS starter (about 35 lines) instead of the 269-line reference. `voicegw init --full` writes the complete annotated config. New `voicegw.minimal.yaml` ships in the wheel alongside the example.

## Validation
- TDD throughout (red then green) for each fix: logger quieting (incl. respecting an explicit level), live version on both endpoints, model filtering (keyed cloud + local in, keyless cloud out), and minimal-vs-`--full` init (the minimal template parses through the real `GatewayConfig.load`).
- Full suite: 1697 passed, 5 skipped. `ruff` clean. `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard footer now displays the actual installed version instead of static text.
  * `voicegw init` command now supports a `--full` flag to write complete reference configuration; default creates minimal starter config.

* **Bug Fixes**
  * Dashboard and health endpoints now report the correct installed version.
  * Status API now lists only models whose providers are configured and callable.
  * Reduced verbose logging from embedded database layer.

* **Tests**
  * Added coverage for version reporting and model filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->