### PR TITLE
docs(get-started): rewrite Get started group (P2)

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,157 +1,143 @@
 ---
-title: Get started
-description: Install VoiceGateway, run the onboarding wizard, see your first provider call land in the dashboard. 60 seconds, excluding the time it takes to fetch your provider API key.
+title: Get started (Self-Host)
+description: Install VoiceGateway alongside your existing LiveKit or Pipecat agent, call attach() once, and see per-call costs in the dashboard in under five minutes.
 ---
 
 # Get started
 
-VoiceGateway runs as a long-lived background daemon that serves both
-the HTTP API and the dashboard on a single port. From a fresh machine
-to your first inference call: one curl, one wizard. The 60-second
-clock starts when you paste the install command and stops when your
-first call shows up in the dashboard, excluding the time spent
-fetching your provider API key.
+VoiceGateway plugs into a LiveKit or Pipecat agent you already have. You keep
+your native provider plugins. VoiceGateway adds one `attach()` call that meters
+every STT, LLM, and TTS request and writes the costs to a local dashboard.
 
-## 1. Install
+<Steps>
+  <Step title="Install the extra for your framework">
+    <CodeGroup>
+    ```bash uv
+    # LiveKit Agents
+    uv pip install "voicegateway[livekit]"
 
-```bash
-curl -fsSL https://voicegateway.mahimai.ca/install.sh | bash
-```
+    # Pipecat
+    uv pip install "voicegateway[pipecat]"
+    ```
+    ```bash pip
+    # LiveKit Agents
+    pip install "voicegateway[livekit]"
 
-What the installer does:
+    # Pipecat
+    pip install "voicegateway[pipecat]"
+    ```
+    </CodeGroup>
 
-- Detects macOS, Linux, or WSL on Windows. Refuses cleanly on
-  anything else.
-- Verifies Python 3.11 or newer is installed. Refuses with package
-  manager pointers if not (does not auto-install Python).
-- Picks `uv tool install` when uv is on PATH, otherwise installs
-  pipx if missing and runs `pipx install voicegateway[cloud,dashboard]`.
-- Asks before any privileged step.
-- Prints the next-step command.
+    Python 3.11 or later is required. See [Installation](/guide/installation) for
+    provider extras and Docker options.
+  </Step>
 
-If you prefer not to pipe a remote script:
+  <Step title="Attach to your existing agent">
+    Add `import voicegateway` and one `attach()` call. Keep every native provider
+    plugin exactly as it is.
 
-```bash
-pipx install 'voicegateway[cloud,dashboard]'
-```
+    <Tabs>
+      <Tab title="LiveKit">
+        ```python
+        from livekit.agents import Agent, AgentSession
+        from livekit.plugins import deepgram, openai, cartesia
 
-```bash
-uv tool install 'voicegateway[cloud,dashboard]'
-```
+        import voicegateway
 
-## 2. Run the wizard
 
-```bash
-voicegw onboard
-```
+        async def entrypoint(ctx):
+            await ctx.connect()
 
-Five questions, four with working defaults (press Enter to accept):
+            session = AgentSession(
+                stt=deepgram.STT(model="nova-3"),
+                llm=openai.LLM(model="gpt-4o-mini"),
+                tts=cartesia.TTS(model="sonic-3"),
+            )
 
-1. **Project name** (default: `default`).
-2. **Provider** (default: `openai`).
-3. **API key** (no default; paste yours).
-4. **Port** (default: `8080`).
-5. **Install daemon?** (default: yes).
+            # One call. Every STT / LLM / TTS request is metered from here.
+            voicegateway.attach(session, project="my-agent")
 
-The wizard then:
+            await session.start(agent=Agent(instructions="Be helpful."), room=ctx.room)
+        ```
+      </Tab>
+      <Tab title="Pipecat">
+        ```python
+        from pipecat.pipeline.pipeline import Pipeline
+        from pipecat.pipeline.task import PipelineParams, PipelineTask
+        from pipecat.services.deepgram.stt import DeepgramSTTService
+        from pipecat.services.openai.llm import OpenAILLMService
+        from pipecat.services.cartesia.tts import CartesiaTTSService
 
-- Validates your API key against the provider with a 5-second
-  timeout. On timeout, the wizard continues with a warning instead
-  of failing.
-- Registers a user-scoped daemon (LaunchAgent on macOS, `systemd
-  --user` unit on Linux, Scheduled Task on Windows) and starts it.
-- Optionally runs `voicegw smoke-test` and confirms the pipeline.
-- Prints the dashboard URL (default `http://127.0.0.1:8080`) and
-  the next-step commands.
+        import voicegateway
 
-Pressing Ctrl+C at any point cleans up partial state. Re-running
-the wizard is always safe.
+        stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+        llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4o-mini")
+        tts = CartesiaTTSService(api_key=os.environ["CARTESIA_API_KEY"], voice_id="your-voice-id")
 
-## 3. Open the dashboard
+        pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])
+        task = PipelineTask(
+            pipeline,
+            params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        )
 
