### PR TITLE
feat(openorca): make the intervention-resolve endpoint real (validate + tenant-scope + persist)

### DIFF
--- a/src/voicegateway/server/api/openorca/routes.py
+++ b/src/voicegateway/server/api/openorca/routes.py
@@ -20,7 +20,7 @@ import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from voicegateway.repository import (
@@ -49,6 +49,31 @@ router = APIRouter(prefix="/openorca", tags=["openorca"])
 bus = EventBus()
 
 _KEEPALIVE_SECONDS = 15.0
+
+# In-memory intervention resolutions, keyed by tenant then interventionId. A
+# resolved intervention is filtered out of subsequent snapshots so it stops
+# reappearing. In-memory (not durable across restarts, not shared across
+# workers): adequate for the console; a persistent store can replace this later.
+_RESOLUTIONS: dict[str | None, dict[str, float]] = {}
+_RESOLUTION_TTL_SECONDS = 24 * 3600
+_RESOLVE_ACTIONS = {"approve", "deny", "later"}
+
+
+def _mark_resolved(tenant_id: str | None, intervention_id: str) -> None:
+    """Record an intervention as resolved for a tenant, pruning stale entries."""
+    now = time.time()
+    bucket = _RESOLUTIONS.setdefault(tenant_id, {})
+    bucket[intervention_id] = now
+    for iid, ts in list(bucket.items()):
+        if now - ts > _RESOLUTION_TTL_SECONDS:
+            del bucket[iid]
+
+
+def _resolved_ids(tenant_id: str | None) -> set[str]:
+    """The set of still-fresh resolved intervention ids for a tenant."""
+    now = time.time()
+    bucket = _RESOLUTIONS.get(tenant_id, {})
+    return {iid for iid, ts in bucket.items() if now - ts <= _RESOLUTION_TTL_SECONDS}
 
 
 def _now_iso() -> str:
@@ -101,6 +126,10 @@ async def _current_snapshot(gateway: Gateway, tenant_id: str | None) -> dict[str
         events = await guardrail_events_repository.list_events(
             db, tenant=tenant_id, limit=50
         )
+    # Drop interventions the operator has already resolved so they do not
+    # reappear on the next snapshot (their id is ``guardrail-{event.id}``).
+    resolved = _resolved_ids(tenant_id)
+    events = [e for e in events if f"guardrail-{e.id}" not in resolved]
     return build_snapshot(
         rows, sessions=sessions, interventions=events, generated_at=generated_at
     )
@@ -132,18 +161,31 @@ async def resolve_intervention(
     request: Request,
     principal: Principal = Depends(require_principal),
 ) -> dict[str, str]:
-    """Publish an intervention resolution to connected dashboards.
+    """Resolve an intervention: validate the request, record the resolution so
+    the intervention drops out of later snapshots, and publish a TENANT-SCOPED
+    ``intervention.resolved`` so only that tenant's dashboards update.
 
-    Gated behind ``require_principal`` so an intervention write requires the
-    same authentication as the dashboard reads. In the default no-static-keys
-    config the operator passes and behavior is unchanged.
+    Gated behind ``require_principal`` so a write requires the same auth as the
+    reads. The tenant is taken from the principal (never the body), so a caller
+    can only ever resolve their own tenant's interventions.
     """
     body: dict[str, Any] = await request.json()
+    intervention_id = body.get("interventionId")
+    action = body.get("action", "later")
+    if not isinstance(intervention_id, str) or not intervention_id:
+        raise HTTPException(status_code=400, detail="interventionId is required")
+    if action not in _RESOLVE_ACTIONS:
+        raise HTTPException(
+            status_code=400, detail="action must be approve, deny, or later"
+        )
+    tenant_id = resolve_read_tenant(principal, request.query_params.get("tenant"))
+    _mark_resolved(tenant_id, intervention_id)
     await bus.publish(
         {
             "type": "intervention.resolved",
-            "interventionId": body.get("interventionId"),
-            "resolution": body.get("action", "later"),
+            "interventionId": intervention_id,
+            "resolution": action,
+            "_tenant": tenant_id,
         }
     )
     return {"status": "resolved"}

--- a/src/voicegateway/tests/server/openorca/test_routes.py
+++ b/src/voicegateway/tests/server/openorca/test_routes.py
@@ -19,7 +19,13 @@ import yaml
 from httpx import ASGITransport, AsyncClient
 
 from voicegateway.core.gateway import Gateway
+from voicegateway.repository import guardrail_events_repository
+from voicegateway.schemas.guardrail_policy_schema import (
+    ACTIVE_GUARDRAIL_ACTIONS,
+    GUARDRAIL_CATEGORIES,
+)
 from voicegateway.server import build_app
+from voicegateway.server.api.openorca import routes as openorca_routes
 from voicegateway.server.api.openorca.routes import _sse
 
 
@@ -104,6 +110,54 @@ async def test_resolve_intervention_passes_operator_default(harness) -> None:
         )
     assert resp.status_code == 200, resp.text
     assert resp.json() == {"status": "resolved"}
+
+
+async def test_resolve_requires_intervention_id(harness) -> None:
+    async with harness.client() as c:
+        resp = await c.post(
+            "/openorca/interventions/resolve", json={"action": "approve"}
+        )
+    assert resp.status_code == 400
+
+
+async def test_resolve_rejects_bad_action(harness) -> None:
+    async with harness.client() as c:
+        resp = await c.post(
+            "/openorca/interventions/resolve",
+            json={"interventionId": "iv-1", "action": "nuke"},
+        )
+    assert resp.status_code == 400
+
+
+async def test_resolving_drops_intervention_from_snapshot(harness) -> None:
+    # A guardrail event surfaces as an intervention; resolving it must filter it
+    # out of the next snapshot so it does not reappear.
+    openorca_routes._RESOLUTIONS.clear()
+    category = next(iter(GUARDRAIL_CATEGORIES))
+    action = next(iter(ACTIVE_GUARDRAIL_ACTIONS))
+    async with harness.gateway.storage._conn.session() as db:
+        eid = await guardrail_events_repository.create_event(
+            db,
+            session_id="s1",
+            event_type="fired",
+            category=category,
+            action=action,
+        )
+        await db.commit()
+
+    async with harness.client() as c:
+        before = (await c.get("/openorca/snapshot")).json()
+        assert f"guardrail-{eid}" in {i["id"] for i in before["interventions"]}
+
+        r = await c.post(
+            "/openorca/interventions/resolve",
+            json={"interventionId": f"guardrail-{eid}", "action": "approve"},
+        )
+        assert r.status_code == 200
+
+        after = (await c.get("/openorca/snapshot")).json()
+    assert all(i["id"] != f"guardrail-{eid}" for i in after["interventions"])
+    openorca_routes._RESOLUTIONS.clear()
 
 
 async def test_runtime_info_advertises_sse(harness) -> None:


### PR DESCRIPTION
Phase 5 (cont.). The `/openorca/interventions/resolve` endpoint previously broadcast an unvalidated, un-scoped event to **every** connected dashboard (a cross-tenant leak). Make it a real write:

- **Validate**: `interventionId` required (400), `action` in `{approve, deny, later}` (400 otherwise).
- **Tenant from the principal, never the body** — a caller can only resolve their own tenant's interventions.
- **Record the resolution** (in-memory, tenant-scoped, TTL-pruned) so `_current_snapshot` filters the resolved intervention out and it stops reappearing.
- **Publish a tenant-scoped `intervention.resolved`** so only that tenant's dashboards update.

## Note
The resolution store is in-memory (not durable across restarts / not shared across workers) — adequate for the console; a persistent store can replace it later. This addresses the review's broadcast-leak + no-validation findings.

## Verified
Missing id / bad action -> 400; resolving a guardrail-derived intervention drops it from the next snapshot. Full openorca suite green (**27 passed**); ruff clean.