### PR TITLE
feat(livekit): Phase 2 (heartbeat roster, latency breakdown, distributed SFU)

### DIFF
--- a/deploy/prober/Dockerfile
+++ b/deploy/prober/Dockerfile
@@ -1,0 +1,30 @@
+# Distributed SFU prober image.
+#
+# A thin image that runs `voicegw livekit sfu --report-to ...` against a
+# coordinator. Deploy N of these across regions (see deploy/prober/fly.toml and
+# the distributed-SFU docs) to load one SFU room concurrently from many
+# vantages. The prober needs only the base install (httpx); the coordinator is
+# the one that needs the [server] extra.
+FROM python:3.12-slim
+
+# Non-root: the prober only makes outbound connections.
+RUN useradd --create-home --uid 10001 prober
+WORKDIR /home/prober
+
+# Pin the same engine version you run the coordinator with so the wire contract
+# (register / job / report) matches. Override at build time: --build-arg VERSION=...
+ARG VERSION=""
+RUN pip install --no-cache-dir "voicegateway${VERSION:+==$VERSION}"
+
+USER prober
+
+# The coordinator URL and vantage label are per-region; set them at deploy time.
+#   COORDINATOR_URL  e.g. http://coordinator.internal:8787
+#   VOICEGW_REGION   the vantage label (Fly injects FLY_REGION; map it in fly.toml)
+# LiveKit creds come from the standard env vars, same as every other command:
+#   LIVEKIT_URL / LIVEKIT_API_KEY / LIVEKIT_API_SECRET
+ENV COORDINATOR_URL="" \
+    VOICEGW_REGION=""
+
+# sh -c so ${...} expands at runtime from the environment.
+ENTRYPOINT ["sh", "-c", "voicegw livekit sfu --report-to \"$COORDINATOR_URL\" --vantage \"$VOICEGW_REGION\" --ramp \"${RAMP:-10,25,50}\" --duration \"${DURATION:-20}\""]

--- a/deploy/prober/Dockerfile
+++ b/deploy/prober/Dockerfile
@@ -23,8 +23,11 @@ USER prober
 #   VOICEGW_REGION   the vantage label (Fly injects FLY_REGION; map it in fly.toml)
 # LiveKit creds come from the standard env vars, same as every other command:
 #   LIVEKIT_URL / LIVEKIT_API_KEY / LIVEKIT_API_SECRET
+# The ramp and duration are dictated by the coordinator's job (every vantage runs
+# the same ones), so the prober takes no --ramp/--duration: set them once on the
+# coordinator, not here.
 ENV COORDINATOR_URL="" \
     VOICEGW_REGION=""
 
 # sh -c so ${...} expands at runtime from the environment.
-ENTRYPOINT ["sh", "-c", "voicegw livekit sfu --report-to \"$COORDINATOR_URL\" --vantage \"$VOICEGW_REGION\" --ramp \"${RAMP:-10,25,50}\" --duration \"${DURATION:-20}\""]
+ENTRYPOINT ["sh", "-c", "voicegw livekit sfu --report-to \"$COORDINATOR_URL\" --vantage \"$VOICEGW_REGION\""]

--- a/deploy/prober/fly.toml
+++ b/deploy/prober/fly.toml
@@ -1,0 +1,35 @@
+# Example Fly.io config for a distributed SFU prober.
+#
+# One prober per region. This is a template: copy it, set your app name, and
+# scale across regions with `fly scale count`. Probers are run-to-completion
+# jobs, not long-lived services, so there are no [http_service] / [[services]]
+# blocks and no public ports.
+#
+# Deploy sketch (from deploy/prober/):
+#   fly apps create vg-sfu-prober
+#   fly secrets set -a vg-sfu-prober \
+#       LIVEKIT_URL=wss://your.livekit.cloud \
+#       LIVEKIT_API_KEY=... LIVEKIT_API_SECRET=... \
+#       COORDINATOR_URL=http://<coordinator-host>:8787
+#   fly deploy -a vg-sfu-prober
+#   fly scale count 3 --region iad,sjc,lhr -a vg-sfu-prober
+#
+# VOICEGW_REGION is mapped from Fly's FLY_REGION below so each machine reports
+# its own vantage label without per-region config.
+
+app = "vg-sfu-prober"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  # Fly injects FLY_REGION per machine; the entrypoint reads VOICEGW_REGION.
+  # Set this per-machine via `fly machine update --env VOICEGW_REGION=$FLY_REGION`,
+  # or bake a small wrapper. Left blank here so it is explicit, not silently "".
+  RAMP = "10,25,50"
+  DURATION = "20"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/deploy/prober/fly.toml
+++ b/deploy/prober/fly.toml
@@ -27,8 +27,8 @@ primary_region = "iad"
   # Fly injects FLY_REGION per machine; the entrypoint reads VOICEGW_REGION.
   # Set this per-machine via `fly machine update --env VOICEGW_REGION=$FLY_REGION`,
   # or bake a small wrapper. Left blank here so it is explicit, not silently "".
-  RAMP = "10,25,50"
-  DURATION = "20"
+  # Ramp and duration are set on the coordinator, not the prober (every vantage
+  # runs the coordinator's job), so there is nothing to configure here for them.
 
 [[vm]]
   size = "shared-cpu-1x"

--- a/docs/cli/livekit.md
+++ b/docs/cli/livekit.md
@@ -50,9 +50,19 @@ Queries the LiveKit server API for all active rooms and the participants current
 | **State** | `active` or `dispatched`. |
 | **Joined** | Timestamp the participant joined. |
 
-### Limitation: idle workers are not shown
+### Idle workers: the heartbeat roster
 
-The LiveKit server API exposes in-room participants only. Agents that are registered and waiting for dispatch (the idle worker pool) are not returned by any current server API. The command footer notes this gap explicitly. Full worker-pool visibility requires a future heartbeat feature (Phase 2) and is not available today.
+The LiveKit server API exposes in-room participants only. Agents that are registered and waiting for dispatch (the idle worker pool) are not returned by any server API. To close that gap, instrument your agents with `voicegateway.register_worker(...)`: each worker then heartbeats its presence (idle / busy / offline) to the collector.
+
+When `VOICEGW_COLLECTOR_URL` and `VOICEGW_API_KEY` are set, `agents` also fetches that roster and prints it below the in-room table. Without the collector, only the in-room view is shown, plus a note on how to enable the roster. The roster fetch is best-effort: if the collector is unreachable, the in-room table still renders.
+
+```
+Registered workers (heartbeat roster):
+AGENT            STATUS    REGION     VERSION
+realty           busy      iad        0.13.0
+concierge        idle      -          0.13.0
+3 workers registered (1 idle, 1 busy, 1 offline).
+```
 
 ### Example output
 
@@ -61,7 +71,8 @@ AGENT            ROOM                   STATE       IN-CALL  AGE
 agent-7f4a       demo-room              active      1        42s
 agent-2c9b       qa-room                dispatched  0        8s
 
-2 agents active in 2 rooms. Idle/registered workers are not reported by LiveKit's server API; run the Phase 2 heartbeat to see the full roster.
+2 agents active in 2 rooms.
+Idle/registered workers are not reported by LiveKit's server API. Set VOICEGW_COLLECTOR_URL + VOICEGW_API_KEY (and run register_worker in your agents) to also list the heartbeat roster.
 ```
 
 ### Options
@@ -71,7 +82,7 @@ agent-2c9b       qa-room                dispatched  0        8s
 | `--url` | `string` | (see Credentials) | LiveKit server WebSocket URL. |
 | `--api-key` | `string` | (see Credentials) | LiveKit API key. |
 | `--api-secret` | `string` | (see Credentials) | LiveKit API secret. |
-| `--json` | flag | off | Emit JSON instead of plain text. |
+| `--json` | flag | off | Emit JSON instead of plain text. With the collector set, the JSON is `{"in_room": [...], "roster": [...]}`. |
 
 ---
 
@@ -85,7 +96,7 @@ voicegw livekit latency [OPTIONS]
 
 ### What it measures
 
-Phase 1 reports **end-to-end latency only**: the time from the end of the caller's speech to the first reply audio frame received from the agent. This is the number users perceive.
+Always reports **end-to-end latency**: the time from the end of the caller's speech to the first reply audio frame received from the agent. This is the number users perceive.
 
 For each probe turn the command:
 
@@ -97,9 +108,11 @@ For each probe turn the command:
 |---|---|
 | **E2E latency** | Caller speech-end to first reply audio (seconds). This is the number users perceive. |
 
-### Phase 2 (not yet available)
+### Per-component breakdown (turn-detect / STT / LLM / TTS)
 
-The latency split across turn-detection, STT, LLM, and TTS is a **Phase 2 capability**. The network leg and the per-component breakdown require agents instrumented with `voicegateway.attach(session)` to emit internal timing spans. That integration is not available in Phase 1.
+When the probed agent is instrumented with `voicegateway.attach(session)`, the command also shows the latency split across turn detection, STT, LLM (time-to-first-token), and TTS. The correlation key is the probe room name: `attach` stamps it on every captured row, and the probe reads those rows back by room after the turns finish.
+
+This read-back is **co-located** in this version: the agent and the prober must share the same local VoiceGateway store (`~/.config/voicegateway/voicegw.db`, or `VOICEGW_DB_PATH`). In collector mode (`VOICEGW_COLLECTOR_URL` set) the rows go to the collector rather than this host, so the split is not shown from the CLI. When no split is available, the command prints a one-line note explaining what is needed.
 
 ### Cost warning
 
@@ -121,9 +134,9 @@ The latency split across turn-detection, STT, LLM, and TTS is a **Phase 2 capabi
 
 ```
 agent-7f4a     E2E avg 0.82s  p50 0.82s  p95 0.84s   GOOD (<1.5s)
-  breakdown (turn-detect/STT/LLM/TTS) lands in Phase 2 (collector correlation)
+  turn-detect 0.30 . STT 0.12 . LLM-ttft 0.45 . TTS 0.09
 agent-2c9b     E2E avg 1.14s  p50 1.14s  p95 1.18s   SLOW (<1.5s)
-  breakdown (turn-detect/STT/LLM/TTS) lands in Phase 2 (collector correlation)
+  breakdown (turn-detect/STT/LLM/TTS) needs an instrumented agent (voicegateway.attach) writing to the same local store, co-located
 ```
 
 ---
@@ -151,19 +164,48 @@ Load-ramp mode (`--load`):
 - Identifies the capacity knee: the concurrency level at which RTT degrades or quality drops.
 - A resource monitor watches CPU and memory on the prober host. If the host itself saturates during the ramp, the output flags this so results are not mistaken for SFU limits.
 
+### Distributed load (multi-vantage)
+
+A single host only shows what one machine can push. To load the SFU concurrently from several regions, run one **coordinator** and N **probers**:
+
+```bash
+# on the coordinator host (needs the [server] extra: pip install 'voicegateway[server]')
+voicegw livekit sfu --coordinator --expect 3 --ramp 10,25,50 --duration 20s
+
+# on each prober host / region (needs only the base install)
+voicegw livekit sfu --report-to http://<coordinator-host>:8787 --vantage iad
+voicegw livekit sfu --report-to http://<coordinator-host>:8787 --vantage sjc
+voicegw livekit sfu --report-to http://<coordinator-host>:8787 --vantage lhr
+```
+
+Each prober registers, waits at a shared barrier so every vantage starts its ramp at the same instant, ramps the **same** room, and reports its per-tier measurements back. The coordinator aggregates: at each tier the SFU sees the sum of all vantages' clients, while rtt / loss / quality report the worst any single vantage saw. It then prints the combined capacity and cleans up the shared rooms.
+
+```
+SFU  distributed: 3 vantages
+  combined: 30(3v)-> 14.0ms 0.0% Good . 75(3v)-> 22.0ms 0.1% Good . 150(3v)-> 55.0ms 1.4% Poor   combined knee ~75 clients
+  iad         : 10-> 12.0ms 0.0% . 25-> 20.0ms 0.0% . 50-> 48.0ms 1.1%
+  sjc         : 10-> 14.0ms 0.0% . 25-> 22.0ms 0.1% . 50-> 55.0ms 1.4%
+  lhr         : 10-> 11.0ms 0.0% . 25-> 18.0ms 0.0% . 50-> 41.0ms 0.9%
+```
+
+To deploy probers across regions (for example on Fly.io), see [Distributed SFU probers](/deployment/distributed-sfu).
+
 ### Limitations
 
-**Single vantage point.** The prober runs from one host. It does not simulate geo-distributed users. Latency for remote users may differ significantly.
-
-**Prober host saturation.** Under high `--ramp` concurrency, the machine running `voicegw` can become the bottleneck before the SFU does. The resource monitor flags CPU or memory saturation in the output so you can distinguish host limits from SFU limits.
+**Prober host saturation.** Under high `--ramp` concurrency, the machine running `voicegw` can become the bottleneck before the SFU does. The resource monitor flags CPU or memory saturation in the output so you can distinguish host limits from SFU limits. Distributing across several smaller prober hosts (above) sidesteps this.
 
 ### Options
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--load` | flag | off | Enable concurrency ramp mode. |
+| `--load` | flag | off | Enable concurrency ramp mode (single host). |
 | `--ramp` | `string` | `2,10,25,50` | Comma-separated concurrency levels for the ramp. |
 | `--duration` | `string` | `20s` | How long to hold each concurrency level. |
+| `--coordinator` | flag | off | Run as the distributed coordinator (needs `[server]` extra). |
+| `--expect` | `integer` | `0` | Number of probers the coordinator waits for. |
+| `--coordinator-port` | `integer` | `8787` | Port the coordinator listens on. |
+| `--report-to` | `string` | (none) | Run as a prober reporting to this coordinator URL. |
+| `--vantage` | `string` | `$VOICEGW_REGION` | Label for this prober's vantage. |
 | `--url` | `string` | (see Credentials) | LiveKit server WebSocket URL. |
 | `--api-key` | `string` | (see Credentials) | LiveKit API key. |
 | `--api-secret` | `string` | (see Credentials) | LiveKit API secret. |
@@ -235,12 +277,13 @@ AGENT            ROOM                   STATE       IN-CALL  AGE
 agent-7f4a       demo-room              active      1        42s
 agent-2c9b       qa-room                dispatched  0        8s
 
-2 agents active in 2 rooms. Idle/registered workers are not reported by LiveKit's server API; run the Phase 2 heartbeat to see the full roster.
+2 agents active in 2 rooms.
+Idle/registered workers are not reported by LiveKit's server API. Set VOICEGW_COLLECTOR_URL + VOICEGW_API_KEY (and run register_worker in your agents) to also list the heartbeat roster.
 
 agent-7f4a     E2E avg 0.82s  p50 0.82s  p95 0.84s   GOOD (<1.0s)
-  breakdown (turn-detect/STT/LLM/TTS) lands in Phase 2 (collector correlation)
+  breakdown (turn-detect/STT/LLM/TTS) needs an instrumented agent (voicegateway.attach) writing to the same local store, co-located
 agent-2c9b     E2E avg 1.14s  p50 1.14s  p95 1.18s   SLOW (<1.0s)
-  breakdown (turn-detect/STT/LLM/TTS) lands in Phase 2 (collector correlation)
+  breakdown (turn-detect/STT/LLM/TTS) needs an instrumented agent (voicegateway.attach) writing to the same local store, co-located
 
 SFU  vantage: co-located   baseline: rtt 11ms . loss 0.0% . Excellent
 ```
@@ -283,13 +326,13 @@ voicegw livekit check --json
 
 The following limitations apply across all four subcommands:
 
-**In-room agents only.** The LiveKit server API does not expose idle (pre-dispatch) workers. `agents` and `latency` see only agents currently in rooms.
+**In-room agents only, unless workers heartbeat.** The LiveKit server API does not expose idle (pre-dispatch) workers. `agents` shows the idle/registered roster only when your agents call `voicegateway.register_worker(...)` and the collector is configured; otherwise it (and `latency`) see only agents currently in rooms.
 
 **Real provider cost on latency probes.** Every `latency` probe invokes the agent's actual STT, LLM, and TTS pipeline. Charges are incurred. Use low `--trials` counts for routine checks.
 
-**Per-component latency breakdown is Phase 2.** The split across turn-detection, STT, LLM, and TTS requires agents instrumented with `voicegateway.attach(session)`. Phase 1 reports E2E latency only; the network leg and per-component breakdown are not yet available.
+**Per-component breakdown needs an instrumented, co-located agent.** The split across turn-detection, STT, LLM, and TTS requires agents instrumented with `voicegateway.attach(session)` writing to the same local store as the prober. In collector mode the split is not shown from the CLI.
 
-**Single co-located vantage.** `sfu` measures from the host running `voicegw`. This is the correct signal for a self-hosted setup where the gateway and SFU share the same network, but it does not represent latency for end users in other regions.
+**SFU vantage.** `sfu` measures from the host running `voicegw`. For a self-hosted setup where the gateway and SFU share a network, the co-located result is the right signal; for end-user latency in other regions, use the distributed coordinator/prober mode above.
 
 **Prober host saturation.** During `sfu --load`, the prober machine can saturate before the SFU does. The resource monitor flags this in the output.
 

--- a/docs/deployment/distributed-sfu.md
+++ b/docs/deployment/distributed-sfu.md
@@ -49,9 +49,15 @@ fly deploy -a vg-sfu-prober
 fly scale count 3 --region iad,sjc,lhr -a vg-sfu-prober
 ```
 
