### PR TITLE
feat(livekit): single-meter attach + control-only guard()

### DIFF
--- a/src/voicegateway/__init__.py
+++ b/src/voicegateway/__init__.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 from voicegateway._version import __version__
 from voicegateway.fleet.worker import register_worker
+from voicegateway.guard import guard
 from voicegateway.inference.session.attach import attach
 
 if TYPE_CHECKING:
@@ -34,6 +35,7 @@ __all__ = [
     "STT",
     "TTS",
     "attach",
+    "guard",
     "inference",
     "register_worker",
     "__version__",

--- a/src/voicegateway/_frameworks.py
+++ b/src/voicegateway/_frameworks.py
@@ -35,20 +35,37 @@ def detect_framework(obj: Any) -> str:
 
     No framework is imported: only the already-set ``__module__`` string on the
     object (or its type) is read.
+
+    A subclass of a framework base class (defined in user/library code outside
+    the framework package, e.g. a custom ``livekit.agents.llm.LLM`` subclass) is
+    still detected: the whole MRO's ``__module__`` strings are inspected, so the
+    inherited framework base is found. Only already-loaded classes are read; no
+    framework is imported to do this.
     """
     # A class carries its own __module__; an instance's class carries it. Prefer
     # the object's own __module__ when obj is a class so callers can pass either.
     module = getattr(obj, "__module__", None)
     if not isinstance(module, str) or not isinstance(obj, type):
         module = getattr(type(obj), "__module__", "")
-    if not isinstance(module, str):
-        return "unknown"
 
-    root = module.split(".", 1)[0]
+    root = module.split(".", 1)[0] if isinstance(module, str) else ""
     if root == "livekit":
         return "livekit"
     if root == "pipecat":
         return "pipecat"
+
+    # Fall back to the MRO: a subclass defined outside the framework package
+    # still inherits from a framework base whose __module__ names the framework.
+    cls = obj if isinstance(obj, type) else type(obj)
+    for base in getattr(cls, "__mro__", ()):
+        base_module = getattr(base, "__module__", "")
+        if not isinstance(base_module, str):
+            continue
+        base_root = base_module.split(".", 1)[0]
+        if base_root == "livekit":
+            return "livekit"
+        if base_root == "pipecat":
+            return "pipecat"
     return "unknown"
 
 

--- a/src/voicegateway/guard.py
+++ b/src/voicegateway/guard.py
@@ -1,0 +1,178 @@
+"""``voicegateway.guard()``: the active control wrapper (framework-neutral).
+
+``guard()`` is the *control* seam that composes with ``attach()`` (the *observe*
+seam). Where ``attach()`` passively meters cost + latency, ``guard()`` actively
+wraps a native provider to add:
+
+- **fallback**: on a primary-provider error, try each fallback provider in order.
+  Before the fallback runs, guard sets a ContextVar so ``attach()`` stamps
+  ``fallback_from=<primary>`` and ``status="fallback"`` on the record it writes
+  for the provider that actually ran.
+- **rate_limit**: a token bucket parsed from a DSL string (``"60/min"``,
+  ``"5/s"``) via the core rate-limiter.
+- **budget**: query the core's accumulated spend for the window and block (raise)
+  when over, parsed from a DSL string (``"$5.00/day"``, ``"$100/month"``).
+
+``guard()`` writes **no** metrics itself: ``attach()`` is the sole meter, so
+``guard(provider)`` + ``attach(session)`` never double-counts.
+
+This module is framework-neutral: importing it (and the neutral ``guard``
+dispatcher) imports **no** framework. The dispatcher detects the provider's
+framework by module string and lazily imports the matching implementation only
+on first use, so ``import voicegateway`` stays pure.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from voicegateway._frameworks import detect_framework, require_extra
+
+# --- DSL parsing -----------------------------------------------------------
+
+# "N/min", "N/s", "N/sec", "N/minute". Whitespace tolerant.
+_RATE_RE = re.compile(
+    r"^\s*(?P<count>\d+(?:\.\d+)?)\s*/\s*(?P<unit>s|sec|second|m|min|minute)\s*$",
+    re.IGNORECASE,
+)
+
+# "$X/day", "X/day", "$X/month". The leading $ is optional; whitespace tolerant.
+_BUDGET_RE = re.compile(
+    r"^\s*\$?\s*(?P<amount>\d+(?:\.\d+)?)\s*/\s*(?P<window>day|month)\s*$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class RateLimitSpec:
+    """A parsed rate limit: ``requests`` per ``per_seconds`` window."""
+
+    requests: int
+    per_seconds: float
+
+    @property
+    def requests_per_minute(self) -> int:
+        """Requests normalized to a per-minute figure for the core limiter."""
+        rpm = self.requests * (60.0 / self.per_seconds)
+        # The core RateLimiter counts whole requests per minute; round to the
+        # nearest integer, but never below 1 for a positive spec.
+        return max(1, round(rpm))
+
+
+@dataclass(frozen=True)
+class BudgetSpec:
+    """A parsed spend cap: ``amount_usd`` per ``window`` ("day" | "month")."""
+
+    amount_usd: float
+    window: str  # "day" | "month"
+
+    @property
+    def period(self) -> str:
+        """Map the window onto the cost-repository period vocabulary."""
+        # The cost repository speaks "today"/"week"/"month"; a daily cap maps to
+        # "today" (spend since local midnight).
+        return "today" if self.window == "day" else "month"
+
+
+def parse_rate_limit(spec: str) -> RateLimitSpec:
+    """Parse a rate-limit DSL string (``"60/min"``, ``"5/s"``) -> RateLimitSpec."""
+    match = _RATE_RE.match(spec)
+    if match is None:
+        raise ValueError(
+            f"invalid rate_limit {spec!r}; expected e.g. '60/min' or '5/s'"
+        )
+    count = float(match.group("count"))
+    unit = match.group("unit").lower()
+    per_seconds = 1.0 if unit in ("s", "sec", "second") else 60.0
+    requests = int(count)
+    if requests <= 0:
+        raise ValueError(f"rate_limit {spec!r} must be a positive request count")
+    return RateLimitSpec(requests=requests, per_seconds=per_seconds)
+
+
+def parse_budget(spec: str) -> BudgetSpec:
+    """Parse a budget DSL string (``"$5.00/day"``, ``"100/month"``) -> BudgetSpec."""
+    match = _BUDGET_RE.match(spec)
+    if match is None:
+        raise ValueError(
+            f"invalid budget {spec!r}; expected e.g. '$5.00/day' or '$100/month'"
+        )
+    amount = float(match.group("amount"))
+    window = match.group("window").lower()
+    if amount < 0:
+        raise ValueError(f"budget {spec!r} must be a non-negative amount")
+    return BudgetSpec(amount_usd=amount, window=window)
+
+
+# --- neutral dispatcher ----------------------------------------------------
+
+
+def guard(
+    provider: Any,
+    *,
+    fallback: Any = (),
+    rate_limit: str | None = None,
+    budget: str | None = None,
+    project: str | None = None,
+) -> Any:
+    """Wrap a native provider with control (fallback / rate-limit / budget).
+
+    Returns a drop-in wrapper of the SAME framework type as ``provider`` (e.g. a
+    ``livekit.agents.llm.LLM`` subclass for a LiveKit LLM plugin), so it slots
+    into an ``AgentSession`` unchanged. The wrapper writes no metrics; pair it
+    with ``attach(session)`` for cost + latency.
+
+    Args:
+        provider: a native framework provider (a LiveKit plugin here).
+        fallback: an ordered list of same-framework providers to try, in order,
+            when the primary raises. attach stamps ``fallback_from`` on the row
+            for whichever provider actually produced the result.
+        rate_limit: a DSL string like ``"60/min"`` or ``"5/s"``. When the bucket
+            is empty the guarded call raises ``RateLimitExceeded``.
+        budget: a DSL string like ``"$5.00/day"`` or ``"$100/month"``. When the
+            window's accumulated spend is at/over the cap the call raises
+            ``BudgetExceededError``.
+        project: project id used for budget lookups + record tagging. Defaults to
+            the active project.
+
+    Raises:
+        ImportError: when the provider's framework extra is not installed.
+        ValueError: when ``rate_limit`` / ``budget`` cannot be parsed, or the
+            provider's framework is not recognized.
+    """
+    framework = detect_framework(provider)
+    if framework == "livekit":
+        require_extra("livekit")
+        # Lazy: importing the LiveKit impl pulls livekit.agents. Keeping it out
+        # of module scope is what preserves ``import voicegateway`` purity.
+        from voicegateway.inference.livekit.guard_livekit import guard_livekit
+
+        return guard_livekit(
+            provider,
+            fallback=fallback,
+            rate_limit=rate_limit,
+            budget=budget,
+            project=project,
+        )
+    if framework == "pipecat":
+        # P3 delivers the Pipecat control wrapper; until then, be explicit.
+        raise NotImplementedError(
+            "voicegateway.guard() does not yet support Pipecat providers "
+            "(coming in a later phase). Use guard() with LiveKit providers."
+        )
+    raise ValueError(
+        "voicegateway.guard() could not detect the framework of "
+        f"{type(provider).__name__!r}. Pass a native LiveKit provider "
+        "(e.g. a livekit.plugins.* STT/LLM/TTS instance)."
+    )
+
+
+__all__ = [
+    "BudgetSpec",
+    "RateLimitSpec",
+    "guard",
+    "parse_budget",
+    "parse_rate_limit",
+]

--- a/src/voicegateway/inference/base_inference.py
+++ b/src/voicegateway/inference/base_inference.py
@@ -29,6 +29,7 @@ plain ``plugin_kwargs: dict[str, Any]`` and delegates to ``cls._build``.
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
@@ -43,6 +44,28 @@ if TYPE_CHECKING:
     pass
 
 _LOCAL_PROVIDERS = frozenset({"ollama", "whisper", "kokoro", "piper"})
+
+_DEPRECATION_MESSAGE = (
+    "voicegateway.LLM/STT/TTS are deprecated. Construct the native provider "
+    "directly and observe it with voicegateway.attach() (the sole meter); add "
+    "voicegateway.guard() for fallback / rate-limit / budget control. The "
+    "factories still work but no longer meter (attach does), and will be "
+    "removed in a future major release."
+)
+
+# Fire the DeprecationWarning at most once per process, regardless of how many
+# times the factories are called, so long-running agents that build many
+# plugins do not spam the log.
+_deprecation_emitted = False
+
+
+def _warn_deprecated_factory() -> None:
+    """Emit the LLM/STT/TTS deprecation warning once per process."""
+    global _deprecation_emitted
+    if _deprecation_emitted:
+        return
+    _deprecation_emitted = True
+    warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=3)
 
 
 class InferenceFactory(ABC):
@@ -118,8 +141,18 @@ class InferenceFactory(ABC):
         model_name: str,
         plugin_kwargs: dict[str, Any],
         api_key_override: str | None,
+        guard_policy: dict[str, Any] | None = None,
     ) -> Any:
