### PR TITLE
build: make the core framework-neutral (livekit + pipecat as extras)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,6 @@ classifiers = [
 ]
 
 dependencies = [
-    "livekit>=1.0",
-    "livekit-agents>=1.5,<1.7",
-    "livekit-api>=1.0",
     "pyyaml>=6.0",
     "aiosqlite>=0.20.0",
     "typer>=0.12.0",
@@ -42,14 +39,37 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Cloud providers (install what you need)
-deepgram = ["livekit-plugins-deepgram>=1.5.0"]
-openai = ["livekit-plugins-openai>=1.5.0"]
-anthropic = ["livekit-plugins-anthropic>=1.5.0"]
-groq = ["livekit-plugins-openai>=1.5.0"]
-cartesia = ["livekit-plugins-cartesia>=1.5.0"]
-elevenlabs = ["livekit-plugins-elevenlabs>=1.5.0"]
-assemblyai = ["livekit-plugins-assemblyai>=1.5.0"]
+# Framework runtimes. The core is framework-neutral: `import voicegateway`
+# imports neither livekit nor pipecat. attach()/guard() lazily import the
+# relevant framework by target type and raise a helpful error pointing at
+# the missing extra ("pip install voicegateway[livekit]" /
+# "voicegateway[pipecat]"). Install exactly the seam(s) you use.
+#
+# livekit bundles the LiveKit agent runtime that voicegateway.inference.LLM/
+# STT/TTS and attach(session) drive. The livekit-plugins-* provider wheels
+# stay their own extras below (they belong to the livekit world); this extra
+# is just the runtime, mirroring the pipecat extra's shape.
+livekit = [
+    "livekit>=1.0",
+    "livekit-agents>=1.5,<1.7",
+    "livekit-api>=1.0",
+]
+# pipecat provides the alternative agent framework attach(task)/Observer and
+# guard() target. Pinned to the current PyPI floor (1.5.0); pipecat-ai uses
+# git-tag dynamic versioning and requires-python >=3.11. Upper bound is the
+# next major so minor releases resolve.
+pipecat = ["pipecat-ai>=1.5.0,<2.0"]
+
+# Cloud providers (install what you need). These are LiveKit plugin wheels,
+# so they imply the livekit extra: pulling a livekit-plugins-* wheel is only
+# useful with the livekit-agents runtime present.
+deepgram = ["voicegateway[livekit]", "livekit-plugins-deepgram>=1.5.0"]
+openai = ["voicegateway[livekit]", "livekit-plugins-openai>=1.5.0"]
+anthropic = ["voicegateway[livekit]", "livekit-plugins-anthropic>=1.5.0"]
+groq = ["voicegateway[livekit]", "livekit-plugins-openai>=1.5.0"]
+cartesia = ["voicegateway[livekit]", "livekit-plugins-cartesia>=1.5.0"]
+elevenlabs = ["voicegateway[livekit]", "livekit-plugins-elevenlabs>=1.5.0"]
+assemblyai = ["voicegateway[livekit]", "livekit-plugins-assemblyai>=1.5.0"]
 
 # Local models
 whisper = ["faster-whisper>=1.0.0"]
@@ -127,6 +147,12 @@ dev = [
     "psutil>=5.9",
     "platformdirs>=4.0",
     "textual>=0.85,<0.90",
+    # livekit is no longer a core dependency (it moved to the `livekit` extra
+    # for framework neutrality), but the test suite exercises the
+    # voicegateway.inference.LLM/STT/TTS factories and attach(session), which
+    # lazily import livekit. Pull the runtime into dev so `pip install -e
+    # ".[dev]"` yields a livekit-enabled test environment as before.
+    "voicegateway[livekit]",
     "chdb>=3.0",
     "testcontainers[clickhouse]>=4.0",
     # Server stack so tests covering core/container, repository/, etc. can

--- a/src/voicegateway/__init__.py
+++ b/src/voicegateway/__init__.py
@@ -1,8 +1,74 @@
-"""VoiceGateway: cost tracking and reconciliation for LiveKit voice agents."""
+"""VoiceGateway: framework-neutral cost tracking for voice agents.
 
-from voicegateway import inference
+The core is framework-neutral: ``import voicegateway`` imports neither
+``livekit`` nor ``pipecat``. Both frameworks are optional extras
+(``pip install voicegateway[livekit]`` / ``voicegateway[pipecat]``).
+
+The ``LLM``/``STT``/``TTS`` factories are LiveKit-plugin factories, so they
+pull ``livekit`` on first use. They are therefore imported lazily via a
+module-level ``__getattr__`` (PEP 562): accessing ``voicegateway.LLM`` triggers
+the import, but a bare ``import voicegateway`` does not. ``attach`` and
+``register_worker`` are safe to import eagerly (their modules do not import any
+framework at load time; ``attach`` duck-types its target and lazily imports the
+framework it detects).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from voicegateway._version import __version__
 from voicegateway.fleet.worker import register_worker
 from voicegateway.inference.session.attach import attach
 
-__all__ = ["attach", "inference", "register_worker", "__version__"]
+if TYPE_CHECKING:
+    # Type-checkers resolve these eagerly (they do not run the module), so the
+    # public names stay visible to tooling without importing livekit at runtime.
+    from voicegateway import inference
+    from voicegateway.inference.llm_inference import LLM
+    from voicegateway.inference.stt_inference import STT
+    from voicegateway.inference.tts_inference import TTS
+
+__all__ = [
+    "LLM",
+    "STT",
+    "TTS",
+    "attach",
+    "inference",
+    "register_worker",
+    "__version__",
+]
+
+# Names exposed lazily via PEP 562 __getattr__. Each pulls livekit on first
+# access, so they must not be imported at module load (that would break core
+# framework neutrality).
+_LAZY = {
+    "LLM": ("voicegateway.inference.llm_inference", "LLM"),
+    "STT": ("voicegateway.inference.stt_inference", "STT"),
+    "TTS": ("voicegateway.inference.tts_inference", "TTS"),
+    "inference": ("voicegateway.inference", None),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve framework-pulling public names (PEP 562).
+
+    Keeps ``import voicegateway`` free of any framework import while preserving
+    ``voicegateway.LLM``/``STT``/``TTS`` and the ``voicegateway.inference``
+    submodule as attribute-access entry points.
+    """
+    target = _LAZY.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    module_name, attr = target
+    module = importlib.import_module(module_name)
+    value = module if attr is None else getattr(module, attr)
+    # Cache on the module so subsequent lookups skip __getattr__.
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__) | set(globals()))

