### PR TITLE
fix(cli): minimal voicegw init config enables cost tracking (v0.8.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.8.6: minimal config records to storage so the dashboard works
+
+### Fixed
+
+- **`voicegw init` enables cost tracking by default again.** The v0.8.4 minimal
+  template dropped the `cost_tracking` block, so `voicegw serve` started with
+  storage disabled (`gateway.storage is None`) and the dashboard showed no costs,
+  sessions, or agents, even though the agent SDK's `voicegateway.attach()` was
+  writing to the default SQLite database. The minimal template now enables
+  `cost_tracking` at that same default path
+  (`~/.config/voicegateway/voicegw.db`), so a first run sees its agents on the
+  dashboard with no extra wiring. Existing configs are unaffected; if your server
+  was already started with storage off, add `cost_tracking: {enabled: true}` or
+  set `VOICEGW_DB_PATH`.
+
 ## v0.8.5: fix the Docker image build
 
 The published Docker images for v0.8.3 and v0.8.4 failed to build and were

--- a/src/voicegateway/data/voicegw.minimal.yaml
+++ b/src/voicegateway/data/voicegw.minimal.yaml
@@ -29,6 +29,15 @@ models:
       provider: cartesia
       model: sonic-3
 
+# Record requests to a local SQLite database so `voicegw serve` and
+# `voicegw dashboard` can show your costs, sessions, and agents. The agent
+# SDK's voicegateway.attach() writes to this same default path, so the
+# dashboard sees your agents with no extra wiring. Without this block the
+# server runs with storage off and the dashboard stays empty.
+cost_tracking:
+  enabled: true
+  db_path: ~/.config/voicegateway/voicegw.db
+
 projects:
   default:
     name: "My Voice Agent"

--- a/src/voicegateway/tests/cli/test_cli.py
+++ b/src/voicegateway/tests/cli/test_cli.py
@@ -68,6 +68,23 @@ def test_init_full_flag_writes_exhaustive_template(tmp_path, monkeypatch):
     assert content.count("\n") > 200
 
 
+def test_init_minimal_template_enables_cost_tracking(tmp_path, monkeypatch):
+    """A first run must turn on storage, or `voicegw serve`'s dashboard is empty.
+
+    With no cost_tracking block (and no VOICEGW_DB_* env), Gateway leaves
+    storage disabled and /api/agents returns nothing even while the agent SDK
+    is writing to the default DB.
+    """
+    from voicegateway.core.config import GatewayConfig
+
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+
+    config = GatewayConfig.load(tmp_path / "voicegw.yaml")
+    assert config.cost_tracking.get("enabled") is True
+
+
 def test_status(temp_config, tmp_path, monkeypatch):
     monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "cli-status.db"))
     result = runner.invoke(app, ["status", "--config", temp_config])


### PR DESCRIPTION
## The bug

Surfaced while dogfooding: `voicegw init` then `voicegw serve` then run an agent, and the dashboard shows **no agents** (or costs or sessions), even though the agent records fine.

Traced it: the agent's `voicegateway.attach()` writes correctly to `~/.config/voicegateway/voicegw.db` (confirmed: 103 requests + 4 sessions tagged `agent-1`). But `voicegw serve` runs with **storage disabled**. Per `gateway.py:40`, storage turns on only via `cost_tracking.enabled`, `VOICEGW_DB_PATH`, or `VOICEGW_DB_URL`. The 34-line minimal template introduced in v0.8.4 dropped the `cost_tracking` block (the old 269-line template had it), so `gateway.storage is None` and `/api/agents` short-circuits to `{"agents": []}` with a 200.

## The fix

The minimal template now enables `cost_tracking` at the default path that `attach()` also writes to:
```yaml
cost_tracking:
  enabled: true
  db_path: ~/.config/voicegateway/voicegw.db
```
So a first run (`voicegw init` then `voicegw serve` then attach in an agent) shows its agents on the dashboard with no extra wiring. Template stays minimal (43 lines).

## Validation

- New regression test `test_init_minimal_template_enables_cost_tracking` loads the generated config and asserts `cost_tracking.enabled is True`.
- Confirmed against the live DB: `agent_observations` already holds the `agent-1` rollup row and `read_agents` has no time-window filter, so enabling storage surfaces it immediately.
- Full suite: 1699 passed, 5 skipped. ruff clean; YAML parses.

Ships as **v0.8.6**. Existing configs are unaffected.