-Each machine reads its region from Fly's `FLY_REGION` and reports it as its vantage label, so a machine in `sjc` shows up as the `sjc` vantage with no per-region config. `RAMP` and `DURATION` are set in `fly.toml` and must match what you pass the coordinator.
+Each machine reads its region from Fly's `FLY_REGION` and reports it as its vantage label, so a machine in `sjc` shows up as the `sjc` vantage with no per-region config. The ramp and duration are dictated by the coordinator (every vantage runs the same job), so there is nothing to set for them on the prober.
 
 Any host that can run a container works the same way: set `COORDINATOR_URL`, the LiveKit creds, and `VOICEGW_REGION`, then run the image. Fly is just a convenient way to place probers in specific regions.
+
+## Limitations
+
+- **The coordinator endpoint is unauthenticated.** `/register`, `/report`, and `/result` have no auth, so anyone who can reach the port can inject fake reports or read the result. Run the coordinator on a private network the probers can reach (a VPC, Fly private networking, an SSH tunnel), not a public interface, and only for the duration of the run.
+- **Per-tier concurrency drifts after the first tier.** The barrier synchronizes only the shared start; each vantage then advances to its next ramp tier as soon as its own measurement finishes. Vantages stay aligned at the first tier, but faster ones run ahead on later tiers, so the combined per-tier client sums are exact at tier one and an upper bound thereafter. Read the combined knee as approximate, and lean on the baseline and first-tier numbers for the tightest signal.
+- **If a prober dies, the run degrades rather than hangs.** The coordinator stops after its timeout (default 10 minutes) and aggregates whatever reported; a prober that never clears the barrier gives up after its own timeout. A missing vantage shows up under `dropped` in the report.
 
 ## Cost and safety
 

