### PR TITLE
feat(openrtc): VoiceGatewayObserver for per-session cost tracking

### DIFF
--- a/docs/examples/openrtc-multi-agent.md
+++ b/docs/examples/openrtc-multi-agent.md
@@ -41,7 +41,7 @@ Per call, rows are tagged:
 - `project`: the value you passed to the observer.
 - `agent_id`: which registered agent handled the call (`info.agent_name`).
 - `tenant_id`: `info.metadata["tenant"]` if present in the room or job
-  metadata, else empty.
+  metadata, else `None`.
 
 ## Where the numbers go
 

--- a/docs/examples/openrtc-multi-agent.md
+++ b/docs/examples/openrtc-multi-agent.md
@@ -1,0 +1,70 @@
+# OpenRTC: track every agent in one worker
+
+[OpenRTC](https://github.com/mahimailabs/openrtc-runtime) runs N LiveKit voice
+agents in one worker. VoiceGateway plugs into its `SessionObserver` seam, so a
+single line gives every session per-call cost tracking, attributed per agent
+and per tenant.
+
+## Install
+
+```bash
+uv add "voicegateway[openrtc]"
+```
+
+## One line: hand the pool an observer
+
+```python
+from openrtc import AgentPool
+from voicegateway.openrtc import VoiceGatewayObserver
+
+pool = AgentPool(
+    observers=[
+        VoiceGatewayObserver(
+            project="prod",
+            collector_url="https://collector.example.com",  # your fleet collector
+            virtual_key="vk_live_...",
+        )
+    ],
+)
+pool.add("restaurant", RestaurantAgent, stt=..., llm=..., tts=...)
+pool.add("dental", DentalAgent, stt=..., llm=..., tts=...)
+pool.run()
+```
+
+You do not touch your `Agent` subclasses, tools, or session wiring. The
+observer attaches VoiceGateway to each live session automatically.
+
+## What gets recorded
+
+Per call, rows are tagged:
+
+- `project`: the value you passed to the observer.
+- `agent_id`: which registered agent handled the call (`info.agent_name`).
+- `tenant_id`: `info.metadata["tenant"]` if present in the room or job
+  metadata, else empty.
+
+## Where the numbers go
+
+- **Fleet mode** (shown above, `collector_url` set): one shared
+  `RemoteCollectorSink` batches rows and POSTs them to
+  `<collector_url>/v1/ingest` with `Authorization: Bearer <virtual_key>`. Every
+  worker pushes to the same collector, so you slice cost by `agent_id`,
+  `project`, and `tenant` across the whole fleet.
+- **Single node** (omit `collector_url`): rows write to a local SQLite database
+  (`db_path`, else `VOICEGW_DB_PATH`, else the default). Run `voicegw dashboard`
+  to read it.
+
+## Multi-tenant attribution
+
+Dispatch jobs with room or job metadata like `{"tenant": "acme-corp"}`. OpenRTC
+parses and merges it, and the observer reads `tenant` per call, so one agent
+serving many tenants produces cleanly separated cost streams with no branching
+in your code.
+
+## How it works
+
+The observer builds one sink lazily on the first session and shares it for the
+worker's life. It holds only configuration, so it is safe to use with OpenRTC
+`process` isolation (it pickles cleanly and rebuilds its sink in the worker).
+`attach()` flushes the shared sink when each session closes but never closes it,
+so one session ending never disrupts the others.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ whisper = ["faster-whisper>=1.0.0"]
 kokoro = ["kokoro-onnx>=0.5.0", "onnxruntime>=1.19.0"]
 piper = ["piper-tts>=1.2.0"]
 
+# OpenRTC integration: drive cost tracking from an AgentPool's SessionObserver
+# seam. The adapter (voicegateway.openrtc) has no hard runtime import of
+# openrtc; this extra pins the release that ships SessionObserver.
+openrtc = ["openrtc>=0.3.0"]
+
 # All cloud providers, plus the daemon-control deps the v0.1.0
 # lifecycle commands rely on (psutil for port + process inspection
 # in voicegw doctor, platformdirs for the OS-canonical config home

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -200,12 +200,18 @@ def _default_agent_id() -> str:
     return os.environ.get("VOICEGW_AGENT_ID") or socket.gethostname() or "agent"
 
 
-def _build_default_sink(collector_url: str | None, virtual_key: str | None) -> Sink:
+def _build_default_sink(
+    collector_url: str | None,
+    virtual_key: str | None,
+    db_path: str | None = None,
+) -> Sink:
     """Build the sink for attach() from env/args.
 
     Single-node default is a LocalSqliteSink over the embedded StorageService.
     Fleet mode (``collector_url`` set) uses the RemoteCollectorSink, which
-    batches rows and pushes them to the collector's ``/v1/ingest``.
+    batches rows and pushes them to the collector's ``/v1/ingest``. ``db_path``
+    overrides the local SQLite path (falls back to ``VOICEGW_DB_PATH`` then the
+    default) and is ignored on the fleet branch.
     """
     if collector_url:
         from voicegateway.services.sinks import RemoteCollectorSink
@@ -215,8 +221,8 @@ def _build_default_sink(collector_url: str | None, virtual_key: str | None) -> S
     from voicegateway.services.sinks import LocalSqliteSink
     from voicegateway.services.storage_service import StorageService
 
-    db_path = os.environ.get("VOICEGW_DB_PATH") or DEFAULT_DB_PATH
-    return LocalSqliteSink(StorageService(db_path))
+    resolved_path = db_path or os.environ.get("VOICEGW_DB_PATH") or DEFAULT_DB_PATH
+    return LocalSqliteSink(StorageService(resolved_path))
 
 
 # Strong refs to in-flight session-close finalize tasks; the event loop only

--- a/src/voicegateway/openrtc.py
+++ b/src/voicegateway/openrtc.py
@@ -1,0 +1,87 @@
+"""OpenRTC integration: drive VoiceGateway cost tracking from session lifecycle.
+
+``VoiceGatewayObserver`` implements OpenRTC's ``SessionObserver`` protocol
+structurally (duck-typed, no runtime ``openrtc`` import) so an OpenRTC
+``AgentPool`` can attach VoiceGateway to every live session with one line::
+
+    from openrtc import AgentPool
+    from voicegateway.openrtc import VoiceGatewayObserver
+
+    pool = AgentPool(observers=[VoiceGatewayObserver(
+        project="prod",
+        collector_url="https://collector.example.com",
+        virtual_key="vk_...",
+    )])
+
+One sink is built lazily per worker process and shared across every session.
+``attach()`` flushes but never closes a passed sink, so the first session
+ending leaves the shared sink usable for the rest. The observer holds only
+config, so it pickles cleanly into OpenRTC ``process``-isolation workers; the
+live sink is rebuilt in-worker on the first session.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from voicegateway.inference.session.attach import _build_default_sink, attach
+
+if TYPE_CHECKING:
+    from livekit.agents import AgentSession
+    from openrtc import SessionInfo, SessionOutcome
+
+    from voicegateway.services.sinks import Sink
+
+
+class VoiceGatewayObserver:
+    """OpenRTC ``SessionObserver`` that tracks per-call cost for every session.
+
+    Attribution per session: ``project`` from this observer, ``agent_id`` from
+    ``info.agent_name``, ``tenant_id`` from ``info.metadata['tenant']``.
+    """
+
+    def __init__(
+        self,
+        *,
+        project: str = "default",
+        collector_url: str | None = None,
+        virtual_key: str | None = None,
+        db_path: str | None = None,
+    ) -> None:
+        self._project = project
+        self._collector_url = collector_url
+        self._virtual_key = virtual_key
+        self._db_path = db_path
+        self._sink: Sink | None = None
+
+    def _ensure_sink(self) -> Sink:
+        # Must stay await-free between the check and the assignment so two
+        # concurrent first-sessions on one event loop cannot both build a sink.
+        if self._sink is None:
+            self._sink = _build_default_sink(
+                self._collector_url or os.environ.get("VOICEGW_COLLECTOR_URL"),
+                self._virtual_key or os.environ.get("VOICEGW_VIRTUAL_KEY"),
+                db_path=self._db_path,
+            )
+        return self._sink
+
+    async def on_session_start(
+        self, info: SessionInfo, session: AgentSession[Any]
+    ) -> None:
+        attach(
+            session,
+            project=self._project,
+            agent_id=info.agent_name,
+            tenant_id=info.metadata.get("tenant"),
+            sink=self._ensure_sink(),
+        )
+
+    async def on_session_end(self, info: SessionInfo, outcome: SessionOutcome) -> None:
+        if self._sink is not None:
+            await self._sink.flush()
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_sink"] = None
+        return state

--- a/src/voicegateway/tests/integration/test_openrtc_observer.py
+++ b/src/voicegateway/tests/integration/test_openrtc_observer.py
@@ -1,0 +1,160 @@
+"""Tests for the OpenRTC SessionObserver adapter (VoiceGatewayObserver)."""
+
+from __future__ import annotations
+
+import pickle
+from typing import Any
+
+from voicegateway.openrtc import VoiceGatewayObserver
+
+
+class _FakeInfo:
+    """Stand-in for openrtc.SessionInfo (duck-typed: agent_name + metadata)."""
+
+    def __init__(self, agent_name: str, metadata: dict[str, str]) -> None:
+        self.agent_name = agent_name
+        self.metadata = metadata
+
+
+class _FakeOutcome:
+    """Stand-in for openrtc.SessionOutcome."""
+
+
+class _FakeSession:
+    """Stand-in for livekit.agents.AgentSession."""
+
+
+class _SentinelSink:
+    """A sink stand-in that records flush calls."""
+
+    def __init__(self) -> None:
+        self.flushes = 0
+        self.closed = False
+
+    async def flush(self) -> None:
+        self.flushes += 1
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _patch(monkeypatch: Any) -> tuple[list[dict[str, Any]], _SentinelSink, list[Any]]:
+    """Patch attach (recorder) and _build_default_sink (sentinel). Returns
+    (attach_calls, the_one_sink, build_args)."""
+    attach_calls: list[dict[str, Any]] = []
+    the_sink = _SentinelSink()
+    build_args: list[Any] = []
+
+    def _fake_attach(session: Any, **kwargs: Any) -> str:
+        attach_calls.append({"session": session, **kwargs})
+        return "session-id"
+
+    def _fake_build(collector_url: Any, virtual_key: Any, db_path: Any = None) -> Any:
+        build_args.append((collector_url, virtual_key, db_path))
+        return the_sink
+
+    monkeypatch.setattr("voicegateway.openrtc.attach", _fake_attach)
+    monkeypatch.setattr("voicegateway.openrtc._build_default_sink", _fake_build)
+    return attach_calls, the_sink, build_args
+
+
+async def test_on_session_start_calls_attach_with_mapped_attribution(
+    monkeypatch: Any,
+) -> None:
+    attach_calls, the_sink, _ = _patch(monkeypatch)
+    obs = VoiceGatewayObserver(project="prod")
+    info = _FakeInfo("restaurant", {"tenant": "acme"})
+
+    await obs.on_session_start(info, _FakeSession())
+
+    assert len(attach_calls) == 1
+    call = attach_calls[0]
+    assert call["project"] == "prod"
+    assert call["agent_id"] == "restaurant"
+    assert call["tenant_id"] == "acme"
+    assert call["sink"] is the_sink
+
+
+async def test_tenant_id_is_none_when_metadata_lacks_tenant(
+    monkeypatch: Any,
+) -> None:
+    attach_calls, _, _ = _patch(monkeypatch)
+    obs = VoiceGatewayObserver()
+    await obs.on_session_start(_FakeInfo("dental", {}), _FakeSession())
+    assert attach_calls[0]["tenant_id"] is None
+
+
+async def test_sink_is_built_once_and_shared_across_sessions(
+    monkeypatch: Any,
+) -> None:
+    attach_calls, the_sink, build_args = _patch(monkeypatch)
+    obs = VoiceGatewayObserver(collector_url="https://c.example.com")
+
+    for _ in range(3):
+        await obs.on_session_start(_FakeInfo("a", {}), _FakeSession())
+
+    assert len(build_args) == 1  # built exactly once
+    assert all(call["sink"] is the_sink for call in attach_calls)
+
+
+async def test_env_fallbacks_and_constructor_precedence(
+    monkeypatch: Any,
+) -> None:
+    _, _, build_args = _patch(monkeypatch)
+    monkeypatch.setenv("VOICEGW_COLLECTOR_URL", "https://env-collector")
+    monkeypatch.setenv("VOICEGW_VIRTUAL_KEY", "vk_env")
+
+    # No constructor collector/key: env wins.
+    obs_env = VoiceGatewayObserver()
+    await obs_env.on_session_start(_FakeInfo("a", {}), _FakeSession())
+    assert build_args[-1][0] == "https://env-collector"
+    assert build_args[-1][1] == "vk_env"
+
+    # Constructor beats env.
+    obs_explicit = VoiceGatewayObserver(
+        collector_url="https://explicit", virtual_key="vk_explicit"
+    )
+    await obs_explicit.on_session_start(_FakeInfo("a", {}), _FakeSession())
+    assert build_args[-1][0] == "https://explicit"
+    assert build_args[-1][1] == "vk_explicit"
+
+
+async def test_db_path_passed_through_to_build(monkeypatch: Any) -> None:
+    _, _, build_args = _patch(monkeypatch)
+    obs = VoiceGatewayObserver(db_path="/tmp/vg.db")
+    await obs.on_session_start(_FakeInfo("a", {}), _FakeSession())
+    assert build_args[-1][2] == "/tmp/vg.db"
+
+
+async def test_on_session_end_flushes(monkeypatch: Any) -> None:
+    _, the_sink, _ = _patch(monkeypatch)
+    obs = VoiceGatewayObserver()
+    await obs.on_session_start(_FakeInfo("a", {}), _FakeSession())
+
+    await obs.on_session_end(_FakeInfo("a", {}), _FakeOutcome())
+
+    assert the_sink.flushes >= 1
+    assert the_sink.closed is False  # flush, never aclose
+
+
+async def test_on_session_end_without_start_does_not_raise(
+    monkeypatch: Any,
+) -> None:
+    _, _, build_args = _patch(monkeypatch)
+    obs = VoiceGatewayObserver()
+    await obs.on_session_end(_FakeInfo("a", {}), _FakeOutcome())  # no start first
+    assert build_args == []  # no sink built
+
+
+def test_observer_is_picklable_and_drops_live_sink(monkeypatch: Any) -> None:
+    _patch(monkeypatch)
+    obs = VoiceGatewayObserver(project="prod", collector_url="https://c")
+    obs._ensure_sink()  # build a live sink
+    assert obs._sink is not None
+
+    restored = pickle.loads(pickle.dumps(obs))
+
+    assert isinstance(restored, VoiceGatewayObserver)
+    assert restored._project == "prod"
+    assert restored._collector_url == "https://c"
+    assert restored._sink is None  # spawn contract: live sink dropped

--- a/src/voicegateway/tests/services/test_build_default_sink_db_path.py
+++ b/src/voicegateway/tests/services/test_build_default_sink_db_path.py
@@ -1,0 +1,48 @@
+"""Tests for the additive db_path kwarg on _build_default_sink."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from voicegateway.inference.session.attach import _build_default_sink
+from voicegateway.services.sinks import LocalSqliteSink, RemoteCollectorSink
+
+
+def test_db_path_used_on_local_branch(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    class _RecordingStorage:
+        def __init__(self, db_path: str) -> None:
+            captured["db_path"] = db_path
+
+    monkeypatch.setattr(
+        "voicegateway.services.storage_service.StorageService", _RecordingStorage
+    )
+
+    sink = _build_default_sink(None, None, db_path="/tmp/custom-vg.db")
+
+    assert isinstance(sink, LocalSqliteSink)
+    assert captured["db_path"] == "/tmp/custom-vg.db"
+
+
+def test_db_path_ignored_on_fleet_branch() -> None:
+    sink = _build_default_sink("https://collector.example.com", "vk_123", db_path="/x")
+    assert isinstance(sink, RemoteCollectorSink)
+
+
+def test_backward_compatible_two_arg_call(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    class _RecordingStorage:
+        def __init__(self, db_path: str) -> None:
+            captured["db_path"] = db_path
+
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.setattr(
+        "voicegateway.services.storage_service.StorageService", _RecordingStorage
+    )
+
+    sink = _build_default_sink(None, None)
+
+    assert isinstance(sink, LocalSqliteSink)
+    assert captured["db_path"] == "~/.config/voicegateway/voicegw.db"


### PR DESCRIPTION
## Summary

Adds an optional VoiceGateway integration for [OpenRTC](https://github.com/mahimailabs/openrtc): a `VoiceGatewayObserver` that implements OpenRTC's `SessionObserver` protocol and drives the existing `attach()` per session. For an OpenRTC user, adopting per-call cost tracking across a whole multi-agent worker becomes one line:

```python
from openrtc import AgentPool
from voicegateway.openrtc import VoiceGatewayObserver

pool = AgentPool(observers=[VoiceGatewayObserver(
    project="prod",
    collector_url="https://collector.example.com",
    virtual_key="vk_...",
)])
```

No change to the user's `Agent` subclasses or session wiring. Purely additive; `attach()` is unchanged.

## What's in it

- `voicegateway/openrtc.py`: `VoiceGatewayObserver`. Builds one sink lazily per worker process and shares it across every session; maps `agent_id` from `info.agent_name`, `tenant_id` from `info.metadata["tenant"]`, and `project` from config.
- `attach.py`: an additive `db_path` kwarg on the private `_build_default_sink` helper (default `None`, existing behavior preserved). The public `attach()` signature and behavior are byte-for-byte unchanged.
- `[openrtc]` optional-dependency extra (pins `openrtc>=0.3.0`, the release that ships the `SessionObserver` seam).
- A "Use with OpenRTC" example doc.

## Design highlights

- **One shared sink per worker.** `attach()` flushes but never closes a passed sink, so one session ending leaves the shared sink usable for the rest. The sink is built lazily on the first session via the reused `_build_default_sink` (RemoteCollectorSink in fleet mode, LocalSqliteSink single-node).
- **Concurrency-safe.** `_ensure_sink` is synchronous with no `await` between the None-check and assignment, so two concurrent first-sessions on one event loop cannot both build a sink. Per-session ContextVar state stays isolated because OpenRTC runs each `on_session_start` in the session's own task.
- **Spawn-safe.** The observer holds only config; `__getstate__` drops the live sink, so it pickles cleanly into OpenRTC `process`-isolation workers and rebuilds its sink in-worker.
- **No hard dependency.** The adapter is duck-typed: `openrtc` types are referenced only under `TYPE_CHECKING`, so `import voicegateway.openrtc` works with `openrtc` not installed.

## Validation

- 11 new tests (8 observer + 3 `_build_default_sink`), all passing. Full suite green; `ruff check src` and `mypy` clean.
- Verified against the real released `openrtc==0.3.0`: `VoiceGatewayObserver` satisfies the actual `SessionObserver` protocol, `SessionInfo` exposes the `agent_name`/`metadata` fields the adapter reads, `AgentPool(observers=[obs])` accepts it, and the observer pickles for process isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenRTC session observer that automatically tracks per-call costs for voice agents, including project/agent attribution and tenant attribution from room/job metadata.
* **Documentation**
  * Added a new guide showing how to run multiple agents in one OpenRTC worker and view ingested metrics (remote collector or local dashboard).
* **Bug Fixes**
  * Improved local SQLite sink setup by resolving `db_path` from explicit input, environment variable, or default.
* **Tests**
  * Added integration tests covering attach/flush behavior, environment-vs-argument precedence, tenant handling, and safe pickling behavior.
* **Chores**
  * Added an `openrtc` optional dependency extra.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->