-        """Shared factory flow: session id, config, key check, create, wrap."""
+        """Shared factory flow: session id, config, key check, create, wrap.
+
+        DEPRECATED path: emits a ``DeprecationWarning`` (once) and returns a
+        control-only wrapper built with ``metering=False`` so ``attach()`` is
+        the sole meter (no double-count). Passing ``guard_policy`` (e.g.
+        ``{"fallback": [...], "rate_limit": "60/min", "budget": "$5/day"}``)
+        adds control via ``voicegateway.guard()``.
+        """
+        _warn_deprecated_factory()
+
         get_or_create_session_id()
 
         gateway = get_gateway()
@@ -138,6 +171,16 @@ class InferenceFactory(ABC):
 
         plugin = cls._create_plugin(provider_instance, model_name, plugin_kwargs)
 
+        if guard_policy:
+            # Control wrapper (guard) also meters nothing; attach still observes.
+            from voicegateway.guard import guard as _guard
+
+            return _guard(plugin, project=project, **guard_policy)
+
+        # metering=False: the factory no longer writes RequestRecords. It still
+        # returns a wrapper (with _log_request/_modality/label intact) so
+        # existing drop-in call sites keep working, but attach() is the sole
+        # meter. The wrapper forwards metrics_collected transparently.
         return wrap_provider(
             instance=plugin,
             modality=cls._modality,
@@ -146,6 +189,7 @@ class InferenceFactory(ABC):
             project=project,
             cost_tracker=gateway._cost_tracker,
             storage=gateway._storage,
+            metering=False,
         )
 
 

--- a/src/voicegateway/inference/livekit/__init__.py
+++ b/src/voicegateway/inference/livekit/__init__.py
@@ -1,0 +1,7 @@
+"""LiveKit-scoped VoiceGateway internals (import ``livekit`` on load).
+
+Modules under this package subclass ``livekit.agents`` types and therefore
+import ``livekit`` when imported. They are loaded lazily by the framework-neutral
+``voicegateway.guard()`` dispatcher, so importing ``voicegateway`` itself stays
+free of any framework import.
+"""

