### PR TITLE
feat(collector): opt-in auto-update overlay with rolling Postgres backups

### DIFF
--- a/docker-compose.autoupdate.yml
+++ b/docker-compose.autoupdate.yml
@@ -1,0 +1,77 @@
+# Opt-in auto-update overlay for the fleet collector.
+#
+# Layer this ON TOP of docker-compose.collector.yml to:
+#   1. track a safe minor release channel (0.10.x patches, never a breaking major),
+#   2. auto-pull and recreate the collector when a new patch ships, and
+#   3. keep rolling Postgres backups so a bad migration is recoverable.
+#
+#   docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml up -d
+#
+# Requires v0.10.0+ to be published (the :0.10 channel tag is created by the
+# release workflow). The agent SDK buffers and retries during the few-second
+# container swap, so updates are effectively seamless for your agents. See
+# https://docs.voicegateway.dev/deployment/auto-update for the full model.
+
+services:
+  collector:
+    # Track the 0.10.x patch channel: auto-gets bug-fix releases, never a
+    # breaking major. Move to :0.11 deliberately when you choose to upgrade.
+    image: mahimairaja/voicegateway:0.10
+    labels:
+      # Only containers carrying this label are touched by Watchtower below,
+      # so the datastores (postgres, the backup sidecar) are never auto-updated.
+      com.centurylinklabs.watchtower.enable: "true"
+
+  # Watches ONLY the labeled collector and recreates it when :0.10 advances.
+  watchtower:
+    image: containrrr/watchtower:1.7.1
+    container_name: voicegw-watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      WATCHTOWER_LABEL_ENABLE: "true"      # only update labeled containers (the collector)
+      WATCHTOWER_CLEANUP: "true"           # remove the superseded image after a successful update
+      WATCHTOWER_POLL_INTERVAL: "3600"     # check hourly
+      WATCHTOWER_NO_STARTUP_MESSAGE: "true"
+    restart: unless-stopped
+    networks:
+      - voicegw-net
+
+  # Rolling Postgres backups so a bad auto-update migration is recoverable.
+  # Uses postgres:16-alpine so pg_dump matches the server version exactly: a
+  # client older than the server refuses to dump, so the matching image is the
+  # safe choice. Writes timestamped dumps to the voicegw-backups volume and
+  # keeps the most recent BACKUP_KEEP files.
+  db-backup:
+    image: postgres:16-alpine
+    container_name: voicegw-db-backup
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ${VOICEGW_PG_PASSWORD:-voicegw}
+      BACKUP_INTERVAL_SECONDS: ${VOICEGW_BACKUP_INTERVAL_SECONDS:-21600}  # every 6 hours
+      BACKUP_KEEP: ${VOICEGW_BACKUP_KEEP:-28}                            # ~7 days at 6h cadence
+    volumes:
+      - voicegw-backups:/backups
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "db-backup: dumping every $${BACKUP_INTERVAL_SECONDS}s, keeping $${BACKUP_KEEP} files";
+        while true; do
+          ts="$$(date +%Y%m%d-%H%M%S)";
+          if pg_dump -h postgres -U voicegw -d voicegw -f "/backups/voicegw-$$ts.sql"; then
+            echo "db-backup: wrote voicegw-$$ts.sql";
+          else
+            echo "db-backup: pg_dump FAILED at $$ts" >&2;
+          fi;
+          ls -1t /backups/voicegw-*.sql 2>/dev/null | tail -n +$$(( $${BACKUP_KEEP} + 1 )) | xargs -r rm -f;
+          sleep "$${BACKUP_INTERVAL_SECONDS}";
+        done
+    restart: unless-stopped
+    networks:
+      - voicegw-net
+
+volumes:
+  voicegw-backups:
+    driver: local

