### PR TITLE
docs(overview): rewrite Overview tab pages (P1)

### DIFF
--- a/docs/guide/decision-tree.md
+++ b/docs/guide/decision-tree.md
@@ -1,60 +1,107 @@
 ---
-title: Is VoiceGateway right for you?
-description: A short matrix to help you pick the right tool for your workload before you invest time integrating.
+title: Which path?
+description: A decision guide for developers arriving from LiveKit Agents or Pipecat. Two axes: self-host vs Cloud, and attach-only vs attach + guard.
 ---
 
-# Is VoiceGateway right for you?
+This page helps you pick the right combination before you write any code. Two decisions:
 
-A short matrix to help you pick the right tool for your workload before you invest time integrating.
+1. Where does VoiceGateway run? (self-host the OSS daemon vs use Hosted Cloud)
+2. How much do you need? (cost visibility only vs control over fallback, rate limits, and budgets)
 
-## The short answer
+## Axis 1: self-host or Hosted Cloud
+
+| | Self-Host (OSS) | Hosted Cloud |
+|---|---|---|
+| Storage | SQLite, single process | ClickHouse, multi-tenant |
+| Ingest | local sink (no network hop) | push to `VOICEGW_COLLECTOR_URL` |
+| Dashboard | `voicegw dashboard` (port 9090) | `dash.voicegateway.dev` |
+| Setup | `pip install voicegateway` + `voicegw.yaml` | 3 env vars (`VOICEGW_COLLECTOR_URL`, `VOICEGW_API_KEY`, `VOICEGW_PROJECT`) |
+| Horizontal scale | single instance | managed, no ops |
+| Right for | local dev, small teams, self-managed infra | multi-agent fleets, SaaS products, agency work |
+
+<Note>
+The `attach()` and `guard()` seams work identically on both paths. The only difference is which sink receives the records.
+</Note>
+
+### Choose self-host when
+
+- You need data on your own infrastructure (compliance, air-gap, cost control).
+- You are building a single-team product or a personal project.
+- You want to iterate locally before paying for cloud ingest.
+
+### Choose Hosted Cloud when
+
+- You run multiple agents across machines and want a single dashboard.
+- You are building a SaaS product and need per-tenant cost isolation.
+- You want zero ops: no SQLite file to manage, no dashboard process to keep running.
+
+See [Hosted Cloud quickstart](/hosted/quickstart) for the three-env-var setup.
+
+## Axis 2: observe-only or observe + control
+
+| | `attach()` only | `attach()` + `guard()` |
+|---|---|---|
+| Per-call cost tracking | Yes | Yes |
+| Per-modality latency | Yes | Yes |
+| Fallback on provider error | No | Yes |
+| Rate limiting | No | Yes |
+| Spend caps (warn/throttle/block) | No | Yes |
+| Code change to provider setup | None | Wrap provider in `guard(...)` |
+
+### Use `attach()` only when
+
+- You want cost and latency visibility without changing provider behavior.
+- You are adding VoiceGateway to an existing agent and want the smallest diff.
+- You trust your providers to be reliable and have no budget enforcement requirement.
+
+### Add `guard()` when
+
+- You need a fallback provider (primary goes down, switch to backup).
+- You want to enforce a per-project or per-day spend cap.
+- You need to rate-limit calls to a provider that has strict quota limits.
+
+## Decision flow
+
+```mermaid
+flowchart TD
+    A[Building a LiveKit or Pipecat voice agent?] -->|yes| B[Need data on your own infra?]
+    A -->|no, text-only LLM| Z1[LiteLLM is the right fit]
+    B -->|yes| C[Self-Host OSS]
+    B -->|no, want zero ops| D[Hosted Cloud]
+    C --> E[Need fallback / rate limits / budget caps?]
+    D --> E
+    E -->|cost visibility only| F[attach only]
+    E -->|yes to any control| G[attach + guard]
+```
+
+## Quick-start paths
+
+<CardGroup cols={2}>
+  <Card title="Self-host: Quick start" icon="server" href="/guide/quick-start">
+    Install the OSS package, write a voicegw.yaml, and attach to your first agent.
+  </Card>
+  <Card title="Hosted Cloud" icon="cloud" href="/hosted/quickstart">
+    Three env vars and your agent is sending data to the cloud dashboard.
+  </Card>
+  <Card title="attach() reference" icon="eye" href="/guide/attach">
+    Full signature, options, and LiveKit / Pipecat examples.
+  </Card>
+  <Card title="guard() reference" icon="shield" href="/guide/guard">
+    Fallback chains, rate limits, and spend caps: full reference.
+  </Card>
+</CardGroup>
+
+## Comparison to other tools
 
 | If you are... | Use |
 |---|---|
