### PR TITLE
docs(deployment): VPS, Railway, and Fly.io collector guides

### DIFF
--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -1,0 +1,79 @@
+---
+title: "Deploy to Fly.io"
+description: "Run the VoiceGateway fleet collector on Fly.io with managed Postgres, automatic HTTPS, and multi-region placement."
+---
+
+# Deploy to Fly.io
+
+Low ops; automatic HTTPS; deploy in multiple regions to sit near your agents.
+
+::: tip
+Deploy in a region close to where your agents run to cut ingest latency. Fly lets you place machines in specific regions with `--region` on `fly deploy` or via the `primary_region` key in `fly.toml`.
+:::
+
+## Prerequisites
+
+- [`flyctl`](https://fly.io/docs/hands-on/install-flyctl/) installed
+- A Fly account: `fly auth login`
+
+## Configure
+
+Create `fly.toml` in a working directory:
+
+```toml
+app = "<your-app-name>"
+
+[build]
+  image = "mahimairaja/voicegateway:0.9.2"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  min_machines_running = 1
+```
+
+## Add Postgres
+
+**Option A: Fly Postgres (unmanaged)**
+
+```bash
+fly postgres create --name <pg-app-name>
+fly postgres attach <pg-app-name> --app <your-app-name>
+```
+
+`fly postgres attach` sets `DATABASE_URL` on your app automatically (in `postgres://...` form).
+
+**Option B: Neon or another managed provider**
+
+Skip `fly postgres create` and supply the connection string directly in the next step.
+
+## Set secrets
+
+::: warning
+Fly's `DATABASE_URL` (from `fly postgres attach`) uses the `postgres://` scheme. VoiceGateway requires `postgresql+asyncpg://`. Copy the connection string and rewrite the scheme; everything after `://` stays the same.
+:::
+
+```bash
+fly secrets set \
+  VOICEGW_DB_URL="postgresql+asyncpg://<user>:<pass>@<host>:<port>/<db>" \
+  VOICEGW_API_KEY="<your-ingest-key>"
+```
+
+`VOICEGW_API_KEY` must not start with `vk_`. Generate it with `openssl rand -hex 32`. No volume is needed since data is stored in Postgres.
+
+## Deploy
+
+```bash
+fly deploy
+```
+
+HTTPS is automatic at `https://<your-app-name>.fly.dev`.
+
+## Verify
+
+Follow the steps at [Verify](/docs/deployment#verify), using `https://<your-app-name>.fly.dev` as the collector URL and `VOICEGW_API_KEY` as the key.
+
+## Connect your agent
+
+See [Connect your agent](/docs/deployment#connect-your-agent). Use `https://<your-app-name>.fly.dev` as `collector_url` and `VOICEGW_API_KEY` as `virtual_key`.

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -1,0 +1,58 @@
+---
+title: "Deployment"
+description: "Self-host the VoiceGateway fleet collector on a VPS, Railway, or Fly.io: Postgres-backed, HTTPS ingest, dashboard."
+---
+
+# Deploy the fleet collector
+
+The collector is a single container that serves `POST /v1/ingest` (agents push cost telemetry, Bearer-keyed), the dashboard, and the cost API on port 8080. It needs Postgres, a public HTTPS URL, and an ingest key you create.
+
+Request flow: `agent -> POST /v1/ingest (Bearer key) -> collector -> Postgres -> dashboard`.
+
+## Pick a platform
+
+| Platform | Ops effort | HTTPS | Postgres | Cost | Best when |
+|---|---|---|---|---|---|
+| [VPS](/docs/deployment/vps) | Highest (you run TLS) | You set up (Caddy) | Self-run or Neon | Cheapest | You already run a box (e.g. your LiveKit server) |
+| [Railway](/docs/deployment/railway) | Lowest | Automatic | One-click managed | Higher | You want zero ops |
+| [Fly.io](/docs/deployment/fly) | Low | Automatic | Fly Postgres or Neon | Low | Multi-region, near your agents |
+
+For a single-node / SQLite setup (just yourself, no fleet), see [Docker deployment](/docs/examples/docker-deployment) instead.
+
+## Connect your agent
+
+Once the collector has a public HTTPS URL and you have the ingest key, point your agents at it. The explicit form:
+
+```python
+from openrtc import AgentPool
+from voicegateway.openrtc import VoiceGatewayObserver
+
+pool = AgentPool(observers=[VoiceGatewayObserver(
+    project="prod",
+    collector_url="https://<your-collector-url>",
+    virtual_key="<your-ingest-key>",
+)])
+```
+
+The env-var form: set `VOICEGW_COLLECTOR_URL` and `VOICEGW_VIRTUAL_KEY` in the agent's environment and use `VoiceGatewayObserver(project="prod")`. Non-OpenRTC agents call `voicegateway.attach(session, collector_url=..., virtual_key=...)` instead.
+
+## Verify
+
+Replace `<url>` and `<key>` with your collector's public URL and ingest key:
+
+```bash
+curl -fsS https://<url>/health && echo                 # -> ok
+
+# auth gates ingest: no key is rejected, the key is accepted
+curl -s -o /dev/null -w "no-key:  %{http_code}  (expect 401/403)\n" \
+  -X POST https://<url>/v1/ingest -H 'content-type: application/json' -d '[]'
+curl -s -o /dev/null -w "with-key: %{http_code}  (expect 2xx)\n" \
+  -X POST https://<url>/v1/ingest -H 'content-type: application/json' \
+  -H 'Authorization: Bearer <key>' -d '[]'
+```
+
+Then open the collector URL in a browser for the dashboard.
+
+## Notes
+
+The Postgres collector path works as of v0.9.2 (pin `>= 0.9.2`; the image is `mahimairaja/voicegateway:0.9.2`). The ingest key must not start with `vk_`. Only `/v1/ingest` and `/health` need to be public; all other endpoints can be firewall-restricted to your internal network.

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -55,4 +55,6 @@ Then open the collector URL in a browser for the dashboard.
 
 ## Notes
 
+::: note
 The Postgres collector path works as of v0.9.2 (pin `>= 0.9.2`; the image is `mahimairaja/voicegateway:0.9.2`). The ingest key must not start with `vk_`. Only `/v1/ingest` and `/health` need to be public; all other endpoints can be firewall-restricted to your internal network.
+:::

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -1,0 +1,58 @@
+---
+title: "Deploy to Railway"
+description: "Run the VoiceGateway fleet collector on Railway with managed Postgres and automatic HTTPS."
+---
+
+# Deploy to Railway
+
+Lowest ops: Railway handles managed Postgres, TLS, and a public URL automatically.
+
+::: tip
+This is the least-ops path. Cost is usage-based and higher than a self-managed VPS.
+:::
+
+## Prerequisites
+
+- A [Railway](https://railway.com) account
+
+## Create the service
+
+1. In your Railway project, click **New** and choose **Docker Image**.
+2. Enter `mahimairaja/voicegateway:0.9.2` as the image.
+3. In the service settings, set the **exposed port** (also shown as "Port" or "Target Port") to `8080`.
+
+## Add Postgres
+
+Click **New** in the same project and add the **PostgreSQL** plugin. Railway provisions a managed Postgres instance and injects a `DATABASE_URL` environment variable (in `postgres://...` form) into services in the project.
+
+## Configure
+
+In the collector service's **Variables** tab, add:
+
+::: warning
+Railway's `DATABASE_URL` uses the `postgres://` scheme. VoiceGateway requires `postgresql+asyncpg://`. Copy the value Railway provides and rewrite the scheme prefix; everything after `://` stays the same.
+
+Example shape:
+```
+VOICEGW_DB_URL=postgresql+asyncpg://<user>:<pass>@<host>:<port>/<db>
+```
+:::
+
+| Variable | Value |
+|---|---|
+| `VOICEGW_DB_URL` | Railway's Postgres URL with scheme rewritten to `postgresql+asyncpg://` |
+| `VOICEGW_API_KEY` | `<your-ingest-key>` (generate with `openssl rand -hex 32`; must not start with `vk_`) |
+
+`VOICEGW_API_KEY` registers a wildcard ingest key without needing a mounted `voicegw.yaml`.
+
+## Deploy
+
+Redeploy the service after setting variables. Railway builds and starts the container; HTTPS is automatic at `https://<your-service>.<your-project>.up.railway.app`. You can also attach a custom domain in the service's **Settings** tab.
+
+## Verify
+
+Follow the steps at [Verify](/docs/deployment#verify), using your Railway service URL as the collector URL and `VOICEGW_API_KEY` as the key.
+
+## Connect your agent
+
+See [Connect your agent](/docs/deployment#connect-your-agent). Use the Railway URL as `collector_url` and `VOICEGW_API_KEY` as `virtual_key`.

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -55,7 +55,7 @@ sudo apt update && sudo apt install caddy
 
 Create `/etc/caddy/Caddyfile`:
 
-```caddyfile
+```text
 collector.<your-domain> {
     reverse_proxy localhost:8080
 }

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -1,0 +1,89 @@
+---
+title: "Deploy to a VPS"
+description: "Run the VoiceGateway fleet collector on your own server with Docker Compose and Caddy for automatic HTTPS."
+---
+
+# Deploy to a VPS
+
+Choose this path when you already control a server (cheapest option; ideal for co-locating with a self-hosted LiveKit server).
+
+## Prerequisites
+
+- A VPS with Docker and Compose installed (`curl -fsSL https://get.docker.com | sh`)
+- A domain you can point at the box
+
+## Deploy the collector
+
+```bash
+mkdir -p ~/voicegw && cd ~/voicegw
+curl -fsSLO https://raw.githubusercontent.com/mahimailabs/voicegateway/main/docker-compose.collector.yml
+sed -i 's#mahimairaja/voicegateway:latest#mahimairaja/voicegateway:0.9.2#' docker-compose.collector.yml
+
+printf 'VOICEGW_PG_PASSWORD=%s\n' "$(openssl rand -hex 24)" > .env
+
+# Ingest key the agents will present (must NOT start with vk_).
+INGEST_KEY="$(openssl rand -hex 32)"
+cat > voicegw.yaml <<EOF
+auth:
+  api_keys:
+    - token: "${INGEST_KEY}"
+      name: fleet-agents
+      scopes: [write]
+EOF
+echo "AGENT KEY (use as the agent virtual_key): ${INGEST_KEY}"
+
+docker compose -f docker-compose.collector.yml up -d
+sleep 10 && curl -fsS http://localhost:8080/health && echo     # -> ok
+```
+
+Postgres runs as a service in this Compose (self-hosted). To use a managed database instead, drop the `postgres` service and set `VOICEGW_DB_URL=postgresql+asyncpg://...` (e.g. a Neon URL) on the `collector` service.
+
+## Expose over HTTPS
+
+### Fresh box (install Caddy)
+
+Install Caddy via the official apt repository:
+
+```bash
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install caddy
+```
+
+Create `/etc/caddy/Caddyfile`:
+
+```caddyfile
+collector.<your-domain> {
+    reverse_proxy localhost:8080
+}
+```
+
+Reload Caddy and open the firewall:
+
+```bash
+sudo systemctl reload caddy
+sudo ufw allow 80,443/tcp
+```
+
+For safety, bind the collector to localhost only by changing the compose port mapping to `127.0.0.1:8080:8080` so only Caddy is internet-facing. Point a DNS A record `collector.<your-domain>` at the VPS IP.
+
+### Reuse an existing reverse proxy
+
+If the box already runs a reverse proxy on 80/443 (for example a self-hosted LiveKit server whose Caddy runs with host networking), that proxy reaches the collector at `localhost:8080` with no extra wiring. The collector publishes 8080 on the host; a host-networked proxy shares the host's network namespace. Add a vhost or TLS-SNI route for `collector.<your-domain>` pointing to `localhost:8080`. Back up the proxy config first and reload it gracefully.
+
+## Security
+
+::: warning
+Only `/v1/ingest` and `/health` need to be public. Put the dashboard and `/v1/virtual-keys` behind basic auth at the proxy level, or reach them via an SSH tunnel from your local machine.
+:::
+
+## Verify
+
+Follow the steps at [Verify](/docs/deployment#verify), using `https://collector.<your-domain>` as the collector URL and the `AGENT KEY` printed above.
+
+## Connect your agent
+
+See [Connect your agent](/docs/deployment#connect-your-agent). Use `https://collector.<your-domain>` as `collector_url` and the `AGENT KEY` as `virtual_key`.

--- a/docs/examples/docker-deployment.md
+++ b/docs/examples/docker-deployment.md
@@ -8,6 +8,8 @@ dashboard reachable on a different external port. Includes
 persistent storage, health checks, and an optional Ollama sidecar
 for local LLM inference.
 
+For hosting the collector on a VPS, Railway, or Fly.io, see [Deployment](/docs/deployment).
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
Adds a `docs/deployment/` section for self-hosting the **fleet collector** (Postgres-backed, public HTTPS ingest), built from the deployment work we did this session.

## What's in it

- **`index.md`** (overview): what you're deploying, a pick-a-platform comparison table, and the shared **Connect your agent** + **Verify** steps every platform page links back to.
- **`vps.md`**: Docker Compose + Postgres, with **two** expose paths, a fresh Caddy (auto-Let's-Encrypt) and **reusing an existing reverse proxy** (the host-networking trick from a self-hosted LiveKit box). Plus the firewall + dashboard-security note. These commands are the ones validated live this session.
- **`railway.md`**: deploy the image, managed Postgres, the `postgres://` -> `postgresql+asyncpg://` scheme rewrite, port 8080.
- **`fly.md`**: `fly.toml` (`internal_port = 8080`), Fly Postgres / Neon, secrets, the same scheme-rewrite callout.
- A cross-link from `examples/docker-deployment.md` to the new section.

Every deploy command pins `mahimairaja/voicegateway:0.9.2` (the release where the Postgres collector works), and the `vk_`/public-endpoint rules are baked into each page.

## Verified

Structure, frontmatter, the shared anchors (`#connect-your-agent` / `#verify` exist and all three platform pages link them), image pinning, and no em dashes. Callouts use the repo's `::: warning` convention. The full Fumadocs/Next.js build runs on Vercel at push.

## Please confirm before publishing (platform drift)

These two were written from the plan but not live-verified against the current provider UIs (flagged by the reviewer):

1. **Railway** (`railway.md`): the page says Railway's Postgres makes `DATABASE_URL` available; current Railway may require referencing it explicitly as `${{Postgres.DATABASE_URL}}` in the collector service's Variables. Confirm the exact step + the "PostgreSQL plugin" vs "Database" UI label.
2. **Fly.io** (`fly.md`): `auto_stop_machines = false` (boolean) may need to be `"off"` (string) in the current `fly.toml` schema; confirm `fly postgres` commands too.

Happy to web-verify and patch both if you want, just say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment guides for self-hosting the VoiceGateway fleet collector
  * New deployment platforms supported: VPS with Docker Compose, Railway, and Fly.io
  * Includes setup instructions for Postgres, HTTPS configuration, secret management, and agent connectivity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->