### PR TITLE
fix(ci): friendly extra error for lazy Observer/LLM access

### DIFF
--- a/src/voicegateway/__init__.py
+++ b/src/voicegateway/__init__.py
@@ -57,6 +57,18 @@ _LAZY = {
     "inference": ("voicegateway.inference", None),
 }
 
+# The extra each lazy name needs, so a missing framework yields the friendly
+# "pip install voicegateway[<extra>]" error instead of a raw ModuleNotFoundError.
+# ``inference`` is intentionally absent: the submodule itself is framework-neutral
+# (its own factories are lazy), so pipecat-only users can reach
+# ``voicegateway.inference.pipecat`` without livekit.
+_LAZY_EXTRA = {
+    "LLM": "livekit",
+    "STT": "livekit",
+    "TTS": "livekit",
+    "Observer": "pipecat",
+}
+
 
 def __getattr__(name: str) -> Any:
     """Lazily resolve framework-pulling public names (PEP 562).
@@ -64,11 +76,17 @@ def __getattr__(name: str) -> Any:
     Keeps ``import voicegateway`` free of any framework import while preserving
     ``voicegateway.LLM``/``STT``/``TTS`` (livekit), ``voicegateway.Observer``
     (pipecat), and the ``voicegateway.inference`` submodule as attribute-access
-    entry points.
+    entry points. When the backing extra is not installed, raises the friendly
+    ``require_extra`` error (with a pip hint) rather than a raw ModuleNotFoundError.
     """
     target = _LAZY.get(name)
     if target is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    extra = _LAZY_EXTRA.get(name)
+    if extra is not None:
+        from voicegateway._frameworks import require_extra
+
+        require_extra(extra)  # no-op when installed; friendly ImportError otherwise
     import importlib
 
     module_name, attr = target

--- a/src/voicegateway/tests/test_framework_neutral.py
+++ b/src/voicegateway/tests/test_framework_neutral.py
@@ -49,24 +49,52 @@ def test_observer_symbol_is_lazy_and_pure() -> None:
     then that resolving the attribute does pull pipecat (so the lazy import is
     wired, not merely absent).
     """
-    code = (
+    # Purity holds whether or not pipecat is installed: importing voicegateway
+    # and referencing Observer via dir() must not pull pipecat.
+    purity = (
         "import voicegateway, sys; "
         "assert 'Observer' in dir(voicegateway), 'Observer not exported'; "
-        "assert 'pipecat' not in sys.modules, 'pipecat imported by dir()'; "
-        "obs_cls = voicegateway.Observer; "
-        "assert 'pipecat' in sys.modules, 'Observer did not lazy-import pipecat'; "
+        "assert 'pipecat' not in sys.modules, 'pipecat imported by import/dir()'; "
         "print('PURE')"
     )
     result = subprocess.run(
-        [sys.executable, "-c", code],
+        [sys.executable, "-c", purity],
         capture_output=True,
         text=True,
     )
     assert result.returncode == 0, (
-        f"Observer lazy-import broke purity.\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        f"import purity broke.\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
     assert "PURE" in result.stdout
+
+    # Resolving the attribute is where the framework is pulled. With pipecat
+    # installed it lazily imports it; without it (e.g. CI's livekit-only env) it
+    # must raise the friendly extra error, not a raw ModuleNotFoundError.
+    import importlib.util
+
+    if importlib.util.find_spec("pipecat") is not None:
+        resolve = (
+            "import voicegateway, sys; "
+            "_ = voicegateway.Observer; "
+            "assert 'pipecat' in sys.modules, 'Observer did not lazy-import pipecat'; "
+            "print('LAZY')"
+        )
+        expect = "LAZY"
+    else:
+        resolve = (
+            "import voicegateway\n"
+            "try:\n"
+            "    voicegateway.Observer\n"
+            "except ImportError as e:\n"
+            "    assert 'voicegateway[pipecat]' in str(e), str(e)\n"
+            "    print('FRIENDLY')\n"
+            "else:\n"
+            "    raise SystemExit('expected ImportError for the missing pipecat extra')\n"
+        )
+        expect = "FRIENDLY"
+    r = subprocess.run([sys.executable, "-c", resolve], capture_output=True, text=True)
+    assert r.returncode == 0, f"Observer resolve failed.\nstderr: {r.stderr}"
+    assert expect in r.stdout
 
 
 class _FakeType:


### PR DESCRIPTION
The Test Coverage CI job failed after the framework-neutral work: CI installs `[livekit]` but not `[pipecat]`, and `test_observer_symbol_is_lazy_and_pure` resolved `voicegateway.Observer` (which lazy-imports pipecat) and asserted success, producing a raw `ModuleNotFoundError: No module named 'pipecat'`. (1934 passed, 1 failed.)

## Fix
- `voicegateway.__getattr__` now calls `require_extra()` before the lazy import, so accessing `Observer` without `[pipecat]` (or `LLM/STT/TTS` without `[livekit]`) raises the friendly `pip install voicegateway[<extra>]` ImportError instead of a raw ModuleNotFoundError. (`inference` is left ungated so pipecat-only users can reach it.)
- The test is now CI-safe: purity is checked without resolving the attribute; then it asserts the lazy import when pipecat is installed, and the friendly error when it is not.

## Verification
- `test_framework_neutral.py`: 9 passed (LAZY branch, pipecat installed locally).
- Simulated the extra-absent case (`_extra_installed=False`): `Observer` and `LLM` both raise the friendly `voicegateway[pipecat]`/`[livekit]` error - the exact path CI's env exercises.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when framework-dependent voice features are accessed without the required optional installation.
  * Preserved lazy loading so framework packages are only loaded when their features are used.

* **Tests**
  * Updated validation to cover both installed and unavailable framework scenarios.
  * Confirmed framework-neutral functionality remains usable without optional dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->