### PR TITLE
fix(docker): copy alembic into the build stage (v0.8.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.8.5: fix the Docker image build
+
+The published Docker images for v0.8.3 and v0.8.4 failed to build and were
+never pushed. This restores them. The Python package is unchanged from v0.8.4.
+
+### Fixed
+
+- **The Docker image builds again.** v0.8.3 added a wheel `force-include` for the
+  Alembic migrations, but neither Dockerfile copied `alembic/` and `alembic.ini`
+  into the build stage, so `pip install` failed during metadata generation with
+  `Forced include not found: /build/alembic`. Both the core and dashboard
+  Dockerfiles now copy the migrations into the builder before installing. PyPI
+  was unaffected (it uses a different build path); only the Docker images failed.
+
 ## v0.8.4: quieter agents, live dashboard version, friendlier init
 
 Polish from dogfooding the agent SDK. Embedded telemetry no longer floods a

--- a/src/dashboard/Dockerfile
+++ b/src/dashboard/Dockerfile
@@ -41,6 +41,11 @@ COPY pyproject.toml README.md ./
 # from pyproject so the src/ structure has to be present during pip install.
 COPY src/voicegateway/ ./src/voicegateway/
 COPY src/dashboard/ ./src/dashboard/
+# The wheel force-includes the migrations (pyproject
+# [tool.hatch.build.targets.wheel.force-include]), so hatchling needs
+# alembic.ini + alembic/ present during pip install, not just at runtime.
+COPY alembic.ini ./
+COPY alembic/ ./alembic/
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}

--- a/src/voicegateway/Dockerfile
+++ b/src/voicegateway/Dockerfile
@@ -33,6 +33,13 @@ COPY pyproject.toml README.md ./
 # directories present at the path it expects.
 COPY src/voicegateway/ ./src/voicegateway/
 COPY src/dashboard/ ./src/dashboard/
+# The wheel force-includes the migrations (pyproject
+# [tool.hatch.build.targets.wheel.force-include]), so hatchling needs
+# alembic.ini + alembic/ present at build time, not just copied into the
+# runtime stage below. Without this the build fails with
+# "Forced include not found: /build/alembic".
+COPY alembic.ini ./
+COPY alembic/ ./alembic/
 
 ARG VERSION=0.5.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}


### PR DESCRIPTION
## The bug

The Docker image builds for **v0.8.3 and v0.8.4 both failed and never published**. v0.8.0 through v0.8.2 published fine.

v0.8.3 added a wheel `force-include` for the Alembic migrations:
```toml
[tool.hatch.build.targets.wheel.force-include]
"alembic.ini" = "voicegateway/alembic.ini"
"alembic" = "voicegateway/alembic"
```
hatchling resolves those source paths against the build root. But both Dockerfiles' builder stages copy only `pyproject.toml`, `README.md`, `src/voicegateway/`, and `src/dashboard/` into `/build`, never `alembic/`. So `pip install` failed during metadata generation:
```
FileNotFoundError: Forced include not found: /build/alembic
ERROR: process "pip install ... .[cloud,mcp,dashboard,tui,postgres]" exit code: 1
```
PyPI was unaffected (different build path), which is why 0.8.3 and 0.8.4 shipped to PyPI but not to Docker Hub.

## The fix

Both the core (`src/voicegateway/Dockerfile`) and dashboard (`src/dashboard/Dockerfile`) builder stages now copy `alembic.ini` + `alembic/` into the build context before `pip install`. (The runtime stage of the core image already copied them for the running container; the gap was build time.)

## Validation

Docker isn't available in my environment, so I reproduced the builder against hatchling directly:
- Replicated the builder's exact copy set (`pyproject.toml` + `README.md` + `src/`, no alembic) and ran a wheel build: reproduced the identical `FileNotFoundError: Forced include not found: .../alembic`.
- Added `alembic.ini` + `alembic/` (what this PR's `COPY` does) and rebuilt: wheel builds, and `voicegateway/alembic.ini` + all five `voicegateway/alembic/versions/*.py` land in the wheel.

The real Docker build runs on the v0.8.5 tag push (the Docker workflow is tag-triggered, not PR-triggered). Ships as **v0.8.5**; the Python package is identical to v0.8.4.
