### PR TITLE
build(console): bundle the /console SPA in the wheel and Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to VoiceGateway are documented here. This project
 follows [Semantic Versioning](https://semver.org/) and
 [Conventional Commits](https://www.conventionalcommits.org/).
 
+## v0.15.0: OpenOrca fleet console + runtime intervention resolve
+
+The `/openorca/*` runtime contract gains the pieces a live fleet console needs,
+and the engine now serves that console itself at `/console`.
+
+### Added
+
+- **OpenOrca fleet console at `/console`.** A standalone React 19 + Tailwind v4
+  SPA (built from `src/dashboard/console`) that renders `<OpenOrcaDashboard
+  mode="runtime">` against this server's own `/openorca/*` endpoints. `voicegw
+  serve` mounts it when built. Kept separate from the React 18 dashboard because
+  `@openorca-ui/react` peers on React 19 and ships source Tailwind v4.
+- **Real intervention-resolve endpoint.** `POST /openorca/interventions/resolve`
+  validates the intervention id and action (`approve` / `deny` / `later`),
+  tenant-scopes the request, persists the resolution with a TTL, and publishes a
+  tenant-scoped `intervention.resolved` event. Resolved interventions drop out of
+  the snapshot.
+- **Snapshot enrichment.** The mapper folds live sessions into agent tasks and
+  guardrail events into interventions per project, and rolls them into
+  `fleetHealth`, so the snapshot reflects real call and guardrail state.
+
+### Packaging
+
+- The wheel and Docker image now build and bundle the console SPA
+  (`build_wheel.sh` stages `_console_dist`; the Dockerfile adds a console builder
+  stage), so `pip install voicegateway` and the published image both serve
+  `/console`.
+
 ## v0.9.2: the Postgres fleet collector actually works
 
 The Postgres collector backend carried several SQLite-only SQL constructs that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ version-file = "src/voicegateway/_version.py"
 [tool.hatch.build]
 artifacts = [
     "src/voicegateway/_dashboard_dist/**/*",
+    "src/voicegateway/_console_dist/**/*",
     "src/voicegateway/livekit_diag/assets/*.wav",
 ]
 
@@ -239,6 +240,16 @@ exclude = [
     "src/dashboard/frontend/vite.config.ts",
     "src/dashboard/frontend/vite.config.d.ts",
     "src/dashboard/frontend/index.html",
+    # Console (React 19 + Tailwind) build inputs: the daemon only needs its
+    # built dist (staged into voicegateway/_console_dist), so keep the source
+    # and toolchain files out of the wheel, mirroring the frontend excludes.
+    "src/dashboard/console/node_modules",
+    "src/dashboard/console/src",
+    "src/dashboard/console/package.json",
+    "src/dashboard/console/package-lock.json",
+    "src/dashboard/console/tsconfig.json",
+    "src/dashboard/console/vite.config.ts",
+    "src/dashboard/console/index.html",
     # Keep compiled migration bytecode out of the force-included alembic tree.
     "alembic/__pycache__",
     "alembic/versions/__pycache__",

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -30,40 +30,49 @@ if [[ -z "${SETUPTOOLS_SCM_PRETEND_VERSION:-}" \
   echo "==> pinning version to ${SETUPTOOLS_SCM_PRETEND_VERSION} (from tag ${GITHUB_REF_NAME})"
 fi
 
+# Build one Vite SPA (dashboard or console) reproducibly, failing loudly if its
+# lockfile or its dist is missing. Each SPA owns its own toolchain and lockfile
+# (the console peers on React 19 + Tailwind v4, the dashboard on React 18).
+build_spa() {
+  local src="$1"
+  if [[ ! -d "$src" ]]; then
+    echo "ERROR: $src missing; this script must run from the repo root." >&2
+    exit 1
+  fi
+  # Refuse to build without a lockfile: an unlocked install would resolve
+  # dependencies against whatever the registry returns today and the wheel
+  # would not be reproducible across runs.
+  if [[ ! -f "$src/package-lock.json" && ! -f "$src/npm-shrinkwrap.json" ]]; then
+    echo "ERROR: no package-lock.json or npm-shrinkwrap.json in $src; refusing to build a non-reproducible wheel." >&2
+    exit 1
+  fi
+  echo "==> npm ci ($src)"
+  npm --prefix "$src" ci
+  echo "==> npm run build ($src)"
+  npm --prefix "$src" run build
+  if [[ ! -d "$src/dist" ]]; then
+    echo "ERROR: $src/dist missing after build; npm build silently failed." >&2
+    exit 1
+  fi
+}
+
 FRONTEND_SRC="src/dashboard/frontend"
 STAGED_DIST="src/voicegateway/_dashboard_dist"
+CONSOLE_SRC="src/dashboard/console"
+CONSOLE_STAGED_DIST="src/voicegateway/_console_dist"
 
-if [[ ! -d "$FRONTEND_SRC" ]]; then
-  echo "ERROR: $FRONTEND_SRC missing; this script must run from the repo root." >&2
-  exit 1
-fi
+build_spa "$FRONTEND_SRC"
+build_spa "$CONSOLE_SRC"
 
-# Refuse to build without a lockfile: an unlocked install would resolve
-# dependencies against whatever the registry returns today and the wheel
-# would not be reproducible across runs.
-if [[ ! -f "$FRONTEND_SRC/package-lock.json" && ! -f "$FRONTEND_SRC/npm-shrinkwrap.json" ]]; then
-  echo "ERROR: no package-lock.json or npm-shrinkwrap.json in $FRONTEND_SRC; refusing to build a non-reproducible wheel." >&2
-  exit 1
-fi
-
-echo "==> npm ci ($FRONTEND_SRC)"
-npm --prefix "$FRONTEND_SRC" ci
-
-echo "==> npm run build ($FRONTEND_SRC)"
-npm --prefix "$FRONTEND_SRC" run build
-
-if [[ ! -d "$FRONTEND_SRC/dist" ]]; then
-  echo "ERROR: $FRONTEND_SRC/dist missing after build; npm build silently failed." >&2
-  exit 1
-fi
-
-# Stage dist into the voicegateway package dir so hatchling picks it
-# up via `packages = ["src/voicegateway"]`. The cleanup trap runs on
-# ANY exit so the source tree never carries a stale _dashboard_dist
+# Stage both dists into the voicegateway package dir so hatchling picks them up
+# via `packages = ["src/voicegateway"]`. ONE EXIT trap cleans both: a second
+# `trap ... EXIT` would replace the first, leaking a staged dir. The trap runs on
+# any exit so the source tree never carries a stale _dashboard_dist / _console_dist
 # across invocations.
-rm -rf "$STAGED_DIST"
-trap 'rm -rf "$STAGED_DIST"' EXIT
+rm -rf "$STAGED_DIST" "$CONSOLE_STAGED_DIST"
+trap 'rm -rf "$STAGED_DIST" "$CONSOLE_STAGED_DIST"' EXIT
 cp -r "$FRONTEND_SRC/dist" "$STAGED_DIST"
+cp -r "$CONSOLE_SRC/dist" "$CONSOLE_STAGED_DIST"
 
 echo "==> uv build"
 uv build

--- a/src/voicegateway/Dockerfile
+++ b/src/voicegateway/Dockerfile
@@ -12,6 +12,17 @@ RUN npm ci
 COPY src/dashboard/frontend/ ./
 RUN npm run build
 
+# -------- Stage 1b: Console builder --------
+# The OpenOrca fleet console (/console) is a separate React 19 + Tailwind v4 +
+# Vite 7 SPA, so it builds in its own stage on Node 22 (Vite 7 needs >=20.19).
+FROM node:22-alpine AS console-builder
+
+WORKDIR /build/console
+COPY src/dashboard/console/package*.json ./
+RUN npm ci
+COPY src/dashboard/console/ ./
+RUN npm run build
+
 # -------- Stage 2: Python builder --------
 FROM python:3.12-slim AS builder
 
@@ -92,6 +103,9 @@ COPY --from=builder --chown=voicegw:voicegw \
 COPY --chown=voicegw:voicegw src/dashboard/__init__.py /app/dashboard/
 COPY --chown=voicegw:voicegw src/dashboard/api/static/ /app/dashboard/api/static/
 COPY --from=frontend-builder --chown=voicegw:voicegw /build/frontend/dist /app/dashboard/frontend/dist
+# The console mounts at /console; static.mount_console resolves its dev-layout
+# candidate (dashboard/console/dist) relative to /app, matching the dashboard above.
+COPY --from=console-builder --chown=voicegw:voicegw /build/console/dist /app/dashboard/console/dist
 
 # Ship the migrations. On first DB access the runtime runs `alembic upgrade
 # head`; Database._find_alembic_ini walks up from /app/voicegateway to /app, and


### PR DESCRIPTION
## Why

The `/console` SPA (#70) is served by `mount_console` **only when a built dist exists**, but the release artifacts never built or shipped it: `scripts/build_wheel.sh` and the engine `Dockerfile` only handled the dashboard. So `pip install voicegateway` and the published Docker image both got a **dead `/console`** (mount found no `_console_dist` and no-oped). This is the prerequisite for cutting `v0.15.0` with a working console.

## What

- **`build_wheel.sh`:** factored the dashboard's build+stage into a `build_spa` helper and run it for the console too, staging `src/dashboard/console/dist` → `src/voicegateway/_console_dist`. One `EXIT` trap cleans both staged dirs (a second `trap ... EXIT` would replace the first).
- **`pyproject.toml`:** opt `_console_dist/**/*` back into the wheel `artifacts` (the path is gitignored) and exclude the console build inputs, mirroring the frontend excludes.
- **`Dockerfile`:** add a Node 22 `console-builder` stage (Vite 7 needs Node >=20.19) and copy its dist to `/app/dashboard/console/dist`, the dev-layout path `mount_console` resolves at runtime (same shape as the dashboard copy).
- **`CHANGELOG.md`:** `v0.15.0` entry.

## Verified

`bash scripts/build_wheel.sh` builds both SPAs and `uv build` succeeds. The wheel now contains:

```
voicegateway/_console_dist/index.html
voicegateway/_console_dist/assets/index-*.js   (530 KB React 19 + Tailwind bundle)
voicegateway/_console_dist/assets/index-*.css  (19.95 KB)
voicegateway/_console_dist/assets/claw-agent-*.png
```

The `EXIT` trap leaves the source tree clean (no staged `_console_dist` / `_dashboard_dist`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone fleet console available at `/console`.
  * Snapshot views now reflect live session, guardrail, and intervention status.
  * Introduced a new intervention resolution endpoint for updating resolution state.

* **Bug Fixes**
  * Improved validation and scoping for intervention resolutions, with persisted updates and tenant-specific event updates.

* **Chores**
  * Updated packaging and Docker builds so the console is included in both wheel and image releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->