-```bash
-voicegw dashboard
-```
+        # One call. Every STT / LLM / TTS request is metered from here.
+        voicegateway.attach(task, project="my-agent")
+        ```
 
-That opens your browser at the daemon URL. The daemon already serves
-the dashboard at `/`, the dashboard API at `/api/*`, and the public
-HTTP API at `/v1/*`, all on the port the wizard collected. Use
-`voicegw dashboard --no-open` to print the URL without launching a
-browser (useful over SSH).
+        <Note>
+          Pipecat requires `enable_metrics=True` and `enable_usage_metrics=True` on
+          `PipelineParams`. Without these flags, Pipecat emits no usage frames and
+          `attach()` has nothing to record.
+        </Note>
+      </Tab>
+    </Tabs>
+  </Step>
 
-Other lifecycle commands:
+  <Step title="Run the dashboard">
+    ```bash
+    voicegw dashboard
+    ```
 
-```bash
-voicegw status        # daemon + provider status
-voicegw doctor        # numbered punch list with fix steps
-voicegw logs          # tail recent activity
-voicegw stop          # bring the daemon down
-voicegw restart       # restart the daemon
-```
+    That opens your browser at `http://127.0.0.1:9090`. The dashboard shows live
+    cost rows the moment your first call completes. Use `--no-open` to print the
+    URL without launching a browser (useful over SSH).
+  </Step>
 
-## 4. Wire it into your LiveKit agent
+  <Step title="See the first call">
+    Run your agent as normal, place a call, and refresh the dashboard. Each row
+    shows the modality (STT / LLM / TTS), provider, model, usage units, and the
+    cost in USD.
 
-Swap one import line:
+    In the terminal:
 
-```python
-from voicegateway.inference import STT, LLM, TTS
+    ```bash
+    voicegw costs    # tabular cost summary
+    voicegw status   # daemon and provider health
+    voicegw logs     # recent request stream
+    ```
+  </Step>
+</Steps>
 
-stt = STT("deepgram/nova-3")
-llm = LLM("openai/gpt-4.1-mini")
-tts = TTS("openai/tts-1")
-```
+<Tip>
+  Want to add fallback providers or enforce a daily spend cap? `guard()` wraps any
+  native provider and returns a drop-in replacement. See [guard()](/guide/guard).
+</Tip>
 
-Pass each to `AgentSession` exactly as you would the upstream
-`livekit.agents.inference` equivalents. Cost tracking, latency
-monitoring, and per-session correlation happen behind the scenes.
-See [Quick start](/guide/quick-start) for the full integration
-walkthrough.
+---
 
-## Troubleshooting
+## What's next
 
-`voicegw doctor` is the first place to look for first-call issues.
-It prints a numbered punch list with concrete fix steps for each
-failed check. No stack traces. No bare "see docs" pointers.
-
-The three most common things that block first-call:
-
-### Python 3.11+ is missing
-
-install.sh refuses on Python below 3.11 because the cloud provider
-SDKs have already moved past 3.10. Install Python first, then
-re-run install.sh.
-
-VoiceGateway will not auto-install Python. That choice is left to
-your OS package manager so we never silently shadow a system
-Python or break a virtualenv you cared about.
-
-### pipx is missing or not on PATH
-
-install.sh installs pipx automatically when it can (or uses uv if
-available). Two failure modes are common:
-
-1. pipx installed but `pipx` is not on your PATH yet. Open a fresh
-   shell and try again, or add `~/.local/bin` to your PATH:
-
-   ```bash
-   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-   exec $SHELL
-   ```
-
-2. The installer printed `pipx ensurepath` and exited cleanly.
-   Your installed-as-user directory is registered but the current
-   shell did not pick it up yet. Open a new terminal tab and
-   re-run `voicegw onboard`.
-
-### Provider key is invalid
-
-The wizard validates your key against the provider with a 5-second
-timeout. If validation returns `401 unauthorized` or similar:
-
-1. Double-check the key in your provider dashboard. The most
-   common cause is a missing character, a stray newline, or the
-   wrong project selected when you generated the key.
-2. Re-run the wizard. It is idempotent: any partial state from a
-   previous attempt is overwritten cleanly.
-3. Run `voicegw doctor`. The provider-key validation check prints
-   exactly which key was rejected and what to verify.
+<CardGroup cols={2}>
+  <Card title="Installation" icon="download" href="/guide/installation">
+    Full install matrix: uv, pip, framework extras, provider extras, Docker.
+  </Card>
+  <Card title="Quick start" icon="bolt" href="/guide/quick-start">
+    Five-minute path from install to reading your first per-call cost row.
+  </Card>
+  <Card title="First agent" icon="code" href="/guide/first-agent">
+    A complete worked agent file with attach() and a guard() fallback example.
+  </Card>
+  <Card title="Core concepts" icon="book" href="/guide/core-concepts">
+    attach(), guard(), projects, sinks, and how the pieces fit together.
+  </Card>
+</CardGroup>

--- a/docs/guide/first-agent.md
+++ b/docs/guide/first-agent.md
@@ -1,222 +1,301 @@
 ---
 title: First agent
-description: Build a working LiveKit voice agent that routes STT / LLM / TTS through VoiceGateway. Costs and latency land in the dashboard automatically.
+description: A complete worked agent for LiveKit and Pipecat with attach() for cost metering and a guard() fallback example. Copy, set your keys, run.
 ---
 
 # First agent
 
-This guide walks through building a voice AI agent using VoiceGateway
-with [LiveKit Agents](https://docs.livekit.io/agents/). By the end
-you have a working agent that listens, thinks, and speaks using
-providers configured through VoiceGateway.
+This page gives you a complete agent file for each framework. Each example uses
+`attach()` to meter cost and latency, and `guard()` to add a fallback LLM. Copy
+the file for your framework, set your environment variables, and run it.
 
 ## Prerequisites
 
-- Python 3.11+
-- VoiceGateway installed with cloud providers:
-  `pipx install 'voicegateway[cloud,dashboard]'`
-- LiveKit Agents SDK: `pip install livekit-agents`
-- API keys for at least one STT, LLM, and TTS provider
-- A LiveKit server (Cloud or self-hosted): setup walkthrough below
+- Python 3.11 or later
+- VoiceGateway installed for your framework (see [Installation](/guide/installation))
+- API keys for Deepgram, OpenAI, and Cartesia (or swap for your own providers)
 
-## LiveKit server setup
+<Tabs>
+  <Tab title="LiveKit">
+    ### Install
 
-A LiveKit Agents worker connects to a LiveKit server over WebSocket.
-You have two options.
+    <CodeGroup>
+    ```bash uv
+    uv pip install "voicegateway[openai,deepgram,cartesia]"
+    pip install "livekit-agents[silero]"
+    ```
+    ```bash pip
+    pip install "voicegateway[openai,deepgram,cartesia]"
+    pip install "livekit-agents[silero]"
+    ```
+    </CodeGroup>
 
-### Option A: LiveKit Cloud (free tier)
+    ### Set environment variables
 
-1. Sign up at [livekit.io](https://livekit.io/).
-2. Create a project from the Cloud dashboard.
-3. On the project's settings page, copy the WebSocket URL and the
-   API key + secret pair.
+    ```bash
+    export LIVEKIT_URL=wss://your-project.livekit.cloud
+    export LIVEKIT_API_KEY=your-livekit-key
+    export LIVEKIT_API_SECRET=your-livekit-secret
 
-### Option B: self-hosted `livekit-server` (local development)
+    export DEEPGRAM_API_KEY=your-deepgram-key
+    export OPENAI_API_KEY=your-openai-key
+    export CARTESIA_API_KEY=your-cartesia-key
+    ```
 
-The fastest path on your laptop is the official Docker image with
-the development flag:
+    For local development with `livekit-server --dev`, use:
 
-```bash
-docker run --rm \
-  -p 7880:7880 \
-  -p 7881:7881 \
-  -p 7882:7882/udp \
-  livekit/livekit-server --dev
-```
+    ```bash
+    export LIVEKIT_URL=ws://localhost:7880
+    export LIVEKIT_API_KEY=devkey
+    export LIVEKIT_API_SECRET=secret
+    ```
 
-The `--dev` flag uses default credentials: API key `devkey`, API
-secret `secret`. For a production self-hosted setup, follow the
-[LiveKit self-hosting guide](https://docs.livekit.io/home/self-hosting/local/).
+    ### agent.py
 
-### Export credentials
+    ```python
+    """LiveKit voice agent with VoiceGateway cost metering and LLM fallback."""
 
-Set three environment variables that `livekit-agents` reads at
-startup:
+    import os
 
-```bash
-# LiveKit Cloud
-export LIVEKIT_URL=wss://<your-project>.livekit.cloud
-export LIVEKIT_API_KEY=<your-key>
-export LIVEKIT_API_SECRET=<your-secret>
+    from livekit.agents import Agent, AgentSession, WorkerOptions, cli
+    from livekit.plugins import cartesia, deepgram, openai
 
-# Self-hosted local --dev
-export LIVEKIT_URL=ws://localhost:7880
-export LIVEKIT_API_KEY=devkey
-export LIVEKIT_API_SECRET=secret
-```
-
-A worker started without these env vars fails with
-`ConnectionError: Failed to connect`. Verify they are set:
-
-```bash
-echo "LIVEKIT_URL=$LIVEKIT_URL"
-echo "LIVEKIT_API_KEY=$LIVEKIT_API_KEY"
-echo "LIVEKIT_API_SECRET=$LIVEKIT_API_SECRET"
-```
-
-## Step 1: configure VoiceGateway
-
-Create or update your `voicegw.yaml`:
-
-```yaml
-projects:
-  my-agent:
-    name: My First Agent
-    description: A demo voice agent
-    daily_budget: 5.00
-    budget_action: warn
-    tags: [dev]
-    providers:
-      deepgram:
-        api_key: ${DEEPGRAM_API_KEY}
-      anthropic:
-        api_key: ${ANTHROPIC_API_KEY}
-      cartesia:
-        api_key: ${CARTESIA_API_KEY}
-
-default_project: my-agent
-
-cost_tracking:
-  enabled: true
-
-observability:
-  latency_tracking: true
-  cost_tracking: true
-  request_logging: true
-```
-
-Export your API keys:
-
-```bash
-export DEEPGRAM_API_KEY="your-key"
-export ANTHROPIC_API_KEY="your-key"
-export CARTESIA_API_KEY="your-key"
-```
-
-## Step 2: write the agent
-
-Create `agent.py`:
-
-```python
-from livekit.agents import AgentSession, Agent
-
-from voicegateway.inference import STT, LLM, TTS
+    import voicegateway
 
 
-class MyAgent(Agent):
-    def __init__(self) -> None:
-        super().__init__(
-            instructions=(
-                "You are a helpful voice assistant. Keep responses concise."
+    class MyAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(
+                instructions=(
+                    "You are a friendly voice assistant. Keep your answers short "
+                    "and clear. One or two sentences unless asked for more."
+                ),
+            )
+
+
+    async def entrypoint(ctx) -> None:
+        await ctx.connect()
+
+        # guard() wraps the LLM with a fallback and a daily budget.
+        # It returns a drop-in openai.LLM, so AgentSession sees no difference.
+        guarded_llm = voicegateway.guard(
+            openai.LLM(model="gpt-4o-mini"),
+            fallback=[openai.LLM(model="gpt-4o")],
+            rate_limit="60/min",
+            budget="$5.00/day",
+            project="my-agent",
+        )
+
+        session = AgentSession(
+            stt=deepgram.STT(model="nova-3"),
+            llm=guarded_llm,
+            tts=cartesia.TTS(model="sonic-3"),
+        )
+
+        # attach() is the single meter. Call it once, before session.start().
+        voicegateway.attach(session, project="my-agent")
+
+        await session.start(agent=MyAgent(), room=ctx.room)
+
+
+    if __name__ == "__main__":
+        cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
+    ```
+
+    ### Run the agent
+
+    ```bash
+    python agent.py dev
+    ```
+
+    Connect to your LiveKit room from a browser or the LiveKit Playground
+    (`https://playground.livekit.io`), say something, and watch the dashboard.
+
+    ### What happens
+
+    1. `deepgram.STT` transcribes speech. `attach()` meters audio minutes and cost.
+    2. `guard(openai.LLM(...))` sends the transcript to GPT-4o mini. If GPT-4o mini
+       returns an error, `guard()` retries with GPT-4o automatically. `attach()`
+       meters prompt tokens, completion tokens, and cost.
+    3. `cartesia.TTS` synthesizes speech. `attach()` meters characters and cost.
+    4. Every row lands in the dashboard at `http://127.0.0.1:9090`.
+  </Tab>
+
+  <Tab title="Pipecat">
+    ### Install
+
+    <CodeGroup>
+    ```bash uv
+    uv pip install "voicegateway[pipecat]"
+    uv pip install "pipecat-ai[openai,deepgram,cartesia,daily]"
+    ```
+    ```bash pip
+    pip install "voicegateway[pipecat]"
+    pip install "pipecat-ai[openai,deepgram,cartesia,daily]"
+    ```
+    </CodeGroup>
+
+    ### Set environment variables
+
+    ```bash
+    export DEEPGRAM_API_KEY=your-deepgram-key
+    export OPENAI_API_KEY=your-openai-key
+    export CARTESIA_API_KEY=your-cartesia-key
+    export DAILY_API_KEY=your-daily-key
+    export DAILY_ROOM_URL=https://your-domain.daily.co/your-room
+    ```
+
+    ### agent.py
+
+    ```python
+    """Pipecat voice agent with VoiceGateway cost metering and LLM fallback."""
+
+    import asyncio
+    import os
+
+    from pipecat.audio.vad.silero import SileroVADAnalyzer
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.runner import PipelineRunner
+    from pipecat.pipeline.task import PipelineParams, PipelineTask
+    from pipecat.processors.aggregators.openai_llm_context import (
+        OpenAILLMContext,
+    )
+    from pipecat.services.cartesia.tts import CartesiaTTSService
+    from pipecat.services.deepgram.stt import DeepgramSTTService
+    from pipecat.services.openai.llm import OpenAILLMService
+    from pipecat.transports.services.daily import DailyParams, DailyTransport
+
+    import voicegateway
+
+
+    async def main() -> None:
+        transport = DailyTransport(
+            os.environ["DAILY_ROOM_URL"],
+            token=None,
+            bot_name="VoiceBot",
+            params=DailyParams(audio_out_enabled=True, vad_analyzer=SileroVADAnalyzer()),
+        )
+
+        stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+
+        # guard() wraps the LLM with a fallback and a daily budget.
+        # It returns a drop-in OpenAILLMService, so the Pipeline sees no difference.
+        llm = voicegateway.guard(
+            OpenAILLMService(
+                api_key=os.environ["OPENAI_API_KEY"],
+                model="gpt-4o-mini",
+            ),
+            fallback=[
+                OpenAILLMService(
+                    api_key=os.environ["OPENAI_API_KEY"],
+                    model="gpt-4o",
+                )
+            ],
+            rate_limit="60/min",
+            budget="$5.00/day",
+            project="my-agent",
+        )
+
+        tts = CartesiaTTSService(
+            api_key=os.environ["CARTESIA_API_KEY"],
+            voice_id="your-voice-id",
+        )
+
+        context = OpenAILLMContext(
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a friendly voice assistant. Keep your answers short "
+                        "and clear. One or two sentences unless asked for more."
+                    ),
+                }
+            ]
+        )
+        context_aggregator = llm.create_context_aggregator(context)
+
+        pipeline = Pipeline(
+            [
+                transport.input(),
+                stt,
+                context_aggregator.user(),
+                llm,
+                tts,
+                transport.output(),
+                context_aggregator.assistant(),
+            ]
+        )
+
+        task = PipelineTask(
+            pipeline,
+            params=PipelineParams(
+                allow_interruptions=True,
+                enable_metrics=True,
+                enable_usage_metrics=True,
             ),
         )
 
+        # attach() is the single meter. Call it once, before runner.run(task).
+        voicegateway.attach(task, project="my-agent")
 
-async def entrypoint(ctx) -> None:
-    await ctx.connect()
+        runner = PipelineRunner()
+        await runner.run(task)
 
-    # default_project: my-agent in voicegw.yaml means the inference
-    # factories pick up my-agent's per-project keys without any extra
-    # call here. Use set_project(...) from voicegateway.core.active_project
-    # to override per request.
-    session = AgentSession(
-        stt=STT("deepgram/nova-3"),
-        llm=LLM("anthropic/claude-sonnet-4-5"),
-        tts=TTS("cartesia/sonic-3"),
-    )
 
-    await session.start(
-        agent=MyAgent(),
-        room=ctx.room,
-    )
-```
+    if __name__ == "__main__":
+        asyncio.run(main())
+    ```
 
-## Step 3: run the agent
+    ### Run the agent
 
-```bash
-python agent.py
-```
+    ```bash
+    python agent.py
+    ```
 
-The agent connects to your LiveKit room and begins listening.
-VoiceGateway routes STT requests to Deepgram, LLM requests to
-Anthropic, and TTS requests to Cartesia. Cost tracking and latency
-monitoring happen automatically.
+    Join your Daily room from a browser. After the call ends, the dashboard at
+    `http://127.0.0.1:9090` shows a cost row per modality.
 
-## Step 4: monitor with the dashboard
+    ### What happens
+
+    1. `DeepgramSTTService` transcribes speech. `attach()` accumulates audio bytes,
+       converts them to minutes, and prices the STT.
+    2. `guard(OpenAILLMService(...))` sends the transcript to GPT-4o mini. If it
+       returns an error, `guard()` retries with GPT-4o automatically. `attach()`
+       meters tokens and cost from the `LLMTokenUsage` frame.
+    3. `CartesiaTTSService` synthesizes speech. `attach()` meters characters and cost.
+    4. On pipeline end, `attach()` flushes all pending rows to the local SQLite sink
+       and the dashboard updates.
+
+    <Warning>
+      Pipecat fallback switches providers before the first output frame only. If the
+      primary service fails partway through a token stream, the error is surfaced
+      rather than patched mid-stream. Size your fallback list for "primary is down
+      or rejecting", not "primary died halfway".
+    </Warning>
+  </Tab>
+</Tabs>
+
+## View costs in the dashboard
 
 ```bash
 voicegw dashboard
 ```
 
-That opens your browser at the daemon URL (default
-`http://127.0.0.1:8080`). The Costs page shows live cost tracking
-per provider and per model, the Latency page shows p50 / p95 / p99
-per model, and the Logs page shows the request stream for your
-agent.
+Opens your browser at `http://127.0.0.1:9090`. Cost rows appear in real time as
+calls complete.
 
-## Routing to a different project
+In the terminal:
 
-The agent above relies on `default_project: my-agent` in YAML. When
-one process serves multiple agents, switch per request context with
-`set_project`:
-
-```python
-from voicegateway.core.active_project import set_project
-from voicegateway.inference import STT
-
-# Inside one async task
-set_project("tony-pizza")
-stt = STT("deepgram/nova-3")  # uses tony-pizza's key
-
-# A separate asyncio.Task gets its own context, so no leakage.
-```
-
-## Adding fallbacks
-
-For resolver-time fallback (try the next model in the chain when
-the primary fails at startup) walk a chain manually using the
-inference factories: iterate the `fallbacks.<modality>` list from
-`voicegw.yaml` and use the first model whose provider plugin imports
-cleanly.
-
-```python
-from voicegateway.inference import LLM
-
-for model_id in ["openai/gpt-4.1-mini", "anthropic/claude-sonnet-4-5"]:
-    try:
-        llm = LLM(model_id)
-        break
-    except ImportError:
-        continue
+```bash
+voicegw costs    # tabular cost summary
+voicegw logs     # recent request stream
+voicegw status   # daemon and provider health
 ```
 
 ## Next steps
 
-- [Core concepts](/guide/core-concepts): understand gateways,
-  stacks, projects, and fallbacks.
-- [Configuration reference](/configuration/voicegw-yaml): full
-  YAML reference.
-- [Projects](/configuration/projects): per-project budgets and
-  tracking.
-- [Providers](/configuration/providers): details on every
-  supported provider.
+- [attach()](/guide/attach): full reference, including `tenant_id` for multi-tenant attribution.
+- [guard()](/guide/guard): full reference, including per-framework fallback scope.
+- [Core concepts](/guide/core-concepts): how attach, guard, projects, and sinks fit together.
+- [Configuration reference](/configuration/voicegw-yaml): every YAML key.
+- [Providers](/configuration/providers): all supported providers and model IDs.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,83 +1,113 @@
 ---
 title: Installation
-description: Every install path for VoiceGateway. curl-bash recommended for first-run; pipx / uv / Docker for everything else.
+description: Install VoiceGateway with uv or pip. Pick the framework extra for LiveKit or Pipecat, then add provider extras for the SDKs you need. Python 3.11+ required.
 ---
 
 # Installation
 
-## System requirements
+## Requirements
 
-- **Python 3.11** or later
-- **SQLite 3.35+** (ships with Python; used for cost tracking and
-  request logs)
-- **macOS, Linux, or WSL on Windows.** Native Windows is supported
-  via Scheduled Tasks for the daemon; the rest of the docs assume a
-  POSIX shell.
-- **Docker** (optional, for containerised deployments)
+- Python 3.11 or later
+- macOS, Linux, or WSL on Windows
 
-## Recommended: curl-bash one-liner
+## Framework extras
 
-```bash
-curl -fsSL https://voicegateway.mahimai.ca/install.sh | bash
+Install the extra that matches your agent framework. The core package is
+framework-neutral: `import voicegateway` imports neither LiveKit Agents nor
+Pipecat.
+
+<CodeGroup>
+```bash uv
+# LiveKit Agents
+uv pip install "voicegateway[livekit]"
+
+# Pipecat
+uv pip install "voicegateway[pipecat]"
 ```
+```bash pip
+# LiveKit Agents
+pip install "voicegateway[livekit]"
 
-The installer:
-
-- Detects your OS (macOS / Linux / WSL).
-- Verifies Python 3.11+ is installed (refuses with package-manager
-  pointers if not; does not auto-install Python).
-- Picks `uv tool install` if uv is on PATH, otherwise installs pipx
-  and runs `pipx install voicegateway[cloud,dashboard]`.
-- Asks before any privileged step.
-
-After install, run `voicegw onboard`. See [Get started](/get-started)
-for the 60-second walkthrough.
-
-## pipx (manual)
-
-```bash
-pipx install 'voicegateway[cloud,dashboard]'
+# Pipecat
+pip install "voicegateway[pipecat]"
 ```
+</CodeGroup>
 
-`pipx` installs VoiceGateway into its own virtualenv so the `voicegw`
-binary lands on your PATH without polluting your system Python.
+## Provider extras (LiveKit)
 
-## uv (manual)
+Provider extras imply `livekit`. A single line pulls the core, the LiveKit
+adapter, and the provider SDK you name.
 
-```bash
-uv tool install 'voicegateway[cloud,dashboard]'
+<CodeGroup>
+```bash uv
+# One provider
+uv pip install "voicegateway[openai]"
+
+# Several at once
+uv pip install "voicegateway[openai,deepgram,cartesia]"
 ```
+```bash pip
+pip install "voicegateway[openai]"
 
-`uv tool install` is faster than pipx and uses the same per-tool-venv
-model. If you have uv already, prefer this.
+pip install "voicegateway[openai,deepgram,cartesia]"
+```
+</CodeGroup>
 
-## Install extras
-
-VoiceGateway uses optional extras to keep the install lightweight.
-Only the provider SDKs you need are installed.
-
-| Extra | What it installs |
+| Extra | Provider SDK installed |
 |---|---|
-| `cloud` | All cloud provider SDKs (Deepgram, OpenAI, Anthropic, Groq, Cartesia, ElevenLabs, AssemblyAI) |
-| `local` | Local model dependencies (Whisper, Kokoro, Piper, Ollama) |
-| `dashboard` | Web dashboard (React bundle + Pillow for logo validation) |
+| `openai` | `livekit-plugins-openai` |
+| `deepgram` | `livekit-plugins-deepgram` |
+| `anthropic` | `livekit-plugins-anthropic` |
+| `groq` | `livekit-plugins-groq` |
+| `cartesia` | `livekit-plugins-cartesia` |
+| `elevenlabs` | `livekit-plugins-elevenlabs` |
+| `assemblyai` | `livekit-plugins-assemblyai` |
+| `whisper` | `livekit-plugins-silero` + `openai-whisper` |
+
+<Note>
+  Each of the provider extras above implies `livekit`. You do not need to install
+  `voicegateway[livekit]` separately when you install a provider extra.
+</Note>
+
+## Provider extras (Pipecat)
+
+For Pipecat, install `voicegateway[pipecat]` and then install provider service
+extras directly from Pipecat. VoiceGateway wraps the native Pipecat services you
+already configure.
+
+<CodeGroup>
+```bash uv
+uv pip install "voicegateway[pipecat]"
+uv pip install "pipecat-ai[openai,deepgram,cartesia]"
+```
+```bash pip
+pip install "voicegateway[pipecat]"
+pip install "pipecat-ai[openai,deepgram,cartesia]"
+```
+</CodeGroup>
+
+## Additional extras
+
+| Extra | What it adds |
+|---|---|
+| `dashboard` | Prebuilt React dashboard bundle (served by `voicegw dashboard`) |
+| `local` | Local model support: Whisper, Kokoro, Piper, Ollama |
 | `mcp` | MCP server for IDE integration |
 | `tui` | Terminal UI (Textual-based status / costs / sessions views) |
 | `all` | Everything above |
 
-You can combine extras:
+You can combine any extras:
 
-```bash
-pipx install 'voicegateway[cloud,dashboard,mcp]'
+<CodeGroup>
+```bash uv
+uv pip install "voicegateway[livekit,dashboard,openai,deepgram]"
 ```
-
-Or install individual provider SDKs:
-
-```bash
-pipx install 'voicegateway[openai,deepgram]'
+```bash pip
+pip install "voicegateway[livekit,dashboard,openai,deepgram]"
 ```
+</CodeGroup>
 
-## From source
+## Install from source
 
 ```bash
 git clone https://github.com/mahimailabs/voicegateway.git
@@ -85,10 +115,8 @@ cd voicegateway
 pip install -e ".[dev]"
 ```
 
-The `dev` extra includes test dependencies (pytest, pytest-asyncio,
-pytest-cov, ruff, mypy).
-
-Running from source ships the React frontend as source. Build it:
+The `dev` extra includes pytest, ruff, and mypy. To build the dashboard
+frontend from source:
 
 ```bash
 cd src/dashboard/frontend
@@ -96,25 +124,17 @@ npm install
 npm run build
 ```
 
-The daemon mounts `src/dashboard/frontend/dist/` at `/` once that
-exists.
-
 ## Docker
 
-VoiceGateway ships a `docker-compose.yml` for running the daemon
-(serving both the HTTP API and the dashboard):
-
 ```bash
-# Daemon (HTTP API + dashboard on one port)
+# HTTP API + dashboard on port 8080
 docker compose up -d
 
-# Plus Ollama (for local LLM)
+# Plus Ollama for local LLM
 docker compose --profile local up -d
 ```
 
-The default Docker setup exposes port **8080**: the daemon serves
-`/v1/*` (HTTP API), `/api/*` (dashboard API), and `/` (React UI)
-on that port. Mount your config and set environment variables:
+Mount your config and pass provider keys as environment variables:
 
 ```bash
 docker compose up -d \
@@ -123,32 +143,26 @@ docker compose up -d \
   -v ./voicegw.yaml:/app/voicegw.yaml
 ```
 
-## Verify the install
+## Verify
 
 ```bash
 voicegw --version
 voicegw status
 ```
 
-If `voicegw` is not on your PATH, run:
-
-```bash
-python -m voicegateway.cli --version
-```
-
-For pipx, you may need `pipx ensurepath && exec $SHELL`.
+If `voicegw` is not on your PATH after a `uv pip install`, activate the
+environment or use `python -m voicegateway.cli --version`.
 
 ## Upgrading
 
-```bash
-pipx upgrade voicegateway
+<CodeGroup>
+```bash uv
+uv pip install --upgrade voicegateway
 ```
-
-Or with uv:
-
-```bash
-uv tool upgrade voicegateway
+```bash pip
+pip install --upgrade voicegateway
 ```
+</CodeGroup>
 
 After upgrading, check for config schema changes:
 
@@ -160,30 +174,25 @@ voicegw init --diff
 
 **`ModuleNotFoundError: No module named 'deepgram'`**
 
-You installed the base package without the provider extra. Install
-the extra you need:
+You installed without the `deepgram` extra. Add it:
 
 ```bash
-pipx install 'voicegateway[deepgram]'
+pip install "voicegateway[deepgram]"
 ```
 
 **`ConfigError: No voicegw.yaml found`**
 
-VoiceGateway searches for config in this order:
+VoiceGateway searches in this order:
 
 1. `./voicegw.yaml` (current directory)
 2. `~/.config/voicegateway/voicegw.yaml`
 3. `/etc/voicegateway/voicegw.yaml`
 
-You can also set the `VOICEGW_CONFIG` environment variable to an
-explicit path. Run `voicegw init` to generate a starter config or
-`voicegw onboard` to be walked through it.
+Set `VOICEGW_CONFIG` to an explicit path, or run `voicegw init` to generate a
+starter config.
 
 ## Next steps
 
-- [Get started](/get-started): 60-second walkthrough.
-- [Quick start](/guide/quick-start): the 5-minute version that
-  exercises the inference factories.
-- [First agent](/guide/first-agent): build a working agent.
-- [Environment variables](/configuration/environment-variables):
-  all supported env vars.
+- [Quick start](/guide/quick-start): five-minute path from install to first cost row.
+- [First agent](/guide/first-agent): a complete worked agent with `attach()` and `guard()`.
+- [Frameworks and extras](/guide/frameworks): framework-neutral core explained.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,159 +1,259 @@
 ---
 title: Quick start
-description: Get VoiceGateway running in 5 minutes. Daemon up, dashboard open, one Python script proves the inference factories resolve correctly.
+description: Install VoiceGateway, attach() it to a LiveKit or Pipecat agent, open the dashboard, and read your first per-call cost row in five minutes.
 ---
 
 # Quick start
 
-By the end of this guide you have a running daemon, an open
-dashboard, and a Python script that exercises the inference
-factories so you can confirm provider keys resolve and costs land
-in the dashboard.
+By the end of this guide you have VoiceGateway installed, `attach()` wired into a
+minimal agent, and cost rows appearing in the dashboard.
 
 ## Prerequisites
 
 - Python 3.11 or later
-- An API key for at least one cloud provider (Deepgram, OpenAI,
-  Anthropic, Groq, Cartesia, ElevenLabs, or AssemblyAI)
+- A running LiveKit or Pipecat agent (or follow the agent skeleton below)
+- API keys for at least one STT, LLM, and TTS provider
 
-## 1. Install
+<Steps>
+  <Step title="Install">
+    Pick the extra for your framework. Provider extras for LiveKit imply the
+    `livekit` extra, so one line is enough.
 
-```bash
-pipx install 'voicegateway[cloud,dashboard]'
-```
+    <Tabs>
+      <Tab title="LiveKit">
+        <CodeGroup>
+        ```bash uv
+        uv pip install "voicegateway[openai,deepgram,cartesia]"
+        ```
+        ```bash pip
+        pip install "voicegateway[openai,deepgram,cartesia]"
+        ```
+        </CodeGroup>
+      </Tab>
+      <Tab title="Pipecat">
+        <CodeGroup>
+        ```bash uv
+        uv pip install "voicegateway[pipecat]"
+        uv pip install "pipecat-ai[openai,deepgram,cartesia]"
+        ```
+        ```bash pip
+        pip install "voicegateway[pipecat]"
+        pip install "pipecat-ai[openai,deepgram,cartesia]"
+        ```
+        </CodeGroup>
+      </Tab>
+    </Tabs>
 
-Or if you prefer uv:
+    See [Installation](/guide/installation) for the full extras table, Docker,
+    and source install.
+  </Step>
 
-```bash
-uv tool install 'voicegateway[cloud,dashboard]'
-```
+  <Step title="Build a minimal agent">
+    Create `agent.py`. Use your native framework providers exactly as you
+    normally would.
 
-The `cloud` extra pulls every cloud provider SDK; the `dashboard`
-extra ships the prebuilt React bundle and the dashboard endpoints.
-For a minimal install of one provider only, see
-[Installation](/guide/installation).
+    <Tabs>
+      <Tab title="LiveKit">
+        ```python
+        # agent.py (LiveKit)
+        from livekit.agents import Agent, AgentSession, WorkerOptions, cli
+        from livekit.plugins import deepgram, openai, cartesia
 
-## 2. Onboard
+        import voicegateway
 
-```bash
-voicegw onboard
-```
 
-Five questions, four with working defaults (press Enter to accept):
+        async def entrypoint(ctx):
+            await ctx.connect()
 
-1. Project name (default: `default`).
-2. Provider (default: `openai`).
-3. API key (no default; paste yours).
-4. Port (default: `8080`).
-5. Install daemon? (default: yes).
+            session = AgentSession(
+                stt=deepgram.STT(model="nova-3"),
+                llm=openai.LLM(model="gpt-4o-mini"),
+                tts=cartesia.TTS(model="sonic-3"),
+            )
 
-The wizard writes `~/.config/voicegateway/voicegw.yaml`, registers
-the daemon with your OS service manager (LaunchAgent on macOS,
-`systemd --user` on Linux, Scheduled Task on Windows), and starts
-it.
+            voicegateway.attach(session, project="my-agent")
 
-## 3. Open the dashboard
+            await session.start(
+                agent=Agent(instructions="You are a helpful voice assistant."),
+                room=ctx.room,
+            )
 
-```bash
-voicegw dashboard
-```
 
-That opens your browser at the daemon URL (default
-`http://127.0.0.1:8080`). The daemon serves the React UI at `/`,
-the dashboard API at `/api/*`, and the public HTTP API at `/v1/*`
-on the same port.
+        if __name__ == "__main__":
+            cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
+        ```
+      </Tab>
+      <Tab title="Pipecat">
+        ```python
+        # agent.py (Pipecat)
+        import os
+        from pipecat.pipeline.pipeline import Pipeline
+        from pipecat.pipeline.task import PipelineParams, PipelineTask
+        from pipecat.pipeline.runner import PipelineRunner
+        from pipecat.services.deepgram.stt import DeepgramSTTService
+        from pipecat.services.openai.llm import OpenAILLMService
+        from pipecat.services.cartesia.tts import CartesiaTTSService
 
-## 4. Verify the inference factories
+        import voicegateway
 
-Create `demo.py`:
 
-```python
-from voicegateway.inference import STT, LLM, TTS
+        async def main():
+            stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+            llm = OpenAILLMService(
+                api_key=os.environ["OPENAI_API_KEY"],
+                model="gpt-4o-mini",
+            )
+            tts = CartesiaTTSService(
+                api_key=os.environ["CARTESIA_API_KEY"],
+                voice_id="your-voice-id",
+            )
 
-# Each call resolves provider/model -> loads the SDK -> wraps with
-# cost-tracking and latency middleware. AgentSession would consume
-# them directly; here we print to confirm wiring.
-stt = STT("openai/whisper-1")
-llm = LLM("openai/gpt-4.1-mini")
-tts = TTS("openai/tts-1")
+            pipeline = Pipeline([stt, llm, tts])
+            task = PipelineTask(
+                pipeline,
+                params=PipelineParams(
+                    enable_metrics=True,
+                    enable_usage_metrics=True,
+                ),
+            )
 
-print("STT:", stt)
-print("LLM:", llm)
-print("TTS:", tts)
-```
+            voicegateway.attach(task, project="my-agent")
 
-Run it:
+            runner = PipelineRunner()
+            await runner.run(task)
 
-```bash
-python demo.py
-```
 
-You should see three instantiated provider objects. VoiceGateway
-resolved the `provider/model` strings, loaded the correct SDKs, and
-wrapped each instance with cost-tracking and latency middleware.
+        if __name__ == "__main__":
+            import asyncio
+            asyncio.run(main())
+        ```
 
-## 5. See costs in the dashboard
+        <Note>
+          `enable_metrics=True` and `enable_usage_metrics=True` are required on
+          `PipelineParams`. Without them, Pipecat emits no usage frames and
+          `attach()` has nothing to record.
+        </Note>
+      </Tab>
+    </Tabs>
+  </Step>
 
-Trigger one call (any request that uses the inference factories
-above) and refresh the dashboard at `http://127.0.0.1:8080/costs`.
-The row shows the model, provider, modality, and the per-call cost
-in USD with the pricing source attribution (`voice-prices@<version>`
-for cloud models, `voicegateway-local` for self-hosted).
+  <Step title="Open the dashboard">
+    In a second terminal, start the dashboard:
 
-In the terminal:
+    ```bash
+    voicegw dashboard
+    ```
 
-```bash
-voicegw costs
-voicegw status
-voicegw logs
-```
+    Your browser opens at `http://127.0.0.1:9090`. The Costs page is empty until
+    your first call completes. Leave it open.
+  </Step>
 
-## Add a project
+  <Step title="Run the agent and place a call">
+    <Tabs>
+      <Tab title="LiveKit">
+        ```bash
+        python agent.py dev
+        ```
 
-Multiple agents share one daemon? Give each its own project entry
-in `voicegw.yaml` so cost rows and provider keys stay separated:
+        Connect to your LiveKit room and say something. After the call, the
+        dashboard Costs page shows a row per modality with the provider, model,
+        usage units, and cost in USD.
+      </Tab>
+      <Tab title="Pipecat">
+        ```bash
+        python agent.py
+        ```
+
+        After the pipeline finishes, the dashboard Costs page shows a row per
+        modality with the provider, model, usage units, and cost in USD.
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Read the cost rows">
+    On the Costs page, each row shows:
+
+    | Column | What it means |
+    |---|---|
+    | Modality | `stt`, `llm`, or `tts` |
+    | Provider | `deepgram`, `openai`, `cartesia`, etc. |
+    | Model | the model id passed to the plugin |
+    | Usage | audio minutes (STT), tokens (LLM), characters (TTS) |
+    | Cost | USD, priced through `voice-prices` |
+    | Project | the `project=` argument you passed to `attach()` |
+
+    In the terminal:
+
+    ```bash
+    voicegw costs    # tabular cost summary
+    voicegw status   # daemon and provider health
+    voicegw logs     # recent request stream
+    ```
+  </Step>
+</Steps>
+
+## Add a project budget
+
+Multiple agents share one daemon? Give each its own project block in
+`voicegw.yaml` to separate cost rows and daily budgets:
 
 ```yaml
 projects:
   my-agent:
     name: My First Agent
     daily_budget: 5.00
-    providers:
-      deepgram:
-        api_key: ${MY_AGENT_DEEPGRAM_KEY}
-      openai:
-        api_key: ${MY_AGENT_OPENAI_KEY}
+    budget_action: warn
 
 default_project: my-agent
 ```
 
-The inference factories pick the project up automatically. Override
-per-context with `set_project("my-agent")` from
-`voicegateway.core.active_project` when you need to.
+Pass `project="my-agent"` to `attach()` (as shown above) and the rows are
+attributed to that project automatically.
 
-## Add fallbacks
+## Add fallback and rate limits
 
-Resolver-time fallback chain in `voicegw.yaml`:
+`guard()` wraps any native provider and returns a drop-in replacement. Use it
+on the specific providers where you want control:
 
-```yaml
-fallbacks:
-  stt: [deepgram/nova-3, openai/whisper-1]
-  llm: [openai/gpt-4.1-mini, anthropic/claude-sonnet-4-5]
-  tts: [openai/tts-1, elevenlabs/eleven_turbo_v2_5]
-```
+<Tabs>
+  <Tab title="LiveKit">
+    ```python
+    import voicegateway
+    from livekit.plugins import openai
 
-Walk the chain at startup by trying each model with
-`STT/LLM/TTS(model_id)` and using the first one whose provider
-plugin imports cleanly. Once `AgentSession` starts, the resolved
-model is used for the whole call.
+    guarded_llm = voicegateway.guard(
+        openai.LLM(model="gpt-4o-mini"),
+        fallback=[openai.LLM(model="gpt-4o")],
+        rate_limit="60/min",
+        budget="$5.00/day",
+    )
+
+    session = AgentSession(stt=stt, llm=guarded_llm, tts=tts)
+    voicegateway.attach(session, project="my-agent")
+    ```
+  </Tab>
+  <Tab title="Pipecat">
+    ```python
+    import voicegateway
+    from pipecat.services.openai.llm import OpenAILLMService
+
+    guarded_llm = voicegateway.guard(
+        OpenAILLMService(model="gpt-4o-mini"),
+        fallback=[OpenAILLMService(model="gpt-4o")],
+        rate_limit="60/min",
+        budget="$5.00/day",
+    )
+
+    pipeline = Pipeline([stt, guarded_llm, tts])
+    ```
+  </Tab>
+</Tabs>
+
+`attach()` remains the single meter. `guard()` writes no metrics of its own.
 
 ## Next steps
 
-- [Installation](/guide/installation): all install variants
-  (curl-bash, pipx, uv, Docker).
-- [First agent](/guide/first-agent): wire VoiceGateway into a
-  full LiveKit voice agent.
-- [Core concepts](/guide/core-concepts): understand the
-  abstractions (modality, provider, project, stack).
-- [Configuration reference](/configuration/voicegw-yaml): every
-  YAML key.
+- [First agent](/guide/first-agent): a complete worked agent file with `guard()`.
+- [attach()](/guide/attach): full `attach()` reference, including `tenant_id` and fleet push.
+- [guard()](/guide/guard): full `guard()` reference with fallback scope details.
+- [Configuration reference](/configuration/voicegw-yaml): every YAML key.


### PR DESCRIPTION
## Summary

- Rewrites all four Self-Host Get started pages to lead with `attach()`/`guard()` instead of the deprecated `voicegateway.inference` API.
- `get-started.md`: tab landing with a `<Steps>` fast-path (install, attach, dashboard, first call) and a `<CardGroup>` into the group.
- `guide/installation.md`: focused install matrix with uv-first ordering, framework extras (`livekit`/`pipecat`), provider extras that imply `livekit`, and Pipecat provider install pattern.
- `guide/quick-start.md`: five-step `<Steps>` path from install to reading a cost row; LiveKit and Pipecat shown side by side via `<Tabs>`.
- `guide/first-agent.md`: complete copy-runnable agent files for both frameworks with a `guard()` fallback/budget example, via `<Tabs>`.

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 4 scoped)
```