### PR TITLE
docs(nav): restructure to 5 tabs, add validator, rebuild home (P0)

### DIFF
--- a/docs/_check_docs.py
+++ b/docs/_check_docs.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""VoiceGateway docs validator: the deterministic gate for the docs restructure loop.
+
+Runs the seven rules from the restructure spec
+(docs/superpowers/specs/2026-07-09-docs-restructure-design.md). Exits non-zero on any
+failure and prints every violation. Stdlib only; locates the docs dir relative to this
+file, so it works from any CWD.
+
+    python3 docs/_check_docs.py                       # full: content rules on ALL pages
+    python3 docs/_check_docs.py index guide/attach    # scoped: content rules on those pages
+
+Structural rules (1, 2, 3) are ALWAYS global: the whole nav must be valid, every page
+mapped, no orphans. The content/link rules (4, 5, 6, 7) apply to the SCOPE: the page
+slugs passed as arguments, or every page when no arguments are given. This mirrors the
+engine loop's "prove this phase's pages are clean, keep the global structure intact"
+gate, so each phase gates on its own rewritten pages while P13 (no args) gates the whole
+site.
+
+Rules:
+  1. docs.json parses and matches the tab shape (navigation.tabs -> groups -> pages).
+  2. Every nav-referenced page has a matching .md/.mdx file.
+  3. Every page file under docs/ (excluding superpowers/, snippets/, dot/underscore
+     names) is referenced exactly once in the nav.
+  4. Every root-absolute internal link (in scope pages) resolves to a nav page.
+  5. Only guide/migration-attach-guard may contain the string "voicegateway.inference".
+  6. No scope page carries VitePress-only frontmatter keys (layout / hero / features).
+  7. Every scope page has non-empty title and description frontmatter.
+  8. No scope page uses `{#custom-anchor}` heading ids (MDX/acorn cannot parse them;
+     Mintlify auto-generates heading slugs). This is the concrete MDX-safety trap that
+     breaks `mint broken-links`; broader "escape literal < and { in prose" guidance lives
+     in the implementer briefs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+DOCS = Path(__file__).resolve().parent
+MIGRATION_PAGE = "guide/migration-attach-guard"
+
+# Link targets that are not nav pages (assets, images, mail, external).
+_IMAGE_EXT = (".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico")
+_FENCE_RE = re.compile(r"(^|\n)(```|~~~).*?(\n\2|\Z)", re.DOTALL)
+_MD_LINK_RE = re.compile(r"\]\(([^)]+)\)")
+_HREF_RE = re.compile(r"""href\s*=\s*["']([^"']+)["']""")
+# `## Heading {#anchor}` custom-id syntax: valid in some markdown flavors, but MDX parses
+# the `{...}` as a JS expression and acorn fails ("Could not parse expression").
+_HEADING_ANCHOR_RE = re.compile(r"^#{1,6}\s.*\{#[^}]+\}\s*$", re.MULTILINE)
+
+
+def _iter_page_refs(nav_node) -> list[str]:
+    """Flatten a navigation node into its page-string references.
+
+    A `pages` entry is either a page string or a nested group dict (which itself has
+    `pages`). Both shapes are walked so nested groups are supported.
+    """
+    refs: list[str] = []
+    for tab in nav_node.get("tabs", []):
+        refs.extend(_iter_group_pages(tab.get("groups", [])))
+    # Also support a bare `groups` nav (pre-restructure shape) so the validator can
+    # report shape errors rather than crashing.
+    refs.extend(_iter_group_pages(nav_node.get("groups", [])))
+    return refs
+
+
+def _iter_group_pages(groups) -> list[str]:
+    refs: list[str] = []
+    for group in groups:
+        for page in group.get("pages", []):
+            if isinstance(page, str):
+                refs.append(page)
+            elif isinstance(page, dict):
+                refs.extend(_iter_group_pages([page]))
+    return refs
+
+
+def _load_docs_json(errors: list[str]) -> tuple[dict, list[str]]:
+    path = DOCS / "docs.json"
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"[rule 1] docs.json does not parse: {exc}")
+        return {}, []
+
+    nav = data.get("navigation", {})
+    tabs = nav.get("tabs")
+    if not isinstance(tabs, list) or not tabs:
+        errors.append("[rule 1] navigation.tabs must be a non-empty list")
+        return data, _iter_page_refs(nav)
+
+    for i, tab in enumerate(tabs):
+        if not isinstance(tab.get("tab"), str) or not tab.get("tab"):
+            errors.append(f"[rule 1] tab[{i}] missing string 'tab'")
+        groups = tab.get("groups")
+        if not isinstance(groups, list) or not groups:
+            errors.append(f"[rule 1] tab '{tab.get('tab', i)}' has no groups list")
+            continue
+        for j, group in enumerate(groups):
+            if not isinstance(group.get("group"), str) or not group.get("group"):
+                errors.append(f"[rule 1] tab '{tab.get('tab')}' group[{j}] missing 'group'")
+            pages = group.get("pages")
+            if not isinstance(pages, list) or not pages:
+                errors.append(
+                    f"[rule 1] group '{group.get('group', j)}' has no pages list"
+                )
+    return data, _iter_page_refs(nav)
+
+
+def _page_files() -> list[str]:
+    """All docs page slugs on disk (excluding superpowers/, snippets/, dot/underscore)."""
+    out: list[str] = []
+    for path in DOCS.rglob("*"):
+        if path.suffix not in (".md", ".mdx"):
+            continue
+        rel = path.relative_to(DOCS)
+        parts = rel.parts
+        if any(p.startswith((".", "_")) for p in parts):
+            continue
+        if parts[0] in ("superpowers", "snippets"):
+            continue
+        out.append(str(rel.with_suffix("")))
+    return out
+
+
+def _resolve_file(slug: str) -> bool:
+    return (DOCS / f"{slug}.md").exists() or (DOCS / f"{slug}.mdx").exists()
+
+
+def _strip_frontmatter(text: str) -> tuple[str, str]:
+    """Return (frontmatter_block, body). Empty frontmatter if none present."""
+    if text.startswith("---\n") or text.startswith("---\r\n"):
+        end = text.find("\n---", 4)
+        if end != -1:
+            fm = text[4:end]
+            body = text[end + 4 :]
+            return fm, body
+    return "", text
+
+
+def _frontmatter_value(fm: str, key: str) -> str | None:
+    for line in fm.splitlines():
+        m = re.match(rf"^{re.escape(key)}\s*:\s*(.*)$", line)
+        if m:
+            return m.group(1).strip().strip("'\"")
+    return None
+
+
+def _has_top_level_key(fm: str, key: str) -> bool:
+    return any(re.match(rf"^{re.escape(key)}\s*:", line) for line in fm.splitlines())
+
+
+def _internal_targets(body: str) -> list[str]:
+    stripped = _FENCE_RE.sub("\n", body)
+    targets = _MD_LINK_RE.findall(stripped) + _HREF_RE.findall(stripped)
+    out: list[str] = []
+    for t in targets:
+        t = t.strip()
+        if not t.startswith("/"):
+            continue  # external, relative, anchor, mailto
+        if t.startswith("//"):
+            continue
+        if t.startswith("/assets/"):
+            continue
+        base = t.split("#", 1)[0].split("?", 1)[0]
+        if base.lower().endswith(_IMAGE_EXT):
+            continue
+        out.append(base)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    errors: list[str] = []
+    _data, refs = _load_docs_json(errors)
+
+    ref_set = set(refs)
+    # Rule 2 (global): every ref has a file.
+    for slug in refs:
+        if not _resolve_file(slug):
+            errors.append(f"[rule 2] nav references '{slug}' but no {slug}.md/.mdx exists")
+    # Rule 3 (global): no duplicate refs.
+    seen: set[str] = set()
+    for slug in refs:
+        if slug in seen:
+            errors.append(f"[rule 3] page '{slug}' referenced more than once in nav")
+        seen.add(slug)
+
+    files = _page_files()
+    file_set = set(files)
+    # Rule 3 (global): every file referenced.
+    for slug in files:
+        if slug not in ref_set:
+            errors.append(f"[rule 3] orphan page file '{slug}' not referenced in nav")
+
+    # Content/link rules (4, 5, 6, 7) apply to the scope: args, or all files.
+    scope = argv or sorted(file_set)
+    unknown = [s for s in scope if s not in file_set]
+    for s in unknown:
+        errors.append(f"[scope] '{s}' is not a docs page file")
+    for slug in sorted(s for s in scope if s in file_set):
+        path = DOCS / f"{slug}.md"
+        if not path.exists():
+            path = DOCS / f"{slug}.mdx"
+        text = path.read_text()
+        fm, body = _strip_frontmatter(text)
+
+        # Rule 7: title + description non-empty.
+        for key in ("title", "description"):
+            val = _frontmatter_value(fm, key)
+            if not val:
+                errors.append(f"[rule 7] '{slug}' missing non-empty {key}: frontmatter")
+
+        # Rule 6: no VitePress keys.
+        for key in ("layout", "hero", "features"):
+            if _has_top_level_key(fm, key):
+                errors.append(f"[rule 6] '{slug}' has VitePress frontmatter key '{key}:'")
+
+        # Rule 5: voicegateway.inference only in the migration page.
+        if slug != MIGRATION_PAGE and "voicegateway.inference" in text:
+            errors.append(
+                f"[rule 5] '{slug}' contains 'voicegateway.inference' "
+                f"(allowed only in {MIGRATION_PAGE})"
+            )
+
+        # Rule 4: root-absolute internal links resolve to a nav page.
+        for target in _internal_targets(body):
+            slug_target = "index" if target == "/" else target.lstrip("/").rstrip("/")
+            slug_target = re.sub(r"\.(md|mdx)$", "", slug_target)
+            if slug_target not in ref_set:
+                errors.append(
+                    f"[rule 4] '{slug}' links to '{target}' which is not a nav page"
+                )
+
+        # Rule 8: no `{#custom-anchor}` heading ids (breaks MDX/acorn).
+        for m in _HEADING_ANCHOR_RE.finditer(body):
+            errors.append(
+                f"[rule 8] '{slug}' uses a {{#anchor}} heading id "
+                f"(MDX cannot parse it): {m.group(0).strip()!r}"
+            )
+
+    if errors:
+        print(f"docs validator: FAIL ({len(errors)} issue(s))")
+        for e in sorted(set(errors)):
+            print("  " + e)
+        return 1
+    scope_note = "all" if not argv else f"{len(scope)} scoped"
+    print(
+        f"docs validator: PASS ({len(files)} pages, {len(refs)} nav refs, "
+        f"content rules on {scope_note})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    raise SystemExit(main(sys.argv[1:]))

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -13,160 +13,190 @@
   },
   "favicon": "/assets/logo.svg",
   "navigation": {
-    "groups": [
+    "tabs": [
       {
-        "group": "Get started",
-        "pages": [
-          "index",
-          "get-started"
+        "tab": "Overview",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "index",
+              "guide/what-is-voicegateway",
+              "guide/frameworks",
+              "guide/decision-tree"
+            ]
+          }
         ]
       },
       {
-        "group": "Hosted cloud",
-        "pages": [
-          "hosted/quickstart"
+        "tab": "Self-Host",
+        "groups": [
+          {
+            "group": "Get started",
+            "pages": [
+              "get-started",
+              "guide/installation",
+              "guide/quick-start",
+              "guide/first-agent"
+            ]
+          },
+          {
+            "group": "Core concepts",
+            "pages": [
+              "guide/core-concepts",
+              "guide/attach",
+              "guide/guard",
+              "guide/migration-attach-guard"
+            ]
+          },
+          {
+            "group": "Configure",
+            "pages": [
+              "configuration/voicegw-yaml",
+              "configuration/providers",
+              "configuration/models",
+              "configuration/stacks",
+              "configuration/projects",
+              "configuration/environment-variables",
+              "configuration/observability"
+            ]
+          },
+          {
+            "group": "Advanced",
+            "pages": [
+              "guide/multi-tenant-quickstart",
+              "guide/agency-quickstart",
+              "guide/cost-reconciliation",
+              "guide/guardrails"
+            ]
+          },
+          {
+            "group": "Deploy",
+            "pages": [
+              "deployment/index",
+              "deployment/fly",
+              "deployment/railway",
+              "deployment/vps",
+              "deployment/auto-update",
+              "deployment/distributed-sfu"
+            ]
+          },
+          {
+            "group": "Examples",
+            "pages": [
+              "examples/index",
+              "examples/basic-voice-agent",
+              "examples/livekit-attach-guard",
+              "examples/pipecat-attach-guard",
+              "examples/budget-enforcement",
+              "examples/fallback-chains",
+              "examples/livekit-fallback-adapter",
+              "examples/local-only",
+              "examples/multi-project",
+              "examples/docker-deployment",
+              "examples/claude-code-integration",
+              "examples/openrtc-multi-agent"
+            ]
+          }
         ]
       },
       {
-        "group": "Guide",
-        "pages": [
-          "guide/what-is-voicegateway",
-          "guide/installation",
-          "guide/quick-start",
-          "guide/first-agent",
-          "guide/core-concepts",
-          "guide/frameworks",
-          "guide/attach",
-          "guide/guard",
-          "guide/migration-attach-guard",
-          "guide/decision-tree",
-          "guide/agency-quickstart",
-          "guide/multi-tenant-quickstart",
-          "guide/cost-reconciliation",
-          "guide/guardrails"
+        "tab": "Cloud",
+        "groups": [
+          {
+            "group": "Hosted cloud",
+            "pages": [
+              "hosted/quickstart"
+            ]
+          }
         ]
       },
       {
-        "group": "Configuration",
-        "pages": [
-          "configuration/voicegw-yaml",
-          "configuration/providers",
-          "configuration/models",
-          "configuration/stacks",
-          "configuration/projects",
-          "configuration/environment-variables",
-          "configuration/observability"
+        "tab": "CLI",
+        "groups": [
+          {
+            "group": "CLI",
+            "pages": [
+              "cli/index",
+              "cli/init",
+              "cli/onboard",
+              "cli/serve",
+              "cli/dashboard",
+              "cli/tui",
+              "cli/status",
+              "cli/costs",
+              "cli/export-costs",
+              "cli/projects",
+              "cli/logs",
+              "cli/reconcile",
+              "cli/replay",
+              "cli/mcp",
+              "cli/smoke-test",
+              "cli/livekit"
+            ]
+          }
         ]
       },
       {
-        "group": "CLI",
-        "pages": [
-          "cli/index",
-          "cli/init",
-          "cli/onboard",
-          "cli/serve",
-          "cli/dashboard",
-          "cli/tui",
-          "cli/status",
-          "cli/costs",
-          "cli/export-costs",
-          "cli/projects",
-          "cli/logs",
-          "cli/reconcile",
-          "cli/replay",
-          "cli/mcp",
-          "cli/smoke-test",
-          "cli/livekit"
-        ]
-      },
-      {
-        "group": "MCP",
-        "pages": [
-          "mcp/index",
-          "mcp/setup",
-          "mcp/authentication",
-          "mcp/transports",
-          "mcp/tools/models",
-          "mcp/tools/providers",
-          "mcp/tools/projects",
-          "mcp/tools/observability"
-        ]
-      },
-      {
-        "group": "Deployment",
-        "pages": [
-          "deployment/index",
-          "deployment/fly",
-          "deployment/railway",
-          "deployment/vps",
-          "deployment/auto-update",
-          "deployment/distributed-sfu"
-        ]
-      },
-      {
-        "group": "Architecture",
-        "pages": [
-          "architecture/index",
-          "architecture/gateway-core",
-          "architecture/provider-abstraction",
-          "architecture/middleware",
-          "architecture/cost-tracking",
-          "architecture/config-layers",
-          "architecture/storage",
-          "architecture/security",
-          "architecture/fleet-worker-heartbeat"
-        ]
-      },
-      {
-        "group": "Storage",
-        "pages": [
-          "storage/replay-storage-costs"
-        ]
-      },
-      {
-        "group": "API",
-        "pages": [
-          "api/index",
-          "api/python-sdk",
-          "api/http-api",
-          "api/dashboard-api"
-        ]
-      },
-      {
-        "group": "Reference",
-        "pages": [
-          "reference/faq",
-          "reference/troubleshooting",
-          "reference/reconcile-formats",
-          "reference/guardrail-prompts"
-        ]
-      },
-      {
-        "group": "Examples",
-        "pages": [
-          "examples/index",
-          "examples/basic-voice-agent",
-          "examples/livekit-attach-guard",
-          "examples/pipecat-attach-guard",
-          "examples/budget-enforcement",
-          "examples/fallback-chains",
-          "examples/livekit-fallback-adapter",
-          "examples/local-only",
-          "examples/multi-project",
-          "examples/docker-deployment",
-          "examples/claude-code-integration",
-          "examples/openrtc-multi-agent"
-        ]
-      },
-      {
-        "group": "Contributing",
-        "pages": [
-          "contributing/index",
-          "contributing/development-setup",
-          "contributing/adding-a-provider",
-          "contributing/testing",
-          "contributing/code-style",
-          "contributing/refreshing-pricing"
+        "tab": "API Reference",
+        "groups": [
+          {
+            "group": "Python & HTTP API",
+            "pages": [
+              "api/index",
+              "api/python-sdk",
+              "api/http-api",
+              "api/dashboard-api"
+            ]
+          },
+          {
+            "group": "MCP server",
+            "pages": [
+              "mcp/index",
+              "mcp/setup",
+              "mcp/authentication",
+              "mcp/transports",
+              "mcp/tools/models",
+              "mcp/tools/providers",
+              "mcp/tools/projects",
+              "mcp/tools/observability"
+            ]
+          },
+          {
+            "group": "Architecture",
+            "pages": [
+              "architecture/index",
+              "architecture/gateway-core",
+              "architecture/provider-abstraction",
+              "architecture/middleware",
+              "architecture/cost-tracking",
+              "architecture/config-layers",
+              "architecture/storage",
+              "architecture/security",
+              "architecture/fleet-worker-heartbeat",
+              "storage/replay-storage-costs"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "reference/faq",
+              "reference/troubleshooting",
+              "reference/reconcile-formats",
+              "reference/guardrail-prompts"
+            ]
+          },
+          {
+            "group": "Contributing",
+            "pages": [
+              "contributing/index",
+              "contributing/development-setup",
+              "contributing/adding-a-provider",
+              "contributing/testing",
+              "contributing/code-style",
+              "contributing/refreshing-pricing"
+            ]
+          }
         ]
       }
     ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,75 +1,79 @@
 ---
-layout: home
-
-hero:
-  name: VoiceGateway
-  text: Cost tracking and reconciliation for LiveKit voice agents
-  tagline: Modality-aware unit accounting. LLM, STT, and TTS prices from voice-prices. Verify against provider invoices with voicegw reconcile.
-  image:
-    src: /logo.svg
-    alt: VoiceGateway
-  actions:
-    - theme: brand
-      text: Get Started
-      link: /guide/quick-start
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/mahimailabs/voicegateway
-
-features:
-  - icon: "\U0001F50C"
-    title: One-line drop-in for livekit.agents.inference
-    details: "voicegateway.inference.STT, LLM, TTS mirror LiveKit's inference module signature. Swap the import line; the rest of your agent code keeps working. Cost tracking, latency monitoring, and session correlation happen transparently."
-    link: /guide/quick-start
-    linkText: See the integration
-
-  - icon: "\U0001F4B0"
-    title: Modality-aware unit accounting
-    details: "LLM cost per-1k-token, STT cost per-audio-minute, TTS cost per-character. Prices for all three modalities come from voice-prices (a fork of pydantic/genai-prices that covers LLM, STT, and TTS)."
-    link: /configuration/observability
-    linkText: How it works
-
-  - icon: "\U0001F9FE"
-    title: Reconciliation tooling
-    details: "voicegw export-costs and voicegw reconcile compare logged costs against your provider's usage export. Per-request line items carry pricing_source attribution. LLM costs may drift up to ~5%; reconciliation is the verification path."
-    link: /guide/cost-reconciliation
-    linkText: Walk through reconcile
-
-  - icon: "\U0001F916"
-    title: MCP server for agent-managed config
-    details: "17 tools (configure providers, create projects with daily budgets, query costs, tail logs, run health checks) over stdio and HTTP/SSE. Claude Code, Cursor, Codex, and Cline can all manage the gateway conversationally."
-    link: /mcp/
-    linkText: Explore MCP
+title: VoiceGateway
+description: Cost tracking, observability, and control for LiveKit and Pipecat voice agents. Attach one line to your existing agent and see per-modality spend land in the dashboard.
 ---
 
-## Where VoiceGateway fits
+VoiceGateway meters what your voice agents actually cost. It attaches to an agent you
+already run on **LiveKit Agents** or **Pipecat**, records LLM tokens, STT audio-minutes,
+and TTS characters per request, prices them through `voice-prices`, and reconciles the
+totals against your provider invoices.
 
-VoiceGateway is purpose-built for LiveKit voice agents that want cost visibility per modality (audio-minutes for STT, tokens for LLM, characters for TTS) and reconciliation against actual provider invoices. For a longer breakdown of which tool fits which workload, see the [decision tree](/guide/decision-tree).
+The core is framework-neutral: `import voicegateway` pulls neither framework. Two seams do
+the work. [`attach()`](/guide/attach) observes (passive: cost and latency).
+[`guard()`](/guide/guard) controls (active: fallback, rate limits, budgets).
+
+<CardGroup cols={2}>
+  <Card title="What is VoiceGateway" icon="circle-question" href="/guide/what-is-voicegateway">
+    The problem it solves and where it fits in a voice stack.
+  </Card>
+  <Card title="Self-host quickstart" icon="rocket" href="/guide/quick-start">
+    Install, attach to your LiveKit or Pipecat agent, see costs in minutes.
+  </Card>
+  <Card title="Hosted Cloud" icon="cloud" href="/hosted/quickstart">
+    Skip the daemon. Point your agent at the hosted collector.
+  </Card>
+  <Card title="CLI reference" icon="terminal" href="/cli/index">
+    Every `voicegw` command: serve, dashboard, costs, reconcile.
+  </Card>
+  <Card title="API reference" icon="code" href="/api/index">
+    Python SDK, HTTP API, MCP server, dashboard API, architecture.
+  </Card>
+  <Card title="Decision tree" icon="signs-post" href="/guide/decision-tree">
+    Self-host or Cloud, attach or guard: pick the right path.
+  </Card>
+</CardGroup>
 
 ## Install
 
+Install the extra for the framework you run. Provider plugin extras imply the framework, so
+one line pulls the runtime and the plugins you name.
+
 <CodeGroup>
 
-```bash pip
-pip install voicegateway[all]
+```bash uv
+uv pip install "voicegateway[livekit]"     # or [pipecat]
 ```
 
-```bash docker
-git clone https://github.com/mahimailabs/voicegateway
-cd voicegateway
-docker compose up -d
+```bash pip
+pip install "voicegateway[livekit]"        # or [pipecat]
 ```
 
 </CodeGroup>
 
-## Use from Claude Code
+## Attach in one line
 
-```bash
-claude mcp add voicegateway --command "voicegw mcp --transport stdio"
-```
+Build your agent exactly as you do today, then hand the session (LiveKit) or task
+(Pipecat) to `attach()`. It detects the framework, meters every request, and writes the
+records. Nothing else in your agent changes.
 
-Now ask Claude Code:
+<Tabs>
+  <Tab title="LiveKit">
+    ```python
+    from voicegateway import attach
 
-> "Add Deepgram with this API key. Register nova-3 for STT. Create a project for Tony's Pizza with a five dollar daily budget using premium stack."
+    session = AgentSession(stt=stt, llm=llm, tts=tts)
+    attach(session, project="my-agent")   # meters cost + latency
+    ```
+  </Tab>
+  <Tab title="Pipecat">
+    ```python
+    from voicegateway import attach
 
-Done in 30 seconds. No YAML editing, no dashboard clicking.
+    task = PipelineTask(pipeline)
+    attach(task, project="my-agent")      # meters cost + latency
+    ```
+  </Tab>
+</Tabs>
+
+Ready to go deeper? Start with [Self-host quickstart](/guide/quick-start), or read how
+[`attach()`](/guide/attach) and [`guard()`](/guide/guard) split observe from control.


### PR DESCRIPTION
## P0 - Nav skeleton + validator + home

First phase of the docs restructure program (5-tab IA + full Mintlify rewrite). Spec and ledger live under the gitignored `docs/superpowers/`.

### What changed
- **`docs.json`**: flat 13-group sidebar to 5 horizontal tabs (Overview, Self-Host, Cloud, CLI, API Reference), each with basic-to-advanced vertical groups. All 90 pages mapped, zero orphans; the lonely Storage page folds under Architecture.
- **`docs/_check_docs.py`**: the 8-rule validator that gates every rewrite phase. Structural rules (nav shape, page mapping, orphans) run global; content rules (link resolution, deprecated-API leak, VitePress frontmatter, title/description, MDX `{#anchor}` safety) run on a page scope so each phase gates its own pages and P13 gates the whole site.
- **`index.md`**: rebuilt as a real Mintlify home (hero + `CardGroup` + one-line `attach()` snippet). Removes the VitePress `layout/hero/features` frontmatter Mintlify never rendered, and the deprecated `voicegateway.inference` front-door sample.

### Acceptance
- `python3 docs/_check_docs.py index` exits 0 (structure global + content on the rebuilt home).
- Full run (`python3 docs/_check_docs.py`) reports the 121-issue backlog the later phases clear (deprecated-API leaks, missing frontmatter, index-style links, `{#anchor}` heading ids). `mint broken-links` is blocked until those pages are MDX-clean, so the Python validator is authoritative until P13.

Docs-only and reversible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation navigation into clearly grouped tabs for Overview, Self-Host, Cloud, CLI, and API Reference.
  * Updated the documentation landing page with streamlined navigation cards, framework-specific installation guidance, and examples for attaching VoiceGateway.
  * Removed outdated homepage sections and usage instructions.
* **Quality Improvements**
  * Added an automated documentation checker to validate navigation, page links, frontmatter, and content consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->