--- a/src/voicegateway/_frameworks.py
+++ b/src/voicegateway/_frameworks.py
@@ -1,0 +1,81 @@
+"""Framework detection and missing-extra errors (no eager framework imports).
+
+The engine core is framework-neutral: ``import voicegateway`` must not import
+``livekit`` or ``pipecat``. ``attach()`` and (later) ``guard()`` need to decide
+which framework a target object belongs to and, when the matching extra is not
+installed, raise a clear, actionable error. Both helpers here do that purely by
+inspecting the object's type/module string, so importing this module (or calling
+``detect_framework``) never imports either framework.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Import name each extra makes available, for the "is it installed?" check.
+# Extras whose distribution name differs from the import name go here; anything
+# not listed falls back to the extra name itself.
+_EXTRA_IMPORT = {
+    "livekit": "livekit",
+    "pipecat": "pipecat",
+}
+
+
+def detect_framework(obj: Any) -> str:
+    """Return the framework a target object belongs to, without importing it.
+
+    Inspects ``type(obj).__module__`` (and the object's own ``__module__`` when
+    it is itself a class) for a top-level package prefix. Returns one of:
+
+    - ``"livekit"`` when the defining module is under the ``livekit`` package
+      (e.g. ``livekit.agents.llm``, ``livekit.agents.voice.agent_session``).
+    - ``"pipecat"`` when the defining module is under the ``pipecat`` package
+      (e.g. ``pipecat.services.openai.llm``, ``pipecat.pipeline.task``).
+    - ``"unknown"`` for anything else.
+
+    No framework is imported: only the already-set ``__module__`` string on the
+    object (or its type) is read.
+    """
+    # A class carries its own __module__; an instance's class carries it. Prefer
+    # the object's own __module__ when obj is a class so callers can pass either.
+    module = getattr(obj, "__module__", None)
+    if not isinstance(module, str) or not isinstance(obj, type):
+        module = getattr(type(obj), "__module__", "")
+    if not isinstance(module, str):
+        return "unknown"
+
+    root = module.split(".", 1)[0]
+    if root == "livekit":
+        return "livekit"
+    if root == "pipecat":
+        return "pipecat"
+    return "unknown"
+
+
+def _extra_installed(extra: str) -> bool:
+    """Whether the framework backing ``extra`` is importable, without importing it."""
+    import importlib.util
+
+    import_name = _EXTRA_IMPORT.get(extra, extra)
+    try:
+        return importlib.util.find_spec(import_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def require_extra(extra: str) -> None:
+    """Raise a clear ImportError with a pip hint if ``extra`` is not installed.
+
+    Example message: ``"voicegateway[pipecat] is required for this operation.
+    Install it with: pip install voicegateway[pipecat]"``. A no-op when the
+    backing framework is already importable.
+    """
+    if _extra_installed(extra):
+        return
+    hint = f"pip install voicegateway[{extra}]"
+    raise ImportError(
+        f"voicegateway[{extra}] is required for this operation. Install it with: {hint}"
+    )
+
+
+__all__ = ["detect_framework", "require_extra"]

--- a/src/voicegateway/inference/__init__.py
+++ b/src/voicegateway/inference/__init__.py
@@ -1,11 +1,25 @@
-"""Drop-in mirror of `livekit.agents.inference` backed by VoiceGateway."""
+"""Drop-in mirror of `livekit.agents.inference` backed by VoiceGateway.
+
+Framework-neutral: importing this package does NOT import ``livekit``. The
+``LLM``/``STT``/``TTS`` factories are LiveKit-plugin factories that pull
+``livekit`` on first use, so they are resolved lazily via a module-level
+``__getattr__`` (PEP 562). The remaining names (``attach``, ``attach_session``,
+``start_session``, ``get_active_project``, ``set_project``) are framework-neutral
+and imported eagerly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from voicegateway.core.active_project import get_active_project, set_project
-from voicegateway.inference.llm_inference import LLM
 from voicegateway.inference.session.attach import attach, attach_session
 from voicegateway.inference.session.context import start_session
