### PR TITLE
fix(api-keys): use RETURNING id so key creation works on Postgres

### DIFF
--- a/src/voicegateway/repository/api_keys_repository.py
+++ b/src/voicegateway/repository/api_keys_repository.py
@@ -133,7 +133,7 @@ async def create_api_key(
             ") VALUES ("
             ":prefix, :digest, :name, :tenant_id, :issued_by, :role, :scopes,"
             " CURRENT_TIMESTAMP"
-            ")"
+            ") RETURNING id"
         ),
         {
             "prefix": prefix,
@@ -145,8 +145,10 @@ async def create_api_key(
             "scopes": scopes,
         },
     )
+    # RETURNING works on both Postgres (asyncpg has no ``lastrowid``) and SQLite
+    # 3.35+. Read the id before commit closes the result.
+    new_id = result.scalar_one()
     await session.commit()
-    new_id = result.lastrowid  # type: ignore[attr-defined]
     if new_id is None:
         raise RuntimeError("INSERT into api_keys did not return a row id")
     row = await get_by_id(session, new_id)


### PR DESCRIPTION
`create_api_key` read `result.lastrowid` after a raw `INSERT`, which asyncpg does not provide (only SQLite). This broke `vk_` key issuance on any Postgres backend (the hosted SaaS), including the cloud dashboard's issue-key flow, with `AsyncAdapt_asyncpg_cursor object has no attribute lastrowid`.

Switch to `INSERT ... RETURNING id` + `scalar_one()`. RETURNING is supported on Postgres and SQLite 3.35+, so both backends work.

Verified end to end against a live Postgres: a `vk_` key now issues, authenticates the cloud `/v1/ingest` endpoint, and telemetry lands in ClickHouse scoped to the key's tenant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key creation so newly inserted keys reliably return their generated ID across supported databases.
  * Fixed an issue that could affect reading the new key’s identifier after saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->