### PR TITLE
ci(docker-publish): deselect integration tests in the release gate

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,11 @@ jobs:
           uv pip install -e ".[dev,dashboard,mcp]"
 
       - name: Run tests
-        run: uv run pytest --tb=short --ignore=src/voicegateway/tests/providers
+        # Deselect integration tests (testcontainers ClickHouse, real Postgres):
+        # they run in their dedicated jobs, and running them here both emits
+        # "Event loop is closed" teardown noise and leaks VOICEGW_DB_PATH into
+        # later unit tests. Matches ci.yml and test-coverage.yml.
+        run: uv run pytest --tb=short -m "not integration" --ignore=src/voicegateway/tests/providers
 
   publish-core:
     needs: test


### PR DESCRIPTION
## The issue

PyPI published fine, but the Docker workflow failed. The Docker workflow has a `test` job that gates the image build/push, and that gate ran the **full** test suite, including the testcontainers ClickHouse and integration tests — because, unlike `ci.yml` and `test-coverage.yml` (which I added `-m "not integration"` to earlier), `docker-publish.yml` was never updated.

Running the integration tests in that gate caused two problems:
1. **"Event loop is closed"** teardown noise from the ClickHouse async clients (the `asyncio.run`-in-module-fixtures pattern).
2. A **`VOICEGW_DB_PATH` leak**: the integration tests set that env var and it bled into a later **unit** test, `tests/inference/test_attach_capture.py::test_metric_capture_records_session_error`, which then failed with `sqlite3.IntegrityError: UNIQUE constraint failed: requests.id`.

The gate failed, so `publish-core`, `publish-dashboard`, and `create-release` were all skipped — hence no Docker images. (The failing test passes in `ci.yml` because that workflow already deselects integration tests.)

## The fix

Add `-m "not integration"` to the `docker-publish.yml` test gate, matching `ci.yml` and `test-coverage.yml`. The release gate now runs the unit suite only; integration tests keep running in their dedicated jobs (`postgres-collector.yml`, and locally via testcontainers).

## Getting Docker images for v0.10.0 after merge

The v0.10.0 tag commit does not contain this fix, so a re-run of the failed workflow would fail again. After merging this PR, re-cut the tag so the workflow runs with the fix:

1. Merge this PR to `main`.
2. Delete the `v0.10.0` tag and its GitHub release.
   - Remote tag: push the empty ref `:refs/tags/v0.10.0`.
   - Release: `gh release delete v0.10.0`.
3. Re-tag `v0.10.0` on the new `main` merge commit and push the tag.

On the re-run: the Docker gate passes and the images publish. PyPI re-runs too, but `skip-existing: true` makes it a no-op since `0.10.0` is already on PyPI. End state: `0.10.0` on both PyPI and Docker Hub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test selection to skip integration tests during the Docker publish workflow, while preserving the existing provider-test exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->