### PR TITLE
feat(clickhouse): by_project rollup in the cost summary

### DIFF
--- a/src/voicegateway/clickhouse/read_repository.py
+++ b/src/voicegateway/clickhouse/read_repository.py
@@ -87,6 +87,20 @@ GROUP BY model_id
 ORDER BY cost DESC
 """
 
+_SQL_COST_BY_PROJECT = """\
+SELECT
+    project,
+    sum(cost_usd) AS cost,
+    count()       AS request_count
+FROM telemetry.requests
+WHERE tenant_id = {tenant:String}
+  AND timestamp >= fromUnixTimestamp64Milli({since_ms:Int64})
+  __UNTIL__
+  __PROJECT__
+GROUP BY project
+ORDER BY cost DESC
+"""
+
 _SQL_COST_BY_DAY = """\
 SELECT
     toStartOfDay(timestamp, 'UTC') AS day,
@@ -310,6 +324,13 @@ async def get_cost_summary(
         for row in model_result.result_rows
     }
 
+    proj_sql = _render(_SQL_COST_BY_PROJECT, until=until, project=project)
+    proj_result = await client.query(proj_sql, parameters=params)
+    by_project: dict[str, dict[str, Any]] = {
+        row[0]: {"cost": float(row[1] or 0.0), "requests": int(row[2] or 0)}
+        for row in proj_result.result_rows
+    }
+
     period_label = f"{since}..{until if until is not None else 'now'}"
     return {
         "period": period_label,
@@ -317,6 +338,7 @@ async def get_cost_summary(
         "total": total,
         "by_provider": by_provider,
         "by_model": by_model,
+        "by_project": by_project,
     }
 
 

--- a/src/voicegateway/tests/clickhouse/test_ch_reads.py
+++ b/src/voicegateway/tests/clickhouse/test_ch_reads.py
@@ -311,6 +311,7 @@ class TestGetCostSummary:
         assert "total" in result
         assert "by_provider" in result
         assert "by_model" in result
+        assert "by_project" in result
         # period carries since/until range marker
         assert result["project"] == "default"
 
@@ -339,6 +340,22 @@ class TestGetCostSummary:
         for _model, stats in result["by_model"].items():
             assert "cost" in stats
             assert "requests" in stats
+
+    async def test_by_project_shape_and_rollup(self, seeded_client):
+        from voicegateway.clickhouse.read_repository import get_cost_summary
+
+        result = await get_cost_summary(
+            seeded_client,
+            tenant="acme",
+            since=float(_DAY0 - 1),
+            until=None,
+        )
+        for _project, stats in result["by_project"].items():
+            assert "cost" in stats
+            assert "requests" in stats
+        # acme's seeded rows all carry project "default" (0.01 + 0.02 + 0.03).
+        assert result["by_project"]["default"]["requests"] == 3
+        assert result["by_project"]["default"]["cost"] == pytest.approx(0.06)
 
     async def test_beta_total(self, seeded_client):
         from voicegateway.clickhouse.read_repository import get_cost_summary


### PR DESCRIPTION
## Add `by_project` rollup to the cost summary

`get_cost_summary` already returns `by_provider` and `by_model`; this adds the same `by_project` rollup so a tenant running several agents under distinct projects can see **per-agent spend**.

### Why
The hosted dashboard is adding a per-agent view (each agent tags its telemetry with a distinct `project`, e.g. `mahimai-realty` / `mahimai-appointment` / `mahimai-portfolio`). The data was already tagged per project; it just wasn't rolled up. The cloud never re-implements telemetry SQL, so the rollup belongs here in the engine's ClickHouse read repository.

### What
- New `_SQL_COST_BY_PROJECT` (`GROUP BY project`), mirroring `_SQL_COST_BY_PROVIDER` / `_SQL_COST_BY_MODEL` exactly: same window, same tenant scope, same optional `project` filter.
- `get_cost_summary` returns `by_project: {project: {cost, requests}}` alongside the existing breakdowns.
- A single-project tenant simply sees one entry; nothing else changes.

### Testing
Runs against the in-process chDB fixture like the other rollups: asserts the `{cost, requests}` shape and that acme's seeded rows roll up to `default` (3 requests, $0.06). All 42 ClickHouse read tests pass; ruff + mypy clean.

Once released, the cloud API surfaces `by_project` on `/v1/costs` for the dashboard's Agents view.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-level cost rollups to the cost summary, showing per-project cost and request counts alongside existing totals and provider/model breakdowns.
* **Tests**
  * Expanded coverage to validate the new project-based summary structure and verify rollup accuracy for sample data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->