--- a/src/voicegateway/inference/livekit/guard_livekit.py
+++ b/src/voicegateway/inference/livekit/guard_livekit.py
@@ -1,0 +1,498 @@
+"""LiveKit implementation of ``voicegateway.guard()`` (control-only).
+
+Importing this module imports ``livekit.agents`` (it subclasses the plugin base
+classes), so it is loaded lazily by the neutral ``voicegateway.guard`` dispatcher.
+
+The guard wrappers are the ``Instrumented{STT,LLM,TTS}`` control shells built with
+``metering=False``: they subclass the matching ``livekit.agents`` type (so they
+drop into an ``AgentSession``), forward the inner plugin's ``metrics_collected``
+events transparently (so ``attach()`` meters them once), and write NO records
+themselves. On top of that shell they add the control layer:
+
+- **rate_limit**: an async token-bucket check before the call (core RateLimiter).
+- **budget**: an async accumulated-spend check before the call (core spend read).
+- **fallback**: on a primary-provider error, try each fallback in order, setting
+  the guard ContextVar so ``attach`` stamps ``fallback_from`` + ``status="fallback"``
+  on the row for the provider that actually ran.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN
+
+from voicegateway.guard import BudgetSpec, RateLimitSpec, parse_budget, parse_rate_limit
+from voicegateway.inference.session.capture import component_identity
+from voicegateway.inference.session.context import (
+    set_guard_fallback_from,
+)
+from voicegateway.middleware.budget_enforcer_middleware import BudgetExceededError
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
+from voicegateway.middleware.instrumented_provider_middleware import (
+    InstrumentedLLM,
+    InstrumentedSTT,
+    InstrumentedTTS,
+)
+from voicegateway.middleware.rate_limiter_middleware import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+
+def _default_spend_reader(project: str, period: str) -> float:
+    """Read accumulated spend for ``project`` over ``period`` from the gateway.
+
+    Returns 0.0 when there is no configured storage (nothing to enforce
+    against). Never raises: a spend-read failure must not wedge the call path,
+    so guard fails open (treats spend as 0) and logs.
+    """
+    try:
+        from voicegateway.core.gateway_factory import get_gateway
+
+        gateway = get_gateway()
+        storage = gateway.storage
+    except Exception:  # noqa: BLE001 - no gateway/storage configured
+        return 0.0
+    if storage is None:
+        return 0.0
+    try:
+        import asyncio
+
+        summary = asyncio.run(storage.get_cost_summary(period, project=project))
+        return float(summary.get("total", 0.0) or 0.0)
+    except RuntimeError:
+        # Already inside a running loop; the async control path uses the async
+        # reader instead. This sync path is a best-effort fallback only.
+        return 0.0
+    except Exception:  # noqa: BLE001
+        logger.warning("guard: spend read failed; treating as $0", exc_info=True)
+        return 0.0
+
+
+async def _async_default_spend_reader(project: str, period: str) -> float:
+    """Async accumulated-spend read from the gateway storage (fails open at 0)."""
+    try:
+        from voicegateway.core.gateway_factory import get_gateway
+
+        gateway = get_gateway()
+        storage = gateway.storage
+    except Exception:  # noqa: BLE001
+        return 0.0
+    if storage is None:
+        return 0.0
+    try:
+        summary = await storage.get_cost_summary(project=project, period=period)
+        return float(summary.get("total", 0.0) or 0.0)
+    except Exception:  # noqa: BLE001
+        logger.warning("guard: spend read failed; treating as $0", exc_info=True)
+        return 0.0
+
+
+class GuardControl:
+    """Framework-neutral control core for a guarded provider.
+
+    Holds the parsed rate-limit / budget specs, the ordered fallback list, and
+    the coordination that stamps ``fallback_from`` via a ContextVar. The LiveKit
+    wrappers delegate their pre-call checks and fallback selection here so the
+    logic is testable without a live provider.
+    """
+
+    def __init__(
+        self,
+        primary: Any,
+        *,
+        fallback: Any = (),
+        rate_limit: str | None = None,
+        budget: str | None = None,
+        project: str | None = None,
+        spend_reader: Any = None,
+    ) -> None:
+        self._primary = primary
+        self._fallbacks: list[Any] = list(fallback or ())
+        self._project = project or "default"
+        self._rate_spec: RateLimitSpec | None = (
+            parse_rate_limit(rate_limit) if rate_limit else None
+        )
+        self._budget_spec: BudgetSpec | None = parse_budget(budget) if budget else None
+        # The primary provider id, used as the ``fallback_from`` marker.
+        self._primary_provider, _ = component_identity(primary)
+        # One shared token bucket keyed by the primary provider id.
+        self._rate_limiter: RateLimiter | None = None
+        if self._rate_spec is not None:
+            self._rate_limiter = RateLimiter(
+                {
+                    self._primary_provider: {
+                        "requests_per_minute": self._rate_spec.requests_per_minute
+                    }
+                }
+            )
+        self._spend_reader = spend_reader or _async_default_spend_reader
+
+    async def check_rate_limit(self) -> None:
+        """Raise ``RateLimitExceeded`` when the bucket is empty; else consume one."""
+        if self._rate_limiter is None:
+            return
+        await self._rate_limiter.acquire(self._primary_provider)
+
+    async def check_budget(self) -> None:
+        """Raise ``BudgetExceededError`` when the window's spend is at/over cap."""
+        if self._budget_spec is None:
+            return
+        spent = await self._call_spend_reader(self._project, self._budget_spec.period)
+        if spent >= self._budget_spec.amount_usd:
+            raise BudgetExceededError(
+                self._project, float(spent), self._budget_spec.amount_usd
+            )
+
+    async def _call_spend_reader(self, project: str, period: str) -> float:
+        import inspect
+
+        result = self._spend_reader(project, period)
+        if inspect.isawaitable(result):
+            result = await result
+        return float(result)
+
+    async def preflight(self) -> None:
+        """Run all pre-call control gates (budget then rate limit)."""
+        await self.check_budget()
+        await self.check_rate_limit()
+
+    def providers_in_order(self) -> list[Any]:
+        """The primary followed by each fallback, in the order they are tried."""
+        return [self._primary, *self._fallbacks]
+
+    async def run_with_fallback(self, invoke: Any) -> Any:
+        """Run ``invoke(provider)`` on the primary, then each fallback in order.
+
+        ``invoke`` is an async callable taking a provider and returning the
+        provider's result. On the primary's error, guard stamps the primary as
+        ``fallback_from`` (via the ContextVar attach reads) BEFORE running the
+        next provider, so the row attach writes for the provider that succeeds
+        carries ``fallback_from=<primary>`` + ``status="fallback"``. Re-raises the
+        last error when every provider fails.
+        """
+        providers = self.providers_in_order()
+        last_error: Exception | None = None
+        for index, provider in enumerate(providers):
+            if index == 0:
+                # Primary attempt: clear any stale fallback marker.
+                set_guard_fallback_from(None)
+            else:
+                set_guard_fallback_from(self._primary_provider)
+            try:
+                return await invoke(provider)
+            except Exception as exc:  # noqa: BLE001 - normalize across providers
+                last_error = exc
+                logger.warning(
+                    "guard: provider %s failed (%s); trying next",
+                    component_identity(provider)[0],
+                    type(exc).__name__,
+                )
+                continue
+        # Everything failed: clear the marker and re-raise the last error.
+        set_guard_fallback_from(None)
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("guard: no providers to run")
+
+    async def iterate_with_fallback(self, open_stream: Any) -> Any:
+        """Yield items from the primary stream; fall back on a PRE-FIRST-TOKEN error.
+
+        LK LLM/TTS surface provider errors during iteration, not when the stream
+        object is created. So for each provider (primary, then fallbacks), guard
+        opens the stream via ``open_stream(provider)`` and starts iterating. If an
+        error occurs BEFORE any item is yielded, guard moves to the next provider
+        (stamping the primary as ``fallback_from`` for attach). Once an item has
+        been yielded, an error can no longer be recovered and propagates: the
+        downstream consumer already saw partial output.
+        """
+        providers = self.providers_in_order()
+        last_error: Exception | None = None
+        for index, provider in enumerate(providers):
+            if index == 0:
+                set_guard_fallback_from(None)
+            else:
+                set_guard_fallback_from(self._primary_provider)
+            yielded_any = False
+            try:
+                stream = open_stream(provider)
+                async for item in stream:
+                    yielded_any = True
+                    yield item
+                return
+            except Exception as exc:  # noqa: BLE001 - normalize across providers
+                if yielded_any:
+                    # Partial output already delivered; cannot recover.
+                    set_guard_fallback_from(None)
+                    raise
+                last_error = exc
+                logger.warning(
+                    "guard: provider %s stream failed before first token (%s); "
+                    "trying next",
+                    component_identity(provider)[0],
+                    type(exc).__name__,
+                )
+                continue
+        set_guard_fallback_from(None)
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("guard: no providers to run")
+
+
+# --- LiveKit wrappers ------------------------------------------------------
+#
+# Each subclasses the metering shell with ``metering=False`` (attach is the sole
+# meter) and layers the control core over the primary call method.
+
+
+def _noop_cost_tracker() -> CostTracker:
+    """A CostTracker with no storage; the shell needs one but never meters here."""
+    return CostTracker(storage=None)
+
+
+class GuardedSTT(InstrumentedSTT):
+    """Control-only STT guard: rate-limit / budget / fallback, no metering."""
+
+    def __init__(self, control: GuardControl, **kwargs: Any) -> None:
+        super().__init__(metering=False, **kwargs)
+        self._control = control
+
+    async def _recognize_impl(
+        self,
+        buffer: Any,
+        *,
+        language: Any = NOT_GIVEN,
+        conn_options: Any = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> Any:
+        await self._control.preflight()
+
+        async def _invoke(provider: Any) -> Any:
+            return await provider._recognize_impl(
+                buffer, language=language, conn_options=conn_options
+            )
+
+        return await self._control.run_with_fallback(_invoke)
+
+    async def recognize(
+        self,
+        buffer: Any,
+        *,
+        language: Any = NOT_GIVEN,
+        conn_options: Any = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> Any:
+        await self._control.preflight()
+
+        async def _invoke(provider: Any) -> Any:
+            return await provider.recognize(
+                buffer, language=language, conn_options=conn_options
+            )
+
+        return await self._control.run_with_fallback(_invoke)
+
+
+class GuardedLLM(InstrumentedLLM):
+    """Control-only LLM guard: rate-limit / budget / fallback, no metering."""
+
+    def __init__(self, control: GuardControl, **kwargs: Any) -> None:
+        super().__init__(metering=False, **kwargs)
+        self._control = control
+
+    def chat(
+        self,
+        *,
+        chat_ctx: Any,
+        tools: Any = None,
+        conn_options: Any = DEFAULT_API_CONNECT_OPTIONS,
+        parallel_tool_calls: Any = NOT_GIVEN,
+        tool_choice: Any = NOT_GIVEN,
+        extra_kwargs: Any = NOT_GIVEN,
+    ) -> Any:
+        # LK's chat() returns a stream synchronously and surfaces errors during
+        # iteration, so control (async preflight + fallback) runs inside a
+        # guard stream wrapper that performs the checks before delegating.
+        return _GuardLLMStream(
+            control=self._control,
+            chat_ctx=chat_ctx,
+            tools=tools,
+            conn_options=conn_options,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            extra_kwargs=extra_kwargs,
+        )
+
+
+class _GuardLLMStream:
+    """Lazy guard stream: runs preflight + fallback on first iteration.
+
+    Duck-typed to LK's async-iterable LLM stream. The heavy control work runs
+    once, when the caller starts consuming the stream, so a synchronous
+    ``chat()`` return does not need to block on the async gates.
+    """
+
+    def __init__(self, *, control: GuardControl, **chat_kwargs: Any) -> None:
+        self._control = control
+        self._chat_kwargs = chat_kwargs
+
+    def __aiter__(self) -> Any:
+        return self._agen()
+
+    async def _agen(self) -> Any:
+        # Rate-limit / budget gates run once, before any provider is opened.
+        await self._control.preflight()
+
+        def _open(provider: Any) -> Any:
+            return provider.chat(**self._chat_kwargs)
+
+        async for item in self._control.iterate_with_fallback(_open):
+            yield item
+
+    async def aclose(self) -> None:
+        return None
+
+    async def __aenter__(self) -> Any:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+
+class GuardedTTS(InstrumentedTTS):
+    """Control-only TTS guard: rate-limit / budget / fallback, no metering."""
+
+    def __init__(self, control: GuardControl, **kwargs: Any) -> None:
+        super().__init__(metering=False, **kwargs)
+        self._control = control
+
+    def synthesize(
+        self, text: str, *, conn_options: Any = DEFAULT_API_CONNECT_OPTIONS
+    ) -> Any:
+        return _GuardTTSStream(
+            control=self._control,
+            method="synthesize",
+            args=(text,),
+            conn_options=conn_options,
+        )
+
+    def stream(self, *, conn_options: Any = DEFAULT_API_CONNECT_OPTIONS) -> Any:
+        return _GuardTTSStream(
+            control=self._control,
+            method="stream",
+            args=(),
+            conn_options=conn_options,
+        )
+
+
+class _GuardTTSStream:
+    """Lazy guard stream for TTS synthesize()/stream() (mirrors the LLM stream)."""
+
+    def __init__(
+        self,
+        *,
+        control: GuardControl,
+        method: str,
+        args: tuple[Any, ...],
+        conn_options: Any,
+    ) -> None:
+        self._control = control
+        self._method = method
+        self._args = args
+        self._conn_options = conn_options
+
+    def __aiter__(self) -> Any:
+        return self._agen()
+
+    async def _agen(self) -> Any:
+        await self._control.preflight()
+
+        def _open(provider: Any) -> Any:
+            method = getattr(provider, self._method)
+            return method(*self._args, conn_options=self._conn_options)
+
+        async for item in self._control.iterate_with_fallback(_open):
+            yield item
+
+    async def aclose(self) -> None:
+        return None
+
+    async def __aenter__(self) -> Any:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+
+_GUARD_CLS = {
+    "stt": GuardedSTT,
+    "llm": GuardedLLM,
+    "tts": GuardedTTS,
+}
+
+
+def _modality_of(provider: Any) -> str | None:
+    """Return the provider's modality by its livekit.agents base class."""
+    from livekit.agents import llm as lk_llm
+    from livekit.agents import stt as lk_stt
+    from livekit.agents import tts as lk_tts
+
+    if isinstance(provider, lk_stt.STT):
+        return "stt"
+    if isinstance(provider, lk_llm.LLM):
+        return "llm"
+    if isinstance(provider, lk_tts.TTS):
+        return "tts"
+    return None
+
+
+def guard_livekit(
+    provider: Any,
+    *,
+    fallback: Any = (),
+    rate_limit: str | None = None,
+    budget: str | None = None,
+    project: str | None = None,
+    spend_reader: Any = None,
+) -> Any:
+    """Build a control-only LiveKit guard wrapper around ``provider``.
+
+    Returns a ``livekit.agents.{stt,llm,tts}`` subclass wrapping ``provider``. The
+    wrapper meters nothing (attach is the sole meter); it adds fallback,
+    rate-limit, and budget control. ``spend_reader`` is an injectable
+    ``(project, period) -> float | awaitable`` for budget lookups (defaults to
+    the gateway storage); tests pass a fake to avoid a live DB.
+    """
+    modality = _modality_of(provider)
+    if modality is None:
+        raise ValueError(
+            f"guard(): {type(provider).__name__!r} is not a recognized LiveKit "
+            "STT/LLM/TTS provider"
+        )
+
+    control = GuardControl(
+        provider,
+        fallback=fallback,
+        rate_limit=rate_limit,
+        budget=budget,
+        project=project,
+        spend_reader=spend_reader,
+    )
+    provider_id, model_id = component_identity(provider)
+    wrapper_cls = _GUARD_CLS[modality]
+    return wrapper_cls(
+        control,
+        wrapped=provider,
+        model_id=model_id,
+        provider=provider_id,
+        project=project or "default",
+        cost_tracker=_noop_cost_tracker(),
+        storage=None,
+    )
+
+
+__all__ = [
+    "GuardControl",
+    "GuardedLLM",
+    "GuardedSTT",
+    "GuardedTTS",
+    "guard_livekit",
+]

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -253,6 +253,19 @@ class MetricCapture:
             status = (
                 "cancelled" if bool(getattr(metric, "cancelled", False)) else "success"
             )
+            # guard() coordination: if the active call fell back from a primary
+            # provider (guard set the ContextVar before the fallback ran), stamp
+            # the primary on this row and mark it a fallback. attach stays the
+            # sole meter; guard writes nothing itself.
+            from voicegateway.inference.session.context import (
+                current_guard_fallback_from,
+            )
+
+            fallback_from = current_guard_fallback_from()
+            if fallback_from is not None and fallback_from != provider:
+                status = "fallback"
+            else:
+                fallback_from = None
             record = self._cost_tracker.create_record(
                 model_id=model_id,
                 modality=modality,
@@ -263,6 +276,7 @@ class MetricCapture:
                 cached_input_units=cached,
                 ttfb_ms=ttfb_ms,
                 status=status,
+                fallback_from=fallback_from,
                 session_id=self._session_id,
                 agent_id=self._agent_id,
             )

--- a/src/voicegateway/inference/session/context.py
+++ b/src/voicegateway/inference/session/context.py
@@ -169,3 +169,29 @@ def current_routing_decision() -> RoutingDecisionTuple | None:
 def reset_routing_decision() -> None:
     """Clear the routing decision (test-only helper)."""
     _current_routing_decision.set(None)
+
+
+# ``guard()`` fallback coordination. When a guarded call falls back from its
+# primary provider to a secondary one, guard sets this ContextVar to the primary
+# provider id BEFORE the fallback provider runs. ``attach()``'s MetricCapture
+# reads it when building the record for the provider that actually ran, so the
+# stored row carries ``fallback_from=<primary>`` and ``status="fallback"``.
+# guard and attach never call each other; this ContextVar is their only channel.
+_current_guard_fallback_from: ContextVar[str | None] = ContextVar(
+    "vg_guard_fallback_from", default=None
+)
+
+
+def set_guard_fallback_from(provider: str | None) -> None:
+    """Record the primary provider a guarded call fell back FROM (or clear it)."""
+    _current_guard_fallback_from.set(provider)
+
+
+def current_guard_fallback_from() -> str | None:
+    """Return the primary provider the active guarded call fell back from."""
+    return _current_guard_fallback_from.get()
+
+
+def reset_guard_fallback_from() -> None:
+    """Clear the guard fallback marker (test-only / turn-boundary helper)."""
+    _current_guard_fallback_from.set(None)

--- a/src/voicegateway/middleware/base_middleware.py
+++ b/src/voicegateway/middleware/base_middleware.py
@@ -84,6 +84,7 @@ class InstrumentationMixin:
     project: str
     _cost_tracker: CostTracker
     _storage: StorageService | None
+    _metering: bool
     _start_time: float
     _first_byte_time: float | None
     _logged: bool
@@ -98,6 +99,7 @@ class InstrumentationMixin:
         project: str,
         cost_tracker: CostTracker,
         storage: StorageService | None,
+        metering: bool = True,
     ) -> None:
         self._wrapped = wrapped
         self._model_id = model_id
@@ -105,6 +107,7 @@ class InstrumentationMixin:
         self.project = project
         self._cost_tracker = cost_tracker
         self._storage = storage
+        self._metering = metering
         self._start_time = time.perf_counter()
         self._first_byte_time = None
         self._logged = False
@@ -114,10 +117,18 @@ class InstrumentationMixin:
         # loss + "Task was destroyed but it is pending" warnings).
         self._pending_log_tasks = set()
 
+        # Always forward the inner plugin's events TRANSPARENTLY so an
+        # ``attach()`` MetricCapture bound to this component still sees each
+        # ``metrics_collected`` / ``error`` exactly once. The metering path
+        # (``_on_metrics_log`` -> ``_log_request`` -> a RequestRecord write) is
+        # only subscribed when ``metering=True``. ``guard()`` and the deprecated
+        # ``LLM/STT/TTS`` factories pass ``metering=False`` so that ``attach``
+        # is the SOLE meter and there is no double-count.
         wrapped.on("metrics_collected", self._forward_metrics)
-        wrapped.on("metrics_collected", self._on_metrics_log)
         wrapped.on("error", self._forward_error)
-        wrapped.on("error", self._on_error_log)
+        if metering:
+            wrapped.on("metrics_collected", self._on_metrics_log)
+            wrapped.on("error", self._on_error_log)
 
     def _forward_metrics(self, *args: Any, **kwargs: Any) -> None:
         self.emit("metrics_collected", *args, **kwargs)

--- a/src/voicegateway/middleware/instrumented_provider_middleware.py
+++ b/src/voicegateway/middleware/instrumented_provider_middleware.py
@@ -36,6 +36,7 @@ class InstrumentedSTT(lk_stt.STT, InstrumentationMixin):
         project: str,
         cost_tracker: CostTracker,
         storage: StorageService | None,
+        metering: bool = True,
     ) -> None:
         super().__init__(capabilities=wrapped.capabilities)
         self._init_instrumentation(
@@ -45,6 +46,7 @@ class InstrumentedSTT(lk_stt.STT, InstrumentationMixin):
             project=project,
             cost_tracker=cost_tracker,
             storage=storage,
+            metering=metering,
         )
 
     @property
