### PR TITLE
feat(pipecat): attach() observer metering into the neutral core

### DIFF
--- a/src/voicegateway/__init__.py
+++ b/src/voicegateway/__init__.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     # public names stay visible to tooling without importing livekit at runtime.
     from voicegateway import inference
     from voicegateway.inference.llm_inference import LLM
+    from voicegateway.inference.pipecat.observer import (
+        VoiceGatewayObserver as Observer,
+    )
     from voicegateway.inference.stt_inference import STT
     from voicegateway.inference.tts_inference import TTS
 
@@ -34,6 +37,7 @@ __all__ = [
     "LLM",
     "STT",
     "TTS",
+    "Observer",
     "attach",
     "guard",
     "inference",
@@ -41,13 +45,15 @@ __all__ = [
     "__version__",
 ]
 
-# Names exposed lazily via PEP 562 __getattr__. Each pulls livekit on first
-# access, so they must not be imported at module load (that would break core
-# framework neutrality).
+# Names exposed lazily via PEP 562 __getattr__. Each pulls a framework on first
+# access (``LLM``/``STT``/``TTS`` pull livekit; ``Observer`` pulls pipecat), so
+# they must not be imported at module load (that would break core framework
+# neutrality).
 _LAZY = {
     "LLM": ("voicegateway.inference.llm_inference", "LLM"),
     "STT": ("voicegateway.inference.stt_inference", "STT"),
     "TTS": ("voicegateway.inference.tts_inference", "TTS"),
+    "Observer": ("voicegateway.inference.pipecat.observer", "VoiceGatewayObserver"),
     "inference": ("voicegateway.inference", None),
 }
 
@@ -56,8 +62,9 @@ def __getattr__(name: str) -> Any:
     """Lazily resolve framework-pulling public names (PEP 562).
 
     Keeps ``import voicegateway`` free of any framework import while preserving
-    ``voicegateway.LLM``/``STT``/``TTS`` and the ``voicegateway.inference``
-    submodule as attribute-access entry points.
+    ``voicegateway.LLM``/``STT``/``TTS`` (livekit), ``voicegateway.Observer``
+    (pipecat), and the ``voicegateway.inference`` submodule as attribute-access
+    entry points.
     """
     target = _LAZY.get(name)
     if target is None:

--- a/src/voicegateway/inference/pipecat/__init__.py
+++ b/src/voicegateway/inference/pipecat/__init__.py
@@ -1,0 +1,8 @@
+"""Pipecat-scoped VoiceGateway internals (import ``pipecat`` on load).
+
+Modules under this package subclass ``pipecat`` types (``BaseObserver``) and
+therefore import ``pipecat`` when imported. They are loaded lazily by the
+framework-neutral ``voicegateway.attach()`` dispatcher and the lazily-resolved
+``voicegateway.Observer`` export, so importing ``voicegateway`` itself stays
+free of any framework import.
+"""

--- a/src/voicegateway/inference/pipecat/observer.py
+++ b/src/voicegateway/inference/pipecat/observer.py
@@ -1,0 +1,606 @@
+"""Pipecat ``VoiceGatewayObserver``: the passive meter for the attach() path.
+
+A Pipecat ``BaseObserver`` that watches frames flowing through a ``PipelineTask``
+and meters them into VoiceGateway's framework-neutral core, exactly like the
+LiveKit ``MetricCapture`` does for ``AgentSession`` events. It reuses the core
+UNCHANGED: ``CostTracker.create_record`` for pricing (via voice-prices), the
+``Sink`` for storage, and the session/tenant ContextVars for correlation.
+
+Mapping (``on_push_frame`` sees ``FramePushed`` events; ``frame.data`` on a
+``MetricsFrame`` is a list of ``MetricsData``):
+
+- ``LLMUsageMetricsData`` (``.value`` is ``LLMTokenUsage``)
+    -> modality=llm, input=prompt_tokens, output=completion_tokens,
+       cached=cache_read_input_tokens.
+- ``TTSUsageMetricsData`` (``.value`` is an int char count)
+    -> modality=tts, input=chars.
+- ``TTFBMetricsData`` (``.value`` seconds) -> ttfb_ms; ``TTFAMetricsData``
+    (``.value`` seconds) -> total_latency_ms.
+- STT has NO usage metric: accumulate ``AudioRawFrame`` bytes routed to each STT
+  processor and derive seconds = bytes / (sample_rate * 2) (16-bit mono PCM),
+  converted to minutes for input_units (the cost path multiplies back by 60).
+
+Correlation boundary rule (the crux)
+-------------------------------------
+Pipecat emits TTFB and usage as SEPARATE ``MetricsData`` (often in separate
+``MetricsFrame``s) from the SAME processor. We buffer per-processor and emit
+exactly ONE ``RequestRecord`` per request:
+
+- LLM/TTS: the USAGE metric is the request boundary. When a ``*UsageMetricsData``
+  arrives for a processor we stitch in any TTFB buffered for that same processor
+  (since the last flush), emit one record, and clear that processor's TTFB
+  buffer. A lone TTFB (no usage yet) emits nothing; it waits for the usage frame.
+  A second usage metric for the same processor is a second request.
+- STT: there is no usage metric, so the boundary is the UTTERANCE. We accumulate
+  audio bytes seen for the STT processor and flush one record on an utterance
+  boundary frame (``UserStoppedSpeakingFrame`` / ``TranscriptionFrame``) or on
+  pipeline end. Any TTFB buffered for the STT processor rides on that record.
+
+A ``MetricsFrame`` may be re-pushed by pipeline wrappers (so the observer can see
+the same frame twice with different ``source``s); we dedupe by frame ``id`` so a
+single logical metric is metered exactly once.
+
+Session finalize: on the pipeline end (``EndFrame`` / ``aclose()``) we drain any
+pending STT audio into a final record, drain in-flight sink writes, and flush the
+sink so a buffered remote sink pushes before shutdown.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+# This module is imported ONLY lazily (via the attach() dispatch and the
+# ``voicegateway.Observer`` export), never by ``import voicegateway``. Importing
+# pipecat at module load here is therefore safe and mirrors how the LiveKit
+# ``guard_livekit`` module imports ``livekit`` at load. ``import voicegateway``
+# purity is preserved by the lazy dispatch, not by dodging the import here.
+from pipecat.observers.base_observer import BaseObserver
+
+from voicegateway.inference.session.context import (
+    current_guard_fallback_from,
+    get_or_create_session_id,
+    set_tenant,
+)
+
+if TYPE_CHECKING:
+    from voicegateway.middleware.cost_tracker_middleware import CostTracker
+    from voicegateway.models.request_model import RequestRecord
+    from voicegateway.services.sinks import Sink
+
+logger = logging.getLogger(__name__)
+
+# 16-bit PCM: 2 bytes per sample per channel. STT audio duration derivation
+# assumes mono 16-bit (the pipecat transport default); num_channels is honored
+# when present so stereo audio does not double-count seconds.
+_BYTES_PER_SAMPLE = 2
+
+
+def _service_base_modality(processor: object) -> str | None:
+    """Return ``"stt"``/``"llm"``/``"tts"`` from a processor's service base class.
+
+    Walks the MRO's ``__module__`` strings to find the pipecat service base a
+    processor derives from, without importing pipecat here (the module strings
+    are already set on the loaded classes). Returns None when the processor is
+    not a recognizable STT/LLM/TTS service (e.g. the Pipeline wrapper).
+    """
+    for base in type(processor).__mro__:
+        module = getattr(base, "__module__", "") or ""
+        name = getattr(base, "__name__", "")
+        if module == "pipecat.services.stt_service" and name == "STTService":
+            return "stt"
+        if module == "pipecat.services.llm_service" and name == "LLMService":
+            return "llm"
+        if module == "pipecat.services.tts_service" and name == "TTSService":
+            return "tts"
+    return None
+
+
+def _provider_from_module(processor: object) -> str:
+    """Best-effort provider id from ``pipecat.services.<provider>.*``.
+
+    Real pipecat provider services live under ``pipecat.services.<provider>``
+    (e.g. ``pipecat.services.openai.llm``). We read the segment after
+    ``services``. Falls back to the leading token of ``processor.name`` when the
+    module is not under a provider package.
+    """
+    module = type(processor).__module__ or ""
+    parts = module.split(".")
+    if "services" in parts:
+        idx = parts.index("services")
+        if idx + 1 < len(parts):
+            candidate = parts[idx + 1]
+            # Skip the base modules (stt_service/llm_service/tts_service/etc.).
+            if candidate and not candidate.endswith("_service"):
+                return candidate
+    name = getattr(processor, "name", "") or ""
+    # Processor names look like "OpenAILLMService#0"; strip the "#N" suffix and
+    # lowercase the leading alpha run as a weak provider hint.
+    head = name.split("#", 1)[0]
+    return head or ""
+
+
+def _model_from_processor(processor: object) -> str:
+    """Best-effort model string from a pipecat service's settings."""
+    settings = getattr(processor, "_settings", None)
+    if settings is not None:
+        model = getattr(settings, "model", None)
+        if isinstance(model, str) and model:
+            return model
+    for attr in ("model_name", "model"):
+        value = getattr(processor, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def pipecat_identity(processor: object) -> tuple[str, str]:
+    """Return ``(provider, modality)`` for a pipecat service processor.
+
+    Analog of the LiveKit ``component_identity()``: modality from the service
+    base class (STTService/LLMService/TTSService), provider from the service
+    module (``pipecat.services.<provider>.*``) or the processor name. Returns
+    ``("", None-ish)`` semantics via the caller; here modality may be ``""`` when
+    the processor is not a recognizable service.
+    """
+    modality = _service_base_modality(processor) or ""
+    provider = _provider_from_module(processor)
+    return provider, modality
+
+
+def _model_id(provider: str, model: str) -> str:
+    """Normalize to VG's ``provider/model`` form (matches the LiveKit path)."""
+    if provider and model:
+        return f"{provider}/{model}"
+    if model:
+        return model
+    return "unknown"
+
+
+class _PendingRequest:
+    """Per-processor buffer stitching TTFB/TTFA with the usage that flushes it."""
+
+    __slots__ = ("ttfb_ms", "total_latency_ms")
+
+    def __init__(self) -> None:
+        self.ttfb_ms: float | None = None
+        self.total_latency_ms: float | None = None
+
+
+class _STTAccumulator:
+    """Per-STT-processor audio byte accumulator, flushed on utterance boundary."""
+
+    __slots__ = ("bytes", "sample_rate", "num_channels")
+
+    def __init__(self) -> None:
+        self.bytes: int = 0
+        self.sample_rate: int = 0
+        self.num_channels: int = 1
+
+    def add(self, audio: bytes, sample_rate: int, num_channels: int) -> None:
+        self.bytes += len(audio)
+        if sample_rate:
+            self.sample_rate = sample_rate
+        if num_channels:
+            self.num_channels = num_channels
+
+    def seconds(self) -> float:
+        if not self.sample_rate:
+            return 0.0
+        frame_bytes = self.sample_rate * _BYTES_PER_SAMPLE * max(1, self.num_channels)
+        return self.bytes / frame_bytes if frame_bytes else 0.0
+
+    def reset(self) -> None:
+        self.bytes = 0
+
+
+def _lazy_frame_types() -> dict[str, Any]:
+    """Import the pipecat frame/metric types this observer matches on.
+
+    Imported lazily inside the observer (not at module top) is not required here
+    because this module is itself only imported by the lazy attach dispatch /
+    Observer export; but keeping the imports in one place documents the exact
+    1.5.0 surface the observer is built against.
+    """
+    from pipecat.frames.frames import (
+        EndFrame,
+        InputAudioRawFrame,
+        MetricsFrame,
+        TranscriptionFrame,
+        UserStoppedSpeakingFrame,
+    )
+    from pipecat.metrics.metrics import (
+        LLMUsageMetricsData,
+        TTFBMetricsData,
+        TTSUsageMetricsData,
+    )
+
+    types: dict[str, Any] = {
+        "MetricsFrame": MetricsFrame,
+        "InputAudioRawFrame": InputAudioRawFrame,
+        "TranscriptionFrame": TranscriptionFrame,
+        "UserStoppedSpeakingFrame": UserStoppedSpeakingFrame,
+        "EndFrame": EndFrame,
+        "LLMUsageMetricsData": LLMUsageMetricsData,
+        "TTSUsageMetricsData": TTSUsageMetricsData,
+        "TTFBMetricsData": TTFBMetricsData,
+    }
+    # TTFAMetricsData (time-to-first-audio) is optional across versions.
+    try:
+        from pipecat.metrics.metrics import TTFAMetricsData
+
+        types["TTFAMetricsData"] = TTFAMetricsData
+    except Exception:  # noqa: BLE001 - older pipecat without TTFA
+        types["TTFAMetricsData"] = ()
+    # AudioRawFrame is the base of InputAudioRawFrame; matching it catches output
+    # audio too, but STT accumulates only input audio, so we key on the base and
+    # let the STT-processor routing decide what counts.
+    try:
+        from pipecat.frames.frames import AudioRawFrame
+
+        types["AudioRawFrame"] = AudioRawFrame
+    except Exception:  # noqa: BLE001
+        types["AudioRawFrame"] = InputAudioRawFrame
+    return types
+
+
+def _build_default_sink(collector_url: str | None, api_key: str | None) -> Sink:
+    """Build the attach() sink from env/args (mirrors the LiveKit attach path)."""
+    if collector_url:
+        from voicegateway.services.sinks import RemoteCollectorSink
+
+        return RemoteCollectorSink(collector_url, api_key)
+    import os
+
+    from voicegateway.inference.session.attach import DEFAULT_DB_PATH
+    from voicegateway.services.sinks import LocalSqliteSink
+    from voicegateway.services.storage_service import StorageService
+
+    resolved_path = os.environ.get("VOICEGW_DB_PATH") or DEFAULT_DB_PATH
+    return LocalSqliteSink(StorageService(resolved_path))
+
+
+class VoiceGatewayObserver(BaseObserver):
+    """A Pipecat ``BaseObserver`` that meters frames into VoiceGateway's core.
+
+    Construct directly for ``PipelineTask(observers=[Observer(...)])`` or let
+    ``attach(task)`` build and register one. It writes one ``RequestRecord`` per
+    request through a ``Sink`` (local SQLite by default, or a remote collector).
+    """
+
+    def __init__(
+        self,
+        *,
+        sink: Sink | None = None,
+        cost_tracker: CostTracker | None = None,
+        project: str = "default",
+        agent_id: str | None = None,
+        session_id: str | None = None,
+        tenant_id: str | None = None,
+        channel: str | None = None,
+        collector_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        # BaseObserver.__init__ wires the pipecat event machinery.
+        super().__init__()
+
+        import os
+
+        from voicegateway.middleware.cost_tracker_middleware import CostTracker
+
+        resolved_collector = collector_url or os.environ.get("VOICEGW_COLLECTOR_URL")
+        resolved_key = api_key or os.environ.get("VOICEGW_API_KEY")
+        if sink is None:
+            sink = _build_default_sink(resolved_collector, resolved_key)
+        if tenant_id is not None:
+            set_tenant(tenant_id)
+
+        self._sink = sink
+        self._cost_tracker = cost_tracker or CostTracker(sink)
+        self._project = project
+        self._agent_id = agent_id or _default_agent_id()
+        self._session_id = session_id or get_or_create_session_id()
+        self._tenant_id = tenant_id
+        self._channel = channel
+        self._types = _lazy_frame_types()
+
+        # Per-processor stitch buffers and STT audio accumulators, keyed by the
+        # processor's stable name (a MetricsData carries only the name string, so
+        # the name is the correlation key that survives across frames).
+        self._pending: dict[str, _PendingRequest] = {}
+        self._stt_audio: dict[str, _STTAccumulator] = {}
+        # STT processors registered for audio routing: name -> (provider, model).
+        self._stt_identity: dict[str, tuple[str, str]] = {}
+        # Frame ids already metered (re-push dedupe).
+        self._seen_frames: set[Any] = set()
+        self._closed = False
+
+    # --- registration ------------------------------------------------------
+
+    def register_stt(self, processor: object) -> None:
+        """Register an STT service so its routed audio is accumulated.
+
+        ``attach(task)`` discovers STT processors from the pipeline and registers
+        them. Tests register a stub directly. Registration records the identity
+        so the STT record carries the right provider/model even though STT emits
+        no usage metric.
+        """
+        name = getattr(processor, "name", None)
+        if not isinstance(name, str) or not name:
+            return
+        provider, modality = pipecat_identity(processor)
+        model = _model_from_processor(processor)
+        self._stt_identity[name] = (provider, model)
+        self._stt_audio.setdefault(name, _STTAccumulator())
+
+    # --- the observer hook -------------------------------------------------
+
+    async def on_push_frame(self, data: Any) -> None:
+        """Handle a ``FramePushed`` event (pipecat's ``BaseObserver`` hook)."""
+        frame = data.frame
+        source = data.source
+        types = self._types
+
+        if isinstance(frame, types["MetricsFrame"]):
+            await self._on_metrics_frame(frame, source)
+            return
+        if isinstance(frame, types["AudioRawFrame"]):
+            self._on_audio_frame(frame, source)
+            return
+        if isinstance(
+            frame, (types["UserStoppedSpeakingFrame"], types["TranscriptionFrame"])
+        ):
+            await self._flush_stt_boundary(source)
+            return
+        if isinstance(frame, types["EndFrame"]):
+            await self.aclose()
+            return
+
+    # --- metrics -----------------------------------------------------------
+
+    async def _on_metrics_frame(self, frame: Any, source: object) -> None:
+        # Dedupe re-pushed frames by id so one logical metric meters once.
+        frame_id = getattr(frame, "id", None)
+        if frame_id is not None:
+            if frame_id in self._seen_frames:
+                return
+            self._seen_frames.add(frame_id)
+
+        types = self._types
+        data_list = getattr(frame, "data", None) or []
+        # Two passes: first apply latency metrics into the per-processor buffer,
+        # then flush usage metrics (so a TTFB in the same frame is stitched).
+        for md in data_list:
+            if isinstance(md, types["TTFBMetricsData"]):
+                self._buffer_for(md).ttfb_ms = float(md.value) * 1000.0
+            elif types["TTFAMetricsData"] and isinstance(md, types["TTFAMetricsData"]):
+                self._buffer_for(md).total_latency_ms = float(md.value) * 1000.0
+        for md in data_list:
+            if isinstance(md, types["LLMUsageMetricsData"]):
+                await self._emit_llm(md, source)
+            elif isinstance(md, types["TTSUsageMetricsData"]):
+                await self._emit_tts(md, source)
+
+    def _processor_name(self, md: Any) -> str:
+        return getattr(md, "processor", "") or ""
+
+    def _buffer_for(self, md: Any) -> _PendingRequest:
+        return self._pending.setdefault(self._processor_name(md), _PendingRequest())
+
+    def _identity_for_metric(
+        self, md: Any, source: object, fallback_modality: str
+    ) -> tuple[str, str]:
+        """Resolve ``(provider, model_id)`` for a usage metric.
+
+        Prefer the live ``source`` processor (its base class + module), which is
+        the same object that pushed the frame; fall back to the metric's own
+        ``model`` string. This mirrors the LiveKit ``component_identity``.
+        """
+        provider, modality = pipecat_identity(source)
+        model = _model_from_processor(source) or (getattr(md, "model", "") or "")
+        if not modality:
+            modality = fallback_modality
+        return provider, _model_id(provider, model)
+
+    async def _emit_llm(self, md: Any, source: object) -> None:
+        usage = md.value
+        input_units = float(getattr(usage, "prompt_tokens", 0) or 0)
+        output_units = float(getattr(usage, "completion_tokens", 0) or 0)
+        cached = float(getattr(usage, "cache_read_input_tokens", 0) or 0)
+        provider, model_id = self._identity_for_metric(md, source, "llm")
+        await self._emit(
+            modality="llm",
+            provider=provider,
+            model_id=model_id,
+            input_units=input_units,
+            output_units=output_units,
+            cached_input_units=cached,
+            processor_name=self._processor_name(md),
+        )
+
+    async def _emit_tts(self, md: Any, source: object) -> None:
+        chars = float(md.value or 0)
+        provider, model_id = self._identity_for_metric(md, source, "tts")
+        await self._emit(
+            modality="tts",
+            provider=provider,
+            model_id=model_id,
+            input_units=chars,
+            output_units=0.0,
+            cached_input_units=0.0,
+            processor_name=self._processor_name(md),
+        )
+
+    async def _emit(
+        self,
+        *,
+        modality: str,
+        provider: str,
+        model_id: str,
+        input_units: float,
+        output_units: float,
+        cached_input_units: float,
+        processor_name: str,
+        ttfb_ms: float | None = None,
+        total_latency_ms: float | None = None,
+    ) -> None:
+        """Build ONE RequestRecord, stitch buffered latency, schedule the write."""
+        pending = self._pending.pop(processor_name, None)
+        if pending is not None:
+            if ttfb_ms is None:
+                ttfb_ms = pending.ttfb_ms
+            if total_latency_ms is None:
+                total_latency_ms = pending.total_latency_ms
+
+        status = "success"
+        fallback_from = current_guard_fallback_from()
+        if fallback_from is not None and fallback_from != provider:
+            status = "fallback"
+        else:
+            fallback_from = None
+
+        record = self._cost_tracker.create_record(
+            model_id=model_id,
+            modality=modality,
+            provider=provider,
+            project=self._project,
+            input_units=input_units,
+            output_units=output_units,
+            cached_input_units=cached_input_units,
+            ttfb_ms=ttfb_ms,
+            total_latency_ms=total_latency_ms,
+            status=status,
+            fallback_from=fallback_from,
+            session_id=self._session_id,
+            agent_id=self._agent_id,
+        )
+        self._stamp_context(record)
+        await self._write(record)
+
+    # --- STT audio ---------------------------------------------------------
+
+    def _on_audio_frame(self, frame: Any, source: object) -> None:
+        # Route audio to an STT processor. When the pushing source is itself an
+        # STT service, attribute audio to it. Otherwise, if exactly one STT
+        # processor is registered, attribute to it (the common single-STT case);
+        # with multiple STT processors and a non-STT source, attribute to all
+        # registered STT accumulators is ambiguous, so we skip (avoids
+        # double-counting) and rely on the source-keyed path.
+        target_name: str | None = None
+        modality = _service_base_modality(source)
+        source_name = getattr(source, "name", None)
+        if modality == "stt" and isinstance(source_name, str):
+            target_name = source_name
+            if target_name not in self._stt_identity:
+                self.register_stt(source)
+        elif len(self._stt_audio) == 1:
+            target_name = next(iter(self._stt_audio))
+        if target_name is None:
+            return
+        acc = self._stt_audio.setdefault(target_name, _STTAccumulator())
+        acc.add(
+            getattr(frame, "audio", b"") or b"",
+            int(getattr(frame, "sample_rate", 0) or 0),
+            int(getattr(frame, "num_channels", 1) or 1),
+        )
+
+    async def _flush_stt_boundary(self, source: object) -> None:
+        """Flush accumulated STT audio into one record per STT processor.
+
+        The utterance boundary (user stopped speaking / a transcription) closes
+        the current STT request. We flush every STT accumulator that has audio,
+        because a boundary frame is not always pushed by the STT processor
+        itself (VAD lives in the transport/turn analyzer).
+        """
+        for name, acc in self._stt_audio.items():
+            if acc.bytes <= 0:
+                continue
+            await self._flush_one_stt(name, acc)
+
+    async def _flush_one_stt(self, name: str, acc: _STTAccumulator) -> None:
+        provider, model = self._stt_identity.get(name, ("", ""))
+        seconds = acc.seconds()
+        acc.reset()
+        if seconds <= 0:
+            return
+        minutes = seconds / 60.0
+        pending = self._pending.pop(name, None)
+        ttfb_ms = pending.ttfb_ms if pending is not None else None
+        record = self._cost_tracker.create_record(
+            model_id=_model_id(provider, model),
+            modality="stt",
+            provider=provider,
+            project=self._project,
+            input_units=minutes,
+            ttfb_ms=ttfb_ms,
+            session_id=self._session_id,
+            agent_id=self._agent_id,
+        )
+        self._stamp_context(record)
+        await self._write(record)
+
+    # --- context stamping (mirrors capture.py) -----------------------------
+
+    def _stamp_context(self, record: RequestRecord) -> None:
+        """Carry tenant + channel on ``metadata`` like the LiveKit capture path.
+
+        ``tenant_id`` is how a per-call tenant survives the wire; ``channel``
+        (telephony vs web) has no RequestRecord column and the dashboard reads it
+        back per call. Absent keys mean the observer had nothing to stamp.
+        """
+        extra: dict[str, Any] = {}
+        if self._tenant_id:
+            extra["tenant_id"] = self._tenant_id
+        if self._channel:
+            extra["channel"] = self._channel
+        if extra:
+            record.metadata = {**record.metadata, **extra}
+
+    # --- write plumbing ----------------------------------------------------
+
+    async def _write(self, record: RequestRecord) -> None:
+        """Await the sink write directly.
+
+        ``on_push_frame`` is an async hook that pipecat awaits, so metering can
+        write inline. A failed write must not break the pipeline, so it is logged
+        and swallowed (the passive-meter contract: observability never affects the
+        call path).
+        """
+        try:
+            await self._sink.log_request(record)
+        except Exception:  # noqa: BLE001 - observability must not break the pipeline
+            logger.warning("pipecat observer: sink write failed", exc_info=True)
+
+    async def drain(self) -> None:
+        """No-op retained for API parity with the LiveKit capture path.
+
+        Writes are awaited inline in ``_write`` (the async ``on_push_frame`` hook
+        makes fire-and-forget unnecessary), so there is nothing to drain. Kept so
+        callers can uniformly ``await observer.drain()``.
+        """
+        return
+
+    async def aclose(self) -> None:
+        """Finalize on pipeline end: drain STT audio, then flush the sink."""
+        if self._closed:
+            return
+        self._closed = True
+        # Drain any STT audio still buffered (no explicit utterance boundary).
+        for name, acc in list(self._stt_audio.items()):
+            if acc.bytes > 0:
+                await self._flush_one_stt(name, acc)
+        try:
+            await self._sink.flush()
+        except Exception:  # noqa: BLE001
+            logger.warning("pipecat observer: sink flush failed", exc_info=True)
+
+
+def _default_agent_id() -> str:
+    """Resolve the agent label: explicit env > hostname > a constant."""
+    import os
+    import socket
+
+    return os.environ.get("VOICEGW_AGENT_ID") or socket.gethostname() or "agent"
+
+
+__all__ = ["VoiceGatewayObserver", "pipecat_identity"]

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -302,34 +302,81 @@ def attach(
     project: str = "default",
     agent_id: str | None = None,
     tenant_id: str | None = None,
+    channel: str | None = None,
     collector_url: str | None = None,
     api_key: str | None = None,
     sink: Sink | None = None,
     room: str | None = None,
 ) -> str:
-    """Attach VoiceGateway to an existing LiveKit ``AgentSession`` in one call.
+    """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
 
-    The *observe* tier: works for ANY plugin (native LiveKit,
-    ``livekit.agents.inference``, or ``voicegateway.inference``) by subscribing
-    to the non-deprecated per-component ``metrics_collected`` events. Captures
-    per-call cost + latency + errors and writes them through a ``Sink`` (local
-    SQLite by default, or a collector when configured via ``collector_url`` /
-    ``VOICEGW_COLLECTOR_URL``).
+    The *observe* tier: a single, passive meter for cost + latency. ``attach()``
+    detects the target's framework (by type/module, without eager framework
+    imports) and installs the matching observer:
+
+    - **LiveKit** ``AgentSession``: subscribes to the non-deprecated
+      per-component ``metrics_collected`` events (works for any plugin).
+    - **Pipecat** ``PipelineTask``: registers a ``VoiceGatewayObserver`` that
+      maps ``MetricsFrame``s and derives STT duration from audio frames.
+
+    Both paths write per-call cost + latency through a ``Sink`` (local SQLite by
+    default, or a collector when ``collector_url`` / ``VOICEGW_COLLECTOR_URL`` is
+    set), and both lazily import the framework they detect so ``import
+    voicegateway`` stays framework-free.
 
     Args:
-        session: the ``AgentSession`` to observe.
+        session: the ``AgentSession`` (LiveKit) or ``PipelineTask`` (Pipecat).
         project: project id to tag rows with.
         agent_id: fleet label; defaults to ``VOICEGW_AGENT_ID`` or hostname.
         tenant_id: optional tenant attribution.
+        channel: ``"telephony"`` | ``"web"``; auto-detected from the transport
+            when omitted.
         collector_url / api_key: fleet push target (env fallbacks).
         sink: advanced/testing override; defaults to local or remote per env.
         room: LiveKit room name for probe correlation; auto-resolved from the
             running job context when omitted (``voicegw livekit latency`` reads
-            the STT/LLM/TTS split back by this).
+            the STT/LLM/TTS split back by this). Ignored on the Pipecat path.
 
     Returns:
         The correlation session id stamped on every captured row.
     """
+    from voicegateway._frameworks import detect_framework
+
+    if detect_framework(session) == "pipecat":
+        return _attach_pipecat(
+            session,
+            project=project,
+            agent_id=agent_id,
+            tenant_id=tenant_id,
+            channel=channel,
+            collector_url=collector_url,
+            api_key=api_key,
+            sink=sink,
+        )
+    return _attach_livekit(
+        session,
+        project=project,
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        collector_url=collector_url,
+        api_key=api_key,
+        sink=sink,
+        room=room,
+    )
+
+
+def _attach_livekit(
+    session: Any,
+    *,
+    project: str = "default",
+    agent_id: str | None = None,
+    tenant_id: str | None = None,
+    collector_url: str | None = None,
+    api_key: str | None = None,
+    sink: Sink | None = None,
+    room: str | None = None,
+) -> str:
+    """LiveKit ``attach()`` body: bind ``MetricCapture`` to an ``AgentSession``."""
     import asyncio
 
     from voicegateway.fleet.worker import bump_active
@@ -395,6 +442,154 @@ def attach(
         # (No-op unless register_worker was called.)
         bump_active(1)
         on("close", _on_close)
+
+    return session_id
+
+
+# --- Pipecat ---------------------------------------------------------------
+
+# Provider modules/serializers that indicate a telephony (phone) channel. Daily,
+# WebRTC, and websocket transports are treated as web.
+_PIPECAT_TELEPHONY_TOKENS: tuple[str, ...] = (
+    "twilio",
+    "telnyx",
+    "plivo",
+    "exotel",
+    "genesys",
+    "vonage",
+)
+
+
+def _iter_pipecat_processors(pipeline: Any) -> Any:
+    """Yield every processor in a pipecat pipeline, descending nested pipelines.
+
+    ``Pipeline.processors`` includes source/sink wrappers and any nested
+    pipelines; we descend so an STT service inside a sub-pipeline is still found.
+    Best-effort and defensive: a shape we do not recognize simply yields nothing.
+    """
+    seen: set[int] = set()
+    stack = [pipeline]
+    while stack:
+        node = stack.pop()
+        if node is None or id(node) in seen:
+            continue
+        seen.add(id(node))
+        children = getattr(node, "processors", None)
+        if children:
+            for child in children:
+                yield child
+                stack.append(child)
+
+
+def _detect_pipecat_channel(task: Any) -> str | None:
+    """Best-effort telephony-vs-web from the pipeline's transport/serializer.
+
+    A telephony serializer/transport module (Twilio/Telnyx/Plivo/...) means a
+    phone call; a Daily/WebRTC/websocket transport means web. Returns None when
+    nothing conclusive is found, so the row simply carries no channel.
+    """
+    pipeline = getattr(task, "pipeline", None)
+    if pipeline is None:
+        return None
+    saw_transport = False
+    for proc in _iter_pipecat_processors(pipeline):
+        module = (type(proc).__module__ or "").lower()
+        if "transports" in module or "serializers" in module:
+            saw_transport = True
+            for token in _PIPECAT_TELEPHONY_TOKENS:
+                if token in module:
+                    return "telephony"
+        # A transport may hold a serializer as an attribute rather than as its
+        # own processor; sniff a ``_serializer`` module too.
+        serializer = getattr(proc, "_serializer", None) or getattr(
+            proc, "serializer", None
+        )
+        if serializer is not None:
+            ser_module = (type(serializer).__module__ or "").lower()
+            saw_transport = True
+            for token in _PIPECAT_TELEPHONY_TOKENS:
+                if token in ser_module:
+                    return "telephony"
+    return "web" if saw_transport else None
+
+
+def _register_pipecat_stt(observer: Any, task: Any) -> None:
+    """Register every STT service found in the task's pipeline with the observer."""
+    from voicegateway.inference.pipecat.observer import _service_base_modality
+
+    pipeline = getattr(task, "pipeline", None)
+    if pipeline is None:
+        return
+    for proc in _iter_pipecat_processors(pipeline):
+        try:
+            if _service_base_modality(proc) == "stt":
+                observer.register_stt(proc)
+        except Exception:  # noqa: BLE001 - never let discovery break attach
+            logger.debug(
+                "attach(pipecat): STT discovery skipped a processor", exc_info=True
+            )
+
+
+def _attach_pipecat(
+    task: Any,
+    *,
+    project: str = "default",
+    agent_id: str | None = None,
+    tenant_id: str | None = None,
+    channel: str | None = None,
+    collector_url: str | None = None,
+    api_key: str | None = None,
+    sink: Sink | None = None,
+) -> str:
+    """Register a ``VoiceGatewayObserver`` on a Pipecat ``PipelineTask``.
+
+    Mirrors the LiveKit ``attach`` path: builds the same sink, stamps the tenant
+    ContextVar, and returns the correlation session id. The observer is the sole
+    meter; it finalizes itself on the pipeline ``EndFrame`` (drain + flush).
+    """
+    from voicegateway.inference.pipecat.observer import VoiceGatewayObserver
+
+    resolved_agent_id = agent_id or _default_agent_id()
+    resolved_collector = collector_url or os.environ.get("VOICEGW_COLLECTOR_URL")
+    resolved_key = api_key or os.environ.get("VOICEGW_API_KEY")
+    session_id = get_or_create_session_id()
+    if tenant_id is not None:
+        set_tenant(tenant_id)
+    if sink is None:
+        sink = _build_default_sink(resolved_collector, resolved_key)
+
+    resolved_channel = channel or _detect_pipecat_channel(task)
+
+    observer = VoiceGatewayObserver(
+        sink=sink,
+        project=project,
+        agent_id=resolved_agent_id,
+        session_id=session_id,
+        tenant_id=tenant_id,
+        channel=resolved_channel,
+    )
+    _register_pipecat_stt(observer, task)
+
+    # Register the observer on the task. Prefer ``add_observer`` (1.5.0 API);
+    # fall back to appending to an observers list if a variant exposes only that.
+    add_observer = getattr(task, "add_observer", None)
+    if callable(add_observer):
+        add_observer(observer)
+    else:  # pragma: no cover - 1.5.0 exposes add_observer
+        observers = getattr(task, "_observers", None)
+        if isinstance(observers, list):
+            observers.append(observer)
+        else:
+            raise TypeError(
+                "attach(pipecat): PipelineTask exposes no add_observer/observers; "
+                "pass Observer(...) to PipelineTask(observers=[...]) instead."
+            )
+
+    # Expose for graceful shutdown + tests.
+    try:
+        task._vg_observer = observer
+    except Exception:  # noqa: BLE001 - real task may forbid attribute set
+        logger.debug("attach(pipecat): could not stash observer on task", exc_info=True)
 
     return session_id
 

--- a/src/voicegateway/tests/inference/test_pipecat_e2e.py
+++ b/src/voicegateway/tests/inference/test_pipecat_e2e.py
@@ -1,0 +1,122 @@
+"""Minimal end-to-end Pipecat pipeline test for ``attach()`` / ``Observer``.
+
+Builds a tiny ``Pipeline`` + ``PipelineTask`` with a stub service that emits a
+real ``MetricsFrame`` during the run, registers a ``VoiceGatewayObserver`` via
+``attach(task)``, runs the task to completion, and asserts a ``RequestRecord``
+was produced. This exercises the full observer wiring inside a live pipeline
+(not just direct ``on_push_frame`` calls), proving the P2 attach path works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+pipecat = pytest.importorskip("pipecat")
+
+from pipecat.frames.frames import Frame, MetricsFrame, StartFrame  # noqa: E402
+from pipecat.metrics.metrics import LLMTokenUsage, LLMUsageMetricsData  # noqa: E402
+from pipecat.pipeline.pipeline import Pipeline  # noqa: E402
+from pipecat.pipeline.runner import PipelineRunner  # noqa: E402
+from pipecat.pipeline.task import PipelineTask  # noqa: E402
+from pipecat.processors.frame_processor import (  # noqa: E402
+    FrameDirection,
+    FrameProcessor,
+)
+
+import voicegateway  # noqa: E402
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+        self.flushed = 0
+
+    async def log_request(self, record: Any) -> None:
+        self.records.append(record)
+
+    async def flush(self) -> None:
+        self.flushed += 1
+
+
+class _EmitterLLM(FrameProcessor):
+    """A stub processor whose module emulates a real pipecat LLM service.
+
+    On the pipeline StartFrame it emits one ``MetricsFrame`` carrying LLM usage,
+    exactly as a real ``LLMService`` would after a completion.
+    """
+
+    # Emulate a real provider service under pipecat.services.openai.llm.
+    __module__ = "pipecat.services.openai.llm"
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, StartFrame):
+            usage = LLMTokenUsage(
+                prompt_tokens=1000,
+                completion_tokens=500,
+                total_tokens=1500,
+                cache_read_input_tokens=200,
+            )
+            md = LLMUsageMetricsData(processor=self.name, model="gpt-4o", value=usage)
+            await self.push_frame(MetricsFrame(data=[md]))
+        await self.push_frame(frame, direction)
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_end_to_end_pipeline_produces_record() -> None:
+    sink = _RecordingSink()
+    emitter = _EmitterLLM()
+    pipeline = Pipeline([emitter])
+    task = PipelineTask(pipeline)
+
+    # attach() dispatches to the Pipecat path and registers the observer.
+    session_id = voicegateway.attach(
+        task, project="e2e", agent_id="agent-e2e", sink=sink
+    )
+    assert isinstance(session_id, str) and session_id
+
+    runner = PipelineRunner()
+
+    async def _stop() -> None:
+        await asyncio.sleep(0.3)
+        await task.stop_when_done()
+
+    await asyncio.gather(runner.run(task), _stop())
+
+    # Exactly one LLM record despite the frame being re-pushed by wrappers.
+    llm_records = [r for r in sink.records if r.modality == "llm"]
+    assert len(llm_records) == 1
+    rec = llm_records[0]
+    assert rec.provider == "openai"
+    assert rec.model_id == "openai/gpt-4o"
+    assert rec.input_units == 1000.0
+    assert rec.output_units == 500.0
+    assert rec.cached_input_units == 200.0
+    assert rec.cost_usd == pytest.approx(0.00725, rel=1e-6)
+    assert rec.project == "e2e"
+    assert rec.agent_id == "agent-e2e"
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_observer_export_usable_in_task_constructor() -> None:
+    """``voicegateway.Observer`` slots into ``PipelineTask(observers=[...])``."""
+    sink = _RecordingSink()
+    observer = voicegateway.Observer(sink=sink, project="ctor", agent_id="a")
+    emitter = _EmitterLLM()
+    pipeline = Pipeline([emitter])
+    task = PipelineTask(pipeline, observers=[observer])
+
+    runner = PipelineRunner()
+
+    async def _stop() -> None:
+        await asyncio.sleep(0.3)
+        await task.stop_when_done()
+
+    await asyncio.gather(runner.run(task), _stop())
+
+    llm_records = [r for r in sink.records if r.modality == "llm"]
+    assert len(llm_records) == 1
+    assert llm_records[0].model_id == "openai/gpt-4o"

--- a/src/voicegateway/tests/inference/test_pipecat_observer.py
+++ b/src/voicegateway/tests/inference/test_pipecat_observer.py
@@ -1,0 +1,339 @@
+"""Tests for the Pipecat ``VoiceGatewayObserver`` (P2 attach path).
+
+These feed synthetic Pipecat frames (``MetricsFrame`` with LLM/TTS usage +
+TTFB, and ``AudioRawFrame``s) to the observer and assert the emitted
+``RequestRecord``s: modality, model, provider, units, cost (via voice-prices),
+ttfb_ms, and that correlation yields exactly one record per request.
+
+The observer reuses the framework-neutral core unchanged: ``CostTracker`` +
+``Sink`` are built exactly like ``attach()`` builds them for LiveKit.
+
+Stub services set ``__module__`` to ``pipecat.services.<provider>.<modality>``
+so provider resolution (which reads the service module, exactly like a real
+pipecat provider under ``pipecat.services.openai.llm`` etc.) is deterministic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+pipecat = pytest.importorskip("pipecat")
+
+from pipecat.frames.frames import (  # noqa: E402
+    EndFrame,
+    InputAudioRawFrame,
+    MetricsFrame,
+    TranscriptionFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.metrics.metrics import (  # noqa: E402
+    LLMTokenUsage,
+    LLMUsageMetricsData,
+    TTFBMetricsData,
+    TTSUsageMetricsData,
+)
+from pipecat.observers.base_observer import FramePushed  # noqa: E402
+from pipecat.processors.frame_processor import FrameDirection  # noqa: E402
+from pipecat.services.llm_service import LLMService  # noqa: E402
+from pipecat.services.stt_service import STTService  # noqa: E402
+from pipecat.services.tts_service import TTSService  # noqa: E402
+
+from voicegateway.inference.pipecat.observer import (  # noqa: E402
+    VoiceGatewayObserver,
+    pipecat_identity,
+)
+
+# --- test doubles ----------------------------------------------------------
+
+
+class _RecordingSink:
+    """Captures every RequestRecord written, in order."""
+
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+        self.flushed = 0
+
+    async def log_request(self, record: Any) -> None:
+        self.records.append(record)
+
+    async def flush(self) -> None:
+        self.flushed += 1
+
+
+class _StubLLM(LLMService):
+    """A minimal concrete LLMService so identity resolves by base class."""
+
+    # Emulate a real provider service living under pipecat.services.openai.llm.
+    __module__ = "pipecat.services.openai.llm"
+
+    def __init__(self, model: str = "gpt-4o") -> None:
+        super().__init__()
+        self._settings.model = model
+
+
+class _StubTTS(TTSService):
+    __module__ = "pipecat.services.cartesia.tts"
+
+    def __init__(self, model: str = "sonic-2") -> None:
+        super().__init__(sample_rate=24000)
+        self._settings.model = model
+
+    async def run_tts(self, text: str) -> Any:  # pragma: no cover - unused
+        yield None
+
+
+class _StubSTT(STTService):
+    __module__ = "pipecat.services.deepgram.stt"
+
+    def __init__(self, model: str = "nova-3") -> None:
+        super().__init__(sample_rate=16000)
+        self._settings.model = model
+
+    async def run_stt(self, audio: bytes) -> Any:  # pragma: no cover - unused
+        yield None
+
+
+def _make_observer(**kwargs: Any) -> tuple[VoiceGatewayObserver, _RecordingSink]:
+    sink = _RecordingSink()
+    obs = VoiceGatewayObserver(sink=sink, project="proj", agent_id="agent-1", **kwargs)
+    return obs, sink
+
+
+def _pushed(source: Any, frame: Any) -> FramePushed:
+    """Build a FramePushed event the observer's on_push_frame consumes."""
+    return FramePushed(
+        source=source,
+        destination=None,
+        frame=frame,
+        direction=FrameDirection.DOWNSTREAM,
+        timestamp=0,
+    )
+
+
+async def _feed(obs: VoiceGatewayObserver, source: Any, frame: Any) -> None:
+    await obs.on_push_frame(_pushed(source, frame))
+
+
+# --- identity --------------------------------------------------------------
+
+
+def test_identity_llm_from_base_class_and_module() -> None:
+    provider, modality = pipecat_identity(_StubLLM())
+    assert modality == "llm"
+    assert provider == "openai"
+
+
+def test_identity_stt_tts_modalities_and_providers() -> None:
+    assert pipecat_identity(_StubSTT()) == ("deepgram", "stt")
+    assert pipecat_identity(_StubTTS()) == ("cartesia", "tts")
+
+
+# --- LLM usage mapping -----------------------------------------------------
+
+
+async def test_llm_usage_maps_units_and_costs() -> None:
+    obs, sink = _make_observer()
+    llm = _StubLLM("gpt-4o")
+    usage = LLMTokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cache_read_input_tokens=200,
+    )
+    md = LLMUsageMetricsData(processor=llm.name, model="gpt-4o", value=usage)
+    await _feed(obs, llm, MetricsFrame(data=[md]))
+    await obs.aclose()
+
+    assert len(sink.records) == 1
+    rec = sink.records[0]
+    assert rec.modality == "llm"
+    assert rec.provider == "openai"
+    assert rec.model_id == "openai/gpt-4o"
+    assert rec.input_units == 1000.0
+    assert rec.output_units == 500.0
+    assert rec.cached_input_units == 200.0
+    # voice-prices priced gpt-4o at these units.
+    assert rec.cost_usd == pytest.approx(0.00725, rel=1e-6)
+
+
+# --- TTS usage mapping -----------------------------------------------------
+
+
+async def test_tts_usage_maps_chars_and_costs() -> None:
+    obs, sink = _make_observer()
+    tts = _StubTTS("sonic-2")
+    md = TTSUsageMetricsData(processor=tts.name, model="sonic-2", value=350)
+    await _feed(obs, tts, MetricsFrame(data=[md]))
+    await obs.aclose()
+
+    assert len(sink.records) == 1
+    rec = sink.records[0]
+    assert rec.modality == "tts"
+    assert rec.provider == "cartesia"
+    assert rec.model_id == "cartesia/sonic-2"
+    assert rec.input_units == 350.0
+    assert rec.cost_usd == pytest.approx(0.014, rel=1e-6)
+
+
+# --- correlation: TTFB stitches into ONE record per request ----------------
+
+
+async def test_ttfb_and_usage_correlate_into_one_llm_record() -> None:
+    """TTFB and usage arrive as SEPARATE frames; observer emits ONE record."""
+    obs, sink = _make_observer()
+    llm = _StubLLM("gpt-4o")
+    # TTFB arrives first (as it does in Pipecat: first token), no usage yet.
+    await _feed(
+        obs, llm, MetricsFrame(data=[TTFBMetricsData(processor=llm.name, value=0.25)])
+    )
+    assert sink.records == []  # nothing emitted on a lone TTFB
+    # Usage arrives next -> flush exactly one stitched record.
+    usage = LLMTokenUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    await _feed(
+        obs,
+        llm,
+        MetricsFrame(data=[LLMUsageMetricsData(processor=llm.name, value=usage)]),
+    )
+
+    assert len(sink.records) == 1
+    rec = sink.records[0]
+    assert rec.ttfb_ms == pytest.approx(250.0)
+    assert rec.input_units == 1000.0
+
+
+async def test_ttfb_and_usage_same_frame_one_record() -> None:
+    obs, sink = _make_observer()
+    tts = _StubTTS("sonic-2")
+    md_ttfb = TTFBMetricsData(processor=tts.name, value=0.1)
+    md_usage = TTSUsageMetricsData(processor=tts.name, value=350)
+    # Both in the same MetricsFrame -> still one record.
+    await _feed(obs, tts, MetricsFrame(data=[md_ttfb, md_usage]))
+
+    assert len(sink.records) == 1
+    assert sink.records[0].ttfb_ms == pytest.approx(100.0)
+    assert sink.records[0].input_units == 350.0
+
+
+async def test_two_llm_requests_two_records() -> None:
+    """A second usage frame for the same processor is a second request."""
+    obs, sink = _make_observer()
+    llm = _StubLLM("gpt-4o")
+    usage = LLMTokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    await _feed(
+        obs,
+        llm,
+        MetricsFrame(data=[LLMUsageMetricsData(processor=llm.name, value=usage)]),
+    )
+    await _feed(
+        obs,
+        llm,
+        MetricsFrame(data=[LLMUsageMetricsData(processor=llm.name, value=usage)]),
+    )
+    assert len(sink.records) == 2
+
+
+# --- STT audio derivation --------------------------------------------------
+
+
+async def test_stt_audio_derivation_by_bytes() -> None:
+    """seconds = bytes/(sample_rate*2); minutes = seconds/60; emit on boundary."""
+    obs, sink = _make_observer()
+    stt = _StubSTT("nova-3")
+    obs.register_stt(stt)
+    sr = 16000
+    chunk = b"\x00\x01" * sr  # 1s of 16-bit mono = sr samples = sr*2 bytes
+    for _ in range(120):
+        await _feed(
+            obs,
+            stt,
+            InputAudioRawFrame(audio=chunk, sample_rate=sr, num_channels=1),
+        )
+    assert sink.records == []  # no boundary crossed yet
+    # Utterance boundary flushes the STT request.
+    await _feed(obs, stt, UserStoppedSpeakingFrame())
+
+    assert len(sink.records) == 1
+    rec = sink.records[0]
+    assert rec.modality == "stt"
+    assert rec.provider == "deepgram"
+    assert rec.model_id == "deepgram/nova-3"
+    # 120 seconds -> 2.0 minutes.
+    assert rec.input_units == pytest.approx(2.0)
+    assert rec.cost_usd == pytest.approx(0.0096, rel=1e-6)
+
+
+async def test_stt_transcription_frame_is_also_a_boundary() -> None:
+    obs, sink = _make_observer()
+    stt = _StubSTT("nova-3")
+    obs.register_stt(stt)
+    sr = 16000
+    await _feed(
+        obs,
+        stt,
+        InputAudioRawFrame(audio=b"\x00\x01" * sr, sample_rate=sr, num_channels=1),
+    )
+    await _feed(obs, stt, TranscriptionFrame("hi", "user", "0"))
+    assert len(sink.records) == 1
+    assert sink.records[0].modality == "stt"
+    assert sink.records[0].input_units == pytest.approx(1.0 / 60.0)
+
+
+# --- metadata stamping -----------------------------------------------------
+
+
+async def test_metadata_stamps_tenant_channel_session() -> None:
+    obs, sink = _make_observer(tenant_id="tenant-x", channel="telephony")
+    llm = _StubLLM("gpt-4o")
+    usage = LLMTokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    await _feed(
+        obs,
+        llm,
+        MetricsFrame(data=[LLMUsageMetricsData(processor=llm.name, value=usage)]),
+    )
+    rec = sink.records[0]
+    assert rec.metadata.get("tenant_id") == "tenant-x"
+    assert rec.metadata.get("channel") == "telephony"
+    assert rec.session_id is not None
+    assert rec.agent_id == "agent-1"
+    assert rec.project == "proj"
+
+
+# --- session finalize ------------------------------------------------------
+
+
+async def test_endframe_finalizes_and_flushes() -> None:
+    obs, sink = _make_observer()
+    stt = _StubSTT("nova-3")
+    obs.register_stt(stt)
+    sr = 16000
+    await _feed(
+        obs,
+        stt,
+        InputAudioRawFrame(audio=b"\x00\x01" * sr, sample_rate=sr, num_channels=1),
+    )
+    # No explicit utterance boundary; EndFrame must drain the pending STT audio.
+    await _feed(obs, stt, EndFrame())
+    assert sink.flushed >= 1
+    assert len(sink.records) == 1
+    assert sink.records[0].modality == "stt"
+
+
+# --- ordering / event-loop safety -----------------------------------------
+
+
+async def test_on_push_frame_is_awaitable_and_non_blocking() -> None:
+    obs, sink = _make_observer()
+    llm = _StubLLM("gpt-4o")
+    usage = LLMTokenUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    # Awaiting many frames sequentially records one per usage frame.
+    for _ in range(5):
+        await _feed(
+            obs,
+            llm,
+            MetricsFrame(data=[LLMUsageMetricsData(processor=llm.name, value=usage)]),
+        )
+    assert len(sink.records) == 5
+    await asyncio.sleep(0)

--- a/src/voicegateway/tests/test_framework_neutral.py
+++ b/src/voicegateway/tests/test_framework_neutral.py
@@ -39,6 +39,36 @@ def test_core_import_pulls_no_framework() -> None:
     assert "PURE" in result.stdout
 
 
+def test_observer_symbol_is_lazy_and_pure() -> None:
+    """Referencing ``voicegateway.Observer`` must not import pipecat.
+
+    ``Observer`` is a lazily-resolved public name (like ``LLM``): it appears in
+    ``dir(voicegateway)`` and is importable, but the pipecat import only happens
+    when the class is actually resolved/instantiated. This subprocess asserts
+    that ``import voicegateway`` plus a ``dir()`` reference stays pipecat-free,
+    then that resolving the attribute does pull pipecat (so the lazy import is
+    wired, not merely absent).
+    """
+    code = (
+        "import voicegateway, sys; "
+        "assert 'Observer' in dir(voicegateway), 'Observer not exported'; "
+        "assert 'pipecat' not in sys.modules, 'pipecat imported by dir()'; "
+        "obs_cls = voicegateway.Observer; "
+        "assert 'pipecat' in sys.modules, 'Observer did not lazy-import pipecat'; "
+        "print('PURE')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Observer lazy-import broke purity.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "PURE" in result.stdout
+
+
 class _FakeType:
     """A stand-in whose class __module__ can be forced for detection tests."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,9 +8,12 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -287,6 +290,62 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "audioop-lts"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz", hash = "sha256:64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0", size = 30686, upload-time = "2025-08-05T16:43:17.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/d4/94d277ca941de5a507b07f0b592f199c22454eeaec8f008a286b3fbbacd6/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd3d4602dc64914d462924a08c1a9816435a2155d74f325853c1f1ac3b2d9800", size = 46523, upload-time = "2025-08-05T16:42:20.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/656d1c2da4b555920ce4177167bfeb8623d98765594af59702c8873f60ec/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:550c114a8df0aafe9a05442a1162dfc8fec37e9af1d625ae6060fed6e756f303", size = 27455, upload-time = "2025-08-05T16:42:22.283Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/83/ea581e364ce7b0d41456fb79d6ee0ad482beda61faf0cab20cbd4c63a541/audioop_lts-0.2.2-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a13dc409f2564de15dd68be65b462ba0dde01b19663720c68c1140c782d1d75", size = 26997, upload-time = "2025-08-05T16:42:23.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/e8964210b5e216e5041593b7d33e97ee65967f17c282e8510d19c666dab4/audioop_lts-0.2.2-cp313-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51c916108c56aa6e426ce611946f901badac950ee2ddaf302b7ed35d9958970d", size = 85844, upload-time = "2025-08-05T16:42:25.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2e/0a1c52faf10d51def20531a59ce4c706cb7952323b11709e10de324d6493/audioop_lts-0.2.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47eba38322370347b1c47024defbd36374a211e8dd5b0dcbce7b34fdb6f8847b", size = 85056, upload-time = "2025-08-05T16:42:26.559Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/cd95eef479656cb75ab05dfece8c1f8c395d17a7c651d88f8e6e291a63ab/audioop_lts-0.2.2-cp313-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba7c3a7e5f23e215cb271516197030c32aef2e754252c4c70a50aaff7031a2c8", size = 93892, upload-time = "2025-08-05T16:42:27.902Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1e/a0c42570b74f83efa5cca34905b3eef03f7ab09fe5637015df538a7f3345/audioop_lts-0.2.2-cp313-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:def246fe9e180626731b26e89816e79aae2276f825420a07b4a647abaa84becc", size = 96660, upload-time = "2025-08-05T16:42:28.9Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/8a0ae607ca07dbb34027bac8db805498ee7bfecc05fd2c148cc1ed7646e7/audioop_lts-0.2.2-cp313-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e160bf9df356d841bb6c180eeeea1834085464626dc1b68fa4e1d59070affdc3", size = 79143, upload-time = "2025-08-05T16:42:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/12/17/0d28c46179e7910bfb0bb62760ccb33edb5de973052cb2230b662c14ca2e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4b4cd51a57b698b2d06cb9993b7ac8dfe89a3b2878e96bc7948e9f19ff51dba6", size = 84313, upload-time = "2025-08-05T16:42:30.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ba/bd5d3806641564f2024e97ca98ea8f8811d4e01d9b9f9831474bc9e14f9e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4a53aa7c16a60a6857e6b0b165261436396ef7293f8b5c9c828a3a203147ed4a", size = 93044, upload-time = "2025-08-05T16:42:31.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/435ce8d5642f1f7679540d1e73c1c42d933331c0976eb397d1717d7f01a3/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:3fc38008969796f0f689f1453722a0f463da1b8a6fbee11987830bfbb664f623", size = 78766, upload-time = "2025-08-05T16:42:33.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/b909e76b606cbfd53875693ec8c156e93e15a1366a012f0b7e4fb52d3c34/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:15ab25dd3e620790f40e9ead897f91e79c0d3ce65fe193c8ed6c26cffdd24be7", size = 87640, upload-time = "2025-08-05T16:42:34.854Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e7/8f1603b4572d79b775f2140d7952f200f5e6c62904585d08a01f0a70393a/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03f061a1915538fd96272bac9551841859dbb2e3bf73ebe4a23ef043766f5449", size = 86052, upload-time = "2025-08-05T16:42:35.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/96/c37846df657ccdda62ba1ae2b6534fa90e2e1b1742ca8dcf8ebd38c53801/audioop_lts-0.2.2-cp313-abi3-win32.whl", hash = "sha256:3bcddaaf6cc5935a300a8387c99f7a7fbbe212a11568ec6cf6e4bc458c048636", size = 26185, upload-time = "2025-08-05T16:42:37.04Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a5/9d78fdb5b844a83da8a71226c7bdae7cc638861085fff7a1d707cb4823fa/audioop_lts-0.2.2-cp313-abi3-win_amd64.whl", hash = "sha256:a2c2a947fae7d1062ef08c4e369e0ba2086049a5e598fda41122535557012e9e", size = 30503, upload-time = "2025-08-05T16:42:38.427Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/20d8fde083123e90c61b51afb547bb0ea7e77bab50d98c0ab243d02a0e43/audioop_lts-0.2.2-cp313-abi3-win_arm64.whl", hash = "sha256:5f93a5db13927a37d2d09637ccca4b2b6b48c19cd9eda7b17a2e9f77edee6a6f", size = 24173, upload-time = "2025-08-05T16:42:39.704Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a7/0a764f77b5c4ac58dc13c01a580f5d32ae8c74c92020b961556a43e26d02/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:73f80bf4cd5d2ca7814da30a120de1f9408ee0619cc75da87d0641273d202a09", size = 47096, upload-time = "2025-08-05T16:42:40.684Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/ebebedde1a18848b085ad0fa54b66ceb95f1f94a3fc04f1cd1b5ccb0ed42/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:106753a83a25ee4d6f473f2be6b0966fc1c9af7e0017192f5531a3e7463dce58", size = 27748, upload-time = "2025-08-05T16:42:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6e/11ca8c21af79f15dbb1c7f8017952ee8c810c438ce4e2b25638dfef2b02c/audioop_lts-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fbdd522624141e40948ab3e8cdae6e04c748d78710e9f0f8d4dae2750831de19", size = 27329, upload-time = "2025-08-05T16:42:42.987Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/0022f93d56d85eec5da6b9da6a958a1ef09e80c39f2cc0a590c6af81dcbb/audioop_lts-0.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:143fad0311e8209ece30a8dbddab3b65ab419cbe8c0dde6e8828da25999be911", size = 92407, upload-time = "2025-08-05T16:42:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1d/48a889855e67be8718adbc7a01f3c01d5743c325453a5e81cf3717664aad/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfbbc74ec68a0fd08cfec1f4b5e8cca3d3cd7de5501b01c4b5d209995033cde9", size = 91811, upload-time = "2025-08-05T16:42:45.325Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a6/94b7213190e8077547ffae75e13ed05edc488653c85aa5c41472c297d295/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cfcac6aa6f42397471e4943e0feb2244549db5c5d01efcd02725b96af417f3fe", size = 100470, upload-time = "2025-08-05T16:42:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e9/78450d7cb921ede0cfc33426d3a8023a3bda755883c95c868ee36db8d48d/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:752d76472d9804ac60f0078c79cdae8b956f293177acd2316cd1e15149aee132", size = 103878, upload-time = "2025-08-05T16:42:47.576Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cd5439aad4f3e34ae1ee852025dc6aa8f67a82b97641e390bf7bd9891d3e/audioop_lts-0.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:83c381767e2cc10e93e40281a04852facc4cd9334550e0f392f72d1c0a9c5753", size = 84867, upload-time = "2025-08-05T16:42:49.003Z" },
+    { url = "https://files.pythonhosted.org/packages/68/4b/9d853e9076c43ebba0d411e8d2aa19061083349ac695a7d082540bad64d0/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c0022283e9556e0f3643b7c3c03f05063ca72b3063291834cca43234f20c60bb", size = 90001, upload-time = "2025-08-05T16:42:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/58/26/4bae7f9d2f116ed5593989d0e521d679b0d583973d203384679323d8fa85/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a2d4f1513d63c795e82948e1305f31a6d530626e5f9f2605408b300ae6095093", size = 99046, upload-time = "2025-08-05T16:42:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/67/a9f4fb3e250dda9e9046f8866e9fa7d52664f8985e445c6b4ad6dfb55641/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c9c8e68d8b4a56fda8c025e538e639f8c5953f5073886b596c93ec9b620055e7", size = 84788, upload-time = "2025-08-05T16:42:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f7/3de86562db0121956148bcb0fe5b506615e3bcf6e63c4357a612b910765a/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:96f19de485a2925314f5020e85911fb447ff5fbef56e8c7c6927851b95533a1c", size = 94472, upload-time = "2025-08-05T16:42:53.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/32/fd772bf9078ae1001207d2df1eef3da05bea611a87dd0e8217989b2848fa/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e541c3ef484852ef36545f66209444c48b28661e864ccadb29daddb6a4b8e5f5", size = 92279, upload-time = "2025-08-05T16:42:54.632Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/41/affea7181592ab0ab560044632571a38edaf9130b84928177823fbf3176a/audioop_lts-0.2.2-cp313-cp313t-win32.whl", hash = "sha256:d5e73fa573e273e4f2e5ff96f9043858a5e9311e94ffefd88a3186a910c70917", size = 26568, upload-time = "2025-08-05T16:42:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2b/0372842877016641db8fc54d5c88596b542eec2f8f6c20a36fb6612bf9ee/audioop_lts-0.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9191d68659eda01e448188f60364c7763a7ca6653ed3f87ebb165822153a8547", size = 30942, upload-time = "2025-08-05T16:42:56.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/baf2b9cc7e96c179bb4a54f30fcd83e6ecb340031bde68f486403f943768/audioop_lts-0.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c174e322bb5783c099aaf87faeb240c8d210686b04bd61dfd05a8e5a83d88969", size = 24603, upload-time = "2025-08-05T16:42:57.571Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/413b5a2804091e2c7d5def1d618e4837f1cb82464e230f827226278556b7/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:f9ee9b52f5f857fbaf9d605a360884f034c92c1c23021fb90b2e39b8e64bede6", size = 47104, upload-time = "2025-08-05T16:42:58.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/daa3308dc6593944410c2c68306a5e217f5c05b70a12e70228e7dd42dc5c/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:49ee1a41738a23e98d98b937a0638357a2477bc99e61b0f768a8f654f45d9b7a", size = 27754, upload-time = "2025-08-05T16:43:00.132Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/86/c2e0f627168fcf61781a8f72cab06b228fe1da4b9fa4ab39cfb791b5836b/audioop_lts-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5b00be98ccd0fc123dcfad31d50030d25fcf31488cde9e61692029cd7394733b", size = 27332, upload-time = "2025-08-05T16:43:01.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/35dce665255434f54e5307de39e31912a6f902d4572da7c37582809de14f/audioop_lts-0.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6d2e0f9f7a69403e388894d4ca5ada5c47230716a03f2847cfc7bd1ecb589d6", size = 92396, upload-time = "2025-08-05T16:43:02.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d2/deeb9f51def1437b3afa35aeb729d577c04bcd89394cb56f9239a9f50b6f/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b0b8a03ef474f56d1a842af1a2e01398b8f7654009823c6d9e0ecff4d5cfbf", size = 91811, upload-time = "2025-08-05T16:43:04.096Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3b/09f8b35b227cee28cc8231e296a82759ed80c1a08e349811d69773c48426/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b267b70747d82125f1a021506565bdc5609a2b24bcb4773c16d79d2bb260bbd", size = 100483, upload-time = "2025-08-05T16:43:05.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/05b48a935cf3b130c248bfdbdea71ce6437f5394ee8533e0edd7cfd93d5e/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0337d658f9b81f4cd0fdb1f47635070cc084871a3d4646d9de74fdf4e7c3d24a", size = 103885, upload-time = "2025-08-05T16:43:06.197Z" },
+    { url = "https://files.pythonhosted.org/packages/83/80/186b7fce6d35b68d3d739f228dc31d60b3412105854edb975aa155a58339/audioop_lts-0.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:167d3b62586faef8b6b2275c3218796b12621a60e43f7e9d5845d627b9c9b80e", size = 84899, upload-time = "2025-08-05T16:43:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/49/89/c78cc5ac6cb5828f17514fb12966e299c850bc885e80f8ad94e38d450886/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0d9385e96f9f6da847f4d571ce3cb15b5091140edf3db97276872647ce37efd7", size = 89998, upload-time = "2025-08-05T16:43:08.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/6401888d0c010e586c2ca50fce4c903d70a6bb55928b16cfbdfd957a13da/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:48159d96962674eccdca9a3df280e864e8ac75e40a577cc97c5c42667ffabfc5", size = 99046, upload-time = "2025-08-05T16:43:09.367Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f8/c874ca9bb447dae0e2ef2e231f6c4c2b0c39e31ae684d2420b0f9e97ee68/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8fefe5868cd082db1186f2837d64cfbfa78b548ea0d0543e9b28935ccce81ce9", size = 84843, upload-time = "2025-08-05T16:43:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/0323e66f3daebc13fd46b36b30c3be47e3fc4257eae44f1e77eb828c703f/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:58cf54380c3884fb49fdd37dfb7a772632b6701d28edd3e2904743c5e1773602", size = 94490, upload-time = "2025-08-05T16:43:12.131Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6b/acc7734ac02d95ab791c10c3f17ffa3584ccb9ac5c18fd771c638ed6d1f5/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:088327f00488cdeed296edd9215ca159f3a5a5034741465789cad403fcf4bec0", size = 92297, upload-time = "2025-08-05T16:43:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c3/c3dc3f564ce6877ecd2a05f8d751b9b27a8c320c2533a98b0c86349778d0/audioop_lts-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:068aa17a38b4e0e7de771c62c60bbca2455924b67a8814f3b0dee92b5820c0b3", size = 27331, upload-time = "2025-08-05T16:43:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/72/bb/b4608537e9ffcb86449091939d52d24a055216a36a8bf66b936af8c3e7ac/audioop_lts-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a5bf613e96f49712073de86f20dbdd4014ca18efd4d34ed18c75bd808337851b", size = 31697, upload-time = "2025-08-05T16:43:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/22/91616fe707a5c5510de2cac9b046a30defe7007ba8a0c04f9c08f27df312/audioop_lts-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:b492c3b040153e68b9fdaff5913305aaaba5bb433d8a7f73d5cf6a64ed3cc1dd", size = 25206, upload-time = "2025-08-05T16:43:16.444Z" },
 ]
 
 [[package]]
@@ -951,6 +1010,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "dependency-injector"
 version = "4.49.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1003,6 +1071,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba624712
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
 name = "docstring-parser"
@@ -1900,6 +1974,34 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a0/acc8ffcd5bdc63df0097e22c719bfcd61b604358343089313a8aebbb24ab/llvmlite-0.48.0.tar.gz", hash = "sha256:543b19f9ef8f3c7c60d1468191e4ee1b1537bf9f8a3d56f64c0ddd98de92edd2", size = 184016, upload-time = "2026-07-02T20:20:05.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/55/595981f14fbae9ba966feb12af552b1fe69889e44e64ac883a731ed335e0/llvmlite-0.48.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:56a7e24607d3f02d7b1bae8d29c7e1e423d53143d68b072999777f19678fe77b", size = 40480651, upload-time = "2026-07-01T18:41:18.438Z" },
+    { url = "https://files.pythonhosted.org/packages/26/08/0109d1b9cb3f4603f3890e30bc66c65332b79185f12a045343b2ae431f67/llvmlite-0.48.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6fa532d6bb3fd3f0803567c736401c54aecfe1a396d3ad25d2440d220e09f0e7", size = 59890118, upload-time = "2026-07-01T18:41:28.184Z" },
+    { url = "https://files.pythonhosted.org/packages/02/eb/c5281be180c789cdffbf45b671884c57d7e61345ef3b0f643a4965e108e8/llvmlite-0.48.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:979a66a3f28a02565383ff463527dce78e9b856298872a361283132488e83591", size = 58343458, upload-time = "2026-07-01T18:41:23.397Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f7/b3222b13f2d424dae3c9e63fde476af25ebccf1f3faf0b52d1b79fc15c70/llvmlite-0.48.0-cp311-cp311-win_amd64.whl", hash = "sha256:efaee0276e5e17c2b99b92e0c974bd484ef5977cf5dbc9168e82b71578edb47f", size = 41864734, upload-time = "2026-07-01T18:41:31.932Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a2/28696a9e61e245d1a79816d29d106692a90a2b6e7d78c98b326db70827af/llvmlite-0.48.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:d66c3beb4209087ddd4cf4ed2a0856b6887e6a913bdcf1aacfec9851cf2cba4e", size = 40480651, upload-time = "2026-07-01T18:41:35.694Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f2/72409351db66d0a317ec5087e076f31fb7b773a640db8a90ce6b5cac9edd/llvmlite-0.48.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:416fa4c2c66c2c6dc6d0a402648c19206e548efa0aa1eff01ad5cdad0af8217d", size = 59890118, upload-time = "2026-07-01T18:41:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/27/5ae2f3722606360480707adb47f001ad89df8251d06b14ee80336e660b66/llvmlite-0.48.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5e5a5131045b72345c71062ea1a91910dde913792b6c9b28ebb2c1c0a712e98", size = 58343459, upload-time = "2026-07-01T18:41:40.306Z" },
+    { url = "https://files.pythonhosted.org/packages/16/78/d824ffff7521cd140dc2006e44ce2bc82e64b48d1b32e90e956308c85a74/llvmlite-0.48.0-cp312-cp312-win_amd64.whl", hash = "sha256:d45c7541a80934ec6d8ab0defe67439494ecd2193cbf852a44ba827808976ac1", size = 41865022, upload-time = "2026-07-01T18:41:48.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/23/fe9316d14626b42c73ef0b502e724705a6ee9450afe53759c0a99c37c2d7/llvmlite-0.48.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a83a99ef0c05b4ccddf9b6218ed9fe84b653a0caf7c1d9dbe148d6d16c67f518", size = 40480652, upload-time = "2026-07-01T18:41:52.216Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4a/90715fa12006d681270b08d881195b6fab3ec39572e048764a1f7f59fed7/llvmlite-0.48.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8761b9e522f55207e24424fcd98370289eec2710bf8e915c82d1053f642450dc", size = 59890120, upload-time = "2026-07-01T18:42:00.748Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5e/7b3e20d64650ca3c80af0cdb664ec4b575ec83d9d4dd05bea8bd31f9bbb6/llvmlite-0.48.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fe5cb59b2063bfa039dcb8ca6481c0181bf552f340d10dcf61d7996a665556e", size = 58343457, upload-time = "2026-07-01T18:41:56.41Z" },
+    { url = "https://files.pythonhosted.org/packages/17/97/5a430055d1838cf1fb7a01cfa943300f5e4c026fc6333a522c5e4a03b0c1/llvmlite-0.48.0-cp313-cp313-win_amd64.whl", hash = "sha256:91c7e24e74cde3f02b88aa5acca678373f9e069f3b98531b3dbb3a142d9d10bb", size = 41865022, upload-time = "2026-07-01T18:42:04.57Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/8e/8170f2e0c217f88069c333d85bb976e536b332aecfcce606ddbdb249385f/llvmlite-0.48.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:321f1ac39b462603f0b589751aecf2d237d056f6d005749c1752b6f23ec3f074", size = 40480650, upload-time = "2026-07-01T18:42:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e1/05b50692b647cac3c18200ac485b04f342f00ed173c9cc46767274469a15/llvmlite-0.48.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05f0103c8f2f96a37441337e3643863c01b8e83e530aff38960dcb383c54a065", size = 59890115, upload-time = "2026-07-01T18:42:17.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c3/470b8c4ff9ae2db2f9cf5c3e73de76ed908a32788ae9eb5602d43e6a476b/llvmlite-0.48.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37d66fae72802175b0bfe1ea06e624b51e2d7aee6c3c34bbd09739b8f88e8e0b", size = 58343457, upload-time = "2026-07-01T18:42:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2d/6a5171fb7236ac0895e1a02ccba3735bf291e8597239aa6421894d3c0ba8/llvmlite-0.48.0-cp314-cp314-win_amd64.whl", hash = "sha256:966dcab0a598e2bd8fb5f2cc082cf7b07bae564fc485a3a8692393caf986facf", size = 42986372, upload-time = "2026-07-01T18:42:21.483Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e3/7a93e09c9f94e637ca90209ceef0334a9a1d45b0bdb7c92ff922d25d6187/llvmlite-0.48.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7a5c413317050a1d67c34708bde97707f9b2257ef1017f7532d21fe7d9a9ff30", size = 40480654, upload-time = "2026-07-01T18:42:25.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/98/a29133b4728671a175f7d616fab8b1c6e1d8c269d1523581d3160697bfb1/llvmlite-0.48.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d9f952dff6c350c529997423d4fa43abae9722a884ac7ffafc37a3af676e7db", size = 59890119, upload-time = "2026-07-01T18:42:33.88Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/cf/7aac11a1f1c7ec54b60c7f6814e87561fb6b55b2f290455d7941eb113420/llvmlite-0.48.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:054aa7d46595935565f276cf0c1659b4f10929c996dd4a606875fae26fba2a23", size = 58343460, upload-time = "2026-07-01T18:42:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/db/41/b96f440c7df5ebba07872cad4e30fbc3560387755b1ea0b629adb76d5ca8/llvmlite-0.48.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d0b3c61aac83b42fb48cc96bffbf57c81b82b2aa92276b7ed6420c814629a99a", size = 42986383, upload-time = "2026-07-01T18:42:37.544Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1970,6 +2072,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -2113,6 +2224,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2239,6 +2359,66 @@ wheels = [
 ]
 
 [[package]]
+name = "nltk"
+version = "3.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "defusedxml" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
+]
+
+[[package]]
+name = "num2words"
+version = "0.5.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docopt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/58/ad645bd38b4b648eb2fc2ba1b909398e54eb0cbb6a7dbd2b4953e38c9621/num2words-0.5.14.tar.gz", hash = "sha256:b066ec18e56b6616a3b38086b5747daafbaa8868b226a36127e0451c0cf379c6", size = 218213, upload-time = "2024-12-17T20:17:10.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/5b/545e9267a1cc080c8a1be2746113a063e34bcdd0f5173fd665a5c13cb234/num2words-0.5.14-py3-none-any.whl", hash = "sha256:1c8e5b00142fc2966fd8d685001e36c4a9911e070d1b120e1beb721fa1edb33d", size = 163525, upload-time = "2024-12-17T20:17:06.074Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a0/570e3dc53e5602b49108f62a13e529f1eec8bfc7ef37d49c825924dcf546/numba-0.66.0.tar.gz", hash = "sha256:b900e63a0e26c05ea9a6d5a3a5a0a177cb64c5011887bf43edb8c3ed2c38d363", size = 2806181, upload-time = "2026-07-01T23:12:46.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/02/970796b4daa709604cde22e87a7cda9bde473c278ea4a75f59fe38cee47f/numba-0.66.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:bbd531c327557a9004507fa6bff06c53ab51a7a5776b75261bb9cef1efe2b2ea", size = 2727049, upload-time = "2026-07-01T23:12:11.296Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/99/33a6ed9c1a0b5e42efa98eb0edf617d61dca576c82625947377b1d4540c9/numba-0.66.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc6629becb21a867d85401ec89f426dd24c484a4193ade8a38309debfd1529ca", size = 3808870, upload-time = "2026-07-01T23:12:12.944Z" },
+    { url = "https://files.pythonhosted.org/packages/04/20/8c51126025211659235b8de2866dfa226984ae0c8273461a3cf374716741/numba-0.66.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aac69f3ccb8af100f5913c1241edc9692bad1cdd2508721713f426eb06c9a659", size = 3514498, upload-time = "2026-07-01T23:12:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c9/9476940bc6d5caf5c0cf2e4c5feecbf01244bbe6f914614082dd7a3e520e/numba-0.66.0-cp311-cp311-win_amd64.whl", hash = "sha256:fb601841d9e02e6237bb6522e36d0741614be3cfe2b482a6f00a41b5ba209443", size = 2780225, upload-time = "2026-07-01T23:12:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a3/70deb7f88461c1cd5d16aa990c2380604102661a427667b8950dcdccc27f/numba-0.66.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:53ca5900b7cab15109796030113a6b28576bae5ad7bb507ad6dd1360ddd81ba4", size = 2727264, upload-time = "2026-07-01T23:12:18.669Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/25c319845e9a4e08f16611ddbda56a192eb7b6ed13e1a2bff2da272ffb97/numba-0.66.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0999e3ee1b18c48e1fb51d11af35ef59852c7f4f50569c9550c25faef0616ad1", size = 3866252, upload-time = "2026-07-01T23:12:20.429Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ef/a82d6fd6bf1b0fe461651e924d3647eeec9ac17f8eee4896264bf7480930/numba-0.66.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efe0d2d5099790df945e0cb6e1b3104bd965d7bbfac50d62f1d5d1d6ade0825d", size = 3566974, upload-time = "2026-07-01T23:12:22.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/eb/9e6171e378822ab191c7abcfd3d8cfc8644516f6c7834c22e210e4acc070/numba-0.66.0-cp312-cp312-win_amd64.whl", hash = "sha256:b075a4e7ebc43dc6294f223e2821659656209fd5e0ce53245877c23d66d6e1a9", size = 2797403, upload-time = "2026-07-01T23:12:23.724Z" },
+    { url = "https://files.pythonhosted.org/packages/03/52/176c02d005c5c5143cde10a85bbcdcb6236d9e34c3aac089380e0506cd1d/numba-0.66.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:380b2556a2019ccd1e956ae77dd257eaa39403f7520768b626d44b755112785e", size = 2727084, upload-time = "2026-07-01T23:12:25.434Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b5/e930010965568fe7f2c6c962fd2849d458cb9f62c3ab7584af8a19a2b40a/numba-0.66.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:939316d5d8619751207b8972a67852b5a7646665298cb4de693cd6bf135152f4", size = 3873663, upload-time = "2026-07-01T23:12:27.308Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ec/5b51457cbe96e4831141d83e892e65191b23a1b78728456c62909d231ace/numba-0.66.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdf506775d9f02eb92a87bf5c5b1e0d25506fd18cafd769f4ed914a8feac73e7", size = 3573529, upload-time = "2026-07-01T23:12:28.944Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7e/cea7710e96913d3c7f2999f16db1b28e6c5be5171cbf40f77f98333a7243/numba-0.66.0-cp313-cp313-win_amd64.whl", hash = "sha256:c5bfe5350284509ab0474390321454c3a8627a188af5b68c910e83df3e2db4a7", size = 2797247, upload-time = "2026-07-01T23:12:30.774Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7a/7e0e73550eb4e41ede6e72fb5371f4539537a4d770a3b73fa9b61aea0622/numba-0.66.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:46ae5f2b19e2af3c33c2df100306a90ea2f981c8158b0390f8bf6c20eee7357e", size = 2727296, upload-time = "2026-07-01T23:12:32.39Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/26/885774c006de6620ed3d10f45d8e20fe0b8e6aad6d573211a2cbc8b3e528/numba-0.66.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e2b101f23b8b63978d334574d2039f27f0dccfe1d891756f33a2e2f3e4c88cf4", size = 3842720, upload-time = "2026-07-01T23:12:33.938Z" },
+    { url = "https://files.pythonhosted.org/packages/93/99/edebf7de890b73973d839dd971cf73734adfb81ffa1b4504f84b9059c3e5/numba-0.66.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63b943eb2c9ba371908ce2cd6dfc643db51fc40f7966993376a1701bc922f537", size = 3543537, upload-time = "2026-07-01T23:12:35.566Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/b46ad28ac3681d035ea21365c5e052149062e1a0a9affd0563d2760ea6ff/numba-0.66.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd57790acd20f6a468e0ad333ef6b82355e309a92310fb7dff80e919f01a21a9", size = 2799250, upload-time = "2026-07-01T23:12:37.154Z" },
+    { url = "https://files.pythonhosted.org/packages/10/6f/5e77a7397a37dd16f57a7b72e7e470db5227b68e3639df0d13a8e674883d/numba-0.66.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:db7735d15ea17a283d6485b9fa3504769f78fd86e5146638ad5e8da57c031b9e", size = 2730342, upload-time = "2026-07-01T23:12:38.758Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fd/e9c9680a3813f3d781c20e5d53c1074801b787d4feecca0472fdd7c05ce1/numba-0.66.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:651a2b53298340956db26ecbe7ab043106b50a40c2807e66d617a4917245a4ab", size = 3878695, upload-time = "2026-07-01T23:12:40.302Z" },
+    { url = "https://files.pythonhosted.org/packages/61/3a/9b363287b85fcd4537ea3878793822878b2ac1008a78159d2096fea628de/numba-0.66.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c1144ba1720ea59ad79f4f488ed54d149b2613b357f7e445678b7d0739c70e9", size = 3596323, upload-time = "2026-07-01T23:12:42.805Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f2/dca53d50b8f2289dd01954ace9da261e0487d5b74b188b4304e4ecc3492c/numba-0.66.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d426178fb991a85714c43112a8ea7b9d9579ea856ad8dcdb9c1c3941903ba5be", size = 2804772, upload-time = "2026-07-01T23:12:44.399Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2319,39 +2499,40 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.25.1"
+version = "1.24.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flatbuffers" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/00/dccf702195572df51a40784fc939304595a0ae3577537d3b5be79273151a/onnxruntime-1.25.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:5cf58ec7601120bb4370f0b868f794d3e3626db7b1b1dba366c27874b224e9de", size = 17762805, upload-time = "2026-04-27T22:00:45.336Z" },
-    { url = "https://files.pythonhosted.org/packages/64/2a/54a784e321093459ed18b8430ebb043af9049838a8b2c485fa7d41dca181/onnxruntime-1.25.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa7d4daa78a18b8f3b410e31e82dab8580363c85cac644179a853f2748618e89", size = 15866935, upload-time = "2026-04-27T21:59:33.842Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/18/e3966c6035789a0b5b494ca0a9a5f331d57b5c15ae7795b9fffae2e277c5/onnxruntime-1.25.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79162f873cdfa38cfc8d53d59a8dc7a71a14074df3d565b2f8ce24289545ddc0", size = 18007288, upload-time = "2026-04-27T22:00:02.34Z" },
-    { url = "https://files.pythonhosted.org/packages/19/c1/a08f7ce3959af4ea7017210233a129c4c3260d08f728fdf6c0d4b743ce2d/onnxruntime-1.25.1-cp311-cp311-win_amd64.whl", hash = "sha256:451b9494056f7f96b1be76a32745ccc4582bd61b2a0e1bc52de3708446151d5d", size = 12899002, upload-time = "2026-04-27T22:00:33.956Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/f4/95de11cdc1b50686454c041273c9f84e67c4d1bc3ee40e36fa3dafe74c0a/onnxruntime-1.25.1-cp311-cp311-win_arm64.whl", hash = "sha256:7e608f8950076da02c0aeceec2dd790d201eeb31dd73acb04ec989b2bf6199dc", size = 12625773, upload-time = "2026-04-27T22:00:22.483Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/52/8b2a10e8dedf5d486332bc2b3bca0b1ed8049c0b9e4a5cced95413aadfdd/onnxruntime-1.25.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:66e52f7a30d1f780a34aa84d68a0a04d382d9f5b141884ecbf45b7566b9fbde9", size = 17770987, upload-time = "2026-04-27T22:00:47.985Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/87/a424d2867477c42ef8c60172709281120797f7b0f1fd33cc36b24329c825/onnxruntime-1.25.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5f41779f044d1ff75593df5c10a4d311bc82563687796d5218e2685b8f9da25", size = 15871829, upload-time = "2026-04-27T21:59:39.088Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/55/7819e64c515f17c86005447ede8122b974ca851255a94125e2119376f0f8/onnxruntime-1.25.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:905409e9eb2ef87f8226e073f56e71faf731c3e480ebd34952cf953730e4a4ff", size = 18024586, upload-time = "2026-04-27T22:00:05.359Z" },
-    { url = "https://files.pythonhosted.org/packages/89/36/b4f3eb5e95c66389aafd490950b5255e87c9333742cf90516eb50898e1dc/onnxruntime-1.25.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4097b75b77486bb45835a8ed25b9a67976040ec6c258aeabae6aadfbdd1201c", size = 12905112, upload-time = "2026-04-27T22:00:36.478Z" },
-    { url = "https://files.pythonhosted.org/packages/38/fa/e5c43397632a399f542663ed3e3e37763ee203ba845b10b266cd2ede8925/onnxruntime-1.25.1-cp312-cp312-win_arm64.whl", hash = "sha256:b6c7aa5cae606d5c90a392679fac074b60f80025a2e83e1e90fdf882bd2a97f0", size = 12634433, upload-time = "2026-04-27T22:00:25.918Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ee/db3ac55ef770347a926ac0f1317df0ab42c8bc604350833b30c7356bf936/onnxruntime-1.25.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e9d9b3b1694196bc3c5bc66f760a237a5e27d7688aaa2e2c9c0f66abd0486699", size = 17770761, upload-time = "2026-04-27T21:59:54.853Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/9a/33225481a94a59906fce44e27ab12fc3bddd2aaecdc6160bd73341ca1aba/onnxruntime-1.25.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:311d29b943e46a55ca72ca1ea48d7815c993122bfc359f68215fddeb9583fff4", size = 15871542, upload-time = "2026-04-27T21:59:41.881Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/09/f20aac60f6fcf840543be54d4e9252cfeb7e8c2bb6d22477aaeb180e763e/onnxruntime-1.25.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98016a038b31160db23208706139fa3b99cd60bc1c5ffdade77aafd6a37a92ad", size = 18036960, upload-time = "2026-04-27T22:00:10.739Z" },
-    { url = "https://files.pythonhosted.org/packages/50/83/47964ac7e2f7e2f9e83c69ec466642c6835466252cc2ef0561eafeb56b66/onnxruntime-1.25.1-cp313-cp313-win_amd64.whl", hash = "sha256:08717d6eee2820807ba60b1b17032af207bd7aaca5b6c4abaee71f83feae877b", size = 12904886, upload-time = "2026-04-27T22:00:39.878Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/6c/a6c5aea47dc95fca7728f8a5af67c184ec9e7d4e7882125c7062e4bba8dd/onnxruntime-1.25.1-cp313-cp313-win_arm64.whl", hash = "sha256:84f8963d70e00167bae273ab7e80e9795bfc5eb94f6b23236a99c5c11af00844", size = 12634117, upload-time = "2026-04-27T22:00:29.15Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/8a/3b65e7911eec86c125e3d6f43d690a6f68671500543c0390ecd6eb59b771/onnxruntime-1.25.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03e800b3a4b48d9f3a2d23aacc4fa95486a3b406b14e51d1a9b8b6981d9adf9c", size = 15882935, upload-time = "2026-04-27T21:59:44.912Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/bb/410a760694f8ae7bbfc5fa81ccbeb7da241e6d520ee02a333a439cf462a2/onnxruntime-1.25.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd83ef5c10cfc051a1cb465db692d57b996a1bc75a2a97b161398e29cdbc47ff", size = 18021727, upload-time = "2026-04-27T22:00:13.846Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/aa/04530bd38e31e26970fa1212346d76cf81705dc16a8ee5e6f4fb24634c11/onnxruntime-1.25.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:395eb662c437fa2407f44266e4778b75bff261b17c2a6fef042421f9069f871d", size = 17773721, upload-time = "2026-04-27T21:59:59.24Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/7f/ec79ab5cece6a688c944a7fa214a8511d548b9d5142a15d1a3d730b705f1/onnxruntime-1.25.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ae85395f41b291ae3e61780ec5092640181d369ef6c268aa8141c478b509e69", size = 15875954, upload-time = "2026-04-27T21:59:49.394Z" },
-    { url = "https://files.pythonhosted.org/packages/67/fe/20428215d822099ea2c1e3cf35c295cf1a58f467bf18b6c607597a39c18a/onnxruntime-1.25.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:828e1b12710fbedb6dfab5e7bae6f11563617cddf3c2e7e8d84c64de566a4a3a", size = 18038703, upload-time = "2026-04-27T22:00:16.199Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/b1/b15db965e6a68bc47ca7eb584de4e6b3d2d2f484d46cc57f715b596f6528/onnxruntime-1.25.1-cp314-cp314-win_amd64.whl", hash = "sha256:2affc9d2fd9ab013b9c9637464e649a0cca870d57ae18bfef74180eee65c3369", size = 13218513, upload-time = "2026-04-27T22:00:42.506Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f9/25cd2d1b29cdc8140eee4afbb6fb930b69125526632b1d579bc747975306/onnxruntime-1.25.1-cp314-cp314-win_arm64.whl", hash = "sha256:3387d75d1a815b4b2495b4e47a05ef1b3bcb64a817ddc68587e0bfcb9702bcf6", size = 12969835, upload-time = "2026-04-27T22:00:31.504Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/0e/6c507d1e65b2421fb44e241cbba577c7276792279485024fb1752b43f5c5/onnxruntime-1.25.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06280b06604660595037f783c6d24bc70cbe5c6093975f194cd1482e77d450de", size = 15883298, upload-time = "2026-04-27T21:59:51.991Z" },
-    { url = "https://files.pythonhosted.org/packages/df/4e/1c9df57496409dc86b320bd38f29ad7a34b7115e4f35b8fca44a827568a7/onnxruntime-1.25.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e79fd5ce7db10ebcc24e020e2ed0159476e69e2326b9b7828e5aadcf6184212", size = 18021249, upload-time = "2026-04-27T22:00:18.954Z" },
+    { url = "https://files.pythonhosted.org/packages/60/69/6c40720201012c6af9aa7d4ecdd620e521bd806dc6269d636fdd5c5aeebe/onnxruntime-1.24.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:0bdfce8e9a6497cec584aab407b71bf697dac5e1b7b7974adc50bf7533bdb3a2", size = 17332131, upload-time = "2026-03-17T22:05:49.005Z" },
+    { url = "https://files.pythonhosted.org/packages/38/e9/8c901c150ce0c368da38638f44152fb411059c0c7364b497c9e5c957321a/onnxruntime-1.24.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:046ff290045a387676941a02a8ae5c3ebec6b4f551ae228711968c4a69d8f6b7", size = 15152472, upload-time = "2026-03-17T22:03:26.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b6/7a4df417cdd01e8f067a509e123ac8b31af450a719fa7ed81787dd6057ec/onnxruntime-1.24.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e54ad52e61d2d4618dcff8fa1480ac66b24ee2eab73331322db1049f11ccf330", size = 17222993, upload-time = "2026-03-17T22:04:34.485Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/59/8febe015f391aa1757fa5ba82c759ea4b6c14ef970132efb5e316665ba61/onnxruntime-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b43b63eb24a2bc8fc77a09be67587a570967a412cccb837b6245ccb546691153", size = 12594863, upload-time = "2026-03-17T22:05:38.749Z" },
+    { url = "https://files.pythonhosted.org/packages/32/84/4155fcd362e8873eb6ce305acfeeadacd9e0e59415adac474bea3d9281bb/onnxruntime-1.24.4-cp311-cp311-win_arm64.whl", hash = "sha256:e26478356dba25631fb3f20112e345f8e8bf62c499bb497e8a559f7d69cf7e7b", size = 12259895, upload-time = "2026-03-17T22:05:28.812Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/38/31db1b232b4ba960065a90c1506ad7a56995cd8482033184e97fadca17cc/onnxruntime-1.24.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cad1c2b3f455c55678ab2a8caa51fb420c25e6e3cf10f4c23653cdabedc8de78", size = 17341875, upload-time = "2026-03-17T22:05:51.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/60/c4d1c8043eb42f8a9aa9e931c8c293d289c48ff463267130eca97d13357f/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a5c5a544b22f90859c88617ecb30e161ee3349fcc73878854f43d77f00558b5", size = 15172485, upload-time = "2026-03-17T22:03:32.182Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d640eb9f3782689b55cfa715094474cd5662f2f137be6a6f847a594b6e9705c", size = 17244912, upload-time = "2026-03-17T22:04:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f4/6b89e297b93704345f0f3f8c62229bee323ef25682a3f9b4f89a39324950/onnxruntime-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:535b29475ca42b593c45fbb2152fbf1cdf3f287315bf650e6a724a0a1d065cdb", size = 12596856, upload-time = "2026-03-17T22:05:41.224Z" },
+    { url = "https://files.pythonhosted.org/packages/43/06/8b8ec6e9e6a474fcd5d772453f627ad4549dfe3ab8c0bf70af5afcde551b/onnxruntime-1.24.4-cp312-cp312-win_arm64.whl", hash = "sha256:e6214096e14b7b52e3bee1903dc12dc7ca09cb65e26664668a4620cc5e6f9a90", size = 12270275, upload-time = "2026-03-17T22:05:31.132Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f0/8a21ec0a97e40abb7d8da1e8b20fb9e1af509cc6d191f6faa75f73622fb2/onnxruntime-1.24.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e99a48078baaefa2b50fe5836c319499f71f13f76ed32d0211f39109147a49e0", size = 17341922, upload-time = "2026-03-17T22:03:56.364Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/25/d7908de8e08cee9abfa15b8aa82349b79733ae5865162a3609c11598805d/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4aaed1e5e1aaacf2343c838a30a7c3ade78f13eeb16817411f929d04040a13", size = 15172290, upload-time = "2026-03-17T22:03:37.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/72/105ec27a78c5aa0154a7c0cd8c41c19a97799c3b12fc30392928997e3be3/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e30c972bc02e072911aabb6891453ec73795386c0af2b761b65444b8a4c4745f", size = 17244738, upload-time = "2026-03-17T22:04:40.625Z" },
+    { url = "https://files.pythonhosted.org/packages/05/fb/a592736d968c2f58e12de4d52088dda8e0e724b26ad5c0487263adb45875/onnxruntime-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:3b6ba8b0181a3aa88edab00eb01424ffc06f42e71095a91186c2249415fcff93", size = 12597435, upload-time = "2026-03-17T22:05:43.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/04/ae2479e9841b64bd2eb44f8a64756c62593f896514369a11243b1b86ca5c/onnxruntime-1.24.4-cp313-cp313-win_arm64.whl", hash = "sha256:71d6a5c1821d6e8586a024000ece458db8f2fc0ecd050435d45794827ce81e19", size = 12269852, upload-time = "2026-03-17T22:05:33.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/af/a479a536c4398ffaf49fbbe755f45d5b8726bdb4335ab31b537f3d7149b8/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1700f559c8086d06b2a4d5de51e62cb4ff5e2631822f71a36db8c72383db71ee", size = 15176861, upload-time = "2026-03-17T22:03:40.143Z" },
+    { url = "https://files.pythonhosted.org/packages/be/13/19f5da70c346a76037da2c2851ecbf1266e61d7f0dcdb887c667210d4608/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c74e268dc808e61e63784d43f9ddcdaf50a776c2819e8bd1d1b11ef64bf7e36", size = 17247454, upload-time = "2026-03-17T22:04:46.643Z" },
+    { url = "https://files.pythonhosted.org/packages/89/db/b30dbbd6037847b205ab75d962bc349bf1e46d02a65b30d7047a6893ffd6/onnxruntime-1.24.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:fbff2a248940e3398ae78374c5a839e49a2f39079b488bc64439fa0ec327a3e4", size = 17343300, upload-time = "2026-03-17T22:03:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/61/88/1746c0e7959961475b84c776d35601a21d445f463c93b1433a409ec3e188/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2b7969e72d8cb53ffc88ab6d49dd5e75c1c663bda7be7eb0ece192f127343d1", size = 15175936, upload-time = "2026-03-17T22:03:43.671Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ba/4699cde04a52cece66cbebc85bd8335a0d3b9ad485abc9a2e15946a1349d/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14ed1f197fab812b695a5eaddb536c635e58a2fbbe50a517c78f082cc6ce9177", size = 17246432, upload-time = "2026-03-17T22:04:49.58Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/4590910841bb28bd3b4b388a9efbedf4e2d2cca99ddf0c863642b4e87814/onnxruntime-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:311e309f573bf3c12aa5723e23823077f83d5e412a18499d4485c7eb41040858", size = 12903276, upload-time = "2026-03-17T22:05:46.349Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/6f/60e2c0acea1e1ac09b3e794b5a19c166eebf91c0b860b3e6db8e74983fda/onnxruntime-1.24.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f0b910e86b759a4732663ec61fd57ac42ee1b0066f68299de164220b660546d", size = 12594365, upload-time = "2026-03-17T22:05:35.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/0c05d10f8f6c40fe0912ebec0d5a33884aaa2af2053507e864dab0883208/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa12ddc54c9c4594073abcaa265cd9681e95fb89dae982a6f508a794ca42e661", size = 15176889, upload-time = "2026-03-17T22:03:48.021Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1d/1666dc64e78d8587d168fec4e3b7922b92eb286a2ddeebcf6acb55c7dc82/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1cc6a518255f012134bc791975a6294806be9a3b20c4a54cca25194c90cf731", size = 17247021, upload-time = "2026-03-17T22:04:52.377Z" },
 ]
 
 [[package]]
@@ -2683,6 +2864,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
     { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
     { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "pipecat-ai"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "docstring-parser" },
+    { name = "loguru" },
+    { name = "markdown" },
+    { name = "nltk" },
+    { name = "num2words" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "openai" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyloudnorm" },
+    { name = "pyyaml" },
+    { name = "pyyaml-include" },
+    { name = "resampy" },
+    { name = "soxr" },
+    { name = "typing-extensions" },
+    { name = "wait-for2", marker = "python_full_version < '3.12'" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/59/7b46ccbeb7c8f68083d0bc1ef39583e78938c6e65af1ff6f707051ea0948/pipecat_ai-1.5.0.tar.gz", hash = "sha256:df9bd5c3176076d425ffba3d510e0122d055b97c9ba8ad35a4390073eb421e18", size = 11624719, upload-time = "2026-07-04T17:11:50.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/05/c7daebbf0fc59fd6106e34e52a255727443c1db49d046f7ed0bd9dcb6e4e/pipecat_ai-1.5.0-py3-none-any.whl", hash = "sha256:6089ac7ec418b310975c9c16dd472c16f99838810aae707d669b4f6f5981cf8a", size = 11264890, upload-time = "2026-07-04T17:11:47.677Z" },
 ]
 
 [[package]]
@@ -3085,6 +3300,20 @@ crypto = [
 ]
 
 [[package]]
+name = "pyloudnorm"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/00/f915eaa75326f4209941179c2b93ac477f2040e4aeff5bb21d16eb8058f9/pyloudnorm-0.2.0.tar.gz", hash = "sha256:8bf597658ea4e1975c275adf490f6deb5369ea409f2901f939915efa4b681b16", size = 14037, upload-time = "2026-01-04T11:43:35.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/b6/65a49a05614b2548edbba3aab118f2ebe7441dfd778accdcdce9f6567f20/pyloudnorm-0.2.0-py3-none-any.whl", hash = "sha256:9bb69afb904f59d007a7f9ba3d75d16fb8aeef35c44d6df822a9f192d69cf13f", size = 10879, upload-time = "2026-01-04T11:43:34.534Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3250,6 +3479,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-include"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/be/2d07ad85e3d593d69640876a8686eae2c533db8cb7bf298d25c421b4d2d5/pyyaml-include-1.4.1.tar.gz", hash = "sha256:1a96e33a99a3e56235f5221273832464025f02ff3d8539309a3bf00dec624471", size = 20592, upload-time = "2024-03-25T14:56:43.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/ca/6a2cc3a73170d10b5af1f1613baa2ed1f8f46f62dd0bfab2bffd2c2fe260/pyyaml_include-1.4.1-py3-none-any.whl", hash = "sha256:323c7f3a19c82fbc4d73abbaab7ef4f793e146a13383866831631b26ccc7fb00", size = 19079, upload-time = "2024-03-25T14:56:41.274Z" },
+]
+
+[[package]]
 name = "rdflib"
 version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3392,6 +3633,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "resampy"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/f1/34be702a69a5d272e844c98cee82351f880985cfbca0cc86378011078497/resampy-0.4.3.tar.gz", hash = "sha256:a0d1c28398f0e55994b739650afef4e3974115edbe96cd4bb81968425e916e47", size = 3080604, upload-time = "2024-03-05T20:36:08.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b9/3b00ac340a1aab3389ebcc52c779914a44aadf7b0cb7a3bf053195735607/resampy-0.4.3-py3-none-any.whl", hash = "sha256:ad2ed64516b140a122d96704e32bc0f92b23f45419e8b8f478e5a05f83edcebd", size = 3076529, upload-time = "2024-03-05T20:36:02.439Z" },
 ]
 
 [[package]]
@@ -3561,6 +3815,144 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
 name = "segments"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3623,6 +4015,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
     { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
     { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
+]
+
+[[package]]
+name = "soxr"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/7e/f4b461944662ad75036df65277d6130f9411002bfb79e9df7dff40a31db9/soxr-1.0.0.tar.gz", hash = "sha256:e07ee6c1d659bc6957034f4800c60cb8b98de798823e34d2a2bba1caa85a4509", size = 171415, upload-time = "2025-09-07T13:22:21.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/ce/a3262bc8733d3a4ce5f660ed88c3d97f4b12658b0909e71334cba1721dcb/soxr-1.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:28e19d74a5ef45c0d7000f3c70ec1719e89077379df2a1215058914d9603d2d8", size = 206739, upload-time = "2025-09-07T13:21:54.572Z" },
+    { url = "https://files.pythonhosted.org/packages/64/dc/e8cbd100b652697cc9865dbed08832e7e135ff533f453eb6db9e6168d153/soxr-1.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8dc69fc18884e53b72f6141fdf9d80997edbb4fec9dc2942edcb63abbe0d023", size = 165233, upload-time = "2025-09-07T13:21:55.887Z" },
+    { url = "https://files.pythonhosted.org/packages/75/12/4b49611c9ba5e9fe6f807d0a83352516808e8e573f8b4e712fc0c17f3363/soxr-1.0.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f15450e6f65f22f02fcd4c5a9219c873b1e583a73e232805ff160c759a6b586", size = 208867, upload-time = "2025-09-07T13:21:57.076Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/70/92146ab970a3ef8c43ac160035b1e52fde5417f89adb10572f7e788d9596/soxr-1.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f73f57452f9df37b4de7a4052789fcbd474a5b28f38bba43278ae4b489d4384", size = 242633, upload-time = "2025-09-07T13:21:58.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a7/628479336206959463d08260bffed87905e7ba9e3bd83ca6b405a0736e94/soxr-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:9f417c3d69236051cf5a1a7bad7c4bff04eb3d8fcaa24ac1cb06e26c8d48d8dc", size = 173814, upload-time = "2025-09-07T13:21:59.798Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c7/f92b81f1a151c13afb114f57799b86da9330bec844ea5a0d3fe6a8732678/soxr-1.0.0-cp312-abi3-macosx_10_14_x86_64.whl", hash = "sha256:abecf4e39017f3fadb5e051637c272ae5778d838e5c3926a35db36a53e3a607f", size = 205508, upload-time = "2025-09-07T13:22:01.252Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1d/c945fea9d83ea1f2be9d116b3674dbaef26ed090374a77c394b31e3b083b/soxr-1.0.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:e973d487ee46aa8023ca00a139db6e09af053a37a032fe22f9ff0cc2e19c94b4", size = 163568, upload-time = "2025-09-07T13:22:03.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/80/10640970998a1d2199bef6c4d92205f36968cddaf3e4d0e9fe35ddd405bd/soxr-1.0.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8ce273cca101aff3d8c387db5a5a41001ba76ef1837883438d3c652507a9ccc", size = 204707, upload-time = "2025-09-07T13:22:05.125Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/2726603c13c2126cb8ded9e57381b7377f4f0df6ba4408e1af5ddbfdc3dd/soxr-1.0.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8f2a69686f2856d37823bbb7b78c3d44904f311fe70ba49b893af11d6b6047b", size = 238032, upload-time = "2025-09-07T13:22:06.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/530252227f4d0721a5524a936336485dfb429bb206a66baf8e470384f4a2/soxr-1.0.0-cp312-abi3-win_amd64.whl", hash = "sha256:2a3b77b115ae7c478eecdbd060ed4f61beda542dfb70639177ac263aceda42a2", size = 172070, upload-time = "2025-09-07T13:22:07.62Z" },
+    { url = "https://files.pythonhosted.org/packages/99/77/d3b3c25b4f1b1aa4a73f669355edcaee7a52179d0c50407697200a0e55b9/soxr-1.0.0-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:392a5c70c04eb939c9c176bd6f654dec9a0eaa9ba33d8f1024ed63cf68cdba0a", size = 209509, upload-time = "2025-09-07T13:22:08.773Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ee/3ca73e18781bb2aff92b809f1c17c356dfb9a1870652004bd432e79afbfa/soxr-1.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fdc41a1027ba46777186f26a8fba7893be913383414135577522da2fcc684490", size = 167690, upload-time = "2025-09-07T13:22:10.259Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f0/eea8b5f587a2531657dc5081d2543a5a845f271a3bea1c0fdee5cebde021/soxr-1.0.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:449acd1dfaf10f0ce6dfd75c7e2ef984890df94008765a6742dafb42061c1a24", size = 209541, upload-time = "2025-09-07T13:22:11.739Z" },
+    { url = "https://files.pythonhosted.org/packages/64/59/2430a48c705565eb09e78346950b586f253a11bd5313426ced3ecd9b0feb/soxr-1.0.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38b35c99e408b8f440c9376a5e1dd48014857cd977c117bdaa4304865ae0edd0", size = 243025, upload-time = "2025-09-07T13:22:12.877Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/1b/f84a2570a74094e921bbad5450b2a22a85d58585916e131d9b98029c3e69/soxr-1.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a39b519acca2364aa726b24a6fd55acf29e4c8909102e0b858c23013c38328e5", size = 184850, upload-time = "2025-09-07T13:22:14.068Z" },
 ]
 
 [[package]]
@@ -3721,6 +4139,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]
@@ -4009,9 +4439,6 @@ dependencies = [
     { name = "clickhouse-connect" },
     { name = "cryptography" },
     { name = "httpx" },
-    { name = "livekit" },
-    { name = "livekit-agents" },
-    { name = "livekit-api" },
     { name = "pillow" },
     { name = "psutil" },
     { name = "pydantic" },
@@ -4027,6 +4454,9 @@ dependencies = [
 all = [
     { name = "faster-whisper" },
     { name = "kokoro-onnx" },
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-anthropic" },
     { name = "livekit-plugins-assemblyai" },
     { name = "livekit-plugins-cartesia" },
@@ -4039,15 +4469,27 @@ all = [
     { name = "psutil" },
 ]
 anthropic = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-anthropic" },
 ]
 assemblyai = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-assemblyai" },
 ]
 cartesia = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-cartesia" },
 ]
 cloud = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-anthropic" },
     { name = "livekit-plugins-assemblyai" },
     { name = "livekit-plugins-cartesia" },
@@ -4067,6 +4509,9 @@ dashboard = [
     { name = "uvicorn" },
 ]
 deepgram = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-deepgram" },
 ]
 dev = [
@@ -4074,6 +4519,9 @@ dev = [
     { name = "chdb" },
     { name = "dependency-injector" },
     { name = "fastapi" },
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "loguru" },
     { name = "platformdirs" },
     { name = "psutil" },
@@ -4087,14 +4535,25 @@ dev = [
     { name = "textual" },
 ]
 elevenlabs = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-elevenlabs" },
 ]
 groq = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-openai" },
 ]
 kokoro = [
     { name = "kokoro-onnx" },
     { name = "onnxruntime" },
+]
+livekit = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
 ]
 local = [
     { name = "faster-whisper" },
@@ -4106,10 +4565,16 @@ mcp = [
     { name = "mcp" },
 ]
 openai = [
+    { name = "livekit" },
+    { name = "livekit-agents" },
+    { name = "livekit-api" },
     { name = "livekit-plugins-openai" },
 ]
 openrtc = [
     { name = "openrtc" },
+]
+pipecat = [
+    { name = "pipecat-ai" },
 ]
 piper = [
     { name = "piper-tts" },
@@ -4158,9 +4623,39 @@ requires-dist = [
     { name = "kokoro-onnx", marker = "extra == 'all'", specifier = ">=0.5.0" },
     { name = "kokoro-onnx", marker = "extra == 'kokoro'", specifier = ">=0.5.0" },
     { name = "kokoro-onnx", marker = "extra == 'local'", specifier = ">=0.5.0" },
-    { name = "livekit", specifier = ">=1.0" },
-    { name = "livekit-agents", specifier = ">=1.5,<1.7" },
-    { name = "livekit-api", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'all'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'anthropic'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'assemblyai'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'cartesia'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'cloud'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'deepgram'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'elevenlabs'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'groq'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'livekit'", specifier = ">=1.0" },
+    { name = "livekit", marker = "extra == 'openai'", specifier = ">=1.0" },
+    { name = "livekit-agents", marker = "extra == 'all'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'anthropic'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'assemblyai'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'cartesia'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'cloud'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'deepgram'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'dev'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'elevenlabs'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'groq'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-agents", marker = "extra == 'openai'", specifier = ">=1.5,<1.7" },
+    { name = "livekit-api", marker = "extra == 'all'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'anthropic'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'assemblyai'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'cartesia'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'cloud'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'deepgram'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'elevenlabs'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'groq'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'livekit'", specifier = ">=1.0" },
+    { name = "livekit-api", marker = "extra == 'openai'", specifier = ">=1.0" },
     { name = "livekit-plugins-anthropic", marker = "extra == 'all'", specifier = ">=1.5.0" },
     { name = "livekit-plugins-anthropic", marker = "extra == 'anthropic'", specifier = ">=1.5.0" },
     { name = "livekit-plugins-anthropic", marker = "extra == 'cloud'", specifier = ">=1.5.0" },
@@ -4189,6 +4684,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "extra == 'local'", specifier = ">=1.19.0" },
     { name = "openrtc", marker = "extra == 'openrtc'", specifier = ">=0.3.0" },
     { name = "pillow", specifier = ">=10.0" },
+    { name = "pipecat-ai", marker = "extra == 'pipecat'", specifier = ">=1.5.0,<2.0" },
     { name = "piper-tts", marker = "extra == 'all'", specifier = ">=1.2.0" },
     { name = "piper-tts", marker = "extra == 'local'", specifier = ">=1.2.0" },
     { name = "piper-tts", marker = "extra == 'piper'", specifier = ">=1.2.0" },
@@ -4222,7 +4718,16 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.32.0" },
     { name = "voice-prices", specifier = ">=0.0.8,<0.1" },
 ]
-provides-extras = ["all", "anthropic", "assemblyai", "cartesia", "cloud", "dashboard", "deepgram", "dev", "elevenlabs", "groq", "kokoro", "local", "mcp", "openai", "openrtc", "piper", "postgres", "server", "tui", "whisper"]
+provides-extras = ["all", "anthropic", "assemblyai", "cartesia", "cloud", "dashboard", "deepgram", "dev", "elevenlabs", "groq", "kokoro", "livekit", "local", "mcp", "openai", "openrtc", "pipecat", "piper", "postgres", "server", "tui", "whisper"]
+
+[[package]]
+name = "wait-for2"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/7c/ea09d6a11990a8aa3ceac206fb7ea82366ea2c200caa87966611e0e18597/wait_for2-0.4.1.tar.gz", hash = "sha256:7f415415d21845c441391d6b4abe68f5959d2c0fbe927c2f61be28a297bc2acb", size = 17519, upload-time = "2025-06-13T19:45:00.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/56/0f88040567af7ff376ec9eaabe18fd980a4f5089d3bf8c7a32598ef06b8d/wait_for2-0.4.1-py3-none-any.whl", hash = "sha256:c694503e8c7420929e8a86bcffd9b00d55acaec2c14223a2b1e92bdc2ebf2154", size = 10985, upload-time = "2025-06-13T19:44:58.82Z" },
+]
 
 [[package]]
 name = "watchfiles"


### PR DESCRIPTION
P2 of the framework-neutral program: Pipecat observability. The hardest phase. Additive; reuses the framework-neutral core unchanged.

## What
- `voicegateway/inference/pipecat/observer.py`: `VoiceGatewayObserver(BaseObserver)`. `on_push_frame` maps `MetricsFrame` data into `RequestRecord`s via the existing `CostTracker` + voice-prices:
  - `LLMUsageMetricsData` -> llm (prompt/completion/cache_read tokens), `TTSUsageMetricsData` -> tts (chars), `TTFBMetricsData`/`TTFAMetricsData` -> ttfb/total latency.
  - STT has no usage metric: derive audio seconds from `AudioRawFrame` bytes (bytes/(sample_rate*2*channels)) -> minutes.
- **Correlation rule**: the usage metric is the LLM/TTS request boundary (stitch buffered TTFB, emit one record, clear); STT boundary is the utterance (`UserStoppedSpeakingFrame`/`TranscriptionFrame`) or `EndFrame`; re-pushed frames deduped by frame id.
- `attach(target)` now dispatches on `detect_framework` (LiveKit path unchanged; new `_attach_pipecat` registers the observer, detects channel from the transport, finalizes on pipeline end). Exported `voicegateway.Observer` (lazy) for `PipelineTask(observers=[Observer(...)])`.

## API note
Built against the INSTALLED `pipecat-ai==1.5.0` (public run surface is `PipelineTask`/`PipelineRunner`, not the newer dev HEAD's `PipelineWorker`), verified by importing the real classes.

## Verification
- `import voicegateway` PURE (Observer/attach lazy-import pipecat only on use).
- 15 new tests pass: modality/provider/model/units, `cost_usd` via voice-prices, ttfb, one-record-per-request correlation, STT byte→minute derivation, metadata stamping, EndFrame finalize, and a live Pipeline+PipelineTask e2e via both `attach(task)` and `voicegateway.Observer`.
- Re-baselined WITH pipecat installed: failing-test-ID set byte-identical (119 pre-existing unchanged; +15 new passing). mypy + ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new observer export for pipeline integrations, with lazy loading to keep imports lightweight.
  * Extended attachment support to work with both LiveKit and Pipecat sessions.
  * Added end-to-end pipeline coverage for exporting usage data during runtime.

* **Bug Fixes**
  * Improved matching of usage, latency, and audio-boundary events so records are emitted more reliably.
  * Added safer handling for export/flush failures so pipelines continue running.

* **Tests**
  * Added broader coverage for observer behavior, metadata stamping, session finalization, and framework-neutral import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->