-from voicegateway.inference.stt_inference import STT
-from voicegateway.inference.tts_inference import TTS
+
+if TYPE_CHECKING:
+    from voicegateway.inference.llm_inference import LLM
+    from voicegateway.inference.stt_inference import STT
+    from voicegateway.inference.tts_inference import TTS
 
 __all__ = [
     "LLM",
@@ -17,3 +31,28 @@ __all__ = [
     "set_project",
     "start_session",
 ]
+
+# Names that pull livekit on first access. Kept out of module-load imports so
+# `import voicegateway.inference` stays framework-neutral.
+_LAZY = {
+    "LLM": ("voicegateway.inference.llm_inference", "LLM"),
+    "STT": ("voicegateway.inference.stt_inference", "STT"),
+    "TTS": ("voicegateway.inference.tts_inference", "TTS"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve the LiveKit-plugin factories (PEP 562)."""
+    target = _LAZY.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    module_name, attr = target
+    value = getattr(importlib.import_module(module_name), attr)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__) | set(globals()))

--- a/src/voicegateway/tests/test_framework_neutral.py
+++ b/src/voicegateway/tests/test_framework_neutral.py
@@ -1,0 +1,108 @@
+"""Framework-neutrality guarantees for the VoiceGateway core.
+
+`import voicegateway` must import neither ``livekit`` nor ``pipecat``, even
+though at least one of them is installed in the dev environment. The
+``LLM``/``STT``/``TTS`` factories stay importable (they pull the framework only
+on first attribute access), and ``detect_framework`` classifies objects by their
+module string without importing either framework.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from voicegateway._frameworks import detect_framework, require_extra
+
+
+def test_core_import_pulls_no_framework() -> None:
+    """A bare `import voicegateway` must not import livekit or pipecat.
+
+    Run in a fresh subprocess so the assertion sees a clean ``sys.modules`` (the
+    test process itself may already have imported livekit via other tests).
+    """
+    code = (
+        "import voicegateway, sys; "
+        "assert 'livekit' not in sys.modules, 'livekit eagerly imported'; "
+        "assert 'pipecat' not in sys.modules, 'pipecat eagerly imported'; "
+        "print('PURE')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import voicegateway pulled a framework.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "PURE" in result.stdout
+
+
+class _FakeType:
+    """A stand-in whose class __module__ can be forced for detection tests."""
+
+
+def _obj_with_module(module: str) -> object:
+    """Return an instance whose ``type(...).__module__`` is ``module``."""
+    cls = type("Fake", (), {})
+    cls.__module__ = module
+    return cls()
+
+
+def test_detect_framework_livekit() -> None:
+    assert detect_framework(_obj_with_module("livekit.agents.llm")) == "livekit"
+    assert (
+        detect_framework(_obj_with_module("livekit.agents.voice.agent_session"))
+        == "livekit"
+    )
+
+
+def test_detect_framework_pipecat() -> None:
+    assert detect_framework(_obj_with_module("pipecat.services.openai")) == "pipecat"
+    assert detect_framework(_obj_with_module("pipecat.pipeline.task")) == "pipecat"
+
+
+def test_detect_framework_unknown() -> None:
+    assert detect_framework(_obj_with_module("builtins")) == "unknown"
+    assert detect_framework(object()) == "unknown"
+    assert detect_framework(_obj_with_module("livekitten.fake")) == "unknown"
+
+
+def test_detect_framework_accepts_class_directly() -> None:
+    """Passing a class (not an instance) reads the class's own __module__."""
+    cls = type("Svc", (), {})
+    cls.__module__ = "pipecat.services.cartesia.tts"
+    assert detect_framework(cls) == "pipecat"
+
+
+def test_require_extra_present_is_noop() -> None:
+    """livekit is installed in the dev env, so require_extra('livekit') passes."""
+    require_extra("livekit")
+
+
+def test_require_extra_missing_raises_with_hint() -> None:
+    """A missing extra raises ImportError carrying the pip install hint."""
+    import importlib.util
+
+    if importlib.util.find_spec("definitely_not_a_framework") is not None:
+        return  # pragma: no cover - guard against an impossible name colliding
+    try:
+        require_extra("definitely_not_a_framework")
+    except ImportError as exc:
+        assert "pip install voicegateway[definitely_not_a_framework]" in str(exc)
+    else:  # pragma: no cover - require_extra must raise for a missing extra
+        raise AssertionError("require_extra did not raise for a missing extra")
+
+
+def test_lazy_llm_still_importable() -> None:
+    """Accessing voicegateway.LLM triggers the lazy import and returns a factory.
+
+    livekit is installed in the dev env, so the lazy import succeeds and yields a
+    callable. This proves the deferral did not break the public factory.
+    """
+    import voicegateway
+
+    assert callable(voicegateway.LLM)
+    assert callable(voicegateway.STT)
+    assert callable(voicegateway.TTS)


### PR DESCRIPTION
P0 of the framework-neutral program (spec: docs/superpowers/specs/2026-07-09-framework-neutral-attach-guard-design.md). NON-BREAKING and additive.

## What
- `livekit-agents` moves from core deps into a `livekit` extra; new `pipecat = ["pipecat-ai>=1.5.0,<2.0"]` extra. Provider extras (openai/deepgram/...) and `dev` imply `voicegateway[livekit]`, so those installs stay unchanged.
- `import voicegateway` now pulls ZERO framework: `LLM/STT/TTS` and the `inference` submodule resolve lazily via PEP 562 `__getattr__`; `attach`/`register_worker` stay eager (they don't import a framework).
- New `voicegateway/_frameworks.py`: `detect_framework(obj)` (module-string sniff, no import) + `require_extra(extra)` (ImportError with a pip hint), for attach()/guard() to use.

## Verification
- Purity: `import voicegateway` in a subprocess -> `livekit`/`pipecat` NOT in sys.modules (`PURE`).
- New suite: 8 passed.
- Baseline vs post failing-test-ID sets are byte-identical (119 pre-existing failures unchanged, +8 new passing). No new failures.

## Cross-repo note (not a blocker; SHA-pinned consumers unaffected now)
Bare `pip install voicegateway` no longer includes livekit. Consumers that import `voicegateway.livekit_diag` or the inference factories must install `voicegateway[livekit]`. The cloud/admin pin the engine by SHA, so they are unaffected until they next bump the pin (then add `[livekit]` if they use those modules).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The core package can now be installed without the LiveKit runtime by default.
  * Added optional LiveKit support as a separate install extra.
  * Provider-specific and dev installs now bring in the required runtime automatically.
  * Top-level APIs now load on demand, improving import flexibility.
* **Bug Fixes**
  * Importing the package no longer eagerly pulls in framework-specific dependencies.
  * Clearer install guidance is shown when an optional extra is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->