### PR TITLE
fix(docker): checkout in the merge job so the README sync finds its file

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -164,6 +164,11 @@ jobs:
             readme: ./src/dashboard/README.dockerhub.md
             short: "Web dashboard for VoiceGateway"
     steps:
+      # Checkout so the Docker Hub README files are on disk for the
+      # dockerhub-description step below (the manifest is built from the
+      # downloaded digests, not the source tree).
+      - uses: actions/checkout@v4
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Follow-up to #59. The native multi-arch build and manifest publish worked on the `v0.10.1-rc1` test run — the images published — but the `merge` job's final step, **Update Docker Hub README**, failed with:

```
Error: ENOENT: no such file or directory, open './src/voicegateway/README.dockerhub.md'
```

## Root cause

The `merge` job builds the manifest from the downloaded digests, so it had no `actions/checkout` step. But `peter-evans/dockerhub-description` reads `README.dockerhub.md` from the workspace, which was empty — hence ENOENT. The old `publish-*` jobs checked out the repo; the merge job needs to as well.

## Fix

Add `actions/checkout@v4` as the first step of the `merge` job. One line. The manifest creation is unaffected (it uses `/tmp/digests`, not the source tree).

## Status of the rc validation

The `v0.10.1-rc1` run proved the important parts of #59 work: `test` passed, all four **native** builds passed (no QEMU, no hang — including the dashboard arm64 build that previously wedged for 4 hours), and the manifests were created and pushed. This PR fixes the only remaining failure (the README description sync).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Docker publishing workflow so the repository contents are checked out before the Docker Hub README update step runs, preventing missing-file issues during publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->