### PR TITLE
feat(telemetry): per-call channel + a per-session requests read

### DIFF
--- a/src/voicegateway/clickhouse/read_repository.py
+++ b/src/voicegateway/clickhouse/read_repository.py
@@ -169,6 +169,24 @@ ORDER BY started_at DESC
 LIMIT {limit:UInt32}
 """
 
+# One call's individual requests, oldest first (the call timeline for the dashboard
+# drill-down). Filters on the session_id column (exact + cheap); LIMIT 1 BY id dedups
+# transient pre-merge duplicates like the recent-requests read.
+_SQL_SESSION_REQUESTS = """\
+SELECT
+    id, timestamp, project, modality, model_id, provider,
+    input_units, output_units, cached_input_units, cost_usd,
+    pricing_source, ttfb_ms, total_latency_ms, status,
+    fallback_from, error_message, metadata, session_id,
+    tenant_id, agent_id
+FROM telemetry.requests
+WHERE tenant_id = {tenant:String}
+  AND session_id = {session_id:String}
+ORDER BY timestamp ASC
+LIMIT 1 BY id
+LIMIT {limit:UInt32}
+"""
+
 # Admin-only: no tenant filter. Returns all tenants.
 _SQL_COST_BY_TENANT_ADMIN = """\
 SELECT
@@ -432,6 +450,55 @@ async def get_recent_requests(
     )
     sql = _render(_SQL_RECENT_REQUESTS, until=until, project=project)
     result = await client.query(sql, parameters=params)