--- a/docs/deployment/auto-update.md
+++ b/docs/deployment/auto-update.md
@@ -1,0 +1,91 @@
+---
+title: "Auto-update the collector"
+description: "Keep a self-hosted fleet collector on the latest patch release automatically, with rolling Postgres backups and effectively no interruption to your agents."
+---
+
+# Auto-update the collector
+
+Once the collector runs on your own box (see [Deploy to a VPS](/deployment/vps)), you can have it pull and apply new patch releases on its own. This page sets that up with an opt-in Compose overlay that adds a release-channel pin, [Watchtower](https://containrrr.dev/watchtower/), and rolling Postgres backups.
+
+## Is it really "no interruption"?
+
+For your **agents**, effectively yes. The SDK's `RemoteCollectorSink` buffers telemetry in memory and retries with backoff, and treats HTTP 429 as backpressure. During the few-second container swap of an update, agents buffer and re-send, so no agent call fails.
+
+Two honest caveats:
+
+- Cost telemetry is **best-effort by design** (it is not billing-of-record). A *long* collector outage can drop some rows; a fast update swap does not.
+- On a **single node**, a container recreate is not literally zero-downtime: the ingest endpoint and dashboard are unavailable for a few seconds. For true zero-downtime you need two collector replicas behind a reverse proxy doing rolling restarts against shared Postgres (and migrations kept backward-compatible across the rollout). That is overkill for one box.
+
+## The release channel: pin to a minor, never `:latest`
+
+The release workflow publishes three Docker tags per version, for example `0.10.0`, `0.10`, and `latest`. The overlay pins the collector to the **minor channel** `:0.10`:
+
+- `:0.10` auto-gets bug-fix patches (`0.10.1`, `0.10.2`, ...) but **never a breaking major**. You move to `:0.11` deliberately.
+- `:latest` would auto-pull the next major and run its migrations unattended. Do not auto-track `:latest` in production.
+
+<Note>
+The `:0.10` channel exists once **v0.10.0** is published. Until then, pin to the highest released minor.
+</Note>
+
+## Turn it on
+
+The overlay ([`docker-compose.autoupdate.yml`](https://github.com/mahimailabs/voicegateway/blob/main/docker-compose.autoupdate.yml)) layers on top of the collector stack. From your deploy directory:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/mahimailabs/voicegateway/main/docker-compose.autoupdate.yml
+docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml up -d
+```
+
+That starts three things alongside the collector:
+
+| Service | What it does |
+| :-- | :-- |
+| `collector` (relabeled) | Now tracks `mahimairaja/voicegateway:0.10` and carries the Watchtower-enable label. |
+| `watchtower` | Checks hourly and recreates **only the labeled collector** when `:0.10` advances, then removes the old image. Postgres and the backup sidecar are never auto-updated. |
+| `db-backup` | A `postgres:16-alpine` sidecar that dumps the database on a schedule (matching server version, so `pg_dump` never refuses), keeping the most recent N dumps in a named volume. |
+
+Always pass **both** `-f` files together for later `up`, `down`, and `logs`, so Compose keeps the merged definition.
+
+## Tuning
+
+Set these in your `.env` next to the Compose files:
+
+| Variable | Default | Meaning |
+| :-- | :-- | :-- |
+| `VOICEGW_BACKUP_INTERVAL_SECONDS` | `21600` (6h) | How often the sidecar dumps. Lower it for a fresher pre-update snapshot. |
+| `VOICEGW_BACKUP_KEEP` | `28` | How many dumps to retain (about 7 days at 6h). |
+
+Watchtower's cadence is `WATCHTOWER_POLL_INTERVAL` (default `3600`, hourly) in the overlay.
+
+## Restore from a backup
+
+Dumps live in the `voicegw-backups` volume as `voicegw-<timestamp>.sql`. To roll back after a bad update:
+
+```bash
+# 1. Stop the collector so nothing writes during the restore.
+docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml stop collector watchtower
+
+# 2. List available dumps (newest first).
+docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml \
+  exec db-backup sh -c 'ls -1t /backups/voicegw-*.sql'
+
+# 3. Restore the chosen dump into Postgres.
+docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml \
+  exec -T db-backup sh -c 'psql -h postgres -U voicegw -d voicegw < /backups/voicegw-<timestamp>.sql'
+
+# 4. Pin the collector back to the known-good version, then bring it up.
+#    (edit the image tag in docker-compose.autoupdate.yml, e.g. :0.10.1)
+docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml up -d
+```
+
+<Warning>
+Migrations run on collector startup and are forward-only. The Compose healthcheck gates a bad boot, but the database is shared state: keep the backups (and ideally a periodic host-level snapshot of the box) so a migration regression is always recoverable.
+</Warning>
+
+## Opting back out
+
+Bring the stack up with only the base file to drop Watchtower and the backup sidecar and return to a manually-pinned collector:
+
+```bash
+docker compose -f docker-compose.collector.yml up -d
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -87,7 +87,8 @@
           "deployment/index",
           "deployment/fly",
           "deployment/railway",
-          "deployment/vps"
+          "deployment/vps",
+          "deployment/auto-update"
         ]
       },
       {


### PR DESCRIPTION
## Summary

Adds an opt-in auto-update path for a self-hosted fleet collector, so a box like a Hetzner VPS picks up new patch releases on its own, with rolling backups and effectively no interruption to agents. Nothing changes for existing deployments unless they layer this overlay in.

## What's added

- **`docker-compose.autoupdate.yml`** (overlay, applied on top of `docker-compose.collector.yml`):
  - Pins the collector to the **`:0.10` minor channel** (auto patches, never a breaking major).
  - **Watchtower**, label-scoped to *only* the collector (hourly poll, cleanup). Postgres and the backup sidecar are never auto-updated.
  - **`db-backup` sidecar** (`postgres:16-alpine`): rolling `pg_dump` on a schedule, version-matched to the server (an older client refuses to dump a newer server), with rotation.
- **`docs/deployment/auto-update.md`** + nav entry: the interruption model, channel pinning, tuning knobs, and restore steps.

## Why a sidecar instead of a pre-update hook

You asked for a `pg_dump` before each update. A literal pre-update hook would run inside the collector container, which (a) lacks `pg_dump` and would need it baked into the shared image, and (b) risks a client/server version mismatch that makes `pg_dump` refuse to run, and (c) only activates after the first update (the hook runs in the old container). The `postgres:16-alpine` sidecar avoids all three: it works immediately, uses a version-correct `pg_dump`, and keeps a continuously-fresh restore point (every 6h by default, configurable lower). If you specifically want the dump tied to the exact update moment, say so and I'll add the in-image hook variant.

## Why opt-in

Auto-updating every collector by default is too strong a default. This is a separate overlay file, so the shipped `docker-compose.collector.yml` is unchanged; users turn it on with a second `-f`.

## Verification

- `docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml config` merges cleanly (exit 0); the `$$`-escaped backup loop resolves correctly.
- Brought up `postgres` + `db-backup` live: it connected, wrote timestamped dumps, and rotated to the keep limit. Torn down with `down -v`.

## Note

The `:0.10` channel tag exists once **v0.10.0** is published (the release workflow emits `{major}.{minor}` tags). Until then the overlay should pin to the highest released minor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional auto-update setup for self-hosted collector deployments, including automated image updates and periodic database backups.
  * Added guidance for restoring from backups and opting out of the auto-update overlay.

* **Documentation**
  * Published a new deployment guide covering setup steps, configuration options, behavior during updates, and important limitations.
  * Updated the deployment navigation to surface the new guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->