### PR TITLE
feat(openorca): map sessions to tasks + guardrail events to interventions

### DIFF
--- a/src/voicegateway/server/api/openorca/mapper.py
+++ b/src/voicegateway/server/api/openorca/mapper.py
@@ -61,34 +61,161 @@ def _build_agent(agent_name: str, group: list[RosterRow]) -> dict[str, Any]:
     }
 
 
-def build_snapshot(rosters: list[RosterRow], *, generated_at: str) -> dict[str, Any]:
-    """Build the OpenOrca snapshot dict from the current fleet roster."""
+def _field(obj: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from a dict (session rows) or an object (GuardrailEvent)."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+_DOMAIN_BY_PROJECT_HINT = {
+    "realty": "communications",
+    "portfolio": "research",
+    "appointment": "productivity",
+    "demo": "communications",
+}
+
+
+def _domain_for_project(project: str | None) -> str:
+    """Map a project to an OpenOrca AgentDomain. Voice calls default to
+    ``communications``; a few name hints refine it."""
+    if not project:
+        return "communications"
+    p = project.lower()
+    for hint, domain in _DOMAIN_BY_PROJECT_HINT.items():
+        if hint in p:
+            return domain
+    return "communications"
+
+
+def _build_tasks(sessions: list[Any]) -> list[dict[str, Any]]:
+    """One OpenOrca AgentTask per recent/live session.
+
+    Duck-typed: a session is any object (a storage row or a plain object) with
+    ``session_id`` (or ``id``) and ``started_at``; ``agent_id``/``project``/
+    ``ended_at``/``error``/``summary`` are optional. A live session (no
+    ``ended_at``) is ``in_progress`` at 0%; an ended one is ``completed`` (or
+    ``failed`` if it saw an error) at 100%.
+    """
+    tasks: list[dict[str, Any]] = []
+    for s in sessions:
+        session_id = _field(s, "session_id", None) or _field(s, "id", None)
+        if not session_id:
+            continue
+        agent = _field(s, "agent_id", None) or _field(s, "project", None) or "agent"
+        ended = _field(s, "ended_at", None)
+        errored = bool(_field(s, "error", False))
+        status = (
+            "in_progress" if ended is None else ("failed" if errored else "completed")
+        )
+        tasks.append(
+            {
+                "id": str(session_id),
+                "agentId": str(agent),
+                "agentName": str(agent),
+                "domain": _domain_for_project(_field(s, "project", None)),
+                "title": "Voice call",
+                "description": _field(s, "summary", "") or "",
+                "status": status,
+                "priority": "medium",
+                "progress": 0 if ended is None else 100,
+                "startTime": _field(s, "started_at", "") or "",
+                "integrationsUsed": [],
+                "collaborators": [],
+            }
+        )
+    return tasks
+
+
+# Guardrail action -> OpenOrca intervention type: a blocked turn needs a
+# permission decision; a held/flagged one needs approval.
+_GUARDRAIL_TYPE = {
+    "blocked": "permission",
+    "held": "approval_needed",
+    "flagged": "approval_needed",
+}
+
+
+def _build_interventions(events: list[Any]) -> list[dict[str, Any]]:
+    """One OpenOrca Intervention per guardrail event needing a human.
+
+    Duck-typed over GuardrailEvent (``id``, ``session_id``, ``project``,
+    ``category``, ``action``, ``context_excerpt``, ``created_at``). The agent is
+    attributed by ``project`` (guardrail events know the project, not the
+    agent_name), which the snapshot folds back onto the matching node.
+    """
+    interventions: list[dict[str, Any]] = []
+    for e in events:
+        action = (_field(e, "action", None) or "").lower()
+        category = _field(e, "category", None) or "policy"
+        project = _field(e, "project", None) or ""
+        interventions.append(
+            {
+                "id": f"guardrail-{_field(e, 'id', '')}",
+                "agentId": str(project),
+                "agentName": str(project),
+                "type": _GUARDRAIL_TYPE.get(action, "approval_needed"),
+                "question": (
+                    f"Guardrail '{category}' {action or 'flagged'} a turn. "
+                    "Approve or deny?"
+                ),
+                "context": (
+                    _field(e, "context_excerpt", None)
+                    or f"session {_field(e, 'session_id', '')}"
+                ),
+                "timestamp": _field(e, "created_at", "") or "",
+                "priority": "high" if action == "blocked" else "medium",
+            }
+        )
+    return interventions
+
+
+def build_snapshot(
+    rosters: list[RosterRow],
+    *,
+    sessions: list[Any] | None = None,
+    interventions: list[Any] | None = None,
+    generated_at: str,
+) -> dict[str, Any]:
+    """Build the OpenOrca snapshot from the roster, plus recent sessions (mapped
+    to tasks) and unresolved guardrail events (mapped to interventions)."""
     groups: dict[str, list[RosterRow]] = {}
     for row in rosters:
         groups.setdefault(row.agent_name, []).append(row)
 
     agents = [_build_agent(name, group) for name, group in groups.items()]