+
+    _COLS = (
+        "id",
+        "timestamp",
+        "project",
+        "modality",
+        "model_id",
+        "provider",
+        "input_units",
+        "output_units",
+        "cached_input_units",
+        "cost_usd",
+        "pricing_source",
+        "ttfb_ms",
+        "total_latency_ms",
+        "status",
+        "fallback_from",
+        "error_message",
+        "metadata",
+        "session_id",
+        "tenant_id",
+        "agent_id",
+    )
+
+    rows = []
+    for row in result.result_rows:
+        record: dict[str, Any] = {col: row[i] for i, col in enumerate(_COLS)}
+        record["timestamp"] = _dt_to_epoch(record["timestamp"])
+        record["metadata"] = _parse_metadata(record["metadata"])
+        rows.append(record)
+    return rows
+
+
+async def get_session_requests(
+    client: Any,
+    *,
+    tenant: str,
+    session_id: str,
+    limit: int = 500,
+) -> list[dict[str, Any]]:
+    """Return every request row for one session, oldest first (the call's timeline).
+
+    Filters on the ``session_id`` column (exact and cheap), so it powers the dashboard call
+    drill-down: the STT/LLM/TTS sequence with per-request latency, cost, and status, plus each
+    row's ``metadata`` (from which the phone/web channel is read). Bounded by ``limit`` so one
+    pathological session cannot return unbounded rows.
+    """
+    params = {"tenant": tenant, "session_id": session_id, "limit": limit}
+    result = await client.query(_SQL_SESSION_REQUESTS, parameters=params)
 
     _COLS = (
         "id",

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -222,6 +222,40 @@ def _resolve_room(session: Any) -> str | None:
     return name if isinstance(name, str) and name else None
 
 
+def _resolve_channel(session: Any) -> str | None:
+    """Best-effort telephony-vs-web classification for the dashboard's per-call chip.
+
+    A SIP remote participant means a phone call; any other remote participant means a web
+    session. Prefers an explicit ``session._vg_channel`` (tests / advanced callers), then the
+    running LiveKit job context. Returns None when it cannot tell (off a job, or no participant
+    has joined yet), so the row simply carries no channel rather than a wrong guess.
+    """
+    ch = getattr(session, "_vg_channel", None)
+    if isinstance(ch, str) and ch:
+        return ch
+    try:
+        from livekit.agents import get_job_context
+
+        ctx = get_job_context(required=False)
+    except Exception:  # noqa: BLE001 - livekit not installed / no job context
+        return None
+    participants = getattr(getattr(ctx, "room", None), "remote_participants", None)
+    if not participants:
+        return None
+    try:
+        from livekit import rtc
+
+        sip_kind = rtc.ParticipantKind.PARTICIPANT_KIND_SIP
+    except Exception:  # noqa: BLE001 - older livekit without the kind enum
+        sip_kind = None
+    saw_participant = False
+    for participant in participants.values():
+        saw_participant = True
+        if sip_kind is not None and getattr(participant, "kind", None) == sip_kind:
+            return "telephony"
+    return "web" if saw_participant else None
+
+
 def _build_default_sink(
     collector_url: str | None,
     api_key: str | None,
@@ -306,6 +340,7 @@ def attach(
     resolved_collector = collector_url or os.environ.get("VOICEGW_COLLECTOR_URL")
     resolved_key = api_key or os.environ.get("VOICEGW_API_KEY")
     resolved_room = room or _resolve_room(session)
+    resolved_channel = _resolve_channel(session)
     session_id = get_or_create_session_id()
     if tenant_id is not None:
         set_tenant(tenant_id)
@@ -321,6 +356,7 @@ def attach(
         session_id=session_id,
         tenant_id=tenant_id,
         room=resolved_room,
+        channel=resolved_channel,
     )
     capture.bind(session)
 

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -217,6 +217,7 @@ class MetricCapture:
         session_id: str | None,
         tenant_id: str | None = None,
         room: str | None = None,
+        channel: str | None = None,
     ) -> None:
         self._cost_tracker = cost_tracker
         self._sink = sink
@@ -225,6 +226,7 @@ class MetricCapture:
         self._session_id = session_id
         self._tenant_id = tenant_id
         self._room = room
+        self._channel = channel
         self._pending: set[asyncio.Task[None]] = set()
         # Per-(provider, model_id) running tally of captured units, so the
         # close-time reconcile can diff against cumulative session.usage.
@@ -339,6 +341,11 @@ class MetricCapture:
             extra["tenant_id"] = self._tenant_id
         if self._room:
             extra["room"] = self._room
+        # ``channel`` (telephony vs web) rides in metadata like room: it has no
+        # RequestRecord column, and the dashboard reads it back per call to show a
+        # phone/web chip. Absent when attach could not classify the participants.
+        if self._channel:
+            extra["channel"] = self._channel
         if extra:
             record.metadata = {**record.metadata, **extra}
 

--- a/src/voicegateway/tests/clickhouse/test_ch_reads.py
+++ b/src/voicegateway/tests/clickhouse/test_ch_reads.py
@@ -961,3 +961,80 @@ class TestGetCostByTenantAdmin:
         for _tenant, stats in result.items():
             assert "cost" in stats
             assert "requests" in stats
+
+
+class TestGetSessionRequests:
+    async def test_scoped_ordered_and_reads_channel(self, ch_session_reads):
+        from voicegateway.clickhouse.read_repository import get_session_requests
+
+        _insert(
+            ch_session_reads,
+            [
+                {
+                    "tenant_id": "acme",
+                    "id": "r1",
+                    "ts": _DAY1,
+                    "modality": "stt",
+                    "provider": "deepgram",
+                    "model_id": "deepgram/nova-3",
+                    "cost_usd": 0.001,
+                    "ttfb_ms": 110.0,
+                    "total_latency_ms": 110.0,
+                    "session_id": "call_a",
+                    "agent_id": "w1",
+                    "metadata": {"channel": "telephony"},
+                },
+                {
+                    "tenant_id": "acme",
+                    "id": "r2",
+                    "ts": _DAY1 + 2,
+                    "modality": "llm",
+                    "provider": "openai",
+                    "model_id": "openai/gpt-4.1-mini",
+                    "cost_usd": 0.004,
+                    "ttfb_ms": 200.0,
+                    "total_latency_ms": 200.0,
+                    "session_id": "call_a",
+                    "agent_id": "w1",
+                    "metadata": {"channel": "telephony"},
+                },
+                {
+                    "tenant_id": "acme",
+                    "id": "r3",
+                    "ts": _DAY1,
+                    "modality": "tts",
+                    "provider": "deepgram",
+                    "model_id": "deepgram/aura-2",
+                    "cost_usd": 0.002,
+                    "ttfb_ms": 135.0,
+                    "total_latency_ms": 135.0,
+                    "session_id": "call_b",
+                    "agent_id": "w1",
+                    "metadata": {},
+                },
+                {
+                    "tenant_id": "beta",
+                    "id": "b1",
+                    "ts": _DAY1,
+                    "modality": "llm",
+                    "provider": "openai",
+                    "model_id": "m",
+                    "cost_usd": 0.004,
+                    "ttfb_ms": 90.0,
+                    "total_latency_ms": 90.0,
+                    "session_id": "call_a",
+                    "agent_id": "w2",
+                    "metadata": {},
+                },
+            ],
+        )
+        client = ChdbAdapter(ch_session_reads)
+        rows = await get_session_requests(client, tenant="acme", session_id="call_a")
+
+        # Only acme's call_a, oldest first (the call timeline).
+        assert [r["id"] for r in rows] == ["r1", "r2"]
+        assert rows[0]["modality"] == "stt"
+        # Channel rides in metadata (no dedicated column).
+        assert rows[0]["metadata"]["channel"] == "telephony"
+        # beta's identically-named session never leaks into acme's drill-down.
+        assert all(r["tenant_id"] == "acme" for r in rows)

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -129,6 +129,44 @@ async def test_metric_capture_writes_llm_row(tmp_path):
     assert row["session_id"] == "vg-test"
 
 
+def _stamp_capture(channel):
+    """A MetricCapture built just to exercise _stamp_context (cost_tracker/sink unused there)."""
+    return MetricCapture(
+        cost_tracker=None,  # type: ignore[arg-type]
+        sink=None,  # type: ignore[arg-type]
+        project="fleet",
+        agent_id="agent-3",
+        session_id="vg-test",
+        channel=channel,
+    )
+
+
+def _blank_record():
+    from voicegateway.models.request_model import RequestRecord
+
+    return RequestRecord(
+        id="r",
+        timestamp=0.0,
+        modality="llm",
+        model_id="openai/gpt-4o-mini",
+        provider="openai",
+    )
+
+
+def test_stamp_context_adds_channel_when_set():
+    """attach()'s telephony/web classification rides on each request's metadata."""
+    record = _blank_record()
+    _stamp_capture("telephony")._stamp_context(record)
+    assert record.metadata["channel"] == "telephony"
+
+
+def test_stamp_context_omits_channel_when_unknown():
+    """No classification means the row carries no channel key, not a guess."""
+    record = _blank_record()
+    _stamp_capture(None)._stamp_context(record)
+    assert "channel" not in record.metadata
+
+
 async def test_metric_capture_handles_three_modalities(tmp_path):
     """STT, LLM, and TTS components each produce a correctly-typed row."""
     storage = StorageService(str(tmp_path / "cap3.db"))


### PR DESCRIPTION
Groundwork in the OSS engine for the cloud dashboard's new **Calls** view (merging Sessions + Logs, with a per-call drill-down). Two additions, no schema migration.

## 1. Per-call channel (telephony vs web)
- `attach.py`: new best-effort `_resolve_channel(session)` — a SIP remote participant means a phone call, any other remote participant means web; `None` when it can't tell (off a job, or no participant joined yet), so a row never carries a wrong guess. Threaded into `MetricCapture(channel=...)`.
- `capture.py`: `_stamp_context` merges `channel` into each request's **`metadata`** (exactly like the existing `room`/`tenant_id`) — no new column, no ClickHouse migration.

## 2. Per-session requests read (call drill-down)
- `read_repository.get_session_requests(client, *, tenant, session_id, limit=500)` — one call's individual requests, **oldest first**, filtered on the existing `session_id` column (exact + cheap), tenant-scoped, deduped via `LIMIT 1 BY id`. Returns the same row shape as `get_recent_requests` (incl. `metadata`, from which the channel is read).

## Testing
- `test_attach_capture.py`: `_stamp_context` adds `channel` when set / omits it when unknown (direct unit tests, no sink).
- `test_ch_reads.py`: `get_session_requests` is oldest-first, session- and tenant-scoped, and reads `channel` from metadata.
- Read-repo suite: 43 passed.

## Note for the reviewer
The 9 failing `test_attach_capture` sink-readback tests are **pre-existing** (they fail on a clean `main` too — a SQLite-sink schema issue) and are unrelated to this change; my capture tests deliberately avoid that path.

## Follow-up
After this releases, the cloud SHA-pins the bump and builds the Calls page (list + stacked-latency drill-down + phone/web chip). A first-class `channel` column (migration `0004`) is a later step only if it needs to be a filterable dimension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session request history can now be retrieved for a specific call, with results shown in chronological order and duplicate entries filtered out.
  * Session records now include a channel label when available, helping distinguish telephony and web calls.

* **Bug Fixes**
  * Improved request filtering so session data stays scoped to the correct tenant and session.

* **Tests**
  * Added coverage for session request ordering, tenant isolation, and channel metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->