### PR TITLE
fix: collector startup (missing _version.py in image + asyncpg cross-loop)

### DIFF
--- a/src/voicegateway/Dockerfile
+++ b/src/voicegateway/Dockerfile
@@ -81,6 +81,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /install /install
 COPY --chown=voicegw:voicegw src/voicegateway/ /app/voicegateway/
+# The source tree copied above lacks the hatch-vcs _version.py: it is gitignored
+# and written only at build time. /app is the WORKDIR and shadows the installed
+# package on sys.path, so without _version.py here the very first import
+# (``from voicegateway._version import __version__`` in __init__.py) crashes the
+# server on startup. Restore it from the wheel the builder already installed.
+COPY --from=builder --chown=voicegw:voicegw \
+    /install/lib/python3.12/site-packages/voicegateway/_version.py \
+    /app/voicegateway/_version.py
 COPY --chown=voicegw:voicegw src/dashboard/__init__.py /app/dashboard/
 COPY --chown=voicegw:voicegw src/dashboard/api/static/ /app/dashboard/api/static/
 COPY --from=frontend-builder --chown=voicegw:voicegw /build/frontend/dist /app/dashboard/frontend/dist

--- a/src/voicegateway/core/database.py
+++ b/src/voicegateway/core/database.py
@@ -8,12 +8,14 @@ import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.pool import NullPool
 from sqlmodel import SQLModel
 
 from voicegateway.core.config import GatewayConfig
@@ -62,6 +64,23 @@ def _find_alembic_ini() -> Path:
     )
 
 
+def _engine_kwargs(url: str) -> dict[str, Any]:
+    """Per-backend ``create_async_engine`` options.
+
+    asyncpg binds each connection to the event loop that created it, and
+    ``Gateway.__init__`` runs its async startup through several short-lived
+    ``asyncio.run()`` loops (the server later uses its own loop). A pooled
+    Postgres connection would then be reused across loops and asyncpg raises
+    "got Future attached to a different loop". ``NullPool`` opens a fresh
+    connection per checkout, bound to the current loop, which is safe across
+    loops (at the cost of no connection pooling). SQLite (aiosqlite) has no such
+    constraint and keeps the default pool with pre-ping.
+    """
+    if url.startswith("sqlite"):
+        return {"echo": False, "pool_pre_ping": True}
+    return {"echo": False, "poolclass": NullPool}
+
+
 class Database:
     """Async SQLAlchemy engine + session factory bound to a config."""
 
@@ -69,15 +88,11 @@ class Database:
         self.config = config
         url = resolve_database_url(config)
         self._db_file_path = _resolve_db_file_path(config)
-        # Only the SQLite backend has a local file to create. A Postgres
-        # collector URL must not touch the filesystem.
         if url.startswith("sqlite"):
+            # Only the SQLite backend has a local file to create. A Postgres
+            # collector URL must not touch the filesystem.
             self._db_file_path.parent.mkdir(parents=True, exist_ok=True)
-        self._engine = create_async_engine(
-            url,
-            echo=False,
-            pool_pre_ping=True,
-        )
+        self._engine = create_async_engine(url, **_engine_kwargs(url))
         self._session_factory = async_sessionmaker(
             bind=self._engine,
             class_=AsyncSession,

--- a/src/voicegateway/tests/core/test_database_url.py
+++ b/src/voicegateway/tests/core/test_database_url.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy.pool import NullPool
 
 from voicegateway.core.config import GatewayConfig
-from voicegateway.core.database import Database, resolve_database_url
+from voicegateway.core.database import Database, _engine_kwargs, resolve_database_url
 
 
 def test_resolve_database_url_honors_db_url_env(monkeypatch):
@@ -35,3 +36,21 @@ def test_database_builds_postgres_engine_for_db_url(monkeypatch):
     monkeypatch.setenv("VOICEGW_DB_URL", "postgresql+asyncpg://u:p@localhost/vg")
     db = Database(GatewayConfig())
     assert db._engine.url.get_backend_name() == "postgresql"
+    # asyncpg connections are loop-bound; the engine must not pool them.
+    assert isinstance(db._engine.pool, NullPool)
+
+
+def test_engine_kwargs_postgres_uses_nullpool():
+    """asyncpg binds connections to their creating loop, so the Postgres engine
+    must use NullPool and not reuse a connection across Gateway.__init__'s
+    short-lived asyncio.run() loops."""
+    kwargs = _engine_kwargs("postgresql+asyncpg://u:p@localhost/vg")
+    assert kwargs["poolclass"] is NullPool
+
+
+def test_engine_kwargs_sqlite_keeps_default_pool():
+    """SQLite (aiosqlite) tolerates cross-loop reuse, so it keeps the default
+    pool with pre-ping rather than switching to NullPool."""
+    kwargs = _engine_kwargs("sqlite+aiosqlite:////tmp/x.db")
+    assert "poolclass" not in kwargs
+    assert kwargs["pool_pre_ping"] is True


### PR DESCRIPTION
Two startup bugs that together prevented the `docker-compose.collector.yml` stack from running. Found while deploying a real collector.

## 1. Core image missing `_version.py` (crash on every boot)

```
File "/app/voicegateway/__init__.py", line 4, in <module>
    from voicegateway._version import __version__
ModuleNotFoundError: No module named 'voicegateway._version'
```

`_version.py` is generated by hatch-vcs at build time and gitignored. The runtime stage `COPY src/voicegateway/ /app/voicegateway/` brings in the raw source (no `_version.py`), and `WORKDIR /app` shadows the correctly-installed package in `/install` on `sys.path`, so the first import fails. **Fix:** copy the generated `_version.py` from the builder's installed wheel into `/app/voicegateway/`. The dashboard image is unaffected (editable install writes the file in place).

## 2. Postgres engine crashes Gateway init (asyncpg cross-loop)

```
RuntimeError: ... got Future ... attached to a different loop
  StorageService.upsert_managed_project() ... asyncpg
```

`Gateway.__init__` runs its async startup through several short-lived `asyncio.run()` loops (and the server later uses its own loop). asyncpg binds each connection to the loop that created it, so a pooled connection gets reused across loops and crashes. SQLite (aiosqlite) tolerates this; asyncpg does not. **Fix:** build the Postgres async engine with `NullPool` (a fresh connection per checkout, bound to the current loop). SQLite keeps its pooled engine. Extracted `_engine_kwargs(url)` so the pool choice is unit-tested without needing asyncpg installed.

## Validation

- New tests: `_engine_kwargs` returns `NullPool` for Postgres / default pool for SQLite (run in CI without asyncpg); the existing Postgres engine test now also asserts `NullPool`.
- `ruff` clean, `mypy` clean (244 files), 579 core/storage/services/server tests pass.
- The image fix was confirmed live: bind-mounting a hand-written `_version.py` makes the same image boot; switching to SQLite then exposed bug #2, which this PR fixes for Postgres.

Ship in **v0.9.1** (the tag rebuilds and republishes the core image).
