### PR TITLE
fix(attach): carry per-call tenant_id on the remote wire via metadata

### DIFF
--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -261,6 +261,7 @@ class MetricCapture:
                 session_id=self._session_id,
                 agent_id=self._agent_id,
             )
+            self._stamp_tenant(record)
             tally = self._recorded.setdefault(
                 (provider, model_id), {"input": 0.0, "output": 0.0, "cached": 0.0}
             )
@@ -286,7 +287,22 @@ class MetricCapture:
             session_id=self._session_id,
             agent_id=self._agent_id,
         )
+        self._stamp_tenant(record)
         self._schedule(self._sink.log_request(record))
+
+    def _stamp_tenant(self, record: RequestRecord) -> None:
+        """Carry the attach() ``tenant_id`` on the record's ``metadata``.
+
+        The remote collector serializes only ``RequestRecord`` fields, which
+        have no tenant column, and the cloud stamps the top-level tenant from
+        the ingest key. Riding in ``metadata`` is how a per-call ``tenant_id``
+        survives the wire, so an embedder that fans many sub-tenants through one
+        ingest key can still separate them downstream. A local sink already gets
+        the tenant first-class from the ``set_tenant`` ContextVar, so this is
+        additive there, not a replacement.
+        """
+        if self._tenant_id:
+            record.metadata = {**record.metadata, "tenant_id": self._tenant_id}
 
     def _schedule(self, coro: Any) -> None:
         try:
@@ -359,6 +375,7 @@ class MetricCapture:
                 agent_id=self._agent_id,
             )
             record.metadata = {"reconciled": True}
+            self._stamp_tenant(record)
             await self._sink.log_request(record)
 
 

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -417,6 +417,103 @@ class _FlushRecordingSink:
         pass
 
 
+# --- per-call tenant on the wire -----------------------------------------
+
+
+async def test_metric_capture_stamps_tenant_in_metadata():
+    """attach(tenant_id=...) rides in ``record.metadata`` so it survives the
+    remote wire: RequestRecord has no tenant field, and the cloud stamps the
+    top-level tenant from the ingest key. A multi-tenant embedder (many
+    sub-tenants behind one ingest key) separates them on this."""
+    sink = _FlushRecordingSink()
+    cost_tracker = CostTracker(sink)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="realty-recall",
+        agent_id="agent-t",
+        session_id="vg-t",
+        tenant_id="org_realtor_42",
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    assert len(sink.rows) == 1
+    assert sink.rows[0].metadata.get("tenant_id") == "org_realtor_42"
+
+
+async def test_metric_capture_omits_tenant_when_unset():
+    """No tenant_id -> no ``tenant_id`` key added to metadata (stays empty)."""
+    sink = _FlushRecordingSink()
+    cost_tracker = CostTracker(sink)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="fleet",
+        agent_id="agent-n",
+        session_id="vg-n",
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    assert "tenant_id" not in sink.rows[0].metadata
+
+
+async def test_metric_capture_error_row_carries_tenant():
+    """The error path also stamps the tenant so failures stay attributed."""
+    sink = _FlushRecordingSink()
+    cost_tracker = CostTracker(sink)
+    session = _FakeSession(llm=_FakeEmitter(model="gpt-4o-mini", provider="openai"))
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="realty-recall",
+        agent_id="agent-te",
+        session_id="vg-te",
+        tenant_id="org_realtor_42",
+    )
+    capture.bind(session)
+    session.emit("error", _ErrorEvent("boom", _LLMErrorSource()))
+    await capture.drain()
+
+    assert sink.rows[0].metadata.get("tenant_id") == "org_realtor_42"
+
+
+async def test_reconcile_correction_carries_tenant():
+    """A close-time reconcile correction keeps both markers: reconciled + tenant."""
+    sink = _FlushRecordingSink()
+    cost_tracker = CostTracker(sink)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    usage = _FakeUsage([_FakeLLMUsage(prompt_tokens=1500, completion_tokens=700)])
+    session = _FakeSessionWithUsage(usage, llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="realty-recall",
+        agent_id="agent-tr",
+        session_id="vg-tr",
+        tenant_id="org_realtor_42",
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+    await capture.reconcile(session)
+
+    recon = [r for r in sink.rows if r.metadata.get("reconciled")]
+    assert len(recon) == 1
+    assert recon[0].metadata.get("tenant_id") == "org_realtor_42"
+
+
 async def test_attach_close_flushes_sink(tmp_path):
     """The session close path drains writes AND flushes the sink (and the
     finalize task is strong-reffed: awaitable via session._vg_close_task)."""


### PR DESCRIPTION
## Problem

`voicegateway.attach(session, tenant_id=...)` sets the tenant `ContextVar` (which a **local** sink reads at enqueue time), but `MetricCapture` never stamps the tenant onto the `RequestRecord` it builds. The `RemoteCollectorSink` serializes only `RequestRecord` fields (`asdict(record)`), and `RequestRecord` has **no tenant column** — so per-call tenancy was silently dropped on the way to a collector.

Net effect: every call pushed through one `vk_` ingest key collapsed to that key's server-stamped tenant. `attach(tenant_id=...)` was a no-op on the remote path, which defeats it for any multi-tenant embedder that fans many sub-tenants through a single ingest key (e.g. a SaaS attributing cost per end-customer).

## Fix

Stamp the attach `tenant_id` into `record.metadata["tenant_id"]` on all three record-producing paths in `MetricCapture` (per-component metric, session error, close-time reconcile). `metadata` **is** a `RequestRecord` field, so it survives `asdict()` → `/v1/ingest` → `ClickHouseSink` (which persists `metadata` as JSON). A downstream consumer separates sub-tenants on `metadata.tenant_id`.

### Isolation is unchanged
The cloud ingest endpoint still stamps the **top-level** `tenant_id` from the ingest key (`RequestRecord` carries no tenant field to spoof). This change is a **secondary attribution dimension** riding in metadata, not a way to write into another tenant's data. A local sink still gets first-class `tenant_id` from the `ContextVar`; the metadata copy is additive there.

## Tests
Adds 4 focused cases (metric path stamps tenant, omitted when unset, error path carries tenant, reconcile correction carries tenant) using the record-recording sink so they assert the exact on-the-wire shape. All green.

Note: the 7 pre-existing `no such table: requests` failures in this test file reproduce on `main` without this change (a StorageService schema-setup gap in the ephemeral test env); they are unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metric records now consistently include tenant information when available, including error events and close-time correction records.
  * Existing metadata is preserved while adding tenant details, and records without a tenant remain unchanged.

* **Tests**
  * Added coverage for tenant-aware metric capture across normal, error, and reconciliation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->