### PR TITLE
fix(collector): make the Postgres backend work, gated by CI

### DIFF
--- a/.github/workflows/postgres-collector.yml
+++ b/.github/workflows/postgres-collector.yml
@@ -1,0 +1,85 @@
+name: Postgres collector
+
+# Gates the fleet collector against a real Postgres backend before release.
+# The "dialect" job runs the collector code against a Postgres service (catches
+# SQLite-vs-Postgres SQL drift); the "image-smoke" job builds the published
+# image and boots the docker-compose.collector.yml stack against Postgres
+# (catches packaging/boot regressions). Both would have caught the v0.9.0-0.9.1
+# collector breakages before they shipped.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  dialect:
+    name: Dialect (code vs Postgres)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: voicegw
+          POSTGRES_PASSWORD: voicegw
+          POSTGRES_DB: voicegw
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U voicegw -d voicegw"
+          --health-interval 5s --health-timeout 5s --health-retries 12
+    env:
+      VOICEGW_DB_URL: postgresql+asyncpg://voicegw:voicegw@localhost:5432/voicegw
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+      - name: Create venv and install
+        run: |
+          uv python install 3.12
+          uv venv --seed --python 3.12
+          uv pip install -e ".[dev,dashboard,mcp,postgres]"
+      - name: Run the Postgres collector integration test
+        run: uv run pytest src/voicegateway/tests/integration/test_postgres_collector.py -v
+
+  image-smoke:
+    name: Image smoke (collector stack on Postgres)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the core image
+        run: docker build -f src/voicegateway/Dockerfile -t voicegateway:ci .
+      - name: Boot the collector stack and smoke init + ingest + costs
+        run: |
+          set -euo pipefail
+          cat > voicegw.yaml <<'EOF'
+          auth:
+            api_keys:
+              - token: "citestkey"
+                name: ci
+                scopes: [write]
+          EOF
+          cat > docker-compose.ci.yml <<'EOF'
+          services:
+            collector:
+              image: voicegateway:ci
+          EOF
+          export VOICEGW_PG_PASSWORD=cipass
+          docker compose -f docker-compose.collector.yml -f docker-compose.ci.yml up -d
+          ok=0
+          for _ in $(seq 1 40); do
+            if curl -fsS http://localhost:8080/health >/dev/null 2>&1; then ok=1; break; fi
+            sleep 3
+          done
+          test "$ok" = 1 || { echo "collector never became healthy"; exit 1; }
+          echo "health: $(curl -fsS http://localhost:8080/health)"
+          curl -fsS -XPOST http://localhost:8080/v1/ingest \
+            -H 'content-type: application/json' -H 'Authorization: Bearer citestkey' \
+            -d '[{"id":"ci1","timestamp":1781880000,"modality":"llm","model_id":"openai/gpt-4o","provider":"openai","project":"default","cost_usd":0.01,"session_id":"ci","agent_id":"ci"}]'
+          curl -fsS http://localhost:8080/v1/costs -H 'Authorization: Bearer citestkey'
+      - name: Collector logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.collector.yml logs collector || true
+      - name: Teardown
+        if: always()
+        run: |
+          docker compose -f docker-compose.collector.yml -f docker-compose.ci.yml down -v || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.9.2: the Postgres fleet collector actually works
+
+The Postgres collector backend carried several SQLite-only SQL constructs that
+crashed the server on startup or on first ingest. They are fixed and now covered
+by a CI job that boots the collector against a real Postgres.
+
+### Fixed
+
+- **Ambiguous `ON CONFLICT` columns.** The project and session upserts referenced
+  bare existing-row columns (`COALESCE(excluded.x, x)`), which Postgres rejects as
+  ambiguous between the target table and `excluded`. They are now table-qualified
+  (`managed_projects.x`, `sessions.x`), which both SQLite and Postgres accept.
+- **`GROUP_CONCAT` in the cost summary.** Replaced with the dialect-appropriate
+  aggregate (`STRING_AGG` on Postgres, `GROUP_CONCAT` on SQLite).
+- **`datetime('now', ...)` in the virtual-key staleness queries.** Replaced with a
+  Postgres-compatible cutoff (`make_interval` / a Python-computed timestamp).
+
+### Added
+
+- **`Postgres collector` CI workflow.** A `dialect` job runs the collector against
+  a Postgres service, and an `image-smoke` job builds the published image and
+  boots `docker-compose.collector.yml` against Postgres. Together they gate the
+  collector on a working Postgres path before release.
+
+## v0.9.1: collector image and Postgres startup fixes
+
+### Fixed
+
+- **The core Docker image boots again.** It shipped without the hatch-vcs
+  generated `_version.py` (the runtime copied the raw source over the installed
+  package), so `import voicegateway` crashed on startup. The generated file is now
+  baked into the image.
+- **Postgres engine event-loop crash.** `Gateway.__init__` runs async startup
+  through several short-lived `asyncio.run()` loops; asyncpg binds connections to
+  their creating loop, so a pooled connection was reused across loops and crashed.
+  The Postgres engine now uses `NullPool`.
+
 ## v0.9.0: per-session cost tracking for OpenRTC multi-agent workers
 
 ### Added