@@ -122,6 +124,7 @@ class InstrumentedLLM(lk_llm.LLM, InstrumentationMixin):
         project: str,
         cost_tracker: CostTracker,
         storage: StorageService | None,
+        metering: bool = True,
     ) -> None:
         super().__init__()
         self._init_instrumentation(
@@ -131,6 +134,7 @@ class InstrumentedLLM(lk_llm.LLM, InstrumentationMixin):
             project=project,
             cost_tracker=cost_tracker,
             storage=storage,
+            metering=metering,
         )
 
     @property
@@ -271,6 +275,7 @@ class InstrumentedTTS(lk_tts.TTS, InstrumentationMixin):
         project: str,
         cost_tracker: CostTracker,
         storage: StorageService | None,
+        metering: bool = True,
     ) -> None:
         super().__init__(
             capabilities=wrapped.capabilities,
@@ -284,6 +289,7 @@ class InstrumentedTTS(lk_tts.TTS, InstrumentationMixin):
             project=project,
             cost_tracker=cost_tracker,
             storage=storage,
+            metering=metering,
         )
 
     @property
@@ -333,8 +339,15 @@ def wrap_provider(
     project: str,
     cost_tracker: CostTracker,
     storage: StorageService | None,
+    metering: bool = True,
 ) -> Any:
