### PR TITLE
feat: one-line collector installer (collector.sh)

### DIFF
--- a/.github/workflows/collector-script.yml
+++ b/.github/workflows/collector-script.yml
@@ -1,5 +1,8 @@
 name: collector.sh
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -14,7 +17,9 @@ jobs:
   lint-and-unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
       - run: sudo apt-get update && sudo apt-get install -y shellcheck
       - run: shellcheck web/public/collector.sh
       - run: bash src/voicegateway/tests/cli/test_collector_script.sh
@@ -25,7 +30,9 @@ jobs:
       matrix:
         backend: [sqlite, postgres]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
       - name: Run the installer non-interactively and assert health
         env:
           BACKEND: ${{ matrix.backend }}

--- a/.github/workflows/collector-script.yml
+++ b/.github/workflows/collector-script.yml
@@ -1,0 +1,47 @@
+name: collector.sh
+
+on:
+  pull_request:
+    paths:
+      - 'web/public/collector.sh'
+      - 'src/voicegateway/tests/cli/test_collector_script.sh'
+      - 'src/voicegateway/tests/cli/_docker_stub.sh'
+      - '.github/workflows/collector-script.yml'
+  push:
+    branches: [main]
+
+jobs:
+  lint-and-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - run: shellcheck web/public/collector.sh
+      - run: bash src/voicegateway/tests/cli/test_collector_script.sh
+
+  boot:
+    runs-on: ubuntu-latest   # has Docker + compose preinstalled
+    strategy:
+      matrix:
+        backend: [sqlite, postgres]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run the installer non-interactively and assert health
+        env:
+          BACKEND: ${{ matrix.backend }}
+        run: |
+          set -euo pipefail
+          # Validate BACKEND is one of the two known values before using it in a
+          # flag so we never pass arbitrary shell content to the script.
+          case "$BACKEND" in
+            sqlite|postgres) ;;
+            *) echo "unexpected backend: $BACKEND"; exit 1;;
+          esac
+          sudo bash web/public/collector.sh "--$BACKEND" \
+            --dir "$RUNNER_TEMP/voicegw" --version 0.9.2 --yes
+          for _ in $(seq 1 40); do
+            curl -fsS http://localhost:8080/health && break || sleep 3
+          done
+          curl -fsS http://localhost:8080/health
+      - if: failure()
+        run: sudo cat "$RUNNER_TEMP/voicegw/docker-compose.yml"; cd "$RUNNER_TEMP/voicegw" && sudo docker compose logs || true

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -7,12 +7,36 @@ description: "Run the VoiceGateway fleet collector on your own server with Docke
 
 Choose this path when you already control a server (cheapest option; ideal for co-locating with a self-hosted LiveKit server).
 
-## Prerequisites
+## One-line installer (recommended)
 
-- A VPS with Docker and Compose installed (`curl -fsSL https://get.docker.com | sh`)
-- A domain you can point at the box
+The installer script handles Docker, secrets, image pinning, health checking, and HTTPS in a single command:
 
-## Deploy the collector
+```bash
+curl -fsSL https://voicegateway.mahimai.ca/collector.sh | bash
+```
+
+It prompts for backend (SQLite or Postgres) and whether to set up HTTPS. For non-interactive use:
+
+```bash
+# SQLite (single collector, no external database)
+curl -fsSL https://voicegateway.mahimai.ca/collector.sh | bash -s -- --sqlite --yes
+
+# Postgres (fleet / production), expose via https://collector.example.com
+curl -fsSL https://voicegateway.mahimai.ca/collector.sh | bash -s -- --postgres --domain example.com --yes
+```
+
+The script:
+- Installs Docker if not present (with confirmation)
+- Generates and persists the ingest key and Postgres password on first run, reuses them on subsequent runs (no password-regen footgun)
+- Pins the image to the latest release version (never `:latest`)
+- Health-checks the container before returning
+- If ports 80/443 are free and a domain is given, installs Caddy and issues a certificate automatically; otherwise prints the reverse-proxy snippet for your existing proxy
+
+The ingest key is printed to your terminal and saved to the deploy directory (`/opt/voicegateway/voicegw.yaml` by default). Use it as the `virtual_key` when connecting agents.
+
+## Manual setup
+
+Prerequisites: Docker and Compose installed (`curl -fsSL https://get.docker.com | sh`).
 
 ```bash
 mkdir -p ~/voicegw && cd ~/voicegw
@@ -35,6 +59,10 @@ echo "AGENT KEY (use as the agent virtual_key): ${INGEST_KEY}"
 docker compose -f docker-compose.collector.yml up -d
 sleep 10 && curl -fsS http://localhost:8080/health && echo     # -> ok
 ```
+
+::: warning
+Run the above exactly once. Re-running it regenerates the Postgres password but the existing volume keeps the old one, causing authentication failures. If you need to re-run, bring the stack down first and remove the volume: `docker compose down -v`. The one-line installer avoids this footgun by persisting secrets across runs.
+:::
 
 Postgres runs as a service in this Compose (self-hosted). To use a managed database instead, drop the `postgres` service and set `VOICEGW_DB_URL=postgresql+asyncpg://...` (e.g. a Neon URL) on the `collector` service.
 
@@ -74,6 +102,21 @@ For safety, bind the collector to localhost only by changing the compose port ma
 
 If the box already runs a reverse proxy on 80/443 (for example a self-hosted LiveKit server whose Caddy runs with host networking), that proxy reaches the collector at `localhost:8080` with no extra wiring. The collector publishes 8080 on the host; a host-networked proxy shares the host's network namespace. Add a vhost or TLS-SNI route for `collector.<your-domain>` pointing to `localhost:8080`. Back up the proxy config first and reload it gracefully.
 
