### PR TITLE
fix(release): pin wheel version from the tag so PyPI accepts it

### DIFF
--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -16,6 +16,20 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Pin the version from the release tag. This script rebuilds the dashboard SPA
+# into the source tree (below), which dirties the git working tree; hatch-vcs
+# would then derive a PEP 440 local version like 0.10.0+g<hash>.d<date>, and
+# PyPI rejects local versions with a 400. Pinning SETUPTOOLS_SCM_PRETEND_VERSION
+# to the tag makes the wheel version exactly the release, immune to tree state,
+# mirroring the Dockerfile (which pins it from its VERSION build arg). Outside a
+# tagged CI run the var is left unset and hatch-vcs derives the version from git.
+if [[ -z "${SETUPTOOLS_SCM_PRETEND_VERSION:-}" \
+      && "${GITHUB_REF_TYPE:-}" == "tag" \
+      && "${GITHUB_REF_NAME:-}" == v* ]]; then
+  export SETUPTOOLS_SCM_PRETEND_VERSION="${GITHUB_REF_NAME#v}"
+  echo "==> pinning version to ${SETUPTOOLS_SCM_PRETEND_VERSION} (from tag ${GITHUB_REF_NAME})"
+fi
+
 FRONTEND_SRC="src/dashboard/frontend"
 STAGED_DIST="src/voicegateway/_dashboard_dist"
 


### PR DESCRIPTION
## Summary

The v0.10.0 PyPI publish failed with a 400: `The use of local versions in '0.10.1.dev0+g253986071.d20260628' is not allowed`. PyPI forbids PEP 440 local versions (the `+g<hash>.d<date>` part).

## Root cause

The v0.10.0 tag points at exactly the built commit (zero distance), so the version was not stale because of the commit. The culprit is a **dirty working tree at build time**: `scripts/build_wheel.sh` runs `npm run build` and stages the SPA into the source tree, so when `uv build` runs, hatch-vcs (setuptools-scm) sees uncommitted changes and appends a local version. PyPI then rejects it.

The Dockerfile already avoids this by pinning `SETUPTOOLS_SCM_PRETEND_VERSION` from its `VERSION` build arg; `build_wheel.sh` did not, so only the wheel publish broke.

## Fix

Pin `SETUPTOOLS_SCM_PRETEND_VERSION` from the release tag (stripping the leading `v`) at the top of `build_wheel.sh`, when running on a tag in CI. The wheel version is then exactly the release, immune to tree state. Outside a tagged run the var is left unset and hatch-vcs derives the version from git as before.

## Verified

With the tree deliberately dirtied:
- before: `voicegateway-0.10.1.dev2+g51e532565.d20260628-py3-none-any.whl` (rejected by PyPI)
- after the pin: `voicegateway-0.10.0-py3-none-any.whl`

## Release steps after merge

1. Merge this PR.
2. Delete the existing `v0.10.0` tag and its GitHub release. PyPI never accepted 0.10.0, so the name is free; Docker images, if published, are overwritten on re-tag.
   - Delete the remote tag: push the empty ref `:refs/tags/v0.10.0`.
   - Delete the GitHub release: `gh release delete v0.10.0`.
3. Re-tag `v0.10.0` on the merge commit and push the tag: the publish workflow re-runs and uploads a clean `0.10.0` wheel.