--- a/src/voicegateway/repository/cost_repository.py
+++ b/src/voicegateway/repository/cost_repository.py
@@ -107,10 +107,21 @@ async def get_cost_summary(
     by_provider = {r[0]: {"cost": r[1], "requests": r[2]} for r in result}
 
     if include_pricing_source:
+        # GROUP_CONCAT is SQLite-only; Postgres spells the same aggregate
+        # STRING_AGG(expr, sep). Pick by the bound dialect (default SQLite).
+        try:
+            dialect = session.bind.dialect.name
+        except Exception:  # noqa: BLE001 - default to the SQLite spelling
+            dialect = "sqlite"
+        sources_agg = (
+            "STRING_AGG(DISTINCT pricing_source, ',')"
+            if dialect == "postgresql"
+            else "GROUP_CONCAT(DISTINCT pricing_source)"
+        )
         result = await session.execute(
             text(
                 f"""SELECT model_id, SUM(cost_usd) as cost, COUNT(*) as count,
-                           GROUP_CONCAT(DISTINCT pricing_source) as sources
+                           {sources_agg} as sources
                     FROM requests {where}
                     GROUP BY model_id ORDER BY cost DESC"""
             ),

--- a/src/voicegateway/repository/managed_project_repository.py
+++ b/src/voicegateway/repository/managed_project_repository.py
@@ -46,9 +46,11 @@ _PROJECT_UPSERT = text(
         llm_model=excluded.llm_model,
         tts_model=excluded.tts_model,
         tags=excluded.tags,
-        branding_json=COALESCE(excluded.branding_json, branding_json),
+        branding_json=COALESCE(
+            excluded.branding_json, managed_projects.branding_json
+        ),
         guardrail_policy_json=COALESCE(
-            excluded.guardrail_policy_json, guardrail_policy_json
+            excluded.guardrail_policy_json, managed_projects.guardrail_policy_json
         ),
         updated_at=excluded.updated_at
     """

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -68,41 +68,44 @@ _UPSERT_SESSION = text(
                :guardrails_active, :guardrails_bypassed,
                :guardrail_snapshot_json)
        ON CONFLICT(id) DO UPDATE SET
-           total_cost_usd = total_cost_usd + excluded.total_cost_usd,
-           request_count = request_count + 1,
-           tenant_id = COALESCE(tenant_id, excluded.tenant_id),
-           agent_id = COALESCE(agent_id, excluded.agent_id),
-           routed_llm = COALESCE(routed_llm, excluded.routed_llm),
-           routed_tts = COALESCE(routed_tts, excluded.routed_tts),
-           budget_ms = COALESCE(budget_ms, excluded.budget_ms),
-           budget_overrun = COALESCE(budget_overrun, excluded.budget_overrun),
+           total_cost_usd = sessions.total_cost_usd + excluded.total_cost_usd,
+           request_count = sessions.request_count + 1,
+           tenant_id = COALESCE(sessions.tenant_id, excluded.tenant_id),
+           agent_id = COALESCE(sessions.agent_id, excluded.agent_id),
+           routed_llm = COALESCE(sessions.routed_llm, excluded.routed_llm),
+           routed_tts = COALESCE(sessions.routed_tts, excluded.routed_tts),
+           budget_ms = COALESCE(sessions.budget_ms, excluded.budget_ms),
+           budget_overrun = COALESCE(
+               sessions.budget_overrun, excluded.budget_overrun
+           ),
            guardrails_active = COALESCE(
-               guardrails_active, excluded.guardrails_active
+               sessions.guardrails_active, excluded.guardrails_active
            ),
            guardrails_bypassed = COALESCE(
-               guardrails_bypassed, excluded.guardrails_bypassed
+               sessions.guardrails_bypassed, excluded.guardrails_bypassed
            ),
            guardrail_policy_snapshot_json = COALESCE(
-               guardrail_policy_snapshot_json,
+               sessions.guardrail_policy_snapshot_json,
                excluded.guardrail_policy_snapshot_json
            ),
            started_at = CASE
-               WHEN started_at IS NULL THEN excluded.started_at
-               WHEN started_at > excluded.started_at THEN excluded.started_at
-               ELSE started_at
+               WHEN sessions.started_at IS NULL THEN excluded.started_at
+               WHEN sessions.started_at > excluded.started_at
+                   THEN excluded.started_at
+               ELSE sessions.started_at
            END,
            ended_at = CASE
-               WHEN ended_at IS NULL THEN excluded.ended_at
-               WHEN ended_at < excluded.ended_at THEN excluded.ended_at
-               ELSE ended_at
+               WHEN sessions.ended_at IS NULL THEN excluded.ended_at
+               WHEN sessions.ended_at < excluded.ended_at THEN excluded.ended_at
+               ELSE sessions.ended_at
            END,
            modalities = CASE
-               WHEN modalities = '' THEN excluded.modalities
+               WHEN sessions.modalities = '' THEN excluded.modalities
                WHEN INSTR(
-                   ',' || modalities || ',',
+                   ',' || sessions.modalities || ',',
                    ',' || excluded.modalities || ','
-               ) > 0 THEN modalities
-               ELSE modalities || ',' || excluded.modalities
+               ) > 0 THEN sessions.modalities
+               ELSE sessions.modalities || ',' || excluded.modalities
            END"""
 )
 

--- a/src/voicegateway/repository/virtual_key_repository.py
+++ b/src/voicegateway/repository/virtual_key_repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import func, select
@@ -81,13 +81,14 @@ class VirtualKeyRepository(BaseRepository[VirtualKey]):
         if stale_after_days < 0:
             raise ValueError(f"stale_after_days must be >= 0, got {stale_after_days}")
         cutoff_clause = func.coalesce(VirtualKey.last_used_at, VirtualKey.issued_at)
+        # Compute the cutoff in Python instead of the SQLite-only datetime()
+        # function, so the comparison adapts to SQLite and Postgres alike.
+        cutoff = datetime.now(UTC) - timedelta(days=stale_after_days)
         async with self._session(session) as s:
             stmt = (
                 select(VirtualKey)
                 .where(VirtualKey.revoked_at.is_(None))  # type: ignore[union-attr]
-                .where(
-                    cutoff_clause <= func.datetime("now", f"-{stale_after_days} days")
-                )
+                .where(cutoff_clause <= cutoff)
                 .order_by(cutoff_clause.asc(), VirtualKey.id.asc())  # type: ignore[union-attr]
             )
             result = await s.execute(stmt)

--- a/src/voicegateway/repository/virtual_keys_repository.py
+++ b/src/voicegateway/repository/virtual_keys_repository.py
@@ -228,15 +228,26 @@ async def list_stale(
     """Return non-revoked keys whose ``last_used_at`` is older than the threshold."""
     if stale_after_days < 0:
         raise ValueError(f"stale_after_days must be >= 0, got {stale_after_days}")
+    # SQLite spells "now minus N days" datetime('now', '-N days'); Postgres has
+    # no datetime(), so use CURRENT_TIMESTAMP - make_interval(days => N).
+    try:
+        dialect = session.bind.dialect.name
+    except Exception:  # noqa: BLE001 - default to the SQLite spelling
+        dialect = "sqlite"
+    if dialect == "postgresql":
+        cutoff_sql = "CURRENT_TIMESTAMP - make_interval(days => :days)"
+        params: dict[str, object] = {"days": stale_after_days}
+    else:
+        cutoff_sql = "datetime('now', :delta || ' days')"
+        params = {"delta": f"-{stale_after_days}"}
     result = await session.execute(
         text(
             f"SELECT {_SELECT_ROW_FIELDS} FROM virtual_keys "
             "WHERE revoked_at IS NULL "
-            "AND COALESCE(last_used_at, issued_at) <= "
-            "    datetime('now', :delta || ' days') "
+            f"AND COALESCE(last_used_at, issued_at) <= {cutoff_sql} "
             "ORDER BY COALESCE(last_used_at, issued_at) ASC, id ASC"
         ),
-        {"delta": f"-{stale_after_days}"},
+        params,
     )
     return [_row_to_dataclass(row) for row in result]
 

--- a/src/voicegateway/tests/integration/test_postgres_collector.py
+++ b/src/voicegateway/tests/integration/test_postgres_collector.py
@@ -1,0 +1,83 @@
+"""Collector paths exercised against a real Postgres backend.
+
+This is the regression gate for SQLite-vs-Postgres dialect drift: every bug that
+broke the fleet collector on Postgres (ambiguous ``ON CONFLICT`` columns,
+``GROUP_CONCAT``, ``datetime('now')``) would fail here.
+
+The test only runs when ``VOICEGW_DB_URL`` points at Postgres; CI sets it to the
+``postgres`` service. It is skipped in the default SQLite test run.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("VOICEGW_DB_URL", "").startswith("postgresql"),
+    reason="requires VOICEGW_DB_URL=postgresql+asyncpg://... (CI postgres service)",
+)
+
+_KEY = "pgtestkey"
+
+
+def _config(tmp_path) -> str:
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {"auth": {"api_keys": [{"token": _KEY, "name": "t", "scopes": ["write"]}]}}
+        )
+    )
+    return str(path)
+
+
+async def test_collector_init_ingest_costs_on_postgres(tmp_path) -> None:
+    """Init (migrations + project upsert), ingest (session upsert), and the cost
+    summary (string aggregate) all succeed against Postgres, and the read
+    endpoints never 500."""
+    gw = Gateway(config_path=_config(tmp_path))  # migrations + _PROJECT_UPSERT
+    app = build_app(gw)
+    headers = {"Authorization": f"Bearer {_KEY}"}
+    record = {
+        "id": f"pg-{time.time()}",
+        "timestamp": time.time(),
+        "modality": "llm",
+        "model_id": "openai/gpt-4o",
+        "provider": "openai",
+        "project": "default",
+        "input_units": 1000,
+        "output_units": 500,
+        "cost_usd": 0.05,
+        "session_id": "pg-sess",
+        "agent_id": "pg-agent",
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as client:
+        ingest = await client.post("/v1/ingest", headers=headers, json=[record])
+        assert ingest.status_code == 200, ingest.text
+        assert ingest.json()["accepted"] == 1  # session upsert ran on Postgres
+
+        costs = await client.get("/v1/costs", headers=headers)
+        assert costs.status_code == 200, costs.text  # GROUP_CONCAT -> STRING_AGG
+        assert costs.json()["total"] >= 0.05
+
+        for path in (
+            "/v1/status",
+            "/v1/models",
+            "/v1/projects",
+            "/v1/logs",
+            "/v1/metrics",
+            "/v1/virtual-keys",
+            "/api/overview",
+            "/api/status",
+        ):
+            resp = await client.get(path, headers=headers)
+            assert resp.status_code < 500, f"{path} -> {resp.status_code}: {resp.text}"


### PR DESCRIPTION
Makes the Postgres fleet collector backend actually work, and adds the CI gate so a broken Postgres image can't ship again. Found by deploying a real collector: each release surfaced the next SQLite-only construct.

## The bugs (all crashed the collector on Postgres, fine on SQLite)

1. **Ambiguous `ON CONFLICT` columns.** The project upsert (`Gateway.__init__`) and the session upsert (ingest hot path) referenced bare existing-row columns, e.g. `COALESCE(excluded.branding_json, branding_json)` and `total_cost_usd = total_cost_usd + excluded.total_cost_usd`. Postgres rejects the bare name as ambiguous between the target table and `excluded`. Fix: table-qualify (`managed_projects.x`, `sessions.x`), which SQLite also accepts (verified).
2. **`GROUP_CONCAT`** in the cost summary -> Postgres has no such function. Fix: dialect-aware `STRING_AGG(DISTINCT pricing_source, ',')` on Postgres.
3. **`datetime('now', ...)`** in the virtual-key staleness queries -> no `datetime()` on Postgres. Fix: `make_interval` (raw SQL path) and a Python-computed cutoff (ORM path).

## The gate (so this stops)

New `Postgres collector` workflow:
- **dialect** job: runs the collector against a `postgres:16` service via a new integration test (`test_postgres_collector.py`) that exercises init + ingest + costs + every read endpoint.
- **image-smoke** job: builds the published image and boots `docker-compose.collector.yml` against Postgres, then curls `/health`, `/v1/ingest`, `/v1/costs`.

Between them they would have caught all three collector breakages (the v0.9.1 `_version.py`/asyncpg ones and these dialect ones) before any 14-minute Docker Hub publish.

## Validation

Reproduced and fixed against a real **Postgres 17** locally:
- init (migrations + project upsert): OK
- `POST /v1/ingest`: accepted 1
- `GET /v1/costs`: 200 with `by_model`/`pricing_source`
- `/v1/status|models|projects|logs|metrics`, `/api/overview|status`, `/v1/virtual-keys` (list + create), both stale-key queries: all green
- 498 SQLite repository/storage/services/server tests still pass; `ruff` + `mypy` clean.

Ship as **v0.9.2**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous integration workflow to validate PostgreSQL support across the collector stack with automated health checks.
  * Added integration test for PostgreSQL collector end-to-end validation against a real database.

* **Bug Fixes**
  * Fixed PostgreSQL compatibility issues in session management, cost aggregation, virtual key staleness queries, and project data upserting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->