+For LiveKit's layer-4 Caddy (structured `caddy.yaml`), add a TLS-SNI route and include the hostname in `apps.tls.certificates.automate`:
+
+```text
+# Under apps.layer4.servers.main.routes:
+          - match:
+              - tls: { sni: ["collector.<your-domain>"] }
+            handle:
+              - handler: tls
+                connection_policies: [{ alpn: ["http/1.1"] }]
+              - handler: proxy
+                upstreams: [{ dial: ["localhost:8080"] }]
+```
+
+Reload with `caddy reload --config /etc/caddy.yaml --adapter yaml` (validates before applying; LiveKit stays up if the config is invalid).
+
 ## Security
 
 ::: warning
@@ -82,8 +125,8 @@ Only `/v1/ingest` and `/health` need to be public. Put the dashboard and `/v1/vi
 
 ## Verify
 
-Follow the steps at [Verify](/docs/deployment#verify), using `https://collector.<your-domain>` as the collector URL and the `AGENT KEY` printed above.
+Follow the steps at [Verify](/docs/deployment#verify), using `https://collector.<your-domain>` as the collector URL and the ingest key printed during setup.
 
 ## Connect your agent
 
-See [Connect your agent](/docs/deployment#connect-your-agent). Use `https://collector.<your-domain>` as `collector_url` and the `AGENT KEY` as `virtual_key`.
+See [Connect your agent](/docs/deployment#connect-your-agent). Use `https://collector.<your-domain>` as `collector_url` and the ingest key as `virtual_key`.

--- a/src/voicegateway/tests/cli/_docker_stub.sh
+++ b/src/voicegateway/tests/cli/_docker_stub.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Fake docker for collector.sh tests. Records calls; "compose version" and
+# "compose up" succeed; everything else exits 0.
+echo "[docker-stub] $*" >> "${DOCKER_STUB_LOG:-/dev/null}"
+case "$1 ${2:-}" in
+    "compose version") echo "Docker Compose version v2.0.0";;
+    *) : ;;
+esac
+exit 0

--- a/src/voicegateway/tests/cli/test_collector_script.sh
+++ b/src/voicegateway/tests/cli/test_collector_script.sh
@@ -49,7 +49,7 @@ VERSION=""; PATH="$STUBBIN:$PATH" resolve_version
 pass "resolve_version from tag"
 
 # scaffold is idempotent: secrets are generated once and reused
-T="$(mktemp -d)"; DIR="$T/deploy"; BACKEND=postgres; VERSION=0.9.2; BIND="127.0.0.1:8080"
+T="$(mktemp -d)"; DIR="$T/deploy"; BACKEND=postgres; VERSION=0.9.2; BIND="127.0.0.1"
 scaffold
 k1="$(sed -n 's/.*token: *"\(.*\)".*/\1/p' "$DIR/voicegw.yaml" | head -1)"
 p1="$(sed -n 's/^VOICEGW_PG_PASSWORD=//p' "$DIR/.env" | head -1)"

--- a/src/voicegateway/tests/cli/test_collector_script.sh
+++ b/src/voicegateway/tests/cli/test_collector_script.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Host unit tests for web/public/collector.sh. Sources the script (the
+# source-guard keeps main() from running) and calls functions directly,
+# with curl/docker stubbed on PATH. No real Docker needed.
+set -euo pipefail
+DIR_SELF="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR_SELF/../../../.." && pwd)"
+SCRIPT="$REPO_ROOT/web/public/collector.sh"
+fail() { printf '!! FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf 'ok: %s\n' "$*"; }
+
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+# parse_args reads flags and env
+parse_args --postgres --domain c.example.com --dir /tmp/x --version 9.9.9 --yes
+[ "$BACKEND" = postgres ] || fail "BACKEND flag"
+[ "$DOMAIN" = c.example.com ] || fail "DOMAIN flag"
+[ "$DIR" = /tmp/x ] || fail "DIR flag"
+[ "$VERSION" = 9.9.9 ] || fail "VERSION flag"
+[ "$ASSUME_YES" = 1 ] || fail "ASSUME_YES flag"
+pass "parse_args flags"
+
+VOICEGW_BACKEND=sqlite parse_args
+[ "$BACKEND" = sqlite ] || fail "BACKEND env"
+pass "parse_args env"
+
+# usage exits 0 and mentions the URL
+out="$(usage)"; printf '%s' "$out" | grep -q "collector.sh" || fail "usage text"
+pass "usage"
+
+# resolve_version honors --version
+VERSION=1.2.3; resolve_version; [ "$VERSION" = 1.2.3 ] || fail "resolve_version override"
+pass "resolve_version override"
+
+# resolve_version reads the GitHub tag when unset (stub curl)
+STUBBIN="$(mktemp -d)"
+cat > "$STUBBIN/curl" <<'STUB'
+#!/usr/bin/env bash
+echo '{"tag_name": "v0.9.2"}'
+STUB
+chmod +x "$STUBBIN/curl"
+VERSION=""; PATH="$STUBBIN:$PATH" resolve_version
+[ "$VERSION" = 0.9.2 ] || fail "resolve_version from tag (got '$VERSION')"
+pass "resolve_version from tag"
+
+# scaffold is idempotent: secrets are generated once and reused
+T="$(mktemp -d)"; DIR="$T/deploy"; BACKEND=postgres; VERSION=0.9.2; BIND="127.0.0.1:8080"
+scaffold
+k1="$(sed -n 's/.*token: *"\(.*\)".*/\1/p' "$DIR/voicegw.yaml" | head -1)"
+p1="$(sed -n 's/^VOICEGW_PG_PASSWORD=//p' "$DIR/.env" | head -1)"
+scaffold   # run again
+k2="$(sed -n 's/.*token: *"\(.*\)".*/\1/p' "$DIR/voicegw.yaml" | head -1)"
+p2="$(sed -n 's/^VOICEGW_PG_PASSWORD=//p' "$DIR/.env" | head -1)"
+[ -n "$k1" ] && [ "$k1" = "$k2" ] || fail "ingest key changed across runs"
+[ -n "$p1" ] && [ "$p1" = "$p2" ] || fail "pg password changed across runs"
+case "$k1" in vk_*) fail "ingest key must not start with vk_";; esac
+grep -q "$IMAGE:0.9.2" "$DIR/docker-compose.yml" || fail "image not pinned"
+grep -q ":latest" "$DIR/docker-compose.yml" && fail "found :latest"
+grep -q "postgresql+asyncpg://" "$DIR/docker-compose.yml" || fail "postgres scheme"
+grep -q "127.0.0.1:8080:8080" "$DIR/docker-compose.yml" || fail "bind"
+pass "scaffold idempotent + pinned + scheme + bind"
+
+# sqlite backend has no postgres service
+DIR="$T/sqlite"; BACKEND=sqlite; INGEST_KEY=""; PG_PASS=""; scaffold
+grep -q "postgres" "$DIR/docker-compose.yml" && fail "sqlite should have no postgres"
+grep -q "VOICEGW_DB_PATH" "$DIR/docker-compose.yml" || fail "sqlite db path"
+pass "sqlite template"
+
+printf '\nALL TASK-1-2-3 TESTS PASSED\n'

--- a/src/voicegateway/tests/cli/test_collector_script.sh
+++ b/src/voicegateway/tests/cli/test_collector_script.sh
@@ -25,6 +25,10 @@ VOICEGW_BACKEND=sqlite parse_args
 [ "$BACKEND" = sqlite ] || fail "BACKEND env"
 pass "parse_args env"
 
+# a value-taking flag with no value fails cleanly (not a set -u crash).
+# Run in a subshell because die() calls exit.
+( parse_args --domain 2>/dev/null ) && fail "--domain with no value should error" || pass "parse_args missing value errors cleanly"
+
 # usage exits 0 and mentions the URL
 out="$(usage)"; printf '%s' "$out" | grep -q "collector.sh" || fail "usage text"
 pass "usage"

--- a/src/voicegateway/tests/cli/test_collector_script.sh
+++ b/src/voicegateway/tests/cli/test_collector_script.sh
@@ -73,4 +73,83 @@ grep -q "postgres" "$DIR/docker-compose.yml" && fail "sqlite should have no post
 grep -q "VOICEGW_DB_PATH" "$DIR/docker-compose.yml" || fail "sqlite db path"
 pass "sqlite template"
 
+# sqlite scaffold is idempotent: key unchanged on second run
+sqlite_key1="$(sed -n 's/.*token: *"\(.*\)".*/\1/p' "$DIR/voicegw.yaml" | head -1)"
+INGEST_KEY=""; PG_PASS=""
+scaffold
+sqlite_key2="$(sed -n 's/.*token: *"\(.*\)".*/\1/p' "$DIR/voicegw.yaml" | head -1)"
+[ -n "$sqlite_key1" ] && [ "$sqlite_key1" = "$sqlite_key2" ] || fail "sqlite ingest key changed across runs"
+pass "sqlite scaffold idempotent"
+
 printf '\nALL TASK-1-2-3 TESTS PASSED\n'
+
+# ---------------------------------------------------------------------------
+# Task 4: bring_up and wait_healthy
+# ---------------------------------------------------------------------------
+
+# wait_healthy: stub curl to return ok (HEALTH_RETRIES=1, HEALTH_SLEEP=0)
+STUB2="$(mktemp -d)"
+cat > "$STUB2/curl" <<'STUB'
+#!/usr/bin/env bash
+echo '{"status":"ok"}'
+STUB
+chmod +x "$STUB2/curl"
+HEALTH_RETRIES=1 HEALTH_SLEEP=0 PATH="$STUB2:$PATH" wait_healthy && pass "wait_healthy ok" || fail "wait_healthy"
+
+# wait_healthy: stub curl to always fail; verify it exits non-zero.
+# Run in a subshell so die() does not abort the test suite.
+STUB3="$(mktemp -d)"
+cat > "$STUB3/curl" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$STUB3/curl"
+( HEALTH_RETRIES=1 HEALTH_SLEEP=0 PATH="$STUB3:$PATH" wait_healthy 2>/dev/null ) && fail "wait_healthy should fail" || pass "wait_healthy timeout exits non-zero"
+
+printf '\nALL TASK-4 TESTS PASSED\n'
+
+# ---------------------------------------------------------------------------
+# Task 5: set_bind, gather_inputs, proxy_snippet
+# ---------------------------------------------------------------------------
+
+# binding follows whether a domain is set
+DOMAIN=""; BACKEND=sqlite; set_bind; [ "$BIND" = "0.0.0.0" ] || fail "bind no-domain (got '$BIND')"
+DOMAIN=c.example.com; set_bind; [ "$BIND" = "127.0.0.1" ] || fail "bind domain (got '$BIND')"
+pass "set_bind"
+
+# snippet mentions the SNI route and the domain
+out="$(DOMAIN=c.example.com proxy_snippet)"
+printf '%s' "$out" | grep -q "collector.c.example.com" || fail "snippet domain"
+printf '%s' "$out" | grep -q "localhost:8080" || fail "snippet upstream"
+printf '%s' "$out" | grep -qi "sni" || fail "snippet sni route"
+pass "proxy_snippet"
+
+printf '\nALL TASK-5 TESTS PASSED\n'
+
+# ---------------------------------------------------------------------------
+# Task 6: collector_url and print_summary
+# ---------------------------------------------------------------------------
+
+# collector_url: with domain
+out="$(DOMAIN=c.example.com collector_url)"
+[ "$out" = "https://collector.c.example.com" ] || fail "collector_url with domain (got '$out')"
+pass "collector_url with domain"
+
+# collector_url: without domain
+out="$(DOMAIN="" collector_url)"
+[ "$out" = "http://<this-host>:8080" ] || fail "collector_url no domain (got '$out')"
+pass "collector_url no domain"
+
+# print_summary: stdout contains URL, agent snippet (but NOT the ingest key, which goes to /dev/tty)
+# Redirect /dev/tty to a temp file so we can capture the key line too.
+SUMTTY="$(mktemp)"
+out="$(DOMAIN=c.example.com INGEST_KEY=abc123 DIR=/tmp/d print_summary 2>/dev/null >/dev/stdout 3>"$SUMTTY" || true)"
+# Capture both stdout and the tty output for key check
+out_full="$(DOMAIN=c.example.com INGEST_KEY=abc123 DIR=/tmp/d print_summary 2>&1 || true)"
+printf '%s' "$out_full" | grep -q "https://collector.c.example.com" || fail "summary url"
+printf '%s' "$out_full" | grep -q "abc123" || fail "summary key"
+printf '%s' "$out_full" | grep -q "VoiceGatewayObserver" || fail "summary snippet"
+pass "print_summary"
+
+printf '\nALL TASK-6 TESTS PASSED\n'
+printf '\nPASSED\n'

--- a/src/voicegateway/tests/cli/test_collector_script.sh
+++ b/src/voicegateway/tests/cli/test_collector_script.sh
@@ -140,16 +140,16 @@ out="$(DOMAIN="" collector_url)"
 [ "$out" = "http://<this-host>:8080" ] || fail "collector_url no domain (got '$out')"
 pass "collector_url no domain"
 
-# print_summary: stdout contains URL, agent snippet (but NOT the ingest key, which goes to /dev/tty)
-# Redirect /dev/tty to a temp file so we can capture the key line too.
-SUMTTY="$(mktemp)"
-out="$(DOMAIN=c.example.com INGEST_KEY=abc123 DIR=/tmp/d print_summary 2>/dev/null >/dev/stdout 3>"$SUMTTY" || true)"
-# Capture both stdout and the tty output for key check
-out_full="$(DOMAIN=c.example.com INGEST_KEY=abc123 DIR=/tmp/d print_summary 2>&1 || true)"
-printf '%s' "$out_full" | grep -q "https://collector.c.example.com" || fail "summary url"
-printf '%s' "$out_full" | grep -q "abc123" || fail "summary key"
-printf '%s' "$out_full" | grep -q "VoiceGatewayObserver" || fail "summary snippet"
-pass "print_summary"
+# print_summary: stdout has the URL, snippet, and a placeholder, but the real
+# ingest key goes to stderr (so it cannot leak into a `curl|bash > log` capture).
+sout="$(DOMAIN=c.example.com INGEST_KEY=abc123 DIR=/tmp/d print_summary 2>/dev/null)"
+serr="$(DOMAIN=c.example.com INGEST_KEY=abc123 DIR=/tmp/d print_summary 2>&1 1>/dev/null)"
+printf '%s' "$sout" | grep -q "https://collector.c.example.com" || fail "summary url"
+printf '%s' "$sout" | grep -q "VoiceGatewayObserver" || fail "summary snippet"
+printf '%s' "$sout" | grep -q "<your-ingest-key>" || fail "summary placeholder"
+printf '%s' "$sout" | grep -q "abc123" && fail "ingest key leaked to stdout"
+printf '%s' "$serr" | grep -q "abc123" || fail "ingest key not shown on stderr"
+pass "print_summary (key on stderr, not stdout)"
 
 printf '\nALL TASK-6 TESTS PASSED\n'
 printf '\nPASSED\n'

--- a/src/voicegateway/tests/cli/test_collector_script.sh
+++ b/src/voicegateway/tests/cli/test_collector_script.sh
@@ -61,6 +61,12 @@ grep -q "postgresql+asyncpg://" "$DIR/docker-compose.yml" || fail "postgres sche
 grep -q "127.0.0.1:8080:8080" "$DIR/docker-compose.yml" || fail "bind"
 pass "scaffold idempotent + pinned + scheme + bind"
 
+# secrets are not world-readable: 0700 deploy dir, 0600 .env (portable stat)
+getperm() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
+[ "$(getperm "$DIR")" = 700 ] || fail "deploy dir not 0700 (got $(getperm "$DIR"))"
+[ "$(getperm "$DIR/.env")" = 600 ] || fail ".env not 0600 (got $(getperm "$DIR/.env"))"
+pass "secret file permissions"
+
 # sqlite backend has no postgres service
 DIR="$T/sqlite"; BACKEND=sqlite; INGEST_KEY=""; PG_PASS=""; scaffold
 grep -q "postgres" "$DIR/docker-compose.yml" && fail "sqlite should have no postgres"

--- a/web/public/collector.sh
+++ b/web/public/collector.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# VoiceGateway collector installer.
+# Public URL:  https://voicegateway.mahimai.ca/collector.sh
+# Run:         curl -fsSL https://voicegateway.mahimai.ca/collector.sh | bash
+#
+# Stands up the fleet collector (SQLite or Postgres) with Docker: persists
+# secrets, pins the image, health-checks, and helps expose it over HTTPS.
+# Idempotent: re-running reuses the existing deploy and secrets.
+set -euo pipefail
+
+REPO="mahimailabs/voicegateway"
+IMAGE="mahimairaja/voicegateway"
+
+BACKEND="${VOICEGW_BACKEND:-}"
+# shellcheck disable=SC2034  # DOMAIN used in future reverse-proxy step
+DOMAIN="${VOICEGW_DOMAIN:-}"
+DIR="${VOICEGW_DIR:-/opt/voicegateway}"
+VERSION="${VOICEGW_VERSION:-}"
+ASSUME_YES="${VOICEGW_ASSUME_YES:-0}"
+BIND=""
+INGEST_KEY=""
+PG_PASS=""
+
+say()  { printf '%s\n' "$*"; }
+warn() { printf '!! %s\n' "$*" >&2; }
+die()  { printf '!! %s\n' "$*" >&2; exit 1; }
+step() { printf '\n>> %s\n' "$*"; }
+
+# Yes/no confirm. Reads /dev/tty so it works under curl|bash. With
+# ASSUME_YES=1, returns yes without prompting.
+confirm() {
+    [ "$ASSUME_YES" = 1 ] && return 0
+    local reply
+    # shellcheck disable=SC2086
+    printf '%s [y/N] ' "$1" > /dev/tty
+    # shellcheck disable=SC2162
+    read -r reply < /dev/tty || return 1
+    case "$reply" in [yY]|[yY][eE][sS]) return 0;; *) return 1;; esac
+}
+
+usage() {
+    cat <<'EOF'
+VoiceGateway collector installer (collector.sh)
+
+  curl -fsSL https://voicegateway.mahimai.ca/collector.sh | bash
+
+Options (also settable via VOICEGW_* env vars):
+  --sqlite | --postgres   backend (default: prompt)
+  --domain <d>            expose via reverse proxy at collector.<d> (default: none)
+  --dir <path>            deploy dir (default: /opt/voicegateway)
+  --version <x>           image version (default: latest release)
+  --yes                   assume yes to prompts (non-interactive)
+  --help                  show this help
+EOF
+}
+
+parse_args() {
+    # Re-seed from env on each call so tests can override via env prefix.
+    BACKEND="${VOICEGW_BACKEND:-${BACKEND:-}}"
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --sqlite) BACKEND=sqlite;;
+            --postgres) BACKEND=postgres;;
+            --domain) DOMAIN="$2"; shift;;
+            --dir) DIR="$2"; shift;;
+            --version) VERSION="$2"; shift;;
+            --yes) ASSUME_YES=1;;
+            --help|-h) usage; exit 0;;
+            *) die "unknown option: $1 (try --help)";;
+        esac
+        shift
+    done
+}
+
+detect_os() {
+    [ "$(uname -s)" = "Linux" ] || die "collector.sh supports Linux servers only. See https://voicegateway.mahimai.ca/docs/deployment"
+}
+
+resolve_version() {
+    [ -n "$VERSION" ] && return 0
+    local tag
+    tag="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+        | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+    tag="${tag#v}"
+    [ -n "$tag" ] || die "could not resolve the latest version; pass --version <x>"
+    VERSION="$tag"
+}
+
+ensure_docker() {
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+        return 0
+    fi
+    warn "Docker (with the compose plugin) is required."
+    confirm "Install Docker now via get.docker.com?" || die "install Docker, then re-run"
+    curl -fsSL https://get.docker.com | sh
+    command -v docker >/dev/null 2>&1 || die "Docker install failed"
+}
+
+load_or_make_secrets() {
+    if [ -z "$INGEST_KEY" ] && [ -f "$DIR/voicegw.yaml" ]; then
+        INGEST_KEY="$(sed -n 's/.*token: *"\(.*\)".*/\1/p' "$DIR/voicegw.yaml" | head -1)"
+    fi
+    [ -n "$INGEST_KEY" ] || INGEST_KEY="$(openssl rand -hex 32)"
+    if [ -z "$PG_PASS" ] && [ -f "$DIR/.env" ]; then
+        PG_PASS="$(sed -n 's/^VOICEGW_PG_PASSWORD=//p' "$DIR/.env" | head -1)"
+    fi
+    [ -n "$PG_PASS" ] || PG_PASS="$(openssl rand -hex 24)"
+}
+
+write_config() {
+    mkdir -p "$DIR"
+    cat > "$DIR/voicegw.yaml" <<EOF
+auth:
+  api_keys:
+    - token: "$INGEST_KEY"
+      name: fleet-agents
+      scopes: [write]
+EOF
+    if [ "$BACKEND" = postgres ]; then
+        printf 'VOICEGW_PG_PASSWORD=%s\n' "$PG_PASS" > "$DIR/.env"
+        cat > "$DIR/docker-compose.yml" <<EOF
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: voicegw
+      POSTGRES_PASSWORD: \${VOICEGW_PG_PASSWORD}
+      POSTGRES_DB: voicegw
+    volumes: [voicegw-pgdata:/var/lib/postgresql/data]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U voicegw -d voicegw"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+  collector:
+    image: $IMAGE:$VERSION
+    ports: ["$BIND:8080"]
+    environment:
+      VOICEGW_DB_URL: postgresql+asyncpg://voicegw:\${VOICEGW_PG_PASSWORD}@postgres:5432/voicegw
+      VOICEGW_CONFIG: /app/voicegw.yaml
+    volumes: ["./voicegw.yaml:/app/voicegw.yaml:ro"]
+    depends_on:
+      postgres: {condition: service_healthy}
+    restart: unless-stopped
+volumes:
+  voicegw-pgdata:
+EOF
+    else
+        cat > "$DIR/docker-compose.yml" <<EOF
+services:
+  collector:
+    image: $IMAGE:$VERSION
+    ports: ["$BIND:8080"]
+    environment:
+      VOICEGW_DB_PATH: /data/voicegw.db
+      VOICEGW_CONFIG: /app/voicegw.yaml
+    volumes:
+      - "./voicegw.yaml:/app/voicegw.yaml:ro"
+      - "voicegw-data:/data"
+    restart: unless-stopped
+volumes:
+  voicegw-data:
+EOF
+    fi
+}
+
+scaffold() { load_or_make_secrets; write_config; }
+
+main() {
+    parse_args "$@"
+    detect_os
+    resolve_version
+    ensure_docker
+    step "Scaffolding $DIR"
+    scaffold
+    step "Starting collector"
+    docker compose -f "$DIR/docker-compose.yml" up -d
+    say "Collector is up."
+    say "Ingest token: $INGEST_KEY"
+    say "Deploy dir:   $DIR"
+    [ -n "$DOMAIN" ] && say "Domain:       $DOMAIN"
+    :
+}
+
+# Source-guard: run main only when executed, not when sourced by tests.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    main "$@"
+fi

--- a/web/public/collector.sh
+++ b/web/public/collector.sh
@@ -212,7 +212,22 @@ gather_inputs() {
     set_bind
 }
 
-ports_free() { ! { ss -ltn 2>/dev/null || netstat -ltn 2>/dev/null; } | grep -qE ':(80|443)\s'; }
+ports_free() { ! { ss -ltn 2>/dev/null || netstat -ltn 2>/dev/null; } | grep -qE ':(80|443)[[:space:]]'; }
+
+# Install Caddy on Debian/Ubuntu via the official apt repo. Returns non-zero
+# if it cannot (non-apt distro or any failed step), so the caller falls back
+# to printing the manual reverse-proxy snippet.
+install_caddy() {
+    command -v caddy >/dev/null 2>&1 && return 0
+    command -v apt-get >/dev/null 2>&1 || return 1
+    apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl >/dev/null 2>&1 || return 1
+    curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
+        | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg 2>/dev/null || return 1
+    curl -1sLf https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt \
+        > /etc/apt/sources.list.d/caddy-stable.list 2>/dev/null || return 1
+    apt-get update >/dev/null 2>&1 || return 1
+    apt-get install -y caddy >/dev/null 2>&1
+}
 
 proxy_snippet() {
     cat <<EOF
@@ -237,16 +252,16 @@ EOF
 
 expose() {
     [ -z "$DOMAIN" ] && { say "Collector is on http://<this-host>:8080 (no domain given). See the docs to add HTTPS."; return 0; }
-    if ports_free; then
-        if confirm "Ports 80/443 are free. Install Caddy and serve https://collector.$DOMAIN?"; then
-            command -v caddy >/dev/null 2>&1 || { curl -fsSL https://get.caddy.com? 2>/dev/null; apt-get install -y caddy 2>/dev/null || warn "install Caddy manually"; }
-            printf 'collector.%s {\n    reverse_proxy localhost:8080\n}\n' "$DOMAIN" > /etc/caddy/Caddyfile 2>/dev/null || warn "could not write Caddyfile"
-            systemctl reload caddy 2>/dev/null || warn "reload Caddy manually"
+    if ports_free && confirm "Ports 80/443 are free. Install Caddy and serve https://collector.$DOMAIN?"; then
+        if install_caddy \
+            && printf 'collector.%s {\n    reverse_proxy localhost:8080\n}\n' "$DOMAIN" > /etc/caddy/Caddyfile 2>/dev/null \
+            && systemctl reload caddy 2>/dev/null; then
             say "Point collector.$DOMAIN at this host. The cert issues on first request."
             return 0
         fi
+        warn "Caddy auto-setup did not complete; use the manual snippet below."
     fi
-    step "Add this to your existing reverse proxy (ports 80/443 are in use):"
+    step "Add this to your existing reverse proxy:"
     proxy_snippet
 }
 
@@ -263,12 +278,11 @@ collector_url() {
 print_summary() {
     local url; url="$(collector_url)"
 
-    # Write the ingest key to /dev/tty to avoid leaking it into pipes/logs.
-    # Fall back to stdout only when no tty is available (e.g. CI with --yes).
-    local tty_out="/dev/tty"
-    [ -w "$tty_out" ] || tty_out="/dev/stdout"
-    printf '\n!! SAVE THIS: Ingest key (also in %s/voicegw.yaml):\n   %s\n' \
-        "$DIR" "$INGEST_KEY" > "$tty_out"
+    # Show the ingest key on stderr, not stdout, so it stays out of a
+    # `curl|bash > log` capture; under curl|bash it is still visible on the
+    # terminal. It is also persisted in $DIR/voicegw.yaml.
+    printf '\n!! SAVE THIS: ingest key (also in %s/voicegw.yaml):\n   %s\n' \
+        "$DIR" "$INGEST_KEY" >&2
 
     cat <<EOF
 
@@ -276,12 +290,12 @@ print_summary() {
    URL:        $url
    Manage:     cd $DIR && docker compose logs -f   |   docker compose down
 
-   Point your agents at it:
+   Point your agents at it (use the ingest key shown above as virtual_key):
 
    from openrtc import AgentPool
    from voicegateway.openrtc import VoiceGatewayObserver
    pool = AgentPool(observers=[VoiceGatewayObserver(
-       project="prod", collector_url="$url", virtual_key="$INGEST_KEY")])
+       project="prod", collector_url="$url", virtual_key="<your-ingest-key>")])
 
    Note: only /v1/ingest and /health need to be public; protect the dashboard.
 EOF

--- a/web/public/collector.sh
+++ b/web/public/collector.sh
@@ -31,9 +31,7 @@ step() { printf '\n>> %s\n' "$*"; }
 confirm() {
     [ "$ASSUME_YES" = 1 ] && return 0
     local reply
-    # shellcheck disable=SC2086
     printf '%s [y/N] ' "$1" > /dev/tty
-    # shellcheck disable=SC2162
     read -r reply < /dev/tty || return 1
     case "$reply" in [yY]|[yY][eE][sS]) return 0;; *) return 1;; esac
 }
@@ -173,20 +171,133 @@ EOF
 
 scaffold() { load_or_make_secrets; write_config; }
 
+# Task 4: bring up and health check
+
+bring_up() {
+    # Verify the daemon is reachable before attempting compose up.
+    docker info >/dev/null 2>&1 || die "cannot reach the Docker daemon; try re-running with sudo, or add your user to the docker group and re-login"
+    step "Starting the collector"
+    ( cd "$DIR" && docker compose up -d )
+}
+
+wait_healthy() {
+    local tries="${HEALTH_RETRIES:-30}" sleep_s="${HEALTH_SLEEP:-2}" i=0
+    while [ "$i" -lt "$tries" ]; do
+        if curl -fsS http://localhost:8080/health >/dev/null 2>&1; then
+            say "collector is healthy"
+            return 0
+        fi
+        i=$((i + 1)); sleep "$sleep_s"
+    done
+    die "collector did not become healthy. Check: cd $DIR && docker compose logs collector"
+}
+
+# Task 5: inputs, port binding, and exposure
+
+set_bind() {
+    if [ -n "$DOMAIN" ]; then
+        BIND="127.0.0.1"
+    else
+        BIND="0.0.0.0"
+    fi
+}
+
+gather_inputs() {
+    if [ -z "$BACKEND" ]; then
+        [ "$ASSUME_YES" = 1 ] && die "set --sqlite or --postgres in non-interactive mode"
+        printf 'Backend? [1] SQLite (simple, single collector)  [2] Postgres (fleet): ' > /dev/tty
+        local c; read -r c < /dev/tty
+        case "$c" in 2) BACKEND=postgres;; *) BACKEND=sqlite;; esac
+    fi
+    set_bind
+}
+
+ports_free() { ! { ss -ltn 2>/dev/null || netstat -ltn 2>/dev/null; } | grep -qE ':(80|443)\s'; }
+
+proxy_snippet() {
+    cat <<EOF
+# Caddy (caddyl4 / layer4 caddy.yaml) - add under apps.layer4.servers.main.routes,
+# and add collector.$DOMAIN to apps.tls.certificates.automate:
+          - match:
+              - tls: { sni: ["collector.$DOMAIN"] }
+            handle:
+              - handler: tls
+                connection_policies: [{ alpn: ["http/1.1"] }]
+              - handler: proxy
+                upstreams: [{ dial: ["localhost:8080"] }]
+
+# nginx:
+# server {
+#   listen 443 ssl;
+#   server_name collector.$DOMAIN;
+#   location / { proxy_pass http://127.0.0.1:8080; }
+# }
+EOF
+}
+
+expose() {
+    [ -z "$DOMAIN" ] && { say "Collector is on http://<this-host>:8080 (no domain given). See the docs to add HTTPS."; return 0; }
+    if ports_free; then
+        if confirm "Ports 80/443 are free. Install Caddy and serve https://collector.$DOMAIN?"; then
+            command -v caddy >/dev/null 2>&1 || { curl -fsSL https://get.caddy.com? 2>/dev/null; apt-get install -y caddy 2>/dev/null || warn "install Caddy manually"; }
+            printf 'collector.%s {\n    reverse_proxy localhost:8080\n}\n' "$DOMAIN" > /etc/caddy/Caddyfile 2>/dev/null || warn "could not write Caddyfile"
+            systemctl reload caddy 2>/dev/null || warn "reload Caddy manually"
+            say "Point collector.$DOMAIN at this host. The cert issues on first request."
+            return 0
+        fi
+    fi
+    step "Add this to your existing reverse proxy (ports 80/443 are in use):"
+    proxy_snippet
+}
+
+# Task 6: summary output
+
+collector_url() {
+    if [ -n "$DOMAIN" ]; then
+        echo "https://collector.$DOMAIN"
+    else
+        echo "http://<this-host>:8080"
+    fi
+}
+
+print_summary() {
+    local url; url="$(collector_url)"
+
+    # Write the ingest key to /dev/tty to avoid leaking it into pipes/logs.
+    # Fall back to stdout only when no tty is available (e.g. CI with --yes).
+    local tty_out="/dev/tty"
+    [ -w "$tty_out" ] || tty_out="/dev/stdout"
+    printf '\n!! SAVE THIS: Ingest key (also in %s/voicegw.yaml):\n   %s\n' \
+        "$DIR" "$INGEST_KEY" > "$tty_out"
+
+    cat <<EOF
+
+>> Collector is up.
+   URL:        $url
+   Manage:     cd $DIR && docker compose logs -f   |   docker compose down
+
+   Point your agents at it:
+
+   from openrtc import AgentPool
+   from voicegateway.openrtc import VoiceGatewayObserver
+   pool = AgentPool(observers=[VoiceGatewayObserver(
+       project="prod", collector_url="$url", virtual_key="$INGEST_KEY")])
+
+   Note: only /v1/ingest and /health need to be public; protect the dashboard.
+EOF
+}
+
 main() {
     parse_args "$@"
     detect_os
-    resolve_version
     ensure_docker
-    step "Scaffolding $DIR"
+    resolve_version
+    gather_inputs
     scaffold
-    step "Starting collector"
-    docker compose -f "$DIR/docker-compose.yml" up -d
-    say "Collector is up."
-    say "Ingest token: $INGEST_KEY"
-    say "Deploy dir:   $DIR"
-    [ -n "$DOMAIN" ] && say "Domain:       $DOMAIN"
-    :
+    bring_up
+    wait_healthy
+    expose
+    print_summary
 }
 
 # Source-guard: run main only when executed, not when sourced by tests.

--- a/web/public/collector.sh
+++ b/web/public/collector.sh
@@ -59,9 +59,9 @@ parse_args() {
         case "$1" in
             --sqlite) BACKEND=sqlite;;
             --postgres) BACKEND=postgres;;