-    """Wrap a provider instance with instrumentation."""
+    """Wrap a provider instance with instrumentation.
+
+    ``metering`` defaults to ``True`` (the wrapper subscribes to the inner
+    plugin's ``metrics_collected`` and writes a RequestRecord per request).
+    Pass ``metering=False`` for a control-only wrapper that forwards metrics
+    transparently but writes nothing, leaving ``attach()`` as the sole meter.
+    """
     wrapper_cls = {
         "stt": InstrumentedSTT,
         "llm": InstrumentedLLM,
@@ -351,4 +364,5 @@ def wrap_provider(
         project=project,
         cost_tracker=cost_tracker,
         storage=storage,
+        metering=metering,
     )

--- a/src/voicegateway/tests/inference/test_factory_deprecation.py
+++ b/src/voicegateway/tests/inference/test_factory_deprecation.py
@@ -1,0 +1,162 @@
+"""The LLM/STT/TTS factories are deprecated shims: they still work, warn once,
+and no longer meter (so LLM()+attach() does not double-count)."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pytest
+import yaml
+
+from voicegateway.core import gateway_factory as factory
+from voicegateway.inference import base_inference
+from voicegateway.inference import llm_inference as llm
+
+
+class _FakeLLM:
+    """Pretends to be a livekit.plugins.<provider>.LLM instance (event emitter)."""
+
+    def __init__(self, model: str, **kwargs: Any) -> None:
+        self.model = model
+        self.provider = "openai"
+        self.kwargs = kwargs
+        self._handlers: dict[str, list[Any]] = {}
+
+    def on(self, event: str, callback: Any) -> None:
+        self._handlers.setdefault(event, []).append(callback)
+
+    def emit(self, event: str, *args: Any) -> None:
+        for handler in list(self._handlers.get(event, [])):
+            handler(*args)
+
+    async def aclose(self) -> None:
+        pass
+
+
+class _FakeProvider:
+    def __init__(self, config: dict[str, Any]) -> None:
+        self._config = config
+
+    def create_llm(self, model: str, **kwargs: Any) -> _FakeLLM:
+        return _FakeLLM(model, **kwargs)
+
+
+@pytest.fixture
+def fake_provider(monkeypatch):
+    def _create(provider_name: str, config: dict[str, Any]) -> _FakeProvider:
+        return _FakeProvider(config)
+
+    monkeypatch.setattr("voicegateway.core.registry.create_provider", _create)
+
+
+@pytest.fixture
+def configured_gateway(tmp_path, monkeypatch):
+    cfg = {
+        "providers": {"openai": {"api_key": "k"}},
+        "models": {"stt": {}, "llm": {}, "tts": {}},
+        "stacks": {},
+        "fallbacks": {"stt": [], "llm": [], "tts": []},
+        "cost_tracking": {"enabled": False},
+        "observability": {"latency_tracking": True},
+    }
+    config_path = tmp_path / "voicegw.yaml"
+    config_path.write_text(yaml.dump(cfg))
+    from voicegateway.core.gateway import Gateway
+
+    gw = Gateway(config_path=str(config_path))
+    monkeypatch.setattr(factory, "_gateway", gw)
+    return gw
+
+
+@pytest.fixture(autouse=True)
+def _reset_deprecation_flag(monkeypatch):
+    # Reset the once-per-process guard so each test can observe the warning.
+    monkeypatch.setattr(base_inference, "_deprecation_emitted", False)
+    yield
+
+
+def test_llm_factory_emits_deprecation_warning(configured_gateway, fake_provider):
+    with pytest.warns(
+        DeprecationWarning, match="voicegateway.LLM/STT/TTS are deprecated"
+    ):
+        result = llm.LLM("openai/gpt-4o-mini")
+    # Still returns a usable, drop-in object.
+    assert result.__class__.__name__ == "InstrumentedLLM"
+    assert result.model == "gpt-4o-mini"
+
+
+def test_deprecation_warning_fires_only_once(configured_gateway, fake_provider):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        llm.LLM("openai/gpt-4o-mini")
+        llm.LLM("openai/gpt-4o-mini")
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep) == 1, "the factory deprecation warning must fire at most once"
+
+
+def test_factory_wrapper_does_not_meter(configured_gateway, fake_provider):
+    """The factory wrapper is metering=False: it does not subscribe its own
+    metering handler to the inner plugin."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = llm.LLM("openai/gpt-4o-mini")
+    assert object.__getattribute__(result, "_metering") is False
+
+
+async def test_no_double_count_factory_plus_attach(
+    configured_gateway, fake_provider, tmp_path
+):
+    """A component produced by LLM() + attach(session): one metrics_collected
+    event yields exactly ONE RequestRecord (attach meters; the factory does not)."""
+    import voicegateway
+
+    class _RecordingSink:
+        def __init__(self) -> None:
+            self.rows: list = []
+
+        async def log_request(self, record: Any) -> None:
+            self.rows.append(record)
+
+        async def flush(self) -> None:
+            pass
+
+        async def aclose(self) -> None:
+            pass
+
+    class _Session:
+        def __init__(self, *, llm: Any) -> None:
+            self.stt = None
+            self.llm = llm
+            self.tts = None
+            self._handlers: dict[str, list[Any]] = {}
+
+        def on(self, event: str, handler: Any) -> None:
+            self._handlers.setdefault(event, []).append(handler)
+
+        def emit(self, event: str, *args: Any) -> None:
+            for handler in list(self._handlers.get(event, [])):
+                handler(*args)
+
+    class _LLMMetric:
+        prompt_tokens = 100
+        completion_tokens = 50
+        prompt_cached_tokens = 0
+        ttft = 0.2
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        wrapper = llm.LLM("openai/gpt-4o-mini")
+
+    inner = object.__getattribute__(wrapper, "_wrapped")
+    session = _Session(llm=wrapper)
+    sink = _RecordingSink()
+    voicegateway.attach(session, project="p", agent_id="a", sink=sink)
+
+    # Fire ONE metric on the inner plugin. The factory wrapper forwards it
+    # transparently; attach (bound to session.llm == wrapper) meters it once.
+    inner.emit("metrics_collected", _LLMMetric())
+    await session._vg_capture.drain()
+
+    assert len(sink.rows) == 1, f"expected exactly one row, got {len(sink.rows)}"
+    assert sink.rows[0].modality == "llm"

--- a/src/voicegateway/tests/inference/test_guard.py
+++ b/src/voicegateway/tests/inference/test_guard.py
@@ -1,0 +1,409 @@
+"""Tests for voicegateway.guard(): control-only wrapper (LiveKit).
+
+guard() is the ACTIVE control seam (fallback / rate-limit / budget). It composes
+with attach() (the sole meter) and writes NO metrics itself. These tests use
+fake LiveKit plugins (real ``livekit.agents.{stt,llm,tts}`` subclasses so the
+isinstance dispatch + component_identity work) driven directly, plus a fake
+session bound to a MetricCapture to prove no double-count and the fallback_from
+stamp.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from livekit.agents import llm as lk_llm
+from livekit.agents import stt as lk_stt
+
+import voicegateway
+from voicegateway.guard import (
+    RateLimitSpec,
+    parse_budget,
+    parse_rate_limit,
+)
+from voicegateway.inference.session.capture import MetricCapture
+from voicegateway.inference.session.context import (
+    reset_guard_fallback_from,
+)
+from voicegateway.middleware.budget_enforcer_middleware import BudgetExceededError
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
+from voicegateway.middleware.rate_limiter_middleware import RateLimitExceeded
+
+# --- fake LiveKit plugins (real subclasses so isinstance dispatch works) ----
+
+
+class _FakeLLM(lk_llm.LLM):
+    def __init__(self, *, model: str, provider: str, fail: bool = False) -> None:
+        super().__init__()
+        self._model = model
+        self._provider_id = provider
+        self._fail = fail
+        self.chat_calls = 0
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def provider(self) -> str:
+        return self._provider_id
+
+    def chat(self, **kwargs: Any) -> Any:
+        self.chat_calls += 1
+        return _FakeLLMStream(fail=self._fail)
+
+
+class _FakeLLMStream:
+    def __init__(self, *, fail: bool) -> None:
+        self._fail = fail
+
+    def __aiter__(self) -> Any:
+        return self._agen()
+
+    async def _agen(self) -> Any:
+        if self._fail:
+            raise RuntimeError("primary llm boom")
+        for token in ("hello", "world"):
+            yield token
+
+    async def aclose(self) -> None:
+        pass
+
+
+class _FakeSTT(lk_stt.STT):
+    def __init__(self, *, model: str, provider: str, fail: bool = False) -> None:
+        super().__init__(
+            capabilities=lk_stt.STTCapabilities(streaming=False, interim_results=False)
+        )
+        self._model = model
+        self._provider_id = provider
+        self._fail = fail
+        self.calls = 0
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def provider(self) -> str:
+        return self._provider_id
+
+    async def _recognize_impl(self, buffer: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        if self._fail:
+            raise RuntimeError("primary stt boom")
+        return f"transcript from {self._provider_id}"
+
+    async def recognize(self, buffer: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        if self._fail:
+            raise RuntimeError("primary stt boom")
+        return f"transcript from {self._provider_id}"
+
+
+# --- an event-emitter double used to bind attach's MetricCapture ------------
+
+
+class _Emitter:
+    """Duck-typed LiveKit plugin: .on()/.emit() with model/provider."""
+
+    def __init__(self, *, model: str, provider: str) -> None:
+        self.model = model
+        self.provider = provider
+        self._handlers: dict[str, list[Any]] = {}
+
+    def on(self, event: str, handler: Any) -> None:
+        self._handlers.setdefault(event, []).append(handler)
+
+    def emit(self, event: str, *args: Any) -> None:
+        for handler in list(self._handlers.get(event, [])):
+            handler(*args)
+
+
+class _Session:
+    def __init__(self, *, stt: Any = None, llm: Any = None, tts: Any = None) -> None:
+        self.stt = stt
+        self.llm = llm
+        self.tts = tts
+        self._handlers: dict[str, list[Any]] = {}
+
+    def on(self, event: str, handler: Any) -> None:
+        self._handlers.setdefault(event, []).append(handler)
+
+    def emit(self, event: str, *args: Any) -> None:
+        for handler in list(self._handlers.get(event, [])):
+            handler(*args)
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.rows: list = []
+
+    async def log_request(self, record: Any) -> None:
+        self.rows.append(record)
+
+    async def flush(self) -> None:
+        pass
+
+    async def aclose(self) -> None:
+        pass
+
+
+class _LLMMetric:
+    prompt_tokens = 100
+    completion_tokens = 50
+    prompt_cached_tokens = 0
+    ttft = 0.2
+
+
+@pytest.fixture(autouse=True)
+def _reset_fallback_marker():
+    reset_guard_fallback_from()
+    yield
+    reset_guard_fallback_from()
+
+
+# --- DSL parsing ------------------------------------------------------------
+
+
+def test_parse_rate_limit_per_minute():
+    spec = parse_rate_limit("60/min")
+    assert spec == RateLimitSpec(requests=60, per_seconds=60.0)
+    assert spec.requests_per_minute == 60
+
+
+def test_parse_rate_limit_per_second():
+    spec = parse_rate_limit("5/s")
+    assert spec.requests == 5
+    assert spec.per_seconds == 1.0
+    assert spec.requests_per_minute == 300
+
+
+def test_parse_rate_limit_rejects_garbage():
+    with pytest.raises(ValueError):
+        parse_rate_limit("banana")
+
+
+def test_parse_budget_dollar_per_day():
+    spec = parse_budget("$5.00/day")
+    assert spec.amount_usd == 5.0
+    assert spec.window == "day"
+    assert spec.period == "today"
+
+
+def test_parse_budget_per_month_no_dollar():
+    spec = parse_budget("100/month")
+    assert spec.amount_usd == 100.0
+    assert spec.window == "month"
+    assert spec.period == "month"
+
+
+def test_parse_budget_rejects_garbage():
+    with pytest.raises(ValueError):
+        parse_budget("5 dollars a fortnight")
+
+
+# --- guard returns a drop-in of the same framework type ---------------------
+
+
+def test_guard_llm_returns_lk_llm_subclass():
+    primary = _FakeLLM(model="gpt-4o-mini", provider="openai")
+    guarded = voicegateway.guard(primary)
+    assert isinstance(guarded, lk_llm.LLM)
+
+
+def test_guard_stt_returns_lk_stt_subclass():
+    primary = _FakeSTT(model="nova-3", provider="deepgram")
+    guarded = voicegateway.guard(primary)
+    assert isinstance(guarded, lk_stt.STT)
+
+
+def test_guard_rejects_unknown_provider():
+    with pytest.raises((ValueError, TypeError)):
+        voicegateway.guard(object())
+
+
+# --- rate limit -------------------------------------------------------------
+
+
+async def test_guard_rate_limit_throttles_llm():
+    """A 1/min bucket admits the first call and rejects the second."""
+    primary = _FakeLLM(model="gpt-4o-mini", provider="openai")
+    guarded = voicegateway.guard(primary, rate_limit="1/min")
+
+    # First call: consumes the single token and streams fine.
+    stream1 = guarded.chat(chat_ctx=None)
+    out = [tok async for tok in stream1]
+    assert out == ["hello", "world"]
+
+    # Second call within the same minute: bucket empty -> raises.
+    stream2 = guarded.chat(chat_ctx=None)
+    with pytest.raises(RateLimitExceeded):
+        _ = [tok async for tok in stream2]
+
+
+async def test_guard_rate_limit_throttles_stt():
+    primary = _FakeSTT(model="nova-3", provider="deepgram")
+    guarded = voicegateway.guard(primary, rate_limit="1/min")
+
+    assert await guarded.recognize(b"audio") == "transcript from deepgram"
+    with pytest.raises(RateLimitExceeded):
+        await guarded.recognize(b"audio")
+
+
+# --- budget -----------------------------------------------------------------
+
+
+async def test_guard_budget_blocks_when_over_window_spend():
+    """When accumulated spend >= cap, the guarded call raises BudgetExceededError."""
+    primary = _FakeLLM(model="gpt-4o-mini", provider="openai")
+
+    async def _spend_reader(project: str, period: str) -> float:
+        # Already spent $6 today; cap is $5/day.
+        return 6.0
+
+    from voicegateway.inference.livekit.guard_livekit import guard_livekit
+
+    guarded = guard_livekit(primary, budget="$5.00/day", spend_reader=_spend_reader)
+    stream = guarded.chat(chat_ctx=None)
+    with pytest.raises(BudgetExceededError):
+        _ = [tok async for tok in stream]
+
+
+async def test_guard_budget_allows_when_under_window_spend():
+    primary = _FakeLLM(model="gpt-4o-mini", provider="openai")
+
+    async def _spend_reader(project: str, period: str) -> float:
+        return 1.0  # under the $5 cap
+
+    from voicegateway.inference.livekit.guard_livekit import guard_livekit
+
+    guarded = guard_livekit(primary, budget="$5.00/day", spend_reader=_spend_reader)
+    stream = guarded.chat(chat_ctx=None)
+    out = [tok async for tok in stream]
+    assert out == ["hello", "world"]
+
+
+# --- fallback ---------------------------------------------------------------
+
+
+async def test_guard_fallback_runs_secondary_on_primary_error():
+    """When the primary stream errors, the fallback provider runs instead."""
+    primary = _FakeLLM(model="gpt-4o-mini", provider="openai", fail=True)
+    backup = _FakeLLM(model="claude-haiku", provider="anthropic", fail=False)
+    guarded = voicegateway.guard(primary, fallback=[backup])
+
+    stream = guarded.chat(chat_ctx=None)
+    out = [tok async for tok in stream]
+    assert out == ["hello", "world"]
+    assert backup.chat_calls == 1
+
+
+async def test_guard_fallback_stt_runs_secondary():
+    primary = _FakeSTT(model="nova-3", provider="deepgram", fail=True)
+    backup = _FakeSTT(model="whisper-1", provider="openai", fail=False)
+    guarded = voicegateway.guard(primary, fallback=[backup])
+
+    result = await guarded.recognize(b"audio")
+    assert result == "transcript from openai"
+
+
+async def test_guard_all_providers_fail_reraises():
+    primary = _FakeSTT(model="nova-3", provider="deepgram", fail=True)
+    backup = _FakeSTT(model="whisper-1", provider="openai", fail=True)
+    guarded = voicegateway.guard(primary, fallback=[backup])
+    with pytest.raises(RuntimeError):
+        await guarded.recognize(b"audio")
+
+
+async def test_guard_fallback_sets_contextvar_for_attach_stamp():
+    """After a fallback, the guard ContextVar carries the primary provider so
+    attach can stamp fallback_from on the record it writes."""
+    from voicegateway.inference.session.context import current_guard_fallback_from
+
+    primary = _FakeSTT(model="nova-3", provider="deepgram", fail=True)
+    backup = _FakeSTT(model="whisper-1", provider="openai", fail=False)
+    guarded = voicegateway.guard(primary, fallback=[backup])
+
+    await guarded.recognize(b"audio")
+    # The marker is the primary provider that was fallen back FROM.
+    assert current_guard_fallback_from() == "deepgram"
+
+
+async def test_attach_stamps_fallback_from_after_guard_fallback():
+    """End-to-end: guard sets the marker; attach's MetricCapture stamps
+    fallback_from + status='fallback' on the metered row."""
+    from voicegateway.inference.session.context import set_guard_fallback_from
+
+    sink = _RecordingSink()
+    cost_tracker = CostTracker(sink)
+    # The component attach binds to is an emitter for the provider that ran.
+    ran = _Emitter(model="whisper-1", provider="openai")
+    session = _Session(stt=ran)
+    capture = MetricCapture(
+        cost_tracker=cost_tracker,
+        sink=sink,
+        project="p",
+        agent_id="a",
+        session_id="s",
+    )
+    capture.bind(session)
+
+    # Guard fell back from deepgram to openai for this call.
+    set_guard_fallback_from("deepgram")
+    ran.emit("metrics_collected", _STTMetric())
+    await capture.drain()
+
+    assert len(sink.rows) == 1
+    assert sink.rows[0].fallback_from == "deepgram"
+    assert sink.rows[0].status == "fallback"
+    assert sink.rows[0].provider == "openai"
+
+
+class _STTMetric:
+    audio_duration = 60.0
+
+
+# --- guard writes NO metrics itself -----------------------------------------
+
+
+async def test_guard_writes_no_records():
+    """Driving a guarded call writes zero rows through the guard itself; only
+    attach (bound separately) would meter."""
+    sink = _RecordingSink()
+    primary = _FakeLLM(model="gpt-4o-mini", provider="openai")
+    guarded = voicegateway.guard(primary)
+
+    stream = guarded.chat(chat_ctx=None)
+    _ = [tok async for tok in stream]
+
+    # The guard shell's cost tracker has no storage and the wrapper is
+    # metering=False, so nothing was written anywhere the guard controls.
+    assert sink.rows == []
+    # And the guard shell must not subscribe its own metering handler.
+    assert object.__getattribute__(guarded, "_metering") is False
+
+
+# --- no double count --------------------------------------------------------
+
+
+async def test_no_double_count_guard_plus_attach():
+    """A guard-wrapped component + attach(session): one metrics_collected event
+    yields exactly ONE RequestRecord (attach meters; guard does not)."""
+    sink = _RecordingSink()
+    # The inner plugin is a real LK LLM (so guard accepts it) that can fire a
+    # metrics_collected event. guard's wrapper forwards it transparently; attach
+    # (bound to session.llm == the guard wrapper) meters it exactly once.
+    inner = _FakeLLM(model="gpt-4o-mini", provider="openai")
+    guarded = voicegateway.guard(inner)
+    session = _Session(llm=guarded)
+
+    voicegateway.attach(session, project="p", agent_id="a", sink=sink)
+
+    inner.emit("metrics_collected", _LLMMetric())
+    await session._vg_capture.drain()
+
+    assert len(sink.rows) == 1, f"expected exactly one row, got {len(sink.rows)}"
+    assert sink.rows[0].modality == "llm"
+    assert sink.rows[0].provider == "openai"


### PR DESCRIPTION
P1 of the framework-neutral program. Makes attach() the SOLE meter and introduces guard(). NON-BREAKING.

## What
- **attach() is now the only meter.** The LiveKit wrappers gain a `metering` flag: they always transparently forward the inner plugin's `metrics_collected`/`error` events (so attach's MetricCapture sees each exactly once), but only subscribe the cost-recording bridge when `metering=True`. `guard()` and the deprecated factories build with `metering=False`, so `LLM()+attach()` no longer double-counts.
- **`voicegateway.guard(provider, *, fallback=(), rate_limit=None, budget=None, project=None)`** — a framework-neutral dispatcher (imports no framework; DSL parsers for `"N/min"` / `"$X/day"`) that lazy-loads the LiveKit impl. Control-only: rate-limit (core RateLimiter), budget (accumulated-spend read, raises BudgetExceededError when over), fallback (try each provider in order; error-before-first-token switches provider for streams; sets a `_current_guard_fallback_from` ContextVar so attach stamps `fallback_from` + `status="fallback"`).
- **Factories deprecated (still work):** `voicegateway.LLM/STT/TTS` emit a one-shot DeprecationWarning and wrap with `metering=False`; optional `guard_policy` kwarg.
- `detect_framework` now walks the MRO (detects subclasses of framework bases without importing any framework).

## Verification
- `import voicegateway` PURE (guard dispatcher imports no framework); `guard` exported.
- 24 new tests pass (fallback+attach stamps fallback_from, rate-limit throttles, budget blocks, guard writes NO records, guard/factory + attach = exactly one record, deprecation warns once and still returns a usable object).
- Baseline vs post failing-test-ID sets byte-identical (119 pre-existing unchanged; +24 new passing). mypy clean (275 files); ruff clean.