-| Building a LiveKit voice agent and want per-modality cost tracking | **VoiceGateway** |
-| Self-hosting voice with local + cloud model unification (Whisper + Ollama + Kokoro/Piper alongside Deepgram, OpenAI, etc.) | **VoiceGateway** |
+| Building a LiveKit or Pipecat voice agent and want per-modality cost tracking | VoiceGateway |
+| Self-hosting voice with local + cloud model unification | VoiceGateway |
 | Building a text-only LLM app (chatbot, RAG, code generation) | [LiteLLM](https://docs.litellm.ai/) |
-| Wanting a hosted multi-tenant LLM proxy with no infrastructure to run | [OpenRouter](https://openrouter.ai/) |
+| Wanting a hosted multi-tenant LLM proxy with no infrastructure | [OpenRouter](https://openrouter.ai/) |
 | At production scale on Cloudflare and want a gateway in that stack | [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) |
-| Building on managed LiveKit Cloud and happy with bundled inference pricing | LiveKit Inference (built into [LiveKit Cloud](https://livekit.io/cloud)) |
+| On managed LiveKit Cloud and happy with bundled inference pricing | LiveKit Inference (built into LiveKit Cloud) |
 
-If your case is not in the matrix, the longer-form notes below cover the remaining common ones.
-
-## Detailed breakdown
-
-### You are building a LiveKit voice agent
-
-VoiceGateway is purpose-built for this. `voicegateway.inference.STT/LLM/TTS` mirror `livekit.agents.inference` signature for signature, so swapping one import line in an existing LiveKit Cloud Inference agent is enough. The factories return wrapped LiveKit plugin instances that drop straight into `AgentSession(stt=, llm=, tts=)` with no proxy hop or plugin shim. Cost tracking happens transparently per modality (audio-minutes for STT, tokens for LLM, characters for TTS) against the active project. `voicegw reconcile` verifies the calculated cost against your actual provider invoice during the first month.
-
-If you use LiveKit Cloud's hosted Inference and are happy with the bundled inference pricing, you do not need VoiceGateway. Pick VG when you want your own provider keys, full per-call cost visibility, and control over the model catalog without leaving the LiveKit Agents code shape.
-
-### You are building a text-only LLM app
-
-[LiteLLM](https://docs.litellm.ai/) is the right tool. 100+ LLM providers, an OpenAI-compatible HTTP proxy that any existing OpenAI client can hit unchanged, multi-level budgets (per-key, per-team, per-user, per-model, per-agent), and a mature admin UI. VoiceGateway has 4 LLM provider integrations and no OpenAI-compat HTTP shim, so for general-purpose text LLM workloads it is the wrong fit.
-
-LiteLLM also ships `/v1/audio/transcriptions` and `/v1/audio/speech` for non-real-time audio (batch transcription, async TTS rendering). Pick those when your audio workload is request/response, not a real-time voice conversation.
-
-### You want a hosted multi-tenant proxy with no ops
-
-[OpenRouter](https://openrouter.ai/) is the fit. They run the proxy, handle billing, and aggregate access to a wide LLM catalog through a single API key. You run no infrastructure. Trade-off: you pay an OpenRouter markup on top of provider prices, and the path is managed-only. You cannot self-host OpenRouter.
-
-### You are at scale on Cloudflare
-
-[Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) integrates with the rest of the Cloudflare stack (Workers, R2, KV, Durable Objects, Logpush). If your existing voice or LLM workload already lives there, the gateway is a natural extension. Trade-off: closed source, managed, and LLM-only routing today.
-
-### You are self-hosting voice with local and cloud models
-
-VoiceGateway's local model support (Whisper via `faster-whisper`, Kokoro for TTS, Piper for TTS, Ollama for LLM) lives in the same `inference` factory as the cloud providers. Switching `inference.STT("deepgram/nova-3")` for `inference.STT("local/whisper-large-v3")` is a single string change. Cost tracking knows local models are zero-cost. No separate orchestrator, no second tool. This is the configuration where VoiceGateway is most distinctive: no other gateway in the matrix unifies cloud and local providers under one factory with cost-aware routing.
-
-## What VoiceGateway is not
-
-A few cases where VoiceGateway is the wrong tool, called out so you do not discover them after integrating:
-
-- **Not an OpenAI-compatible HTTP proxy.** There is no `/v1/chat/completions` endpoint, no `/v1/audio/transcriptions` endpoint, no HTTP shim of any kind for inference. The `voicegateway.inference` Python module is the integration surface. If your callers expect to make OpenAI-shaped HTTP requests, use LiteLLM.
-- **Not a horizontally scaled multi-tenant gateway.** SQLite is the storage layer; the supported topology is single-instance. Multiple instances pointing at the same SQLite file each have an independent in-memory budget cache, so per-project budgets are not strictly enforced across replicas. This is fine for self-hosted single-team deployments and a poor fit for SaaS infrastructure that needs Postgres + horizontal scale.
-- **Not a real-time fallback engine.** VoiceGateway's resolver-time fallback walks a chain at startup, not during a call. For runtime / error-driven failover during an active call (the "Cloud outage? Switch to local" pattern), compose LiveKit's `FallbackAdapter` around VG `inference.*` instances.
-- **Not a key-rotation system.** API keys can be re-entered if the encryption secret changes, but there is no built-in rotation tooling, MultiFernet versioning, or KMS integration. Treat the encryption secret as a long-lived credential.
-
-## Still unsure?
-
-Jump to the [quick start](/guide/quick-start) and try VoiceGateway in five minutes against a Deepgram + OpenAI + Cartesia stack. The shape fits your workload or it does not; the integration is small enough that finding out is cheap.
+<Tip>
+Jump to the [quick start](/guide/quick-start) to try VoiceGateway in five minutes. The integration is small enough that finding the right shape is cheap.
+</Tip>

--- a/docs/guide/frameworks.md
+++ b/docs/guide/frameworks.md
@@ -3,8 +3,6 @@ title: Frameworks and extras
 description: VoiceGateway's core is framework-neutral. Pick the extra for the agent framework you run (LiveKit or Pipecat); import voicegateway pulls neither.
 ---
 
-# Frameworks and extras
-
 VoiceGateway's engine core is framework-neutral. A bare `import voicegateway`
 imports neither [LiveKit Agents](https://docs.livekit.io/agents/) nor
 [Pipecat](https://docs.pipecat.ai/). The record model, pricing (via
@@ -17,20 +15,34 @@ That means you install exactly the framework you run, and nothing else.
 
 ## Install the extra you use
 
-```bash
+<CodeGroup>
+```bash uv
+# LiveKit Agents
+uv pip install "voicegateway[livekit]"
+
+# Pipecat
+uv pip install "voicegateway[pipecat]"
+```
+```bash pip
 # LiveKit Agents
 pip install "voicegateway[livekit]"
 
 # Pipecat
 pip install "voicegateway[pipecat]"
 ```
+</CodeGroup>
 
 The provider wheels for LiveKit are their own extras and imply the `livekit`
-extra, so a single line pulls the runtime plus the plugin you name:
+extra, so a single line pulls the runtime plus the plugins you name:
 
-```bash
+<CodeGroup>
+```bash uv
+uv pip install "voicegateway[openai,deepgram,cartesia]"
+```
+```bash pip
 pip install "voicegateway[openai,deepgram,cartesia]"
 ```
+</CodeGroup>
 
 For Pipecat, install the Pipecat service extras you need directly from Pipecat
 (for example `pip install "pipecat-ai[openai,deepgram,cartesia]"`) alongside

--- a/docs/guide/what-is-voicegateway.md
+++ b/docs/guide/what-is-voicegateway.md
@@ -1,116 +1,139 @@
 ---
 title: What is VoiceGateway?
-description: A thin routing layer for LiveKit voice agents with first-class cost tracking and reconciliation across cloud and local providers.
+description: VoiceGateway is a thin observability and control layer for LiveKit and Pipecat voice agents. It tracks per-modality cost across STT, LLM, and TTS, and adds fallback and budget enforcement without a proxy hop.
 ---
 
-# What is VoiceGateway?
-
-VoiceGateway is **a thin routing layer for LiveKit voice agents with first-class cost tracking and reconciliation**. It returns native LiveKit STT, LLM, and TTS plugin instances that drop straight into `AgentSession`, layering modality-aware unit accounting (audio-minutes for STT, tokens for LLM, characters for TTS), resolver-time fallback chains, rate limiting, and per-project budget enforcement on top. LLM, STT, and TTS prices flow through [`voice-prices`](https://github.com/mahimailabs/voice-prices); a `voicegw reconcile` command verifies VoiceGateway's recorded numbers against your provider invoices.
+VoiceGateway slots between your agent framework and your provider SDKs. It does not sit in the audio or data path. Instead, it hooks two seams: `attach()` is a passive observer that meters every STT, LLM, and TTS call; `guard()` is an active control wrapper that adds fallback chains, rate limits, and spend caps around any provider.
 
 ## The problem
 
-Building a production voice AI agent means juggling multiple providers. You need Deepgram or AssemblyAI for transcription, OpenAI or Anthropic for reasoning, and Cartesia or ElevenLabs for speech synthesis. Each provider has its own SDK, authentication scheme, pricing model, and failure modes.
+Production voice AI agents juggle three provider categories at once: STT (Deepgram, AssemblyAI, Whisper), LLM (OpenAI, Anthropic, Groq, Ollama), and TTS (Cartesia, ElevenLabs, Kokoro, Piper). Each category has its own pricing unit: STT is billed in audio-minutes, LLM in tokens, and TTS in characters. No single dashboard shows you what a call cost across all three.
 
-As your project grows, so do the operational headaches:
+As a project grows, the pain compounds:
 
-- **Vendor lock-in** -- switching from one STT provider to another means rewriting integration code.
-- **No unified cost tracking** -- you have to log into each provider's dashboard separately to understand spend.
-- **No fallback story** -- if your primary TTS provider goes down at 2 AM, your agent goes silent.
-- **Per-project budgets are impossible** -- when multiple teams or customers share the same API keys, there is no easy way to track or cap usage per project.
-- **Local/cloud split** -- running Whisper locally for development but Deepgram in production requires maintaining two code paths.
+- **No per-call cost visibility.** You see monthly totals per provider, never the cost of one conversation.
+- **No fallback story.** When a provider goes down at 2 AM, your agent goes silent.
+- **Per-project budgets are impossible.** When multiple agents or customers share the same API keys, there is no easy way to track or cap spend per project.
+- **Local and cloud code paths diverge.** Running Whisper locally for development and Deepgram in production means two different wiring setups.
 
-## The solution
+## The two-seam model
 
-VoiceGateway solves these problems with a thin routing layer that drops in for `livekit.agents.inference`. You describe your providers, models, and policies in a single YAML file (`voicegw.yaml`), then construct `inference.STT/LLM/TTS` from your Python code exactly the way you would on LiveKit Cloud. VoiceGateway handles the rest: provider instantiation, middleware execution (cost tracking, latency monitoring, rate limiting), and budget enforcement.
+VoiceGateway exposes exactly two integration points.
 
-```python
-from voicegateway import inference
+| Seam | Role | What it does |
+|---|---|---|
+| `attach(session)` | observe (passive) | Meters every provider call; records cost, latency, and tokens to storage |
+| `guard(provider)` | control (active) | Wraps one provider; adds fallback, rate limiting, and budget caps |
 
-stt = inference.STT("deepgram/nova-3")
-llm = inference.LLM("anthropic/claude-sonnet-4-20250514")
-tts = inference.TTS("cartesia/sonic-3")
+`attach()` is the **only** source of metrics. `guard()` writes no metrics of its own. Use both together and nothing is double-counted.
+
+<Tabs>
+  <Tab title="LiveKit">
+    ```python
+    from livekit.agents import AgentSession
+    from livekit.plugins import deepgram, openai, cartesia
+    from voicegateway import attach, guard
+
+    session = AgentSession(
+        stt=guard(deepgram.STT(), fallback=[openai.STT()]),
+        llm=guard(openai.LLM("gpt-4o"), budget="$5.00/day"),
+        tts=cartesia.TTS("sonic-3"),
+    )
+    attach(session, project="my-project")
+    await session.start(agent=MyAgent(), room=ctx.room)
+    ```
+  </Tab>
+  <Tab title="Pipecat">
+    ```python
+    from pipecat.pipeline.task import PipelineTask
+    from pipecat.services.deepgram import DeepgramSTTService
+    from pipecat.services.openai import OpenAILLMService
+    from pipecat.services.cartesia import CartesiaTTSService
+    from voicegateway import attach, guard
+
+    task = PipelineTask(pipeline=Pipeline([
+        guard(DeepgramSTTService(), fallback=[openai_stt]),
+        guard(OpenAILLMService(model="gpt-4o"), budget="$5.00/day"),
+        CartesiaTTSService(voice_id="..."),
+    ]))
+    attach(task, project="my-project")
+    await task.run()
+    ```
+  </Tab>
+</Tabs>
+
+## Modality-aware cost tracking
+
+Voice calls mix three different pricing units. VoiceGateway tracks each one separately and converts them to a dollar cost per call:
+
+| Modality | Unit | Example |
+|---|---|---|
+| STT | audio-minutes | Deepgram: $0.0059/min |
+| LLM | input + output tokens | OpenAI gpt-4o: $2.50/$10.00 per 1M |
+| TTS | characters | Cartesia sonic-3: $65 per 1M chars |
+
+Prices are maintained in [`voice-prices`](https://github.com/mahimailabs/voice-prices), a fork of `pydantic/genai-prices` extended for audio modalities. The `voicegw reconcile` command verifies VoiceGateway's calculated totals against your actual provider invoice.
+
+Local models (Whisper, Kokoro, Piper, Ollama) are recorded as zero-cost, so per-project totals always reflect what you actually pay.
+
+## Where it fits in your stack
+
+```
+Your agent code (LiveKit or Pipecat)
+  ├── attach(session / task)        # passive observer, meters every call
+  └── guard(provider)               # active wrapper, adds control per provider
+       ├── native provider SDK      # deepgram, openai, cartesia, etc.
+       └── fallback providers       # tried in order when primary fails
+
+Records flow to:
+  └── storage (SQLite or Cloud ClickHouse)
+       ├── voicegw dashboard        # per-call cost, latency, provider breakdown
+       ├── voicegw reconcile        # verify against provider invoices
+       └── MCP server               # query from your AI editor
 ```
 
-Switching providers is a one-line config change. Per-project budgets are built in. Cost data flows to the dashboard, the CLI, and the MCP tools without any extra plumbing in your agent code.
-
-## Who is it for?
-
-- **Voice AI engineers** building agents with [LiveKit Agents](https://docs.livekit.io/agents/) or similar frameworks who want clean provider abstraction.
-- **Platform teams** running multi-tenant voice infrastructure that need per-project cost tracking and budget controls.
-- **Indie developers** who want to use local models (Whisper, Kokoro, Piper) during development and cloud providers in production, without changing application code.
-- **Cost-conscious teams** who need visibility into per-request costs across STT, LLM, and TTS with a single dashboard.
-
-## Feature comparison
-
-| Feature | VoiceGateway | Direct SDK calls | LiteLLM |
-|---|---|---|---|
-| STT + LLM + TTS routing | Yes | Manual | LLM only |
-| Unified config (YAML) | Yes | No | Partial |
-| Fallback chains | Yes | Manual | Yes |
-| Per-project cost tracking | Yes | No | No |
-| Budget enforcement (warn/throttle/block) | Yes | No | No |
-| Local model support | Yes (Whisper, Kokoro, Piper, Ollama) | N/A | Ollama only |
-| Drop-in for `livekit.agents.inference` | Yes | No | No |
-| Web dashboard | Yes | No | No |
-| MCP server integration | Yes | No | No |
-| LiveKit Agents compatible | Yes | Yes | Partial |
+VoiceGateway does not sit in the audio or inference path. There is no proxy hop and no added latency on happy-path calls.
 
 ## Supported providers
 
-VoiceGateway ships with 11 provider integrations spanning cloud and local:
-
-**Cloud providers:**
+**Cloud:**
 
 | Provider | STT | LLM | TTS |
 |---|---|---|---|
-| Deepgram | Yes | -- | Yes |
+| Deepgram | Yes | | Yes |
 | OpenAI | Yes | Yes | Yes |
-| Anthropic | -- | Yes | -- |
-| Groq | Yes | Yes | -- |
-| Cartesia | -- | -- | Yes |
-| ElevenLabs | -- | -- | Yes |
-| AssemblyAI | Yes | -- | -- |
+| Anthropic | | Yes | |
+| Groq | Yes | Yes | |
+| Cartesia | | | Yes |
+| ElevenLabs | | | Yes |
+| AssemblyAI | Yes | | |
 
-**Local providers:**
+**Local:**
 
 | Provider | STT | LLM | TTS |
 |---|---|---|---|
-| Whisper | Yes | -- | -- |
-| Ollama | -- | Yes | -- |
-| Kokoro | -- | -- | Yes |
-| Piper | -- | -- | Yes |
+| Whisper (faster-whisper) | Yes | | |
+| Ollama | | Yes | |
+| Kokoro | | | Yes |
+| Piper | | | Yes |
 
-## Architecture overview
+## Self-host or Hosted Cloud
 
-The request flow through VoiceGateway follows a clean pipeline:
-
-```
-Your code
-  --> voicegateway.inference.STT() / LLM() / TTS()
-    --> Resolve "provider/model" + per-project key
-      --> Wrap a livekit.plugins.<provider>.* instance
-        --> Middleware pipeline
-            - Cost tracking
-            - Latency monitoring
-            - Session correlation
-            - Budget enforcement
-        --> SQLite storage
-          --> Dashboard (reads stored data)
-```
-
-Key architectural decisions:
-
-- **Async throughout** -- all database, HTTP, and provider operations use `async/await`.
-- **Lazy provider instantiation** -- providers are created on first use via a registry factory, so unused providers cost nothing.
-- **Modular installs** -- `pip install voicegateway[openai,deepgram]` installs only the SDKs you need.
-- **Pydantic validation** -- the config schema uses `extra="forbid"` to catch typos in your YAML before they cause runtime errors.
-- **SQLite storage** -- request logs, cost records, and project data are stored locally in a SQLite database. No external dependencies.
-
-For a deeper dive into the internal architecture, see the [Architecture](/architecture/) section.
+VoiceGateway ships as an open-source Python package you run yourself (SQLite, single process). VoiceGateway Hosted Cloud is a managed version with a ClickHouse-backed ingest endpoint, multi-tenant isolation, and a shared dashboard at `dash.voicegateway.dev`. The two seams (`attach` / `guard`) work identically in both; only the storage sink differs.
 
 ## Next steps
 
-- [Quick Start](/guide/quick-start) -- get running in 5 minutes
-- [Installation](/guide/installation) -- system requirements and install options
-- [First Agent](/guide/first-agent) -- build a working voice agent with LiveKit
-- [Core Concepts](/guide/core-concepts) -- understand the key abstractions
+<CardGroup cols={2}>
+  <Card title="Quick start" icon="bolt" href="/guide/quick-start">
+    Get running in 5 minutes against a Deepgram + OpenAI + Cartesia stack.
+  </Card>
+  <Card title="attach()" icon="eye" href="/guide/attach">
+    Full reference for the passive observability seam.
+  </Card>
+  <Card title="guard()" icon="shield" href="/guide/guard">
+    Add fallback, rate limiting, and budget caps to any provider.
+  </Card>
+  <Card title="Which path?" icon="map" href="/guide/decision-tree">
+    Self-host or Cloud? attach-only or guard too? A decision guide.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- **what-is-voicegateway**: Introduces the two-seam model (attach observes, guard controls), modality-aware cost units (audio-minutes / tokens / characters via voice-prices), side-by-side LiveKit/Pipecat wiring using Mintlify Tabs, provider support tables, and CardGroup onward links. Removes the deprecated `voicegateway.inference` factory pattern; all examples now use `from voicegateway import attach, guard`.
- **frameworks**: Light polish: install snippets updated to show `uv` as primary with `pip` as alternate via CodeGroup; links to `/guide/attach` and `/guide/guard` preserved; deprecated factory section retained for accuracy without `voicegateway.inference` string.
- **decision-tree**: Full rewrite as a two-axis decision guide (self-host vs Cloud; attach-only vs attach+guard). Adds Mermaid decision flowchart, structured comparison tables, and CardGroup quick-start links. Removes all `voicegateway.inference` references.

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 3 scoped)
```

All seven validator rules pass on the three scoped pages.