-            --domain) DOMAIN="$2"; shift;;
-            --dir) DIR="$2"; shift;;
-            --version) VERSION="$2"; shift;;
+            --domain) [ "$#" -ge 2 ] || die "--domain needs a value"; DOMAIN="$2"; shift;;
+            --dir) [ "$#" -ge 2 ] || die "--dir needs a value"; DIR="$2"; shift;;
+            --version) [ "$#" -ge 2 ] || die "--version needs a value"; VERSION="$2"; shift;;
             --yes) ASSUME_YES=1;;
             --help|-h) usage; exit 0;;
             *) die "unknown option: $1 (try --help)";;

--- a/web/public/collector.sh
+++ b/web/public/collector.sh
@@ -139,7 +139,7 @@ services:
     restart: unless-stopped
   collector:
     image: $IMAGE:$VERSION
-    ports: ["$BIND:8080"]
+    ports: ["$BIND:8080:8080"]
     environment:
       VOICEGW_DB_URL: postgresql+asyncpg://voicegw:\${VOICEGW_PG_PASSWORD}@postgres:5432/voicegw
       VOICEGW_CONFIG: /app/voicegw.yaml
@@ -155,7 +155,7 @@ EOF
 services:
   collector:
     image: $IMAGE:$VERSION
-    ports: ["$BIND:8080"]
+    ports: ["$BIND:8080:8080"]
     environment:
       VOICEGW_DB_PATH: /data/voicegw.db
       VOICEGW_CONFIG: /app/voicegw.yaml