+    tasks = _build_tasks(sessions or [])
+    intervention_nodes = _build_interventions(interventions or [])
+
+    # Fold interventionRequired back onto agent nodes: guardrail events carry the
+    # project, and an agent node's ``domain`` is its project, so match on that (or
+    # on the node id). A flagged, non-offline agent flips to intervention_required.
+    flagged = {i["agentId"] for i in intervention_nodes}
+    for a in agents:
+        if a["domain"] in flagged or a["id"] in flagged:
+            a["interventionRequired"] = True
+            if a["status"] != "offline":
+                a["status"] = "intervention_required"
 
     active_agents = sum(1 for a in agents if a["status"] == "active")
     offline_agents = sum(1 for a in agents if a["status"] == "offline")
-    tasks_in_progress = sum(a["activeSessions"] for a in agents)
 
     fleet_health = {
         "totalAgents": len(agents),
         "activeAgents": active_agents,
         "offlineAgents": offline_agents,
-        "interventionsRequired": 0,
-        "tasksInProgress": tasks_in_progress,
-        "tasksCompletedToday": 0,
+        "interventionsRequired": len(intervention_nodes),
+        "tasksInProgress": sum(a["activeSessions"] for a in agents),
+        "tasksCompletedToday": sum(1 for t in tasks if t["status"] == "completed"),
         "swarmsActive": 0,
-        "overallHealth": "healthy",
+        "overallHealth": "degraded" if intervention_nodes else "healthy",
     }
 
     return {
         "agents": agents,
-        "tasks": [],
+        "tasks": tasks,
         "actionLog": [],
-        "interventions": [],
+        "interventions": intervention_nodes,
         "swarms": [],
         "machines": [],
         "fleetHealth": fleet_health,

--- a/src/voicegateway/server/api/openorca/routes.py
+++ b/src/voicegateway/server/api/openorca/routes.py
@@ -23,7 +23,11 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
-from voicegateway.repository import workers_repository
+from voicegateway.repository import (
+    guardrail_events_repository,
+    session_repository,
+    workers_repository,
+)
 from voicegateway.repository.workers_repository import DEFAULT_TTL_SECONDS
 from voicegateway.server.api._deps import (
     Depends,
@@ -89,7 +93,17 @@ async def _current_snapshot(gateway: Gateway, tenant_id: str | None) -> dict[str
             now=time.time(),
             ttl_seconds=DEFAULT_TTL_SECONDS,
         )
-    return build_snapshot(rows, generated_at=generated_at)
+        # Recent sessions -> tasks; guardrail events -> interventions. Both are
+        # tenant-scoped exactly like the roster above.
+        sessions = await session_repository.list_sessions(
+            db, tenant=tenant_id, limit=100
+        )
+        events = await guardrail_events_repository.list_events(
+            db, tenant=tenant_id, limit=50
+        )
+    return build_snapshot(
+        rows, sessions=sessions, interventions=events, generated_at=generated_at
+    )
 
 
 @router.get("/runtime-info")

--- a/src/voicegateway/tests/server/openorca/test_mapper.py
+++ b/src/voicegateway/tests/server/openorca/test_mapper.py
@@ -8,10 +8,38 @@ in the fleet rollup.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 from voicegateway.repository.workers_repository import RosterRow
 from voicegateway.server.api.openorca.mapper import build_snapshot
+
+
+def _session(**o: Any) -> SimpleNamespace:
+    base: dict[str, Any] = {
+        "session_id": "s1",
+        "agent_id": "alpha",
+        "project": "realty",
+        "started_at": "2026-07-05T00:00:00+00:00",
+        "ended_at": None,
+        "error": False,
+    }
+    base.update(o)
+    return SimpleNamespace(**base)
+
+
+def _guardrail(**o: Any) -> SimpleNamespace:
+    base: dict[str, Any] = {
+        "id": 7,
+        "session_id": "s1",
+        "project": "realty",
+        "category": "pii",
+        "action": "held",
+        "context_excerpt": "redacted turn",
+        "created_at": "2026-07-05T00:00:00+00:00",
+    }
+    base.update(o)
+    return SimpleNamespace(**base)
 
 
 def _row(**overrides: Any) -> RosterRow:
@@ -100,3 +128,94 @@ def test_fleet_counts_across_mixed_agents() -> None:
     assert fleet["activeAgents"] == 1
     assert fleet["offlineAgents"] == 1
     assert fleet["tasksInProgress"] == 1
+
+
+# --- Enrichment: sessions -> tasks ------------------------------------------
+
+
+def test_live_session_becomes_in_progress_task() -> None:
+    snap = build_snapshot(
+        [_row(agent_name="alpha", project="realty")],
+        sessions=[_session(ended_at=None)],
+        generated_at="x",
+    )
+    assert len(snap["tasks"]) == 1
+    t = snap["tasks"][0]
+    assert t["id"] == "s1"
+    assert t["status"] == "in_progress"
+    assert t["progress"] == 0
+    assert t["domain"] == "communications"  # realty hint -> communications
+
+
+def test_ended_session_is_completed_or_failed() -> None:
+    done = build_snapshot([], sessions=[_session(ended_at="t")], generated_at="x")
+    assert done["tasks"][0]["status"] == "completed"
+    assert done["tasks"][0]["progress"] == 100
+    failed = build_snapshot(
+        [], sessions=[_session(ended_at="t", error=True)], generated_at="x"
+    )
+    assert failed["tasks"][0]["status"] == "failed"
+
+
+def test_session_without_id_is_skipped() -> None:
+    snap = build_snapshot(
+        [], sessions=[SimpleNamespace(started_at="t")], generated_at="x"
+    )
+    assert snap["tasks"] == []
+
+
+def test_completed_tasks_counted_in_fleet_health() -> None:
+    snap = build_snapshot(
+        [],
+        sessions=[_session(session_id="s1", ended_at="t"), _session(session_id="s2")],
+        generated_at="x",
+    )
+    assert snap["fleetHealth"]["tasksCompletedToday"] == 1
+
+
+# --- Enrichment: guardrail events -> interventions --------------------------
+
+
+def test_held_guardrail_becomes_intervention_and_flags_agent() -> None:
+    snap = build_snapshot(
+        [_row(agent_name="alpha", project="realty", status="busy")],
+        interventions=[_guardrail(action="held", project="realty")],
+        generated_at="x",
+    )
+    assert len(snap["interventions"]) == 1
+    iv = snap["interventions"][0]
+    assert iv["id"] == "guardrail-7"
+    assert iv["type"] == "approval_needed"  # held -> approval
+    assert iv["agentId"] == "realty"
+    # folded onto the matching agent node (its domain is the project)
+    agent = snap["agents"][0]
+    assert agent["interventionRequired"] is True
+    assert agent["status"] == "intervention_required"
+    assert snap["fleetHealth"]["interventionsRequired"] == 1
+    assert snap["fleetHealth"]["overallHealth"] == "degraded"
+
+
+def test_blocked_guardrail_is_permission_high_priority() -> None:
+    iv = build_snapshot(
+        [], interventions=[_guardrail(action="blocked")], generated_at="x"
+    )["interventions"][0]
+    assert iv["type"] == "permission"
+    assert iv["priority"] == "high"
+
+
+def test_offline_agent_flagged_but_not_flipped() -> None:
+    snap = build_snapshot(
+        [
+            _row(
+                agent_name="alpha",
+                project="realty",
+                status="offline",
+                active_sessions=0,
+            )
+        ],
+        interventions=[_guardrail(project="realty")],
+        generated_at="x",
+    )
+    agent = snap["agents"][0]
+    assert agent["interventionRequired"] is True
+    assert agent["status"] == "offline"  # offline stays offline


### PR DESCRIPTION
Phase 5 keystone. The OpenOrca console snapshot returned `agents` + `fleetHealth` but empty `tasks`/`interventions`; this fills them so the task timeline and intervention panels light up for every consumer (including RealtyRecall's future console).

## What
- **sessions -> AgentTask**: live session = `in_progress`/0%, ended = `completed` (or `failed` on error)/100%; `domain` inferred from the project.
- **guardrail events -> Intervention**: `held`/`flagged` -> `approval_needed`, `blocked` -> `permission` (high priority); attributed by project and **folded back onto the agent node** (`interventionRequired` + `intervention_required` status; an offline agent stays offline).
- **fleetHealth**: real `interventionsRequired`, `tasksCompletedToday`; `overallHealth` degrades when interventions are open.
- `routes._current_snapshot` reads recent sessions + guardrail events **tenant-scoped like the roster** and passes them through; the SSE stream inherits the enrichment via the same builder.

## Notes
- Mappers are duck-typed over dict rows (`list_sessions`) and objects (`GuardrailEvent`) via a small `_field` accessor.
- Interventions currently come from guardrail events; error/budget/dead-air sources + a real resolve endpoint + the openorca-ui cost model are the next Phase 5 steps.

## Verified
11 mapper tests (session->task variants, guardrail->intervention, agent-flip, offline-not-flipped, fleet health); full openorca suite green (**24 passed**); ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard snapshots now include recent session activity as tasks and guardrail events as interventions.
  * Agent status can now reflect intervention requirements alongside existing fleet data.
  * Fleet health now shows completed tasks and whether interventions are required.

* **Bug Fixes**
  * Improved handling of live, completed, failed, and missing-session records.
  * Guardrail events now map more consistently to the related agent and surface the right intervention type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->