--- a/docs/deployment/distributed-sfu.md
+++ b/docs/deployment/distributed-sfu.md
@@ -1,0 +1,63 @@
+---
+title: Distributed SFU probers
+description: Load-test a LiveKit SFU concurrently from several regions using a coordinator and per-region prober containers.
+---
+
+# Distributed SFU probers
+
+`voicegw livekit sfu --load` measures SFU capacity from a single host. That answers "what can this one machine push," not "does my SFU hold up when clients from several regions join the same room at once." Distributed mode answers the second question: one **coordinator** synchronizes N **probers**, each running from a different region, all ramping the same room together.
+
+See the [`voicegw livekit sfu`](/cli/livekit#voicegw-livekit-sfu) reference for the combined-report format. This page covers deploying the probers.
+
+## How it works
+
+1. The **coordinator** (`sfu --coordinator --expect N`) serves a small HTTP barrier. It hands every prover the same job (room, ramp tiers, duration, thresholds) and a shared `start_at` timestamp once all N have registered.
+2. Each **prober** (`sfu --report-to <url> --vantage <label>`) registers, waits for the barrier so all vantages start at the same instant, ramps the shared room, and posts its per-tier measurements back.
+3. When every prover has reported, the coordinator aggregates (summing clients per tier, taking the worst rtt / loss / quality), prints the combined capacity, and deletes the shared rooms.
+
+The coordinator needs the `[server]` extra (`pip install 'voicegateway[server]'`) for its HTTP layer. Probers need only the base install.
+
+## Coordinator
+
+Run the coordinator somewhere the probers can reach over HTTP (a bastion host, a small VM, or a Fly machine with an internal address):
+
+```bash
+pip install 'voicegateway[server]'
+export LIVEKIT_URL=wss://your.livekit.cloud
+export LIVEKIT_API_KEY=... LIVEKIT_API_SECRET=...
+
+voicegw livekit sfu --coordinator --expect 3 \
+    --ramp 10,25,50 --duration 20s --coordinator-port 8787
+```
+
+It blocks until all three probers report, then prints the combined report and exits.
+
+## Probers on Fly.io
+
+The `deploy/prober/` directory ships a `Dockerfile` and an example `fly.toml`. The image is a run-to-completion job that runs one prober and exits.
+
+```bash
+cd deploy/prober
+
+fly apps create vg-sfu-prober
+fly secrets set -a vg-sfu-prober \
+    LIVEKIT_URL=wss://your.livekit.cloud \
+    LIVEKIT_API_KEY=... LIVEKIT_API_SECRET=... \
+    COORDINATOR_URL=http://<coordinator-host>:8787
+
+fly deploy -a vg-sfu-prober
+fly scale count 3 --region iad,sjc,lhr -a vg-sfu-prober
+```
+
+Each machine reads its region from Fly's `FLY_REGION` and reports it as its vantage label, so a machine in `sjc` shows up as the `sjc` vantage with no per-region config. `RAMP` and `DURATION` are set in `fly.toml` and must match what you pass the coordinator.
+
+Any host that can run a container works the same way: set `COORDINATOR_URL`, the LiveKit creds, and `VOICEGW_REGION`, then run the image. Fly is just a convenient way to place probers in specific regions.
+
+## Cost and safety
+
+Distributed probing opens real SFU connections from many hosts at once. Unlike `latency`, it does not invoke STT/LLM/TTS providers (there is no agent in the loop), so there is no per-turn provider cost. It does consume SFU capacity for the duration of the ramp, so run it against a test project or during a maintenance window, not against production traffic.
+
+## Related
+
+- [`voicegw livekit sfu`](/cli/livekit#voicegw-livekit-sfu): the command reference and combined-report format.
+- [Deploy on Fly.io](/deployment/fly): deploying the VoiceGateway engine itself.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -89,7 +89,8 @@
           "deployment/fly",
           "deployment/railway",
           "deployment/vps",
-          "deployment/auto-update"
+          "deployment/auto-update",
+          "deployment/distributed-sfu"
         ]
       },
       {

--- a/src/voicegateway/__init__.py
+++ b/src/voicegateway/__init__.py
@@ -2,6 +2,7 @@
 
 from voicegateway import inference
 from voicegateway._version import __version__
+from voicegateway.fleet.worker import register_worker
 from voicegateway.inference.session.attach import attach
 
-__all__ = ["attach", "inference", "__version__"]
+__all__ = ["attach", "inference", "register_worker", "__version__"]

--- a/src/voicegateway/cli/livekit_cli.py
+++ b/src/voicegateway/cli/livekit_cli.py
@@ -307,6 +307,12 @@ def _run_sfu_coordinator(
     except Exception as exc:  # noqa: BLE001
         _cli.error(f"coordinator failed: {exc}")
         raise typer.Exit(1) from None
+    reported = len(result.get("vantages", []))
+    if reported < expect:
+        _cli.warn(
+            f"only {reported}/{expect} prober(s) reported before the timeout; "
+            "aggregating what arrived."
+        )
     _cli.console.print(render_distributed_sfu(result))
 
 

--- a/src/voicegateway/cli/livekit_cli.py
+++ b/src/voicegateway/cli/livekit_cli.py
@@ -36,7 +36,9 @@ _cli = BaseCli()
 livekit_app = typer.Typer(help="Diagnose a LiveKit deployment (agents, latency, SFU).")
 
 
-def _creds(url: str | None, api_key: str | None, api_secret: str | None, config: str | None) -> LiveKitCreds:
+def _creds(
+    url: str | None, api_key: str | None, api_secret: str | None, config: str | None
+) -> LiveKitCreds:
     try:
         return resolve_creds(url, api_key, api_secret, config)
     except CredsError as exc:
@@ -46,7 +48,31 @@ def _creds(url: str | None, api_key: str | None, api_secret: str | None, config:
 
 def _utterance_path() -> str:
     import voicegateway.livekit_diag as pkg
+
     return str(pathlib.Path(pkg.__file__).parent / "assets" / "probe.wav")
+
+
+def _component_reader() -> ComponentReader:
+    """A reader that reads the STT/LLM/TTS split back from the local VG store.
+
+    Read-back is co-located: the instrumented agent's ``attach`` wrote the split
+    to the local SQLite DB, and the probe correlates on the room name. In
+    collector mode the rows went to the collector, not this host, so return a
+    storeless reader (the split simply won't render). We also skip it when no DB
+    file exists yet, to avoid alembic-bootstrapping a DB just to read nothing.
+    """
+    if os.environ.get("VOICEGW_COLLECTOR_URL"):
+        return ComponentReader()
+    db_path = os.environ.get("VOICEGW_DB_PATH") or os.path.expanduser(
+        "~/.config/voicegateway/voicegw.db"
+    )
+    if not os.path.exists(db_path):
+        return ComponentReader()
+    from voicegateway.services.storage_service import StorageService
+
+    # Poll ~2s: the agent flushes its rows from another process around when the
+    # probe finishes, so the first read can race ahead of the write.
+    return ComponentReader(StorageService(db_path), poll_attempts=6, poll_delay=0.4)
 
 
 @livekit_app.command("agents")
@@ -113,11 +139,17 @@ def latency_cmd(
         admin.url = creds.url  # let ProbeRunner build client urls
         try:
             targets = agent or [r.agent_name for r in await admin.list_agents()]
-            runner = ProbeRunner(admin, lambda u, t: SyntheticClient(creds.url, t),
-                                  UtteranceSource(_utterance_path()), ComponentReader())
+            runner = ProbeRunner(
+                admin,
+                lambda u, t: SyntheticClient(creds.url, t),
+                UtteranceSource(_utterance_path()),
+                _component_reader(),
+            )
             out = []
             for name in targets:
-                out.append(await runner.probe(name, trials, warmup, room_name, metadata))
+                out.append(
+                    await runner.probe(name, trials, warmup, room_name, metadata)
+                )
             return out
         finally:
             await admin.aclose()
@@ -155,7 +187,9 @@ def sfu_cmd(
             steps, resource = ([], None)
             if load:
                 counts = [int(x) for x in ramp.split(",") if x.strip()]
-                steps, resource = await probe.ramp(room, counts, duration, target_rtt_ms, max_loss)
+                steps, resource = await probe.ramp(
+                    room, counts, duration, target_rtt_ms, max_loss
+                )
             knee = find_knee(steps, target_rtt_ms, max_loss) if steps else None
             return base, steps, resource, knee
         finally:
@@ -186,10 +220,16 @@ def check_cmd(
         admin.url = creds.url
         try:
             agents = await admin.list_agents()
-            runner = ProbeRunner(admin, lambda u, t: SyntheticClient(creds.url, t),
-                                 UtteranceSource(_utterance_path()), ComponentReader())
+            runner = ProbeRunner(
+                admin,
+                lambda u, t: SyntheticClient(creds.url, t),
+                UtteranceSource(_utterance_path()),
+                _component_reader(),
+            )
             lat = [await runner.probe(a.agent_name, 2, True, None, "") for a in agents]
-            probe = SfuProbe(admin, lambda u, t: SyntheticClient(creds.url, t), ResourceMonitor())
+            probe = SfuProbe(
+                admin, lambda u, t: SyntheticClient(creds.url, t), ResourceMonitor()
+            )
             base = await probe.baseline("vg-check")
             return agents, lat, base
         finally:
@@ -205,7 +245,9 @@ def check_cmd(
         _cli.console.print_json(_json.dumps(js))
     else:
         js = check_json(agents, lat, base, [], None, None, summarize, target_ms)
-        _cli.console.print(render_check(agents, lat, base, [], None, None, summarize, target_ms))
+        _cli.console.print(
+            render_check(agents, lat, base, [], None, None, summarize, target_ms)
+        )
     if js["verdict"] != "PASS":
         raise typer.Exit(1)
 

--- a/src/voicegateway/cli/livekit_cli.py
+++ b/src/voicegateway/cli/livekit_cli.py
@@ -18,12 +18,18 @@ from voicegateway.cli.base_cli import BaseCli
 from voicegateway.livekit_diag.admin import LiveKitAdmin
 from voicegateway.livekit_diag.client import SyntheticClient, UtteranceSource
 from voicegateway.livekit_diag.config import CredsError, LiveKitCreds, resolve_creds
+from voicegateway.livekit_diag.distributed import (
+    Coordinator,
+    run_prober,
+    serve_coordinator,
+)
 from voicegateway.livekit_diag.latency import ComponentReader, ProbeRunner, summarize
 from voicegateway.livekit_diag.report import (
     agents_json,
     check_json,
     render_agents,
     render_check,
+    render_distributed_sfu,
     render_latency,
     render_sfu,
 )
@@ -170,12 +176,42 @@ def sfu_cmd(
     room: str = typer.Option("vg-sfu-probe", "--room"),
     target_rtt_ms: float = typer.Option(50.0, "--target-rtt-ms"),
     max_loss: float = typer.Option(1.0, "--max-loss"),
+    coordinator: bool = typer.Option(False, "--coordinator"),
+    expect: int = typer.Option(0, "--expect"),
+    coordinator_port: int = typer.Option(8787, "--coordinator-port"),
+    report_to: str = typer.Option(None, "--report-to"),
+    vantage: str = typer.Option(None, "--vantage"),
     url: str = typer.Option(None, "--url"),
     api_key: str = typer.Option(None, "--api-key"),
     api_secret: str = typer.Option(None, "--api-secret"),
     config: str = typer.Option(None, "--config", "-c"),
 ) -> None:
-    """Measure SFU connection quality (and capacity with --load)."""
+    """Measure SFU connection quality (single host, or distributed).
+
+    Single host: ``--load`` ramps synthetic clients from this machine.
+    Distributed: run one ``--coordinator --expect N``, then N probers with
+    ``--report-to <coordinator-url> --vantage <label>``; every vantage ramps the
+    same room at once and the coordinator prints the combined capacity.
+    """
+    if report_to:
+        _run_sfu_prober(report_to, vantage, ramp, url, api_key, api_secret, config)
+        return
+    if coordinator:
+        _run_sfu_coordinator(
+            expect,
+            coordinator_port,
+            room,
+            ramp,
+            duration,
+            target_rtt_ms,
+            max_loss,
+            url,
+            api_key,
+            api_secret,
+            config,
+        )
+        return
+
     creds = _creds(url, api_key, api_secret, config)
 
     async def _run():
@@ -201,6 +237,77 @@ def sfu_cmd(
         _cli.error(f"sfu probe failed: {exc}")
         raise typer.Exit(1) from None
     _cli.console.print(render_sfu("co-located", base, steps, resource, knee))
+
+
+def _run_sfu_prober(report_to, vantage, ramp, url, api_key, api_secret, config):
+    """Prober mode: register, wait for the barrier, ramp the shared room, report."""
+    creds = _creds(url, api_key, api_secret, config)
+    label = vantage or os.environ.get("VOICEGW_REGION") or "vantage"
+    _cli.warn(f"Reporting to coordinator {report_to} as vantage '{label}'.")
+
+    async def _run():
+        admin = LiveKitAdmin(creds)
+        admin.url = creds.url
+        probe = SfuProbe(admin, lambda u, t: SyntheticClient(u, t), ResourceMonitor())
+        try:
+            return await run_prober(report_to, probe, vantage=label)
+        finally:
+            await admin.aclose()
+
+    try:
+        payload = asyncio.run(_run())
+    except Exception as exc:  # noqa: BLE001
+        _cli.error(f"prober failed: {exc}")
+        raise typer.Exit(1) from None
+    _cli.console.print(f"vantage '{label}' reported {len(payload['steps'])} tiers.")
+
+
+def _run_sfu_coordinator(
+    expect,
+    port,
+    room,
+    ramp,
+    duration,
+    target_rtt_ms,
+    max_loss,
+    url,
+    api_key,
+    api_secret,
+    config,
+):
+    """Coordinator mode: serve the barrier, aggregate reports, clean up rooms."""
+    if expect < 1:
+        _cli.error("--coordinator needs --expect N (number of probers, >= 1).")
+        raise typer.Exit(1)
+    creds = _creds(url, api_key, api_secret, config)
+    counts = [int(x) for x in ramp.split(",") if x.strip()]
+    coord = Coordinator(
+        expect=expect,
+        room=room,
+        ramp=counts,
+        duration=duration,
+        target_rtt_ms=target_rtt_ms,
+        max_loss=max_loss,
+    )
+    _cli.warn(f"Waiting for {expect} prober(s) on port {port}; ramp {counts}.")
+
+    async def _run():
+        result = await serve_coordinator(coord, port=port)
+        admin = LiveKitAdmin(creds)
+        admin.url = creds.url
+        try:
+            for tier_room in coord.rooms:
+                await admin.delete_room(tier_room)  # best-effort shared cleanup
+        finally:
+            await admin.aclose()
+        return result
+
+    try:
+        result = asyncio.run(_run())
+    except Exception as exc:  # noqa: BLE001
+        _cli.error(f"coordinator failed: {exc}")
+        raise typer.Exit(1) from None
+    _cli.console.print(render_distributed_sfu(result))
 
 
 @livekit_app.command("check")

--- a/src/voicegateway/cli/livekit_cli.py
+++ b/src/voicegateway/cli/livekit_cli.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import os
 import pathlib
 
 import typer
@@ -27,6 +28,7 @@ from voicegateway.livekit_diag.report import (
     render_sfu,
 )
 from voicegateway.livekit_diag.resources import ResourceMonitor
+from voicegateway.livekit_diag.roster import fetch_roster
 from voicegateway.livekit_diag.sfu import SfuProbe, find_knee
 
 _cli = BaseCli()
@@ -55,25 +57,38 @@ def agents_cmd(
     config: str = typer.Option(None, "--config", "-c"),
     as_json: bool = typer.Option(False, "--json"),
 ) -> None:
-    """List agents currently in rooms on the LiveKit server."""
+    """List agents currently in rooms on the LiveKit server.
+
+    When ``VOICEGW_COLLECTOR_URL`` (and ``VOICEGW_API_KEY``) are set, also fetch
+    the heartbeat roster so idle/registered workers show alongside the in-room
+    agents. Without the collector, only the in-room view (the LiveKit server API)
+    is shown, plus a note on how to enable the roster.
+    """
     creds = _creds(url, api_key, api_secret, config)
+    collector = os.environ.get("VOICEGW_COLLECTOR_URL")
 
     async def _run():
         admin = LiveKitAdmin(creds)
         try:
-            return await admin.list_agents()
+            rows = await admin.list_agents()
         finally:
             await admin.aclose()
+        roster = None
+        if collector:
+            roster = await fetch_roster(collector, os.environ.get("VOICEGW_API_KEY"))
+        return rows, roster
 
     try:
-        rows = asyncio.run(_run())
+        rows, roster = asyncio.run(_run())
     except Exception as exc:  # noqa: BLE001 - diagnostics never crash raw
         _cli.error(f"could not reach LiveKit server: {exc}")
         raise typer.Exit(1) from None
     if as_json:
-        _cli.console.print_json(_json.dumps(agents_json(rows)))
+        _cli.console.print_json(
+            _json.dumps({"in_room": agents_json(rows), "roster": roster or []})
+        )
     else:
-        _cli.console.print(render_agents(rows))
+        _cli.console.print(render_agents(rows, roster))
 
 
 @livekit_app.command("latency")

--- a/src/voicegateway/fleet/__init__.py
+++ b/src/voicegateway/fleet/__init__.py
@@ -1,0 +1,5 @@
+"""Fleet presence: the worker heartbeat that backs the roster view."""
+
+from voicegateway.fleet.worker import register_worker
+
+__all__ = ["register_worker"]

--- a/src/voicegateway/fleet/worker.py
+++ b/src/voicegateway/fleet/worker.py
@@ -111,6 +111,17 @@ def register_worker(
     _api_key = api_key or os.environ.get("VOICEGW_API_KEY")
     _interval = interval
     _ensure_pusher()
+    if _collector_url and _pusher is None:
+        # Registered outside a running event loop: the idle heartbeat can't start
+        # yet, so this worker stays invisible in the roster until its first
+        # session (attach -> bump_active) spins the pusher up. Call from your
+        # async entrypoint to be visible while idle.
+        logger.warning(
+            "register_worker(%s): no running event loop; the idle heartbeat will "
+            "not start until the first session. Call register_worker from your "
+            "async agent entrypoint to appear in the roster while idle.",
+            _worker.agent_id,
+        )
     return _worker.agent_id
 
 

--- a/src/voicegateway/fleet/worker.py
+++ b/src/voicegateway/fleet/worker.py
@@ -1,0 +1,186 @@
+"""Process-level worker presence for the fleet roster.
+
+The LiveKit server API lists agents that are IN a room, but not the idle/registered
+worker pool, so ``voicegw livekit agents`` can only ever show busy agents. This
+closes that gap from the agent side: a worker calls :func:`register_worker` once at
+boot, and the process then pushes a periodic heartbeat to the collector's
+``/v1/agents/heartbeat``. The heartbeat carries an idle/busy status that
+``voicegateway.attach`` keeps accurate by bumping an active-session counter on each
+session open/close, plus the version, project, host, and region the LiveKit server
+never knows.
+
+Best-effort by design: it never blocks or breaks the agent. No collector configured
+means the registry still tracks status locally but nothing is pushed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import time
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Milliseconds is overkill for presence; a quarter-minute keeps the roster fresh
+# without hammering the collector. The read side ages a worker out after a small
+# multiple of this (see the cloud /v1/agents TTL).
+_DEFAULT_INTERVAL = 15.0
+
+
+@dataclass
+class _Worker:
+    agent_id: str
+    agent_name: str
+    version: str
+    project: str
+    tenant_id: str | None
+    region: str | None
+    host: str
+    started_at: float
+    active_sessions: int = 0
+
+    @property
+    def status(self) -> str:
+        return "busy" if self.active_sessions > 0 else "idle"
+
+    def presence(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "agent_name": self.agent_name,
+            "status": self.status,
+            "active_sessions": self.active_sessions,
+            "version": self.version,
+            "project": self.project,
+            "tenant_id": self.tenant_id,
+            "region": self.region,
+            "host": self.host,
+            "started_at": self.started_at,
+            "ts": time.time(),
+        }
+
+
+# Process-wide singletons. One worker per process (a worker registers one agent).
+_worker: _Worker | None = None
+_pusher: asyncio.Task | None = None
+_collector_url: str | None = None
+_api_key: str | None = None
+_interval: float = _DEFAULT_INTERVAL
+_client: Any = None
+
+
+def _agent_id() -> str:
+    return os.environ.get("VOICEGW_AGENT_ID") or socket.gethostname()
+
+
+def register_worker(
+    agent_name: str,
+    *,
+    project: str = "default",
+    tenant_id: str | None = None,
+    collector_url: str | None = None,
+    api_key: str | None = None,
+    region: str | None = None,
+    version: str | None = None,
+    interval: float = _DEFAULT_INTERVAL,
+) -> str:
+    """Register this process as an agent worker and start heartbeating.
+
+    Call once at worker boot (ideally inside the running event loop, so the periodic
+    push starts immediately and an idle worker is visible before its first call).
+    ``collector_url`` / ``api_key`` fall back to ``VOICEGW_COLLECTOR_URL`` /
+    ``VOICEGW_API_KEY``; ``region`` to ``VOICEGW_REGION``. Returns the agent id.
+    """
+    global _worker, _collector_url, _api_key, _interval
+    from voicegateway._version import __version__
+
+    _worker = _Worker(
+        agent_id=_agent_id(),
+        agent_name=agent_name,
+        version=version or __version__,
+        project=project,
+        tenant_id=tenant_id,
+        region=region or os.environ.get("VOICEGW_REGION"),
+        host=socket.gethostname(),
+        started_at=time.time(),
+    )
+    _collector_url = collector_url or os.environ.get("VOICEGW_COLLECTOR_URL")
+    _api_key = api_key or os.environ.get("VOICEGW_API_KEY")
+    _interval = interval
+    _ensure_pusher()
+    return _worker.agent_id
+
+
+def bump_active(delta: int) -> None:
+    """Move the active-session count (attach() calls +1 on open, -1 on close).
+
+    A no-op when no worker is registered, so attach() stays decoupled from whether
+    the agent opted into the fleet roster. Also (re)starts the pusher, so a worker
+    that registered before its loop was running still begins heartbeating on its
+    first session.
+    """
+    if _worker is None:
+        return
+    _worker.active_sessions = max(0, _worker.active_sessions + delta)
+    _ensure_pusher()
+
+
+def _ensure_pusher() -> None:
+    global _pusher
+    if _pusher is not None or _worker is None or not _collector_url:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return  # no loop yet; a later bump_active() (in an async context) starts it
+    _pusher = loop.create_task(_run())
+
+
+async def _run() -> None:
+    try:
+        while True:
+            await push_once()
+            await asyncio.sleep(_interval)
+    except asyncio.CancelledError:
+        pass
+
+
+async def push_once() -> None:
+    """Push one presence heartbeat. Best-effort: a failure is swallowed."""
+    global _client
+    if _worker is None or not _collector_url:
+        return
+    try:
+        import httpx
+
+        if _client is None:
+            _client = httpx.AsyncClient(timeout=10.0)
+        headers = {"Authorization": f"Bearer {_api_key}"} if _api_key else {}
+        await _client.post(
+            _collector_url.rstrip("/") + "/v1/agents/heartbeat",
+            json=_worker.presence(),
+            headers=headers,
+        )
+    except Exception:  # noqa: BLE001 - presence is never load-bearing
+        logger.debug("worker heartbeat push failed", exc_info=True)
+
+
+async def aclose() -> None:
+    """Stop the pusher and close the client (call on worker shutdown)."""
+    global _pusher, _client
+    if _pusher is not None:
+        _pusher.cancel()
+        try:
+            await _pusher
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        _pusher = None
+    if _client is not None:
+        try:
+            await _client.aclose()
+        except Exception:  # noqa: BLE001
+            pass
+        _client = None

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -272,6 +272,7 @@ def attach(
     """
     import asyncio
 
+    from voicegateway.fleet.worker import bump_active
     from voicegateway.inference.session.capture import MetricCapture
     from voicegateway.middleware.cost_tracker_middleware import CostTracker
 
@@ -295,6 +296,10 @@ def attach(
     )
     capture.bind(session)
 
+    # Mark this worker busy for the fleet roster (a no-op unless register_worker
+    # was called); the close path drops it back toward idle.
+    bump_active(1)
+
     # Expose for graceful shutdown + tests; flush in-flight writes on close.
     try:
         session._vg_capture = capture
@@ -305,6 +310,7 @@ def attach(
         # Reconcile cumulative session.usage against the per-call rows, drain
         # in-flight writes, then flush the sink so a buffered RemoteCollectorSink
         # sub-batch is pushed before shutdown. A graceful close loses nothing.
+        bump_active(-1)
         await capture.reconcile(session)
         await capture.drain()
         await sink.flush()

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -200,6 +200,28 @@ def _default_agent_id() -> str:
     return os.environ.get("VOICEGW_AGENT_ID") or socket.gethostname() or "agent"
 
 
+def _resolve_room(session: Any) -> str | None:
+    """Best-effort LiveKit room name for probe correlation.
+
+    ``voicegw livekit latency`` dispatches an agent to a throwaway room and
+    reads the STT/LLM/TTS + turn-detection split back by that room name, so the
+    captured rows must carry it. Prefer an explicit ``session._vg_room`` (tests
+    / advanced callers), then the running LiveKit job context. Returns None off
+    a job (nothing to correlate; the rows simply carry no room), never raises.
+    """
+    room = getattr(session, "_vg_room", None)
+    if isinstance(room, str) and room:
+        return room
+    try:
+        from livekit.agents import get_job_context
+
+        ctx = get_job_context(required=False)
+    except Exception:  # noqa: BLE001 - livekit not installed / no job context
+        return None
+    name = getattr(getattr(ctx, "room", None), "name", None)
+    return name if isinstance(name, str) and name else None
+
+
 def _build_default_sink(
     collector_url: str | None,
     api_key: str | None,
@@ -249,6 +271,7 @@ def attach(
     collector_url: str | None = None,
     api_key: str | None = None,
     sink: Sink | None = None,
+    room: str | None = None,
 ) -> str:
     """Attach VoiceGateway to an existing LiveKit ``AgentSession`` in one call.
 
@@ -266,6 +289,9 @@ def attach(
         tenant_id: optional tenant attribution.
         collector_url / api_key: fleet push target (env fallbacks).
         sink: advanced/testing override; defaults to local or remote per env.
+        room: LiveKit room name for probe correlation; auto-resolved from the
+            running job context when omitted (``voicegw livekit latency`` reads
+            the STT/LLM/TTS split back by this).
 
     Returns:
         The correlation session id stamped on every captured row.
@@ -279,6 +305,7 @@ def attach(
     resolved_agent_id = agent_id or _default_agent_id()
     resolved_collector = collector_url or os.environ.get("VOICEGW_COLLECTOR_URL")
     resolved_key = api_key or os.environ.get("VOICEGW_API_KEY")
+    resolved_room = room or _resolve_room(session)
     session_id = get_or_create_session_id()
     if tenant_id is not None:
         set_tenant(tenant_id)
@@ -293,6 +320,7 @@ def attach(
         agent_id=resolved_agent_id,
         session_id=session_id,
         tenant_id=tenant_id,
+        room=resolved_room,
     )
     capture.bind(session)
 

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -324,10 +324,6 @@ def attach(
     )
     capture.bind(session)
 
-    # Mark this worker busy for the fleet roster (a no-op unless register_worker
-    # was called); the close path drops it back toward idle.
-    bump_active(1)
-
     # Expose for graceful shutdown + tests; flush in-flight writes on close.
     try:
         session._vg_capture = capture
@@ -357,6 +353,11 @@ def attach(
 
     on = getattr(session, "on", None)
     if callable(on):
+        # Only mark this worker busy for the fleet roster once we have a close
+        # handler to drop it back toward idle; pairing the +1 with the -1 means a
+        # session that cannot signal close never pins the worker "busy" forever.
+        # (No-op unless register_worker was called.)
+        bump_active(1)
         on("close", _on_close)
 
     return session_id

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -216,6 +216,7 @@ class MetricCapture:
         agent_id: str | None,
         session_id: str | None,
         tenant_id: str | None = None,
+        room: str | None = None,
     ) -> None:
         self._cost_tracker = cost_tracker
         self._sink = sink
@@ -223,6 +224,7 @@ class MetricCapture:
         self._agent_id = agent_id
         self._session_id = session_id
         self._tenant_id = tenant_id
+        self._room = room
         self._pending: set[asyncio.Task[None]] = set()
         # Per-(provider, model_id) running tally of captured units, so the
         # close-time reconcile can diff against cumulative session.usage.
@@ -262,7 +264,7 @@ class MetricCapture:
                 session_id=self._session_id,
                 agent_id=self._agent_id,
             )
-            self._stamp_tenant(record)
+            self._stamp_context(record)
             tally = self._recorded.setdefault(
                 (provider, model_id), {"input": 0.0, "output": 0.0, "cached": 0.0}
             )
@@ -288,7 +290,7 @@ class MetricCapture:
             session_id=self._session_id,
             agent_id=self._agent_id,
         )
-        self._stamp_tenant(record)
+        self._stamp_context(record)
         self._schedule(self._sink.log_request(record))
 
     def _on_session_metric(self, metric: object, *_a: Any, **_k: Any) -> None:
@@ -310,25 +312,35 @@ class MetricCapture:
         record.metadata = {
             "eou": {
                 "end_of_utterance_delay": float(eou),
-                "transcription_delay": float(getattr(metric, "transcription_delay", 0.0) or 0.0),
+                "transcription_delay": float(
+                    getattr(metric, "transcription_delay", 0.0) or 0.0
+                ),
             }
         }
-        self._stamp_tenant(record)
+        self._stamp_context(record)
         self._schedule(self._sink.log_request(record))
 
-    def _stamp_tenant(self, record: RequestRecord) -> None:
-        """Carry the attach() ``tenant_id`` on the record's ``metadata``.
+    def _stamp_context(self, record: RequestRecord) -> None:
+        """Carry the attach() ``tenant_id`` and probe ``room`` on ``metadata``.
 
-        The remote collector serializes only ``RequestRecord`` fields, which
-        have no tenant column, and the cloud stamps the top-level tenant from
-        the ingest key. Riding in ``metadata`` is how a per-call ``tenant_id``
-        survives the wire, so an embedder that fans many sub-tenants through one
-        ingest key can still separate them downstream. A local sink already gets
-        the tenant first-class from the ``set_tenant`` ContextVar, so this is
-        additive there, not a replacement.
+        Both ride in ``metadata`` because ``RequestRecord`` has no column for
+        them and the remote collector serializes only ``RequestRecord`` fields.
+        ``tenant_id`` is how a per-call tenant survives the wire (the cloud
+        stamps the top-level tenant from the ingest key), so an embedder that
+        fans many sub-tenants through one ingest key can separate them
+        downstream. ``room`` is how ``voicegw livekit latency`` correlates a
+        throwaway probe room back to the STT/LLM/TTS + turn-detection split this
+        agent captured. A local sink already gets the tenant first-class from the
+        ``set_tenant`` ContextVar, so tenant is additive there, not a
+        replacement.
         """
+        extra: dict[str, Any] = {}
         if self._tenant_id:
-            record.metadata = {**record.metadata, "tenant_id": self._tenant_id}
+            extra["tenant_id"] = self._tenant_id
+        if self._room:
+            extra["room"] = self._room
+        if extra:
+            record.metadata = {**record.metadata, **extra}
 
     def _schedule(self, coro: Any) -> None:
         try:
@@ -401,7 +413,7 @@ class MetricCapture:
                 agent_id=self._agent_id,
             )
             record.metadata = {"reconciled": True}
-            self._stamp_tenant(record)
+            self._stamp_context(record)
             await self._sink.log_request(record)
 
 

--- a/src/voicegateway/livekit_diag/distributed.py
+++ b/src/voicegateway/livekit_diag/distributed.py
@@ -1,0 +1,362 @@
+"""Distributed SFU load: many prober vantages hammer one room together.
+
+A single-host ``voicegw livekit sfu --load`` only shows what one machine can
+push through the SFU. Real capacity questions ("does my SFU hold up when 200
+clients from four regions join at once?") need load applied concurrently from
+several vantages. This module coordinates that:
+
+- a **coordinator** (``sfu --coordinator --expect N``) hands out one shared job
+  (room, ramp tiers, duration, thresholds) and a synchronized ``start_at``, then
+  collects each vantage's per-tier measurements and aggregates them;
+- a **prober** (``sfu --report-to URL --vantage LABEL``) registers, waits for the
+  barrier, runs the ramp against the shared room, and reports back.
+
+The intellectual core (the barrier + aggregation) is plain and unit-tested here;
+the HTTP layer is a thin FastAPI adapter, and the real multi-region run is a
+deploy exercise (see ``deploy/prober/`` and the distributed-SFU docs).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel
+
+# Worst-to-best quality ranking; the aggregate reports the worst any vantage saw
+# at a tier. "Unknown" sits above the healthy states but below the bad ones: it
+# is a missing signal, not evidence of failure.
+_QUALITY_RANK = {"Excellent": 0, "Good": 1, "Unknown": 2, "Poor": 3, "Lost": 4}
+
+
+class RegisterBody(BaseModel):
+    """POST /register body. Module-level so FastAPI can resolve the annotation
+    under ``from __future__ import annotations`` (get_type_hints reads module
+    globals, not a function's local scope)."""
+
+    vantage: str | None = None
+
+
+class ReportBody(BaseModel):
+    """POST /report/{prover_id} body: one vantage's per-tier steps."""
+
+    vantage: str
+    steps: list[dict]
+    baseline: dict | None = None
+
+
+@dataclass
+class VantageReport:
+    """One prover's ramp result: per-tier steps in ramp order, plus its label."""
+
+    vantage: str
+    steps: list[dict]  # each: {clients, rtt_ms, loss_pct, quality}
+    baseline: dict | None = None
+
+
+def _worst_quality(qualities: list[str]) -> str:
+    if not qualities:
+        return "Unknown"
+    return max(qualities, key=lambda q: _QUALITY_RANK.get(q, 2))
+
+
+def aggregate_vantages(
+    reports: list[VantageReport], target_rtt_ms: float, max_loss: float
+) -> dict[str, Any]:
+    """Fold N vantage reports into one combined capacity view.
+
+    Every vantage runs the SAME ramp tiers, so tier *index* i is the comparable
+    unit: the SFU sees the SUM of each vantage's client count at tier i, while
+    rtt / loss / quality take the WORST any single vantage observed (the SFU is
+    only as healthy as its unhappiest vantage). The combined knee is the last
+    tier whose total client count stayed within both thresholds. Vantages that
+    reported short (a failed tier) only contribute the tiers they have.
+    """
+    valid = [r for r in reports if r.steps]
+    tier_count = min((len(r.steps) for r in valid), default=0)
+    combined: list[dict[str, Any]] = []
+    for i in range(tier_count):
+        row = [r.steps[i] for r in valid]
+        combined.append(
+            {
+                "tier": i,
+                "clients": sum(int(s.get("clients", 0)) for s in row),
+                "vantages": len(row),
+                "rtt_ms": max((float(s.get("rtt_ms", 0.0)) for s in row), default=0.0),
+                "loss_pct": max(
+                    (float(s.get("loss_pct", 0.0)) for s in row), default=0.0
+                ),
+                "quality": _worst_quality(
+                    [str(s.get("quality", "Unknown")) for s in row]
+                ),
+            }
+        )
+
+    knee: int | None = None
+    for tier in combined:
+        if tier["rtt_ms"] > target_rtt_ms or tier["loss_pct"] > max_loss:
+            break
+        knee = tier["clients"]
+
+    return {
+        "vantages": [{"vantage": r.vantage, "steps": r.steps} for r in valid],
+        "combined": combined,
+        "knee": knee,
+        "target_rtt_ms": target_rtt_ms,
+        "max_loss": max_loss,
+        "dropped": [r.vantage for r in reports if not r.steps],
+    }
+
+
+class Coordinator:
+    """Barrier + report sink for a distributed SFU run. HTTP-agnostic.
+
+    Provers ``register``; once ``expect`` of them have, the coordinator fixes a
+    shared ``start_at`` a couple seconds out so every vantage begins its ramp at
+    the same wall-clock instant. Each prover then ``submit_report``s its steps;
+    ``result`` aggregates once ``all_reported``.
+    """
+
+    def __init__(
+        self,
+        *,
+        expect: int,
+        room: str,
+        ramp: list[int],
+        duration: float,
+        target_rtt_ms: float,
+        max_loss: float,
+        start_delay: float = 3.0,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._expect = expect
+        self._room = room
+        self._ramp = list(ramp)
+        self._duration = duration
+        self._target_rtt_ms = target_rtt_ms
+        self._max_loss = max_loss
+        self._start_delay = start_delay
+        self._clock = clock
+        self._registered: list[str | None] = []
+        self._reports: dict[int, VantageReport] = {}
+        self._start_at: float | None = None
+
+    def register(self, vantage: str | None = None) -> dict[str, Any]:
+        """Admit one prover; arm the shared start once the last expected joins."""
+        prover_id = len(self._registered)
+        self._registered.append(vantage)
+        if len(self._registered) >= self._expect and self._start_at is None:
+            self._start_at = self._clock() + self._start_delay
+        return {"prover_id": prover_id, "expected": self._expect}
+
+    def job_for(self, prover_id: int) -> dict[str, Any]:
+        """The shared job. ``ready`` flips true once the barrier is armed."""
+        return {
+            "room": self._room,
+            "ramp": self._ramp,
+            "duration": self._duration,
+            "target_rtt_ms": self._target_rtt_ms,
+            "max_loss": self._max_loss,
+            "start_at": self._start_at,
+            "ready": self._start_at is not None,
+        }
+
+    def submit_report(self, prover_id: int, report: VantageReport) -> None:
+        self._reports[prover_id] = report
+
+    @property
+    def all_reported(self) -> bool:
+        return self._expect > 0 and len(self._reports) >= self._expect
+
+    @property
+    def rooms(self) -> list[str]:
+        """The shared per-tier room names, for post-run cleanup."""
+        return [f"{self._room}-{n}" for n in self._ramp]
+
+    def result(self) -> dict[str, Any]:
+        return aggregate_vantages(
+            list(self._reports.values()), self._target_rtt_ms, self._max_loss
+        )
+
+
+def build_coordinator_app(coordinator: Coordinator) -> Any:
+    """Wrap a :class:`Coordinator` in a FastAPI app (register/job/report/result).
+
+    FastAPI lives under the ``[server]`` extra, so it is imported lazily: the
+    prober path needs only core ``httpx``.
+    """
+    try:
+        from fastapi import FastAPI
+    except ImportError as exc:  # pragma: no cover - import guard
+        raise RuntimeError(
+            "the SFU coordinator needs the server extra: pip install 'voicegateway[server]'"
+        ) from exc
+
+    app = FastAPI(title="voicegateway SFU coordinator")
+
+    @app.post("/register")
+    async def register(body: RegisterBody) -> dict[str, Any]:
+        return coordinator.register(body.vantage)
+
+    @app.get("/job/{prover_id}")
+    async def job(prover_id: int) -> dict[str, Any]:
+        return coordinator.job_for(prover_id)
+
+    @app.post("/report/{prover_id}")
+    async def report(prover_id: int, body: ReportBody) -> dict[str, Any]:
+        coordinator.submit_report(
+            prover_id, VantageReport(body.vantage, body.steps, body.baseline)
+        )
+        return {"ok": True, "all_reported": coordinator.all_reported}
+
+    @app.get("/result")
+    async def result() -> dict[str, Any]:
+        return coordinator.result()
+
+    return app
+
+
+async def serve_coordinator(
+    coordinator: Coordinator, *, host: str = "0.0.0.0", port: int = 8787
+) -> dict[str, Any]:
+    """Serve the coordinator until every prover has reported, then aggregate.
+
+    uvicorn (also ``[server]``) is imported lazily for the same reason as
+    FastAPI. Returns the aggregated result; the caller renders + cleans up.
+    """
+    try:
+        import uvicorn
+    except ImportError as exc:  # pragma: no cover - import guard
+        raise RuntimeError(
+            "the SFU coordinator needs the server extra: pip install 'voicegateway[server]'"
+        ) from exc
+
+    app = build_coordinator_app(coordinator)
+    server = uvicorn.Server(
+        uvicorn.Config(app, host=host, port=port, log_level="warning")
+    )
+
+    async def _watch() -> None:
+        while not coordinator.all_reported:
+            await asyncio.sleep(0.5)
+        server.should_exit = True
+
+    watcher = asyncio.ensure_future(_watch())
+    try:
+        await server.serve()
+    finally:
+        watcher.cancel()
+    return coordinator.result()
+
+
+@dataclass
+class _Http:
+    """Tiny httpx wrapper so run_prober is testable with a fake transport."""
+
+    base_url: str
+    _client: Any = field(default=None)
+
+    async def __aenter__(self) -> _Http:
+        import httpx
+
+        self._client = httpx.AsyncClient(timeout=30.0)
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+
+    async def post(self, path: str, json: dict) -> dict:
+        resp = await self._client.post(self.base_url.rstrip("/") + path, json=json)
+        resp.raise_for_status()
+        body: dict = resp.json()
+        return body
+
+    async def get(self, path: str) -> dict:
+        resp = await self._client.get(self.base_url.rstrip("/") + path)
+        resp.raise_for_status()
+        body: dict = resp.json()
+        return body
+
+
+async def run_prober(
+    report_to: str,
+    probe: Any,
+    *,
+    vantage: str,
+    http: Any = None,
+    sleep: Callable[[float], Any] = asyncio.sleep,
+    clock: Callable[[], float] = time.time,
+    poll_interval: float = 1.0,
+) -> dict[str, Any]:
+    """Register with the coordinator, wait for the barrier, ramp, report.
+
+    ``http`` (an object with async ``post(path, json)`` / ``get(path)``), ``sleep``
+    and ``clock`` are injectable so the flow is unit-testable without a live
+    coordinator or SFU. Runs the ramp with ``cleanup=False``: the room is shared,
+    so the coordinator deletes it after all vantages report.
+    """
+    own_http = http is None
+    client = http if http is not None else _Http(report_to)
+    if own_http:
+        await client.__aenter__()
+    try:
+        reg = await client.post("/register", {"vantage": vantage})
+        prover_id = reg["prover_id"]
+
+        while True:
+            job = await client.get(f"/job/{prover_id}")
+            if job.get("ready"):
+                break
+            await sleep(poll_interval)
+
+        start_at = job.get("start_at")
+        if start_at is not None:
+            delay = float(start_at) - clock()
+            if delay > 0:
+                await sleep(delay)
+
+        ramp = job["ramp"]
+        counts = (
+            [int(x) for x in str(ramp).split(",") if str(x).strip()]
+            if isinstance(ramp, str)
+            else [int(x) for x in ramp]
+        )
+        steps, _resource = await probe.ramp(
+            job["room"],
+            counts,
+            float(job["duration"]),
+            float(job["target_rtt_ms"]),
+            float(job["max_loss"]),
+            cleanup=False,
+        )
+        payload = {
+            "vantage": vantage,
+            "steps": [
+                {
+                    "clients": s.clients,
+                    "rtt_ms": s.rtt_ms,
+                    "loss_pct": s.loss_pct,
+                    "quality": s.quality,
+                }
+                for s in steps
+            ],
+        }
+        await client.post(f"/report/{prover_id}", payload)
+        return payload
+    finally:
+        if own_http:
+            await client.__aexit__(None, None, None)
+
+
+__all__ = [
+    "Coordinator",
+    "VantageReport",
+    "aggregate_vantages",
+    "build_coordinator_app",
+    "run_prober",
+    "serve_coordinator",
+]

--- a/src/voicegateway/livekit_diag/distributed.py
+++ b/src/voicegateway/livekit_diag/distributed.py
@@ -95,11 +95,17 @@ def aggregate_vantages(
             }
         )
 
+    # Knee: the last healthy total client count BEFORE the first tier that breaks
+    # a threshold. Matches single-host find_knee semantics exactly, including None
+    # when no tier breaks ("no knee within ramp: sustained the whole ramp"), so
+    # the two SFU modes never report contradictory things for an all-healthy run.
     knee: int | None = None
+    last_ok: int | None = None
     for tier in combined:
         if tier["rtt_ms"] > target_rtt_ms or tier["loss_pct"] > max_loss:
+            knee = last_ok
             break
-        knee = tier["clients"]
+        last_ok = tier["clients"]
 
     return {
         "vantages": [{"vantage": r.vantage, "steps": r.steps} for r in valid],
@@ -220,12 +226,19 @@ def build_coordinator_app(coordinator: Coordinator) -> Any:
 
 
 async def serve_coordinator(
-    coordinator: Coordinator, *, host: str = "0.0.0.0", port: int = 8787
+    coordinator: Coordinator,
+    *,
+    host: str = "0.0.0.0",
+    port: int = 8787,
+    timeout: float = 600.0,
 ) -> dict[str, Any]:
     """Serve the coordinator until every prover has reported, then aggregate.
 
-    uvicorn (also ``[server]``) is imported lazily for the same reason as
-    FastAPI. Returns the aggregated result; the caller renders + cleans up.
+    Stops after ``timeout`` seconds even if some provers never report, so a
+    crashed or missing prover cannot hang the run forever: it aggregates whatever
+    did arrive (``result()["dropped"]`` and a short roster tell the caller who is
+    missing). uvicorn (also ``[server]``) is imported lazily like FastAPI.
+    Returns the aggregated result; the caller renders + cleans up.
     """
     try:
         import uvicorn
@@ -240,8 +253,10 @@ async def serve_coordinator(
     )
 
     async def _watch() -> None:
-        while not coordinator.all_reported:
+        waited = 0.0
+        while not coordinator.all_reported and waited < timeout:
             await asyncio.sleep(0.5)
+            waited += 0.5
         server.should_exit = True
 
     watcher = asyncio.ensure_future(_watch())
@@ -291,13 +306,16 @@ async def run_prober(
     sleep: Callable[[float], Any] = asyncio.sleep,
     clock: Callable[[], float] = time.time,
     poll_interval: float = 1.0,
+    barrier_timeout: float = 300.0,
 ) -> dict[str, Any]:
     """Register with the coordinator, wait for the barrier, ramp, report.
 
     ``http`` (an object with async ``post(path, json)`` / ``get(path)``), ``sleep``
     and ``clock`` are injectable so the flow is unit-testable without a live
     coordinator or SFU. Runs the ramp with ``cleanup=False``: the room is shared,
-    so the coordinator deletes it after all vantages report.
+    so the coordinator deletes it after all vantages report. Gives up at the
+    barrier after ``barrier_timeout`` seconds (raises) rather than waiting forever
+    when a peer prover never registers.
     """
     own_http = http is None
     client = http if http is not None else _Http(report_to)
@@ -307,10 +325,18 @@ async def run_prober(
         reg = await client.post("/register", {"vantage": vantage})
         prover_id = reg["prover_id"]
 
+        max_polls = max(1, int(barrier_timeout / poll_interval)) if poll_interval else 1
+        polls = 0
         while True:
             job = await client.get(f"/job/{prover_id}")
             if job.get("ready"):
                 break
+            polls += 1
+            if polls >= max_polls:
+                raise RuntimeError(
+                    f"barrier timed out after ~{barrier_timeout}s waiting for all "
+                    f"{reg.get('expected', '?')} probers to register"
+                )
             await sleep(poll_interval)
 
         start_at = job.get("start_at")

--- a/src/voicegateway/livekit_diag/latency.py
+++ b/src/voicegateway/livekit_diag/latency.py
@@ -5,6 +5,7 @@ read the STT/LLM/TTS + turn-detection split from VoiceGateway telemetry.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass, field
 from statistics import mean
@@ -18,39 +19,116 @@ class LatencyResult:
     error: str | None = None
 
 
+def aggregate_components(rows: list[dict]) -> dict | None:
+    """Reduce the probe room's request rows to a turn-detect/STT/LLM/TTS split.
+
+    ``rows`` are ``metadata.room``-tagged request records the instrumented agent
+    wrote during the probe. Turn detection comes from the ``eou`` row's
+    ``end_of_utterance_delay``; STT from the per-component ttfb (falling back to
+    the eou row's ``transcription_delay``); LLM/TTS from their ttfb. Values are
+    seconds, averaged when a probe ran several turns. Returns None when nothing
+    usable is present (an uninstrumented agent, or rows without latencies).
+    """
+    eou: list[float] = []
+    transcription: list[float] = []
+    stt: list[float] = []
+    llm: list[float] = []
+    tts: list[float] = []
+    for row in rows:
+        metadata = row.get("metadata") or {}
+        modality = row.get("modality")
+        ttfb_ms = row.get("ttfb_ms")
+        if modality == "eou":
+            eou_meta = metadata.get("eou") or {}
+            delay = eou_meta.get("end_of_utterance_delay")
+            if delay is not None:
+                eou.append(float(delay))
+            td = eou_meta.get("transcription_delay")
+            if td is not None:
+                transcription.append(float(td))
+        elif modality == "stt" and ttfb_ms is not None:
+            stt.append(float(ttfb_ms) / 1000.0)
+        elif modality == "llm" and ttfb_ms is not None:
+            llm.append(float(ttfb_ms) / 1000.0)
+        elif modality == "tts" and ttfb_ms is not None:
+            tts.append(float(ttfb_ms) / 1000.0)
+
+    out: dict[str, float] = {}
+    if eou:
+        out["eou"] = mean(eou)
+    if stt:
+        out["stt"] = mean(stt)
+    elif transcription:
+        out["stt"] = mean(transcription)
+    if llm:
+        out["llm_ttft"] = mean(llm)
+    if tts:
+        out["tts"] = mean(tts)
+    return out or None
+
+
 class ComponentReader:
-    """Reads the probe session's component + EOU rows from a VG store. Optional;
-    returns None when no store is configured or the agent is not instrumented.
+    """Reads the probe room's component + EOU rows from a VG store and reduces
+    them to a latency split. Optional; returns None when no store is configured
+    or the agent is not instrumented.
+
+    Because the agent writes those rows from a separate process (and possibly
+    still flushing when the probe finishes), ``read`` polls the store a bounded
+    number of times. Defaults are a single no-wait read so unit tests and the
+    uninstrumented path stay instant; the CLI opts into a short poll for the
+    real cross-process case.
     """
 
-    def __init__(self, store=None) -> None:
+    def __init__(
+        self, store=None, *, poll_attempts: int = 1, poll_delay: float = 0.0
+    ) -> None:
         self._store = store
+        self._poll_attempts = max(1, poll_attempts)
+        self._poll_delay = poll_delay
 
     async def read(self, room: str) -> dict | None:
         if self._store is None:
             return None
-        result: dict | None = await self._store.components_for_room(room)
-        return result
+        for attempt in range(self._poll_attempts):
+            rows = await self._store.get_requests_for_room(room)
+            components = aggregate_components(rows)
+            if components is not None:
+                return components
+            if attempt + 1 < self._poll_attempts and self._poll_delay > 0:
+                await asyncio.sleep(self._poll_delay)
+        return None
 
 
 class ProbeRunner:
-    def __init__(self, admin, client_factory, utterance, reader: ComponentReader | None = None) -> None:
+    def __init__(
+        self, admin, client_factory, utterance, reader: ComponentReader | None = None
+    ) -> None:
         self._admin = admin
         self._url = getattr(admin, "url", "")
         self._make_client = client_factory
         self._utterance = utterance
         self._reader = reader or ComponentReader()
 
-    async def probe(self, agent: str, trials: int, warmup: bool, room_name: str | None, metadata: str) -> LatencyResult:
+    async def probe(
+        self,
+        agent: str,
+        trials: int,
+        warmup: bool,
+        room_name: str | None,
+        metadata: str,
+    ) -> LatencyResult:
         result = LatencyResult(agent=agent)
         total = trials + (1 if warmup else 0)
+        last_room: str | None = None
         for i in range(total):
             room = room_name or f"vg-probe-{agent}-{uuid.uuid4().hex[:8]}"
             e2e = None
             try:
                 await self._admin.create_room(room)
                 await self._admin.create_dispatch(room, agent, metadata)
-                client = self._make_client(self._url, self._admin.join_token(room, "vg-probe"))
+                client = self._make_client(
+                    self._url, self._admin.join_token(room, "vg-probe")
+                )
                 await client.connect()
                 try:
                     t0 = await client.publish_utterance(self._utterance)
@@ -66,8 +144,12 @@ class ProbeRunner:
                 continue  # discard cold start
             if e2e is not None:
                 result.e2e_samples.append(e2e)
-                if result.components is None:
-                    result.components = await self._reader.read(room)
+                last_room = room
+        # Read the component split once, after the turns are done: the agent
+        # writes those rows from its own process and may still be flushing, so
+        # the reader polls. Correlate on the last successful room.
+        if last_room is not None:
+            result.components = await self._reader.read(last_room)
         return result
 
 

--- a/src/voicegateway/livekit_diag/latency.py
+++ b/src/voicegateway/livekit_diag/latency.py
@@ -26,8 +26,10 @@ def aggregate_components(rows: list[dict]) -> dict | None:
     wrote during the probe. Turn detection comes from the ``eou`` row's
     ``end_of_utterance_delay``; STT from the per-component ttfb (falling back to
     the eou row's ``transcription_delay``); LLM/TTS from their ttfb. Values are
-    seconds, averaged when a probe ran several turns. Returns None when nothing
-    usable is present (an uninstrumented agent, or rows without latencies).
+    seconds, averaged across every row for the room (so a fixed ``--room-name``
+    reused across turns averages them; the default per-trial rooms each hold one
+    turn). Returns None when nothing usable is present (an uninstrumented agent,
+    or rows without latencies).
     """
     eou: list[float] = []
     transcription: list[float] = []
@@ -67,6 +69,17 @@ def aggregate_components(rows: list[dict]) -> dict | None:
     return out or None
 
 
+def _split_complete(components: dict) -> bool:
+    """Whether a split has the always-present reply components (LLM + TTS).
+
+    Every voice reply goes through the LLM then the TTS, so both should land for
+    a finished turn. Turn detection (eou) and STT ttfb can legitimately be
+    absent, so they do not gate completeness. Used to decide when a polled
+    read-back has captured the whole turn versus a mid-flush fragment.
+    """
+    return "llm_ttft" in components and "tts" in components
+
+
 class ComponentReader:
     """Reads the probe room's component + EOU rows from a VG store and reduces
     them to a latency split. Optional; returns None when no store is configured
@@ -89,14 +102,25 @@ class ComponentReader:
     async def read(self, room: str) -> dict | None:
         if self._store is None:
             return None
+        latest: dict | None = None
         for attempt in range(self._poll_attempts):
             rows = await self._store.get_requests_for_room(room)
-            components = aggregate_components(rows)
-            if components is not None:
-                return components
+            if not rows:
+                # A first empty read means no rows will ever correlate for this room
+                # (uninstrumented agent, a remote agent writing elsewhere, or
+                # collector mode): give up now rather than dead-wait the whole poll.
+                if latest is None:
+                    return None
+            else:
+                latest = aggregate_components(rows)
+                # Return only once the split looks whole. Returning a partial split
+                # mid cross-process flush would render missing components as 0.00
+                # ("instant"), which is worse than waiting a beat for the rest.
+                if latest is not None and _split_complete(latest):
+                    return latest
             if attempt + 1 < self._poll_attempts and self._poll_delay > 0:
                 await asyncio.sleep(self._poll_delay)
-        return None
+        return latest
 
 
 class ProbeRunner:

--- a/src/voicegateway/livekit_diag/report.py
+++ b/src/voicegateway/livekit_diag/report.py
@@ -9,12 +9,19 @@ from dataclasses import asdict
 from voicegateway.livekit_diag.admin import AgentRow
 
 _ROSTER_NOTE = (
-    "Idle/registered workers are not reported by LiveKit's server API; "
-    "run the Phase 2 heartbeat to see the full roster."
+    "Idle/registered workers are not reported by LiveKit's server API. Set "
+    "VOICEGW_COLLECTOR_URL + VOICEGW_API_KEY (and run register_worker in your "
+    "agents) to also list the heartbeat roster."
 )
 
 
-def render_agents(rows: list[AgentRow]) -> str:
+def render_agents(rows: list[AgentRow], roster: list[dict] | None = None) -> str:
+    """Render the in-room agents, plus the heartbeat roster when it is available.
+
+    ``roster`` is None when the collector is not configured (we then print the
+    note that says how to enable it); an empty list means it is configured but no
+    workers have reported yet.
+    """
     lines = [f"{'AGENT':16} {'ROOM':22} {'STATE':11} {'IN-CALL':8} {'AGE':6}"]
     for r in rows:
         age = f"{int(r.age_s)}s" if r.age_s is not None else "-"
@@ -24,7 +31,26 @@ def render_agents(rows: list[AgentRow]) -> str:
         )
     room_count = len({r.room for r in rows})
     lines.append("")
-    lines.append(f"{len(rows)} agents active in {room_count} rooms. {_ROSTER_NOTE}")
+    lines.append(f"{len(rows)} agents active in {room_count} rooms.")
+    if roster is None:
+        lines.append(_ROSTER_NOTE)
+        return "\n".join(lines)
+    lines.append("")
+    lines.append("Registered workers (heartbeat roster):")
+    lines.append(f"{'AGENT':16} {'STATUS':9} {'REGION':10} {'VERSION':10}")
+    for w in roster:
+        lines.append(
+            f"{str(w.get('agent_name') or ''):16.16} "
+            f"{str(w.get('status') or ''):9} "
+            f"{str(w.get('region') or '-'):10.10} "
+            f"{str(w.get('version') or ''):10.10}"
+        )
+    idle = sum(1 for w in roster if w.get("status") == "idle")
+    busy = sum(1 for w in roster if w.get("status") == "busy")
+    offline = sum(1 for w in roster if w.get("status") == "offline")
+    lines.append(
+        f"{len(roster)} workers registered ({idle} idle, {busy} busy, {offline} offline)."
+    )
     return "\n".join(lines)
 
 

--- a/src/voicegateway/livekit_diag/report.py
+++ b/src/voicegateway/livekit_diag/report.py
@@ -26,8 +26,7 @@ def render_agents(rows: list[AgentRow], roster: list[dict] | None = None) -> str
     for r in rows:
         age = f"{int(r.age_s)}s" if r.age_s is not None else "-"
         lines.append(
-            f"{r.agent_name:16.16} {r.room:22.22} {r.state:11} "
-            f"{r.humans:<8} {age:6}"
+            f"{r.agent_name:16.16} {r.room:22.22} {r.state:11} {r.humans:<8} {age:6}"
         )
     room_count = len({r.room for r in rows})
     lines.append("")
@@ -69,7 +68,7 @@ def render_latency(results: list, target_ms: float, summarize) -> str:
         verdict = "GOOD" if s["avg"] * 1000 <= target_ms else "SLOW"
         head = (
             f"{r.agent:14} E2E avg {s['avg']:.2f}s  p50 {s['p50']:.2f}s  "
-            f"p95 {s['p95']:.2f}s   {verdict} (<{target_ms/1000:.1f}s)"
+            f"p95 {s['p95']:.2f}s   {verdict} (<{target_ms / 1000:.1f}s)"
         )
         lines.append(head)
         if r.components:
@@ -79,11 +78,23 @@ def render_latency(results: list, target_ms: float, summarize) -> str:
                 f". LLM-ttft {c.get('llm_ttft', 0):.2f} . TTS {c.get('tts', 0):.2f}"
             )
         else:
-            lines.append("  breakdown (turn-detect/STT/LLM/TTS) lands in Phase 2 (collector correlation)")
+            lines.append(
+                "  breakdown (turn-detect/STT/LLM/TTS) needs an instrumented agent "
+                "(voicegateway.attach) writing to the same local store, co-located"
+            )
     return "\n".join(lines)
 
 
-def check_json(agents, latency_results, base, steps, resource, knee, summarize, target_ms: float = 1500.0) -> dict:
+def check_json(
+    agents,
+    latency_results,
+    base,
+    steps,
+    resource,
+    knee,
+    summarize,
+    target_ms: float = 1500.0,
+) -> dict:
     verdict = "PASS"
     for r in latency_results:
         s = summarize(r)
@@ -95,20 +106,35 @@ def check_json(agents, latency_results, base, steps, resource, knee, summarize, 
         verdict = "FAIL"
     return {
         "agents": agents_json(agents),
-        "latency": [{"agent": r.agent, "stats": summarize(r),
-                     "components": r.components} for r in latency_results],
+        "latency": [
+            {"agent": r.agent, "stats": summarize(r), "components": r.components}
+            for r in latency_results
+        ],
         "sfu": {
-            "baseline": {"clients": base.clients, "rtt_ms": base.rtt_ms,
-                         "loss_pct": base.loss_pct, "quality": base.quality} if base else None,
-            "ramp": [{"clients": s.clients, "rtt_ms": s.rtt_ms, "loss_pct": s.loss_pct} for s in (steps or [])],
+            "baseline": {
+                "clients": base.clients,
+                "rtt_ms": base.rtt_ms,
+                "loss_pct": base.loss_pct,
+                "quality": base.quality,
+            }
+            if base
+            else None,
+            "ramp": [
+                {"clients": s.clients, "rtt_ms": s.rtt_ms, "loss_pct": s.loss_pct}
+                for s in (steps or [])
+            ],
             "knee": knee,
         },
         "verdict": verdict,
     }
 
 
-def render_check(agents, latency_results, base, steps, resource, knee, summarize, target_ms) -> str:
-    js = check_json(agents, latency_results, base, steps, resource, knee, summarize, target_ms)
+def render_check(
+    agents, latency_results, base, steps, resource, knee, summarize, target_ms
+) -> str:
+    js = check_json(
+        agents, latency_results, base, steps, resource, knee, summarize, target_ms
+    )
     parts = [
         f"VERDICT: {js['verdict']}",
         "",
@@ -127,11 +153,17 @@ def render_sfu(vantage: str, baseline, ramp_steps, resource, knee) -> str:
         f"loss {baseline.loss_pct}% . {baseline.quality}"
     ]
     if ramp_steps:
-        seg = " . ".join(f"{s.clients}-> {s.rtt_ms}ms {s.loss_pct}%" for s in ramp_steps)
+        seg = " . ".join(
+            f"{s.clients}-> {s.rtt_ms}ms {s.loss_pct}%" for s in ramp_steps
+        )
         knee_txt = f"knee ~{knee} clients" if knee else "no knee within ramp"
         lines.append(f"  ramp: {seg}   {knee_txt}")
     if resource:
-        sat = " (prober saturated: results reflect this host, not the SFU)" if resource.saturated else ""
+        sat = (
+            " (prober saturated: results reflect this host, not the SFU)"
+            if resource.saturated
+            else ""
+        )
         lines.append(
             f"  prober: ~{resource.per_client['cpu_pct']}% CPU + "
             f"~{resource.per_client['kbps_up']} kbps up per client; "

--- a/src/voicegateway/livekit_diag/report.py
+++ b/src/voicegateway/livekit_diag/report.py
@@ -170,3 +170,32 @@ def render_sfu(vantage: str, baseline, ramp_steps, resource, knee) -> str:
             f"host sustains ~{resource.sustainable_n} before CPU-bound{sat}"
         )
     return "\n".join(lines)
+
+
+def render_distributed_sfu(result: dict) -> str:
+    """Render a multi-vantage distributed SFU run (coordinator aggregate).
+
+    Combined tiers show the SFU's total concurrent load and the worst rtt / loss
+    / quality any vantage saw; the per-vantage lines below attribute it.
+    """
+    combined = result.get("combined") or []
+    vantages = result.get("vantages") or []
+    knee = result.get("knee")
+    lines = [f"SFU  distributed: {len(vantages)} vantages"]
+    if combined:
+        seg = " . ".join(
+            f"{t['clients']}({t['vantages']}v)-> {t['rtt_ms']}ms "
+            f"{t['loss_pct']}% {t['quality']}"
+            for t in combined
+        )
+        knee_txt = f"combined knee ~{knee} clients" if knee else "no knee within ramp"
+        lines.append(f"  combined: {seg}   {knee_txt}")
+    for v in vantages:
+        vseg = " . ".join(
+            f"{s['clients']}-> {s['rtt_ms']}ms {s['loss_pct']}%" for s in v["steps"]
+        )
+        lines.append(f"  {v['vantage']:12.12}: {vseg}")
+    dropped = result.get("dropped") or []
+    if dropped:
+        lines.append(f"  dropped (no steps reported): {', '.join(dropped)}")
+    return "\n".join(lines)

--- a/src/voicegateway/livekit_diag/report.py
+++ b/src/voicegateway/livekit_diag/report.py
@@ -73,10 +73,20 @@ def render_latency(results: list, target_ms: float, summarize) -> str:
         lines.append(head)
         if r.components:
             c = r.components
-            lines.append(
-                f"  turn-detect {c.get('eou', 0):.2f} . STT {c.get('stt', 0):.2f} "
-                f". LLM-ttft {c.get('llm_ttft', 0):.2f} . TTS {c.get('tts', 0):.2f}"
-            )
+            # Show only components that were actually captured; a missing one must
+            # not render as 0.00 (that reads as "instant"). Labels in pipeline order.
+            labels = [
+                ("eou", "turn-detect"),
+                ("stt", "STT"),
+                ("llm_ttft", "LLM-ttft"),
+                ("tts", "TTS"),
+            ]
+            parts = [
+                f"{label} {c[key]:.2f}"
+                for key, label in labels
+                if c.get(key) is not None
+            ]
+            lines.append("  " + " . ".join(parts))
         else:
             lines.append(
                 "  breakdown (turn-detect/STT/LLM/TTS) needs an instrumented agent "
@@ -184,17 +194,18 @@ def render_distributed_sfu(result: dict) -> str:
     lines = [f"SFU  distributed: {len(vantages)} vantages"]
     if combined:
         seg = " . ".join(
-            f"{t['clients']}({t['vantages']}v)-> {t['rtt_ms']}ms "
-            f"{t['loss_pct']}% {t['quality']}"
+            f"{t.get('clients', 0)}({t.get('vantages', 0)}v)-> {t.get('rtt_ms', 0)}ms "
+            f"{t.get('loss_pct', 0)}% {t.get('quality', 'Unknown')}"
             for t in combined
         )
         knee_txt = f"combined knee ~{knee} clients" if knee else "no knee within ramp"
         lines.append(f"  combined: {seg}   {knee_txt}")
     for v in vantages:
         vseg = " . ".join(
-            f"{s['clients']}-> {s['rtt_ms']}ms {s['loss_pct']}%" for s in v["steps"]
+            f"{s.get('clients', 0)}-> {s.get('rtt_ms', 0)}ms {s.get('loss_pct', 0)}%"
+            for s in v.get("steps", [])
         )
-        lines.append(f"  {v['vantage']:12.12}: {vseg}")
+        lines.append(f"  {str(v.get('vantage', '')):12.12}: {vseg}")
     dropped = result.get("dropped") or []
     if dropped:
         lines.append(f"  dropped (no steps reported): {', '.join(dropped)}")

--- a/src/voicegateway/livekit_diag/roster.py
+++ b/src/voicegateway/livekit_diag/roster.py
@@ -1,0 +1,33 @@
+"""Fetch the agent worker roster from the VoiceGateway collector.
+
+The roster (idle / busy / offline registered workers) is what closes the gap the
+LiveKit server API leaves. It is populated by each agent's ``register_worker``
+heartbeat and read here with the same ``vk_`` key, tenant-scoped server-side.
+Best-effort: any error (unset collector, network, auth) yields an empty roster so
+``voicegw livekit agents`` still shows the in-room view.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_roster(collector_url: str, api_key: str | None) -> list[dict[str, Any]]:
+    """GET ``{collector}/v1/agents``; return the roster, or [] on any error."""
+    try:
+        import httpx
+
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                collector_url.rstrip("/") + "/v1/agents", headers=headers
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        return data if isinstance(data, list) else []
+    except Exception:  # noqa: BLE001 - roster is a best-effort enrichment
+        logger.debug("fetch_roster failed", exc_info=True)
+        return []

--- a/src/voicegateway/livekit_diag/sfu.py
+++ b/src/voicegateway/livekit_diag/sfu.py
@@ -18,7 +18,9 @@ class RampStep:
     quality: str
 
 
-def find_knee(steps: list[RampStep], target_rtt_ms: float, max_loss: float) -> int | None:
+def find_knee(
+    steps: list[RampStep], target_rtt_ms: float, max_loss: float
+) -> int | None:
     """The last healthy client count before the first step that breaks a
     threshold. None when every step is within budget.
     """
@@ -36,11 +38,16 @@ class SfuProbe:
         self._make_client = client_factory
         self._monitor = monitor
 
-    async def _measure(self, room: str, n: int, seconds: float) -> RampStep:
+    async def _measure(
+        self, room: str, n: int, seconds: float, *, cleanup: bool = True
+    ) -> RampStep:
         clients = []
         try:
             for i in range(n):
-                c = self._make_client(getattr(self._admin, "url", ""), self._admin.join_token(room, f"c{i}"))
+                c = self._make_client(
+                    getattr(self._admin, "url", ""),
+                    self._admin.join_token(room, f"c{i}"),
+                )
                 await c.connect()
                 clients.append(c)
             await asyncio.sleep(seconds)
@@ -55,17 +62,32 @@ class SfuProbe:
                 await c.disconnect()
             # Delete the probe room so it does not linger on the server and show up
             # as a phantom (empty-name) agent in a later list_agents. Best-effort.
-            await self._admin.delete_room(room)
+            # Skipped for a shared distributed room, where one vantage deleting it
+            # mid-measurement would drop the other vantages' clients; the
+            # coordinator cleans those up after every vantage has reported.
+            if cleanup:
+                await self._admin.delete_room(room)
 
     async def baseline(self, room: str, seconds: float = 10.0) -> RampStep:
         return await self._measure(room, 2, seconds)
 
-    async def ramp(self, room: str, steps: list[int], duration: float, target_rtt_ms: float, max_loss: float):
+    async def ramp(
+        self,
+        room: str,
+        steps: list[int],
+        duration: float,
+        target_rtt_ms: float,
+        max_loss: float,
+        *,
+        cleanup: bool = True,
+    ):
         await self._monitor.start()
         results = []
         try:
             for n in steps:
-                results.append(await self._measure(f"{room}-{n}", n, duration))
+                results.append(
+                    await self._measure(f"{room}-{n}", n, duration, cleanup=cleanup)
+                )
         finally:
             await self._monitor.stop()
         return results, self._monitor.report_for(max(steps) if steps else 0)

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -377,7 +377,12 @@ async def get_requests_for_room(
     fewer), so the exact match below never drops a true row.
     """
     column_list = ", ".join(_REQUEST_COLUMNS)
-    like = f'%"room": "{room}"%'  # matches json.dumps({"room": room}) spacing
+    # Build the needle with json.dumps so it matches the write path byte-for-byte,
+    # including ensure_ascii escaping (\uXXXX for non-ASCII, escaped quotes): a
+    # raw f-string would miss a room name with such characters. ``[1:-1]`` strips
+    # the object braces, leaving the exact ``"room": "<escaped>"`` substring.
+    key = json.dumps({"room": room})[1:-1]
+    like = f"%{key}%"
     query = (
         f"SELECT {column_list} FROM requests WHERE metadata LIKE :like "
         "ORDER BY timestamp ASC"

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -362,6 +362,35 @@ async def get_recent_requests(
     return [_row_to_dict(row) for row in result]
 
 
+async def get_requests_for_room(
+    session: AsyncSession,
+    room: str,
+) -> list[dict[str, Any]]:
+    """Return every request row tagged ``metadata.room == room``.
+
+    Used by ``voicegw livekit latency`` to correlate a throwaway probe room
+    with the STT/LLM/TTS + turn-detection rows the instrumented agent wrote
+    (``attach`` stamps the room on ``metadata``). There is no room column, so
+    a ``LIKE`` on the serialized ``metadata`` JSON pre-filters, then an exact
+    parsed match rejects any incidental substring hit. The ``LIKE`` only ever
+    widens the candidate set (``_`` / ``%`` in a room name match more, never
+    fewer), so the exact match below never drops a true row.
+    """
+    column_list = ", ".join(_REQUEST_COLUMNS)
+    like = f'%"room": "{room}"%'  # matches json.dumps({"room": room}) spacing
+    query = (
+        f"SELECT {column_list} FROM requests WHERE metadata LIKE :like "
+        "ORDER BY timestamp ASC"
+    )
+    result = await session.execute(text(query), {"like": like})
+    rows = [_row_to_dict(row) for row in result]
+    return [
+        r
+        for r in rows
+        if isinstance(r.get("metadata"), dict) and r["metadata"].get("room") == room
+    ]
+
+
 async def get_requests_in_window(
     session: AsyncSession,
     start_ts: float | None = None,
@@ -390,6 +419,7 @@ async def get_requests_in_window(
 __all__ = [
     "get_audit_log",
     "get_recent_requests",
+    "get_requests_for_room",
     "get_requests_in_window",
     "log_audit_event",
     "log_request",

--- a/src/voicegateway/services/request_log_service.py
+++ b/src/voicegateway/services/request_log_service.py
@@ -61,6 +61,11 @@ class RequestLogService:
                 s, limit, modality, project, tenant, agent
             )
 
+    async def get_requests_for_room(self, room: str) -> list[dict[str, Any]]:
+        """Return every request row tagged with ``metadata.room == room``."""
+        async with self._db.session() as s:
+            return await repo.get_requests_for_room(s, room)
+
     async def get_requests_in_window(
         self,
         start_ts: float | None = None,

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -243,6 +243,11 @@ class StorageService:
             limit, modality, project, tenant, agent
         )
 
+    async def get_requests_for_room(self, room: str) -> list[dict[str, Any]]:
+        """Delegate to RequestLogService.get_requests_for_room."""
+        await self._ensure_initialized()
+        return await self._request_log_service.get_requests_for_room(room)
+
     async def get_project_stats(self, project: str) -> dict[str, Any]:
         """Delegate to CostService.get_project_stats."""
         await self._ensure_initialized()

--- a/src/voicegateway/tests/fleet/test_worker.py
+++ b/src/voicegateway/tests/fleet/test_worker.py
@@ -1,0 +1,93 @@
+"""Worker presence: registration, idle/busy tracking, and the heartbeat push."""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.fleet import worker
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    worker._worker = None
+    worker._pusher = None
+    worker._collector_url = None
+    worker._api_key = None
+    worker._client = None
+    yield
+    worker._worker = None
+    worker._pusher = None
+    worker._client = None
+
+
+def test_register_populates_presence(monkeypatch):
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w1")
+    aid = worker.register_worker(
+        "realty", project="p", tenant_id="t", collector_url="http://c", api_key="k"
+    )
+    assert aid == "w1"
+    p = worker._worker.presence()
+    assert p["agent_id"] == "w1"
+    assert p["agent_name"] == "realty"
+    assert p["status"] == "idle"
+    assert p["active_sessions"] == 0
+    assert p["project"] == "p"
+    assert p["tenant_id"] == "t"
+    assert p["version"]  # from _version
+
+
+def test_bump_active_toggles_status_and_clamps(monkeypatch):
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w1")
+    worker.register_worker("realty")
+    worker.bump_active(1)
+    assert worker._worker.status == "busy"
+    assert worker._worker.active_sessions == 1
+    worker.bump_active(1)
+    assert worker._worker.active_sessions == 2
+    worker.bump_active(-1)
+    worker.bump_active(-1)
+    assert worker._worker.status == "idle"
+    worker.bump_active(-1)  # never goes negative
+    assert worker._worker.active_sessions == 0
+
+
+def test_bump_active_without_worker_is_noop():
+    worker.bump_active(1)
+    assert worker._worker is None
+
+
+async def test_push_once_posts_presence_with_bearer(monkeypatch):
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w1")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    worker.register_worker("realty")  # no collector -> no auto-pusher started
+    worker._collector_url = "http://collector"
+    worker._api_key = "vk_x"
+    posts: list = []
+
+    class _FakeClient:
+        async def post(self, url, json=None, headers=None):
+            posts.append((url, json, headers))
+
+    worker._client = _FakeClient()
+    await worker.push_once()
+    assert len(posts) == 1
+    url, body, headers = posts[0]
+    assert url == "http://collector/v1/agents/heartbeat"
+    assert body["agent_name"] == "realty"
+    assert body["status"] == "idle"
+    assert headers["Authorization"] == "Bearer vk_x"
+
+
+async def test_push_once_noop_without_collector(monkeypatch):
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w1")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    worker.register_worker("realty")
+    posts: list = []
+
+    class _FakeClient:
+        async def post(self, *a, **k):
+            posts.append(1)
+
+    worker._client = _FakeClient()
+    await worker.push_once()
+    assert posts == []

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -581,3 +581,28 @@ async def test_attach_close_flushes_sink(tmp_path):
 
     assert sink.flushes >= 1
     assert len(sink.rows) >= 1
+
+
+async def test_attach_marks_worker_busy_then_idle(monkeypatch):
+    """With a registered worker, attach reflects a live session as busy and the
+    close path drops it back to idle (the fleet-roster status signal)."""
+    import voicegateway
+    from voicegateway.fleet import worker
+
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    worker._worker = None
+    try:
+        voicegateway.register_worker("realty")  # no collector -> local status only
+        session = _FakeSessionWithUsage(
+            _FakeUsage([]), llm=_FakeEmitter(model="gpt-4o-mini", provider="openai")
+        )
+        voicegateway.attach(session, project="fleet", sink=_FlushRecordingSink())
+        assert worker._worker.active_sessions == 1
+        assert worker._worker.status == "busy"
+
+        session.emit("close")
+        await session._vg_close_task
+        assert worker._worker.active_sessions == 0
+        assert worker._worker.status == "idle"
+    finally:
+        worker._worker = None

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -526,8 +526,12 @@ async def test_metric_capture_records_eou(tmp_path):
     cost_tracker = CostTracker(sink)
     session = _FakeSession(llm=_FakeEmitter(model="gpt-4o-mini", provider="openai"))
     capture = MetricCapture(
-        cost_tracker=cost_tracker, sink=sink, project="p",
-        agent_id="a", session_id="s", tenant_id="t",
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="p",
+        agent_id="a",
+        session_id="s",
+        tenant_id="t",
     )
     capture.bind(session)
     session.emit("metrics_collected", _EOUMetric())
@@ -551,8 +555,12 @@ async def test_metric_capture_records_eou_wrapped():
     cost_tracker = CostTracker(sink)
     session = _FakeSession(llm=_FakeEmitter(model="gpt-4o-mini", provider="openai"))
     capture = MetricCapture(
-        cost_tracker=cost_tracker, sink=sink, project="p",
-        agent_id="a", session_id="s", tenant_id="t",
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="p",
+        agent_id="a",
+        session_id="s",
+        tenant_id="t",
     )
     capture.bind(session)
     session.emit("metrics_collected", _MetricsCollectedEvent(_EOUMetric()))
@@ -606,3 +614,103 @@ async def test_attach_marks_worker_busy_then_idle(monkeypatch):
         assert worker._worker.status == "idle"
     finally:
         worker._worker = None
+
+
+# --- probe room correlation ----------------------------------------------
+
+
+async def test_metric_capture_stamps_room_in_metadata():
+    """attach(room=...) rides in ``record.metadata`` so ``voicegw livekit
+    latency`` can correlate a throwaway probe room back to this agent's split."""
+    sink = _FlushRecordingSink()
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=CostTracker(sink),
+        sink=sink,
+        project="p",
+        agent_id="a",
+        session_id="s",
+        room="vg-probe-realty-abc123",
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    assert sink.rows[0].metadata.get("room") == "vg-probe-realty-abc123"
+
+
+async def test_metric_capture_omits_room_when_unset():
+    """No room -> no ``room`` key added (normal in-production capture)."""
+    sink = _FlushRecordingSink()
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=CostTracker(sink),
+        sink=sink,
+        project="p",
+        agent_id="a",
+        session_id="s",
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    assert "room" not in sink.rows[0].metadata
+
+
+async def test_eou_row_carries_room():
+    """The eou (turn-detection) row also carries the room, so the split's
+    turn-detect number correlates with the same probe."""
+    sink = _FlushRecordingSink()
+    session = _FakeSession(llm=_FakeEmitter(model="gpt-4o-mini", provider="openai"))
+    capture = MetricCapture(
+        cost_tracker=CostTracker(sink),
+        sink=sink,
+        project="p",
+        agent_id="a",
+        session_id="s",
+        room="vg-probe-x",
+    )
+    capture.bind(session)
+    session.emit("metrics_collected", _EOUMetric())
+    await capture.drain()
+
+    eou = [r for r in sink.rows if r.metadata.get("eou")]
+    assert eou[0].metadata["room"] == "vg-probe-x"
+    assert eou[0].metadata["eou"]["end_of_utterance_delay"] == 0.12
+
+
+async def test_attach_resolves_room_from_session_vg_room():
+    """attach picks up an explicit ``session._vg_room`` and stamps it, without a
+    LiveKit job context (the resolution's testable seam)."""
+    import voicegateway
+
+    sink = _FlushRecordingSink()
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+    session._vg_room = "vg-probe-from-ctx"
+
+    voicegateway.attach(session, project="fleet", agent_id="a", sink=sink)
+    llm.emit("metrics_collected", _LLMMetric())
+    await session._vg_capture.drain()
+
+    assert sink.rows[0].metadata.get("room") == "vg-probe-from-ctx"
+
+
+async def test_attach_explicit_room_overrides_session():
+    """An explicit ``room=`` arg wins over ``session._vg_room``."""
+    import voicegateway
+
+    sink = _FlushRecordingSink()
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+    session._vg_room = "from-session"
+
+    voicegateway.attach(session, project="fleet", sink=sink, room="explicit-room")
+    llm.emit("metrics_collected", _LLMMetric())
+    await session._vg_capture.drain()
+
+    assert sink.rows[0].metadata.get("room") == "explicit-room"

--- a/src/voicegateway/tests/livekit_diag/test_distributed.py
+++ b/src/voicegateway/tests/livekit_diag/test_distributed.py
@@ -40,7 +40,8 @@ def test_aggregate_sums_clients_and_takes_worst_rtt():
     assert [t["clients"] for t in out["combined"]] == [4, 10]  # 2+2, 5+5
     assert out["combined"][0]["vantages"] == 2
     assert out["combined"][1]["rtt_ms"] == 40.0  # worst of 20/40
-    assert out["knee"] == 10  # both tiers within budget
+    # No tier breaks -> no knee (sustained the whole ramp), matching find_knee.
+    assert out["knee"] is None
 
 
 def test_aggregate_knee_stops_at_first_broken_tier():
@@ -49,7 +50,7 @@ def test_aggregate_knee_stops_at_first_broken_tier():
         VantageReport("sjc", _steps([12.0, 15.0])),
     ]
     out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
-    assert out["knee"] == 4  # last healthy total (tier 1)
+    assert out["knee"] == 4  # last healthy total (tier 1) before the break
 
 
 def test_aggregate_worst_quality_wins():
@@ -221,3 +222,30 @@ async def test_run_prober_waits_reports_and_disables_cleanup():
     assert probe.ramp_calls[0]["cleanup"] is False
     # slept once for the not-ready poll; start delay was <= 0 so not again.
     assert slept == [0.5]
+
+
+class _NeverReadyHttp:
+    """A coordinator whose barrier never arms (a peer prover never registers)."""
+
+    async def post(self, path, json):
+        return {"prover_id": 0, "expected": 2}
+
+    async def get(self, path):
+        return {"ready": False, "start_at": None}
+
+
+async def test_run_prober_barrier_times_out_instead_of_hanging():
+    async def _sleep(_d):
+        pass
+
+    with pytest.raises(RuntimeError, match="barrier timed out"):
+        await run_prober(
+            "http://coord",
+            _FakeProbe(),
+            vantage="iad",
+            http=_NeverReadyHttp(),
+            sleep=_sleep,
+            clock=lambda: 0.0,
+            poll_interval=1.0,
+            barrier_timeout=3.0,  # -> at most 3 polls, then raise
+        )

--- a/src/voicegateway/tests/livekit_diag/test_distributed.py
+++ b/src/voicegateway/tests/livekit_diag/test_distributed.py
@@ -1,0 +1,223 @@
+"""Distributed SFU: the barrier + aggregation core, the HTTP contract, and the
+prober flow. The real multi-region run is a deploy exercise; here we prove the
+logic that stitches vantages together.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from voicegateway.livekit_diag.distributed import (
+    Coordinator,
+    VantageReport,
+    aggregate_vantages,
+    build_coordinator_app,
+    run_prober,
+)
+from voicegateway.livekit_diag.sfu import RampStep
+
+
+def _steps(rtts, *, clients=(2, 5), loss=0.0, quality="Good"):
+    # strict=False on purpose: pass fewer rtts than client tiers to model a
+    # vantage that reported short (the ragged-report case).
+    return [
+        {"clients": c, "rtt_ms": r, "loss_pct": loss, "quality": quality}
+        for c, r in zip(clients, rtts, strict=False)
+    ]
+
+
+# --- aggregation ---------------------------------------------------------
+
+
+def test_aggregate_sums_clients_and_takes_worst_rtt():
+    reports = [
+        VantageReport("iad", _steps([10.0, 20.0])),
+        VantageReport("sjc", _steps([12.0, 40.0])),
+    ]
+    out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
+    assert [t["clients"] for t in out["combined"]] == [4, 10]  # 2+2, 5+5
+    assert out["combined"][0]["vantages"] == 2
+    assert out["combined"][1]["rtt_ms"] == 40.0  # worst of 20/40
+    assert out["knee"] == 10  # both tiers within budget
+
+
+def test_aggregate_knee_stops_at_first_broken_tier():
+    reports = [
+        VantageReport("iad", _steps([10.0, 80.0])),  # tier 2 blows target
+        VantageReport("sjc", _steps([12.0, 15.0])),
+    ]
+    out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
+    assert out["knee"] == 4  # last healthy total (tier 1)
+
+
+def test_aggregate_worst_quality_wins():
+    reports = [
+        VantageReport("iad", _steps([10.0], clients=(2,), quality="Excellent")),
+        VantageReport("sjc", _steps([10.0], clients=(2,), quality="Poor")),
+    ]
+    out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
+    assert out["combined"][0]["quality"] == "Poor"
+
+
+def test_aggregate_ragged_reports_use_common_tier_count_and_flag_empty():
+    reports = [
+        VantageReport("iad", _steps([10.0, 20.0])),  # 2 tiers
+        VantageReport("sjc", _steps([12.0])),  # only 1 tier
+        VantageReport("lhr", []),  # reported nothing
+    ]
+    out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
+    assert len(out["combined"]) == 1  # min common tier count among valid vantages
+    assert out["dropped"] == ["lhr"]
+
+
+# --- coordinator barrier -------------------------------------------------
+
+
+def test_coordinator_arms_start_only_when_full():
+    clock = [1000.0]
+    coord = Coordinator(
+        expect=2,
+        room="vg",
+        ramp=[2, 5],
+        duration=1.0,
+        target_rtt_ms=50.0,
+        max_loss=1.0,
+        start_delay=3.0,
+        clock=lambda: clock[0],
+    )
+    r0 = coord.register("iad")
+    assert r0 == {"prover_id": 0, "expected": 2}
+    assert coord.job_for(0)["ready"] is False  # not full yet
+    coord.register("sjc")
+    job = coord.job_for(1)
+    assert job["ready"] is True
+    assert job["start_at"] == 1003.0  # clock + start_delay
+    assert job["ramp"] == [2, 5]
+
+
+def test_coordinator_all_reported_and_result_and_rooms():
+    coord = Coordinator(
+        expect=2,
+        room="vg",
+        ramp=[2, 5],
+        duration=1.0,
+        target_rtt_ms=50.0,
+        max_loss=1.0,
+    )
+    coord.register("iad")
+    coord.register("sjc")
+    assert coord.all_reported is False
+    coord.submit_report(0, VantageReport("iad", _steps([10.0, 20.0])))
+    assert coord.all_reported is False
+    coord.submit_report(1, VantageReport("sjc", _steps([12.0, 22.0])))
+    assert coord.all_reported is True
+    assert coord.rooms == ["vg-2", "vg-5"]  # shared per-tier rooms
+    assert [t["clients"] for t in coord.result()["combined"]] == [4, 10]
+
+
+# --- HTTP contract (ASGI, no port) ---------------------------------------
+
+
+async def test_coordinator_app_register_job_report_result():
+    pytest.importorskip("fastapi")
+    from httpx import ASGITransport, AsyncClient
+
+    coord = Coordinator(
+        expect=1,
+        room="vg",
+        ramp=[2],
+        duration=1.0,
+        target_rtt_ms=50.0,
+        max_loss=1.0,
+        start_delay=0.0,
+        clock=lambda: 500.0,
+    )
+    app = build_coordinator_app(coord)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        reg = (await c.post("/register", json={"vantage": "iad"})).json()
+        assert reg == {"prover_id": 0, "expected": 1}
+        job = (await c.get("/job/0")).json()
+        assert job["ready"] is True and job["room"] == "vg"
+        rep = await c.post(
+            "/report/0",
+            json={"vantage": "iad", "steps": _steps([10.0], clients=(2,))},
+        )
+        assert rep.json() == {"ok": True, "all_reported": True}
+        result = (await c.get("/result")).json()
+    assert result["combined"][0]["clients"] == 2
+
+
+# --- prober flow ---------------------------------------------------------
+
+
+class _FakeHttp:
+    """Stands in for the coordinator: not-ready once, then ready."""
+
+    def __init__(self, ready_after: int = 2) -> None:
+        self.posts: list[tuple[str, dict]] = []
+        self._job_calls = 0
+        self._ready_after = ready_after
+
+    async def post(self, path: str, json: dict) -> dict:
+        self.posts.append((path, json))
+        if path == "/register":
+            return {"prover_id": 0, "expected": 1}
+        return {"ok": True, "all_reported": True}
+
+    async def get(self, path: str) -> dict:
+        self._job_calls += 1
+        ready = self._job_calls >= self._ready_after
+        return {
+            "room": "vg-sfu-probe",
+            "ramp": [2, 5],
+            "duration": 1.0,
+            "target_rtt_ms": 50.0,
+            "max_loss": 1.0,
+            "start_at": 100.0 if ready else None,
+            "ready": ready,
+        }
+
+
+class _FakeProbe:
+    def __init__(self) -> None:
+        self.ramp_calls: list[Any] = []
+
+    async def ramp(self, room, counts, duration, target, max_loss, *, cleanup):
+        self.ramp_calls.append({"room": room, "counts": counts, "cleanup": cleanup})
+        steps = [RampStep(n, 10.0 * i, 0.0, "Good") for i, n in enumerate(counts, 1)]
+        return steps, None
+
+
+async def test_run_prober_waits_reports_and_disables_cleanup():
+    http = _FakeHttp(ready_after=2)
+    probe = _FakeProbe()
+    slept: list[float] = []
+
+    async def _sleep(d):
+        slept.append(d)
+
+    payload = await run_prober(
+        "http://coord",
+        probe,
+        vantage="iad",
+        http=http,
+        sleep=_sleep,
+        clock=lambda: 100.0,  # start_at 100 -> no start wait
+        poll_interval=0.5,
+    )
+
+    # registered, polled job until ready, reported.
+    assert http.posts[0] == ("/register", {"vantage": "iad"})
+    assert http.posts[-1][0] == "/report/0"
+    assert http.posts[-1][1]["vantage"] == "iad"
+    assert payload["steps"][0]["clients"] == 2
+    # ramp ran against the shared room with cleanup disabled.
+    assert probe.ramp_calls[0]["room"] == "vg-sfu-probe"
+    assert probe.ramp_calls[0]["counts"] == [2, 5]
+    assert probe.ramp_calls[0]["cleanup"] is False
+    # slept once for the not-ready poll; start delay was <= 0 so not again.
+    assert slept == [0.5]

--- a/src/voicegateway/tests/livekit_diag/test_latency.py
+++ b/src/voicegateway/tests/livekit_diag/test_latency.py
@@ -1,33 +1,171 @@
-from voicegateway.livekit_diag.latency import ProbeRunner, summarize
+from voicegateway.livekit_diag.latency import (
+    ComponentReader,
+    ProbeRunner,
+    aggregate_components,
+    summarize,
+)
 
 
 class _FakeAdmin:
-    def __init__(self): self.created, self.deleted, self.dispatched = [], [], []
-    async def create_room(self, n): self.created.append(n)
-    async def delete_room(self, n): self.deleted.append(n)
-    async def create_dispatch(self, r, a, metadata=""): self.dispatched.append((r, a))
-    def join_token(self, r, i): return "tok"
-    async def aclose(self): pass
+    def __init__(self):
+        self.created, self.deleted, self.dispatched = [], [], []
+
+    async def create_room(self, n):
+        self.created.append(n)
+
+    async def delete_room(self, n):
+        self.deleted.append(n)
+
+    async def create_dispatch(self, r, a, metadata=""):
+        self.dispatched.append((r, a))
+
+    def join_token(self, r, i):
+        return "tok"
+
+    async def aclose(self):
+        pass
 
 
 class _FakeClient:
     seq = iter([1.40, 1.44, 1.42, 1.41])  # warmup + 3
-    def __init__(self, url, token): pass
-    async def connect(self): pass
-    async def publish_utterance(self, src): return 0.0
-    async def wait_reply(self, t0, timeout=15.0): return next(_FakeClient.seq)
-    def quality(self): return "Excellent"
-    async def disconnect(self): pass
+
+    def __init__(self, url, token):
+        pass
+
+    async def connect(self):
+        pass
+
+    async def publish_utterance(self, src):
+        return 0.0
+
+    async def wait_reply(self, t0, timeout=15.0):
+        return next(_FakeClient.seq)
+
+    def quality(self):
+        return "Excellent"
+
+    async def disconnect(self):
+        pass
 
 
 async def test_probe_discards_warmup_and_aggregates():
     runner = ProbeRunner(_FakeAdmin(), _FakeClient, utterance=_StubUtterance())
-    result = await runner.probe("realty", trials=3, warmup=True, room_name=None, metadata="")
-    assert len(result.e2e_samples) == 3          # warmup discarded
+    result = await runner.probe(
+        "realty", trials=3, warmup=True, room_name=None, metadata=""
+    )
+    assert len(result.e2e_samples) == 3  # warmup discarded
     stats = summarize(result)
     assert round(stats["avg"], 2) == 1.42
 
 
 class _StubUtterance:
     duration_s = 0.8
-    def frames(self): return iter([(b"\x00\x00", 16000)])
+
+    def frames(self):
+        return iter([(b"\x00\x00", 16000)])
+
+
+# --- component breakdown read-back (Phase 2b) ----------------------------
+
+
+def _split_rows(room="vg-probe-x"):
+    return [
+        {
+            "modality": "eou",
+            "ttfb_ms": None,
+            "metadata": {
+                "room": room,
+                "eou": {"end_of_utterance_delay": 0.30, "transcription_delay": 0.08},
+            },
+        },
+        {"modality": "stt", "ttfb_ms": 120.0, "metadata": {"room": room}},
+        {"modality": "llm", "ttfb_ms": 450.0, "metadata": {"room": room}},
+        {"modality": "tts", "ttfb_ms": 90.0, "metadata": {"room": room}},
+    ]
+
+
+def test_aggregate_components_full_split():
+    out = aggregate_components(_split_rows())
+    assert out == {"eou": 0.30, "stt": 0.12, "llm_ttft": 0.45, "tts": 0.09}
+
+
+def test_aggregate_components_stt_falls_back_to_transcription_delay():
+    rows = [
+        {
+            "modality": "eou",
+            "ttfb_ms": None,
+            "metadata": {
+                "eou": {"end_of_utterance_delay": 0.30, "transcription_delay": 0.08}
+            },
+        }
+    ]
+    out = aggregate_components(rows)
+    assert out == {"eou": 0.30, "stt": 0.08}  # no stt row -> transcription_delay
+
+
+def test_aggregate_components_averages_multiple_turns():
+    rows = [
+        {"modality": "llm", "ttfb_ms": 400.0, "metadata": {}},
+        {"modality": "llm", "ttfb_ms": 600.0, "metadata": {}},
+    ]
+    assert aggregate_components(rows) == {"llm_ttft": 0.5}
+
+
+def test_aggregate_components_empty_is_none():
+    assert aggregate_components([]) is None
+    assert (
+        aggregate_components([{"modality": "llm", "ttfb_ms": None, "metadata": {}}])
+        is None
+    )
+
+
+class _FakeStore:
+    """Returns queued row-batches per get_requests_for_room call (poll sim)."""
+
+    def __init__(self, batches):
+        self._batches = list(batches)
+        self.calls = 0
+
+    async def get_requests_for_room(self, room):
+        self.calls += 1
+        return self._batches.pop(0) if self._batches else []
+
+
+async def test_component_reader_reads_and_aggregates():
+    reader = ComponentReader(_FakeStore([_split_rows()]))
+    out = await reader.read("vg-probe-x")
+    assert out == {"eou": 0.30, "stt": 0.12, "llm_ttft": 0.45, "tts": 0.09}
+
+
+async def test_component_reader_no_store_returns_none():
+    assert await ComponentReader().read("vg-probe-x") is None
+
+
+async def test_component_reader_polls_until_rows_appear():
+    store = _FakeStore([[], [], _split_rows()])  # empty twice, then rows
+    reader = ComponentReader(store, poll_attempts=5, poll_delay=0.0)
+    out = await reader.read("vg-probe-x")
+    assert out is not None and out["llm_ttft"] == 0.45
+    assert store.calls == 3  # stopped as soon as rows landed
+
+
+async def test_component_reader_gives_up_after_attempts():
+    store = _FakeStore([])  # always empty
+    reader = ComponentReader(store, poll_attempts=3, poll_delay=0.0)
+    assert await reader.read("vg-probe-x") is None
+    assert store.calls == 3
+
+
+async def test_probe_reads_components_after_loop():
+    reader = ComponentReader(_FakeStore([_split_rows()]))
+    _FakeClient.seq = iter([2.0, 2.0])  # warmup + 1
+    runner = ProbeRunner(_FakeAdmin(), _FakeClient, _StubUtterance(), reader)
+    result = await runner.probe(
+        "realty", trials=1, warmup=True, room_name="vg-probe-x", metadata=""
+    )
+    assert result.components == {
+        "eou": 0.30,
+        "stt": 0.12,
+        "llm_ttft": 0.45,
+        "tts": 0.09,
+    }

--- a/src/voicegateway/tests/livekit_diag/test_latency.py
+++ b/src/voicegateway/tests/livekit_diag/test_latency.py
@@ -1,9 +1,11 @@
 from voicegateway.livekit_diag.latency import (
     ComponentReader,
+    LatencyResult,
     ProbeRunner,
     aggregate_components,
     summarize,
 )
+from voicegateway.livekit_diag.report import render_latency
 
 
 class _FakeAdmin:
@@ -141,19 +143,48 @@ async def test_component_reader_no_store_returns_none():
     assert await ComponentReader().read("vg-probe-x") is None
 
 
-async def test_component_reader_polls_until_rows_appear():
-    store = _FakeStore([[], [], _split_rows()])  # empty twice, then rows
+def _partial_rows(room="vg-probe-x"):
+    # STT + LLM present but no TTS yet: a mid cross-process flush.
+    return [
+        {
+            "modality": "eou",
+            "ttfb_ms": None,
+            "metadata": {
+                "room": room,
+                "eou": {"end_of_utterance_delay": 0.30, "transcription_delay": 0.08},
+            },
+        },
+        {"modality": "stt", "ttfb_ms": 120.0, "metadata": {"room": room}},
+        {"modality": "llm", "ttfb_ms": 450.0, "metadata": {"room": room}},
+    ]
+
+
+async def test_component_reader_polls_until_split_is_complete():
+    # Partial (no TTS) twice, then the full split: keep polling until whole.
+    store = _FakeStore([_partial_rows(), _partial_rows(), _split_rows()])
     reader = ComponentReader(store, poll_attempts=5, poll_delay=0.0)
     out = await reader.read("vg-probe-x")
-    assert out is not None and out["llm_ttft"] == 0.45
-    assert store.calls == 3  # stopped as soon as rows landed
+    assert out is not None and out["tts"] == 0.09
+    assert store.calls == 3  # did not return the TTS-less partial early
 
 
-async def test_component_reader_gives_up_after_attempts():
+async def test_component_reader_gives_up_immediately_on_first_empty_read():
+    # No rows for the room (uninstrumented / remote / collector mode): return
+    # None on the first read, do NOT dead-wait the whole poll budget.
     store = _FakeStore([])  # always empty
-    reader = ComponentReader(store, poll_attempts=3, poll_delay=0.0)
+    reader = ComponentReader(store, poll_attempts=6, poll_delay=0.0)
     assert await reader.read("vg-probe-x") is None
-    assert store.calls == 3
+    assert store.calls == 1
+
+
+async def test_component_reader_returns_partial_after_exhausting_polls():
+    # Rows exist but the split never completes (agent emits no TTS ttfb): return
+    # what we have rather than None, and let the renderer show only those.
+    store = _FakeStore([_partial_rows(), _partial_rows()])
+    reader = ComponentReader(store, poll_attempts=2, poll_delay=0.0)
+    out = await reader.read("vg-probe-x")
+    assert out == {"eou": 0.30, "stt": 0.12, "llm_ttft": 0.45}  # no tts key
+    assert store.calls == 2
 
 
 async def test_probe_reads_components_after_loop():
@@ -169,3 +200,16 @@ async def test_probe_reads_components_after_loop():
         "llm_ttft": 0.45,
         "tts": 0.09,
     }
+
+
+def test_render_latency_shows_only_present_components():
+    # A partial split (no TTS) must not fabricate "TTS 0.00" (reads as instant).
+    r = LatencyResult(
+        agent="a",
+        e2e_samples=[0.8],
+        components={"eou": 0.30, "stt": 0.12, "llm_ttft": 0.45},
+    )
+    out = render_latency([r], target_ms=1500, summarize=summarize)
+    assert "LLM-ttft 0.45" in out
+    assert "TTS" not in out  # missing component omitted, not shown as 0.00
+    assert "0.00" not in out

--- a/src/voicegateway/tests/livekit_diag/test_report.py
+++ b/src/voicegateway/tests/livekit_diag/test_report.py
@@ -25,3 +25,30 @@ def test_agents_json_shape():
     js = agents_json(_rows())
     assert js[0]["agent_name"] == "concierge"  # sorted
     assert set(js[0]) == {"agent_name", "room", "identity", "state", "humans", "age_s"}
+
+
+def _roster():
+    return [
+        {"agent_name": "realty", "status": "busy", "region": "iad", "version": "0.13.0"},
+        {"agent_name": "concierge", "status": "idle", "region": None, "version": ""},
+        {"agent_name": "night-shift", "status": "offline", "region": "sjc", "version": "0.12.0"},
+    ]
+
+
+def test_render_agents_with_roster_shows_worker_table():
+    out = render_agents(_rows(), _roster())
+    # in-room view is still present
+    assert "2 agents active" in out
+    # roster section replaces the "not reported" note
+    assert "not reported by LiveKit" not in out
+    assert "Registered workers (heartbeat roster):" in out
+    assert "night-shift" in out
+    assert "3 workers registered (1 idle, 1 busy, 1 offline)." in out
+
+
+def test_render_agents_empty_roster_is_configured_not_note():
+    out = render_agents(_rows(), [])
+    # collector configured but no workers reported: table header, no note
+    assert "not reported by LiveKit" not in out
+    assert "Registered workers (heartbeat roster):" in out
+    assert "0 workers registered (0 idle, 0 busy, 0 offline)." in out

--- a/src/voicegateway/tests/livekit_diag/test_report.py
+++ b/src/voicegateway/tests/livekit_diag/test_report.py
@@ -1,5 +1,9 @@
 from voicegateway.livekit_diag.admin import AgentRow
-from voicegateway.livekit_diag.report import agents_json, render_agents
+from voicegateway.livekit_diag.report import (
+    agents_json,
+    render_agents,
+    render_distributed_sfu,
+)
 
 
 def _rows():
@@ -29,9 +33,19 @@ def test_agents_json_shape():
 
 def _roster():
     return [
-        {"agent_name": "realty", "status": "busy", "region": "iad", "version": "0.13.0"},
+        {
+            "agent_name": "realty",
+            "status": "busy",
+            "region": "iad",
+            "version": "0.13.0",
+        },
         {"agent_name": "concierge", "status": "idle", "region": None, "version": ""},
-        {"agent_name": "night-shift", "status": "offline", "region": "sjc", "version": "0.12.0"},
+        {
+            "agent_name": "night-shift",
+            "status": "offline",
+            "region": "sjc",
+            "version": "0.12.0",
+        },
     ]
 
 
@@ -52,3 +66,36 @@ def test_render_agents_empty_roster_is_configured_not_note():
     assert "not reported by LiveKit" not in out
     assert "Registered workers (heartbeat roster):" in out
     assert "0 workers registered (0 idle, 0 busy, 0 offline)." in out
+
+
+def test_render_distributed_sfu_shows_combined_and_vantages():
+    result = {
+        "vantages": [
+            {
+                "vantage": "iad",
+                "steps": [{"clients": 2, "rtt_ms": 10.0, "loss_pct": 0.0}],
+            },
+            {
+                "vantage": "sjc",
+                "steps": [{"clients": 2, "rtt_ms": 12.0, "loss_pct": 0.0}],
+            },
+        ],
+        "combined": [
+            {
+                "tier": 0,
+                "clients": 4,
+                "vantages": 2,
+                "rtt_ms": 12.0,
+                "loss_pct": 0.0,
+                "quality": "Good",
+            }
+        ],
+        "knee": 4,
+        "dropped": ["lhr"],
+    }
+    out = render_distributed_sfu(result)
+    assert "2 vantages" in out
+    assert "4(2v)-> 12.0ms" in out
+    assert "combined knee ~4 clients" in out
+    assert "iad" in out and "sjc" in out
+    assert "dropped (no steps reported): lhr" in out

--- a/src/voicegateway/tests/livekit_diag/test_roster.py
+++ b/src/voicegateway/tests/livekit_diag/test_roster.py
@@ -1,0 +1,64 @@
+"""fetch_roster: GET the collector's worker roster with the vk_ key, best-effort.
+
+The engine's heartbeat writes the roster; this reads it back for the CLI. Any
+error (unset collector, network, auth, non-list body) yields [] so
+``voicegw livekit agents`` still renders the in-room view.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from voicegateway.livekit_diag.roster import fetch_roster
+
+# Capture the real class up front: the tests monkeypatch httpx.AsyncClient, so
+# the factory must not route back through the patched symbol (that recurses).
+_RealAsyncClient = httpx.AsyncClient
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return _RealAsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def test_fetch_roster_returns_list_and_sends_bearer(monkeypatch):
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json=[{"agent_name": "realty", "status": "idle"}])
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _client(handler))
+    out = await fetch_roster("https://collector.test/", "vk_secret")
+    assert out == [{"agent_name": "realty", "status": "idle"}]
+    assert seen["url"] == "https://collector.test/v1/agents"  # trailing slash trimmed
+    assert seen["auth"] == "Bearer vk_secret"
+
+
+async def test_fetch_roster_no_api_key_sends_no_auth_header(monkeypatch):
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json=[])
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _client(handler))
+    out = await fetch_roster("https://collector.test", None)
+    assert out == []
+    assert seen["auth"] is None
+
+
+async def test_fetch_roster_swallows_http_error(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "nope"})
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _client(handler))
+    assert await fetch_roster("https://collector.test", "vk_bad") == []
+
+
+async def test_fetch_roster_non_list_body_is_empty(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"unexpected": "shape"})
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _client(handler))
+    assert await fetch_roster("https://collector.test", "vk_x") == []

--- a/src/voicegateway/tests/storage/test_requests_by_room.py
+++ b/src/voicegateway/tests/storage/test_requests_by_room.py
@@ -1,0 +1,81 @@
+"""Phase 2b: read a probe room's request rows back by ``metadata.room``.
+
+``voicegw livekit latency`` correlates a throwaway probe room with the STT /
+LLM / TTS + turn-detection rows an instrumented agent wrote. There is no room
+column, so the repo pre-filters on the serialized ``metadata`` JSON with a
+``LIKE`` and then rejects incidental substring hits with an exact parsed match.
+These round-trip through real SQLite to prove both halves.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from voicegateway.livekit_diag.latency import aggregate_components
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.services.storage_service import StorageService
+
+
+def _rec(modality: str, *, room: str | None, ttfb: float | None = None, eou=None):
+    metadata: dict = {}
+    if room is not None:
+        metadata["room"] = room
+    if eou is not None:
+        metadata["eou"] = eou
+    return RequestRecord(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        modality=modality,
+        model_id="openai/gpt-4o-mini" if modality == "llm" else "",
+        provider="openai" if modality == "llm" else "",
+        project="fleet",
+        ttfb_ms=ttfb,
+        metadata=metadata,
+        session_id=f"vg-{uuid.uuid4()}",
+    )
+
+
+async def test_get_requests_for_room_returns_only_that_room(tmp_path):
+    storage = StorageService(str(tmp_path / "room.db"))
+    await storage.log_request(
+        _rec(
+            "eou",
+            room="vg-probe-a",
+            eou={"end_of_utterance_delay": 0.30, "transcription_delay": 0.08},
+        )
+    )
+    await storage.log_request(_rec("stt", room="vg-probe-a", ttfb=120.0))
+    await storage.log_request(_rec("llm", room="vg-probe-a", ttfb=450.0))
+    await storage.log_request(_rec("tts", room="vg-probe-a", ttfb=90.0))
+    await storage.log_request(_rec("llm", room="vg-probe-b", ttfb=999.0))
+    await storage.log_request(_rec("llm", room=None, ttfb=111.0))
+
+    rows = await storage.get_requests_for_room("vg-probe-a")
+    assert len(rows) == 4
+    assert all(r["metadata"]["room"] == "vg-probe-a" for r in rows)
+
+    # Full read-back: the split aggregates to the expected seconds.
+    assert aggregate_components(rows) == {
+        "eou": 0.30,
+        "stt": 0.12,
+        "llm_ttft": 0.45,
+        "tts": 0.09,
+    }
+
+
+async def test_get_requests_for_room_exact_match_rejects_like_wildcard(tmp_path):
+    """A ``_`` in the queried room is a LIKE wildcard; the exact parsed match
+    must still reject a stored room that only matches via that wildcard."""
+    storage = StorageService(str(tmp_path / "wild.db"))
+    await storage.log_request(_rec("llm", room="vgXprobe", ttfb=100.0))
+
+    # 'vg_probe' -> LIKE '%"room": "vg_probe"%' matches 'vgXprobe' (_ = any char)
+    rows = await storage.get_requests_for_room("vg_probe")
+    assert rows == []  # exact match rejects the wildcard hit
+
+
+async def test_get_requests_for_room_empty_when_absent(tmp_path):
+    storage = StorageService(str(tmp_path / "none.db"))
+    await storage.log_request(_rec("llm", room="vg-probe-a", ttfb=100.0))
+    assert await storage.get_requests_for_room("nope") == []


### PR DESCRIPTION
## Phase 2: fleet heartbeat, latency breakdown, distributed SFU

Builds on the v0.12.0 LiveKit diagnostics (PR #63). Three capabilities that were scoped as "Phase 2" in that work, now delivered. Pairs with the cloud roster endpoints (voicegateway-cloud PR, separate repo).

### 2a: Agent heartbeat roster
The LiveKit server API only knows about agents currently in a room, so idle/registered workers were invisible. `register_worker()` heartbeats each agent's presence (idle/busy/offline) to the collector; `attach()` flips a worker busy on session start and back toward idle on close. `voicegw livekit agents` now fetches that roster when `VOICEGW_COLLECTOR_URL` + `VOICEGW_API_KEY` are set and prints it below the in-room table. Best-effort: if the collector is unreachable the in-room view still renders. `--json` grows to `{in_room, roster}`.

### 2b: Latency breakdown read-back
`voicegw livekit latency` now shows the turn-detect/STT/LLM/TTS split, not just end-to-end. The correlation key is the probe room name: `attach()` stamps it on `metadata.room` for every captured row (auto-resolved from the LiveKit job context, or passed explicitly), and the probe reads those rows back by room after the turns finish. Storage gains `get_requests_for_room()` (LIKE pre-filter plus an exact parsed match that rejects wildcard hits); `aggregate_components()` reduces rows to the seconds split. Read-back is co-located in this version (agent and prober share the local SQLite store); collector-side correlation is a later step.

### 2c: Distributed SFU load
Single-host `sfu --load` only shows what one machine can push. Distributed mode loads one SFU room concurrently from many vantages: a coordinator (`sfu --coordinator --expect N`) synchronizes N probers (`sfu --report-to URL --vantage LABEL`) at a barrier so every vantage starts at the same instant, each ramps the shared room, and the coordinator aggregates (sum clients per tier, worst rtt/loss/quality, combined knee). `SfuProbe` gains `cleanup=` so shared rooms are not deleted mid-measurement; the coordinator cleans them up after all vantages report. Ships a run-to-completion prober `Dockerfile` + example `fly.toml` under `deploy/prober/`. No deploy in this change.

### Notes
- The coordinator HTTP layer lazy-imports FastAPI/uvicorn (the `[server]` extra); the prober needs only the base install.
- Docs: `docs/cli/livekit.md` updated to reflect the now-shipped roster, latency breakdown, and distributed SFU (dropped the stale "Phase 2 not yet available" notes); new `docs/deployment/distributed-sfu.md`.

### Testing
- Full unit suite green (1862 passed), `ruff check src` + `mypy` clean.
- New tests cover: worker presence + busy/idle, roster render + fetch, room stamping + resolution, `get_requests_for_room` round-trip through real SQLite (including the LIKE-wildcard guard), `aggregate_components`, `ComponentReader` polling, `aggregate_vantages`, the coordinator barrier, the HTTP contract (ASGI), and the prober flow.
- Out of scope (by design): dashboard web surfacing and any live Fly deploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distributed SFU load testing with coordinator/prober workflows across multiple regions.
  * Added roster-based worker presence in LiveKit diagnostics.
  * Added room-aware session correlation for better latency and probe reporting.

* **Bug Fixes**
  * Improved latency breakdowns and delayed component aggregation to avoid incomplete results.
  * Refined SFU cleanup behavior during ramp runs.

* **Documentation**
  * Updated CLI and deployment docs with new diagnostic, distributed testing, and Fly.io setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->