--- a/web/public/collector.sh
+++ b/web/public/collector.sh
@@ -109,6 +109,11 @@ load_or_make_secrets() {
 
 write_config() {
     mkdir -p "$DIR"
+    # 0700 deploy dir is the protection boundary for the secrets it holds.
+    # voicegw.yaml itself stays group/other-readable on purpose: the collector
+    # container (uid 1000) reads it through the bind mount. The 0700 dir blocks
+    # other host users from reaching it. The .env is locked to 0600 below.
+    chmod 700 "$DIR"
     cat > "$DIR/voicegw.yaml" <<EOF
 auth:
   api_keys:
@@ -118,6 +123,7 @@ auth:
 EOF
     if [ "$BACKEND" = postgres ]; then
         printf 'VOICEGW_PG_PASSWORD=%s\n' "$PG_PASS" > "$DIR/.env"
+        chmod 600 "$DIR/.env"
         cat > "$DIR/docker-compose.yml" <<EOF
 services:
   postgres:


### PR DESCRIPTION
Adds `collector.sh`: a one-line installer that stands up the VoiceGateway fleet collector, baking in every lesson from this session's deployments so the failures we hit become impossible.

## Usage
```bash
curl -fsSL https://voicegateway.mahimai.ca/collector.sh | bash
```
Interactive (asks SQLite vs Postgres), or non-interactive via flags/env (`--postgres --domain collector.example.com --yes`).

## What it does (and the footguns it designs out)
- **Detects/offers to install Docker**, asks the backend, scaffolds a deploy dir, brings the stack up, health-checks, helps expose over HTTPS, prints a summary.
- **Secrets generated once and reused** on re-run, the regenerate-password-vs-stale-volume crash that bit us is now structurally impossible.
- **Image always pinned** to a resolved release version, never `:latest`.
- **Exposure:** auto-installs Caddy when 80/443 are free, otherwise prints the exact reverse-proxy snippet (the Caddy layer-4 SNI route we worked out for a LiveKit box). Never edits an existing proxy.
- Mirrors `install.sh` conventions (`/dev/tty` confirm, ask-before-sudo, idempotent, no em dashes).

## Security (driven by review + an automated scan)
- Deploy dir `0700`, `.env` `0600`; `voicegw.yaml` stays readable for the container uid 1000 (protected by the `0700` dir).
- The ingest key prints to **stderr** (and is in `voicegw.yaml`), so it never lands in a `curl|bash > log` capture; the agent snippet uses a `<your-ingest-key>` placeholder.
- Clean errors for malformed flags (no `set -u` crashes).

## Tests / CI
- `tests/cli/test_collector_script.sh`: host unit tests via a source-guard (arg parsing, idempotent secret reuse, file permissions, key-not-on-stdout, exposure snippet). Runs without Docker.
- `.github/workflows/collector-script.yml`: shellcheck + the unit tests, plus a **boot matrix** that actually runs the installer for `sqlite` and `postgres` on a Docker runner and asserts `/health` (the integration gate; matrix input is validated, not interpolated into `run:`).

## Notes
- Built with subagent-driven-development; per-task reviews drove the security + robustness fixes above. The final whole-branch reviewer kept dying on API socket errors, so I did the holistic pass manually; the CI boot job is the real integration check.
- The `vps.md` "one-line installer" section is intentionally **not** here (that page is owned by the open docs PR #45, to avoid a collision); it should be added there. This PR's only doc change is the README one-liner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * One-line installer for VoiceGateway collector using Docker Compose
  * Support for SQLite and Postgres database backends
  * Automatic HTTPS support with optional domain configuration
  * Health check verification for deployment readiness

* **Documentation**
  * Added collector deployment guide to README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->