### PR TITLE
docs(concepts): rewrite Core concepts group (P3)

### DIFF
--- a/docs/guide/attach.md
+++ b/docs/guide/attach.md
@@ -14,6 +14,11 @@ hard line, and control lives in [`guard()`](/guide/guard).
 Because `attach()` is the *single* meter, pairing it with `guard()` never
 double-counts. `guard()` writes no metrics of its own.
 
+<Note>
+For the conceptual model behind these two seams (attach observes, guard controls,
+RequestRecord, Sink, projects, voice-prices), read [Core Concepts](/guide/core-concepts) first.
+</Note>
+
 ## Signature
 
 ```python
@@ -34,92 +39,93 @@ voicegateway.attach(
 observer. The return value is the session id that ties every captured row
 together, so you can echo it into your own logs.
 
-## LiveKit: attach(session)
+## Wiring
 
-Construct your `AgentSession` with native `livekit.plugins` providers, then
-attach before you start it:
+<Tabs>
+  <Tab title="LiveKit">
+    Construct your `AgentSession` with native `livekit.plugins` providers, then
+    attach before you start it:
 
-```python
-from livekit.agents import Agent, AgentSession
-from livekit.plugins import deepgram, openai, cartesia
+    ```python
+    from livekit.agents import Agent, AgentSession
+    from livekit.plugins import deepgram, openai, cartesia
 
-import voicegateway
+    import voicegateway
 
 
-async def entrypoint(ctx):
-    await ctx.connect()
+    async def entrypoint(ctx):
+        await ctx.connect()
 
-    session = AgentSession(
-        stt=deepgram.STT(model="nova-3"),
-        llm=openai.LLM(model="gpt-4o-mini"),
-        tts=cartesia.TTS(model="sonic-3"),
+        session = AgentSession(
+            stt=deepgram.STT(model="nova-3"),
+            llm=openai.LLM(model="gpt-4o-mini"),
+            tts=cartesia.TTS(model="sonic-3"),
+        )
+
+        # One call. Every STT / LLM / TTS metric is metered from here on.
+        voicegateway.attach(session, project="my-agent")
+
+        await session.start(agent=Agent(instructions="Be helpful."), room=ctx.room)
+    ```
+
+    On the LiveKit path `attach()` subscribes to the per-component
+    `metrics_collected` events, so it works with any plugin without wrapping it.
+    The session's `close` event finalizes the meter (drains in-flight writes and
+    flushes the sink), so a graceful shutdown loses nothing.
+  </Tab>
+  <Tab title="Pipecat">
+    Pipecat has no cumulative usage aggregate, so `attach()` sums the metrics it
+    observes. Enable Pipecat's metrics on the task, then either call `attach(task)`
+    or pass an exported `Observer` to the task constructor. Both do the same thing.
+
+    <Warning>
+    Pipecat metrics must be explicitly enabled. Without `enable_metrics` and
+    `enable_usage_metrics`, Pipecat emits no usage frames and there is nothing for
+    `attach()` to record.
+    </Warning>
+
+    **Option A: attach(task).**
+
+    ```python
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.task import PipelineParams, PipelineTask
+    from pipecat.services.deepgram.stt import DeepgramSTTService
+    from pipecat.services.openai.llm import OpenAILLMService
+    from pipecat.services.cartesia.tts import CartesiaTTSService
+
+    import voicegateway
+
+    stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
+    llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini")
+    tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
+
+    pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
     )
 
-    # One call. Every STT / LLM / TTS metric is metered from here on.
-    voicegateway.attach(session, project="my-agent")
+    voicegateway.attach(task, project="my-agent")
+    ```
 
-    await session.start(agent=Agent(instructions="Be helpful."), room=ctx.room)
-```
+    **Option B: Observer in the constructor.**
 
-On the LiveKit path `attach()` subscribes to the per-component
-`metrics_collected` events, so it works with any plugin without wrapping it. The
-session's `close` event finalizes the meter (drains in-flight writes and flushes
-the sink), so a graceful shutdown loses nothing.
+    ```python
+    import voicegateway
 
-## Pipecat: attach(task) or Observer
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        observers=[voicegateway.Observer(project="my-agent")],
+    )
+    ```
 
-Pipecat has no cumulative usage aggregate, so `attach()` sums the metrics it
-observes. Enable Pipecat's metrics on the task, then either call `attach(task)`
-or pass an exported `Observer` to the task constructor. Both do the same thing.
-
-**Enable Pipecat metrics.** The observer meters `MetricsFrame`s, so the pipeline
-must emit them:
-
-```python
-from pipecat.pipeline.task import PipelineParams, PipelineTask
-
-params = PipelineParams(enable_metrics=True, enable_usage_metrics=True)
-```
-
-Without `enable_metrics` / `enable_usage_metrics`, Pipecat emits no usage frames
-and there is nothing for `attach()` to record.
-
-**Option A: attach(task).**
-
-```python
-from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.task import PipelineParams, PipelineTask
-from pipecat.services.deepgram.stt import DeepgramSTTService
-from pipecat.services.openai.llm import OpenAILLMService
-from pipecat.services.cartesia.tts import CartesiaTTSService
-
-import voicegateway
-
-pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])
-task = PipelineTask(
-    pipeline,
-    params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
-)
-
-voicegateway.attach(task, project="my-agent")
-```
-
-**Option B: Observer in the constructor.**
-
-```python
-import voicegateway
-
-task = PipelineTask(
-    pipeline,
-    params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
-    observers=[voicegateway.Observer(project="my-agent")],
-)
-```
-
-`voicegateway.Observer` takes the same keyword arguments as `attach()`
-(`project`, `agent_id`, `tenant_id`, `channel`, `collector_url`, `api_key`,
-`sink`). The observer finalizes itself on the pipeline end (`EndFrame`): it drains
-any pending STT audio into a final record and flushes the sink.
+    `voicegateway.Observer` takes the same keyword arguments as `attach()`
+    (`project`, `agent_id`, `tenant_id`, `channel`, `collector_url`, `api_key`,
+    `sink`). The observer finalizes itself on the pipeline end (`EndFrame`): it
+    drains any pending STT audio into a final record and flushes the sink.
+  </Tab>
+</Tabs>
 
 ## What it records
 
@@ -157,13 +163,19 @@ telephony, while a Daily / WebRTC / websocket transport means web. Pass
 **Session** correlation is automatic. Every row from one attached session (or
 pipeline) shares the returned session id, which the dashboard uses to group a
 conversation and its per-turn timeline. On LiveKit the id is created when the
-session context opens; on Pipecat it is created when you attach. Multi-tenant
-operators pass `tenant_id=` to slice costs per customer.
+session context opens; on Pipecat it is created when you attach.
+
+<Tip>
+Multi-tenant operators pass `tenant_id=` to slice costs per customer. Each row
+is labelled so the dashboard and API can filter or group by tenant. See
+[Multi-tenant quickstart](/guide/multi-tenant-quickstart) for a worked example.
+</Tip>
 
 ## See also
 
+- [Core Concepts](/guide/core-concepts): the two-seam model, RequestRecord, Sink, projects, and voice-prices.
 - [guard()](/guide/guard): the active control seam that composes with `attach()`.
 - [Frameworks and extras](/guide/frameworks): install `voicegateway[livekit]` vs
   `voicegateway[pipecat]`.
 - [Migration guide](/guide/migration-attach-guard): moving off the deprecated
-  `voicegateway.LLM/STT/TTS` factories.
+  `voicegateway.LLM/STT/TTS` factories to native + attach + guard.

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -1,77 +1,122 @@
 ---
 title: Core Concepts
-description: Definitions of the key abstractions in VoiceGateway, from the inference module to providers, modalities, projects, and middleware.
+description: The framework-neutral model at the heart of VoiceGateway: two seams (attach observes, guard controls), RequestRecord and Sink, projects, cost via voice-prices, and ContextVars for session and tenant correlation.
 ---
 
 # Core Concepts
 
-This page defines the key abstractions in VoiceGateway. Understanding these concepts will help you navigate the configuration and API.
+VoiceGateway sits beside your framework, not between you and it. You keep native LiveKit or Pipecat providers; VoiceGateway adds two thin seams that observe and control those providers. This page explains the model behind those seams and the shared vocabulary the rest of the docs use.
 
-## Inference module
+## The two seams
 
-The public Python surface. `voicegateway.inference` mirrors `livekit.agents.inference` so an agent written for LiveKit Cloud Inference moves to VoiceGateway with one import-line change. Each factory call (`STT`, `LLM`, `TTS`) constructs the matching LiveKit plugin and wraps it with VG's middleware.
+VoiceGateway exposes exactly two public entry points for wiring into an agent:
+
+| Seam | Role | Effect on calls |
+|---|---|---|
+| `attach(session)` | observe (passive) | none; measures only |
+| `guard(provider)` | control (active) | reroutes, throttles, or blocks |
+
+The rule is hard: **observability is `attach`, control is `guard`**. The two seams never call each other. They coordinate through the shared core (spend state, routing ContextVars). Because `attach` is the sole meter, pairing it with `guard` never double-counts.
+
+## attach()
+
+`attach()` takes a LiveKit `AgentSession` or a Pipecat `PipelineTask`, subscribes to its per-component metric events, and writes one `RequestRecord` row per STT, LLM, and TTS call. It returns a session id that ties every row from that conversation together.
 
 ```python
-from voicegateway import inference
-stt = inference.STT("deepgram/nova-3")
+from voicegateway import attach
+
+session_id = attach(session, project="my-agent", tenant_id=ctx.room.name)
 ```
 
-See: [Quick Start](/guide/quick-start), [First Agent](/guide/first-agent), [Python SDK Reference](/api/python-sdk)
+The full signature is documented in [attach()](/guide/attach). The key points here:
 
-## Provider
+- `attach()` is the **single meter**. There is no other path that writes cost or latency rows.
+- It is framework-neutral: the same function detects the target type and installs the right observer.
+- It is passive: it cannot reroute, throttle, or block.
 
-A backend service that performs inference. VoiceGateway supports 11 providers: 7 cloud (Deepgram, OpenAI, Anthropic, Groq, Cartesia, ElevenLabs, AssemblyAI) and 4 local (Whisper, Ollama, Kokoro, Piper). Each provider wraps a corresponding `livekit.plugins.<name>` package and is instantiated lazily on first inference call.
+## guard()
 
-See: [Providers](/configuration/providers)
+`guard()` wraps a native provider and returns a drop-in replacement of the same type. It adds three controls around the underlying call: fallback chains, rate limiting, and spend caps.
 
-## Model ID
+```python
+from voicegateway import guard
 
-A string in `"provider/model"` format that uniquely identifies a model. For example, `deepgram/nova-3`, `openai/gpt-4.1-mini`, or `cartesia/sonic-3`. STT model IDs can include a language suffix (`deepgram/nova-3:en`), and TTS model IDs can include a voice suffix (`cartesia/sonic-3:narrator`). LLM model IDs preserve trailing colons verbatim, so Ollama tags like `ollama/qwen2.5:3b` work as expected.
+llm = guard(
+    openai.LLM(model="gpt-4o-mini"),
+    fallback=[openai.LLM(model="gpt-4o")],
+    rate_limit="60/min",
+    budget="$5.00/day",
+)
+```
 
-See: [Models](/configuration/models)
+`guard()` writes **no** metrics. Budget enforcement reads the accumulated spend that `attach()` has already written, closing the measure-then-enforce loop. The full signature and DSL are in [guard()](/guide/guard).
 
-## Modality
+## RequestRecord and Sink
 
-The type of inference operation: **STT** (speech-to-text), **LLM** (large language model), or **TTS** (text-to-speech). Each provider supports one or more modalities. The factory classes `inference.STT`, `inference.LLM`, and `inference.TTS` correspond directly to these three modalities.
+Every row written by `attach()` is a `RequestRecord`: a flat dataclass carrying modality, provider, model, usage units (tokens, characters, audio seconds), priced cost, latency, and the correlation fields (session id, project, agent id, tenant id, channel).
 
-See: [Providers](/configuration/providers) for a modality support matrix
+A `Sink` is the destination for those records. Two sinks ship with VoiceGateway:
 
-## Project
+- **LocalSQLiteSink** (default): writes to a SQLite file on disk, readable by the dashboard and CLI.
+- **RemoteCollectorSink**: POSTs records to a hosted ingest endpoint when you set `VOICEGW_COLLECTOR_URL` and `VOICEGW_API_KEY`. Use this for fleet deployments where each agent pushes metrics to a central store.
 
-A logical grouping for per-project provider keys, cost tracking, and budget enforcement. Each project has a name, optional `daily_budget`, a `budget_action` (warn, throttle, or block), and an optional `providers:` block carrying its own API keys. The active project is set via `inference.set_project(...)`, the `VOICEGW_ACTIVE_PROJECT` env var, the `default_project` field in YAML, or the auto-created `default` fallback.
+You can pass a custom `sink=` to `attach()` for testing or alternative backends. The architecture details are in [Storage](/architecture/storage).
 
-See: [Projects](/configuration/projects)
+## Projects
 
-## Session
+A project is a named cost and budget scope. Every `RequestRecord` carries a project label. You assign a project at attach time:
 
-A logical voice conversation: one caller turn through STT, LLM, and TTS. VoiceGateway tags every request from the same async context with a shared `session_id` (`"vg-<uuid>"`), accumulating cost and modality data into the `sessions` table.
+```python
+attach(session, project="customer-support")
+```
 
-See: [Python SDK Reference](/api/python-sdk#session-correlation)
+Projects are created automatically if they do not already exist. You can pre-configure a project with a daily budget in `voicegw.yaml`:
 
-## Fallback Chain
+```yaml
+projects:
+  customer-support:
+    daily_budget: "$20.00"
+    budget_action: warn   # warn | throttle | block
+```
 
-An ordered list of model IDs in `voicegw.yaml` for resolver-time fallback. Walk the chain at agent startup using the inference factories; the first model whose provider plugin imports cleanly and whose key resolves wins. Once `AgentSession` starts, that model is used for the whole call.
+The budget action is enforced by `guard()` when it checks accumulated spend, not by `attach()`. See [Projects](/configuration/projects) for the full options.
 
-See: [voicegw.yaml Reference](/configuration/voicegw-yaml)
+## Cost via voice-prices
 
-## Budget Action
+VoiceGateway prices every request through `voice-prices`, a fork of `pydantic/genai-prices` extended to cover STT audio minutes and TTS characters in addition to LLM tokens. The cost field in `RequestRecord` is computed from the usage units the provider metric reports:
 
-The enforcement behavior when a project exceeds its `daily_budget`. Three options:
+- **LLM**: prompt tokens, completion tokens, cached tokens priced per provider rate table.
+- **TTS**: character count priced per provider per-character rate.
+- **STT**: audio duration in seconds priced per provider per-minute rate.
 
-- **warn** -- log a warning but allow requests to continue.
-- **throttle** -- add artificial delay to requests to slow down consumption.
-- **block** -- reject requests entirely until the budget resets.
+Price tables ship with the library and can be refreshed without a code change. See [Cost Tracking](/architecture/cost-tracking) for the lookup path.
 
-See: [Projects](/configuration/projects)
+## ContextVars for session and tenant correlation
 
-## Middleware
+VoiceGateway uses Python `contextvars.ContextVar` to carry the active session id and tenant id across async tasks without passing them explicitly. When `attach()` runs, it sets the session id in the current context. Every `RequestRecord` written in that context inherits it automatically.
 
-Processing layers that wrap every inference call. VoiceGateway includes four built-in middleware components: cost tracking, latency monitoring, rate limiting, and request logging. Middleware runs transparently around each provider invocation. You control which middleware is active via the `observability` config section.
+This matters in two situations:
 
-See: [Observability](/configuration/observability)
+1. **Multi-tenant agents.** Pass `tenant_id=` to `attach()` when one agent instance serves multiple end-users. Each call's record is labelled with the tenant so the dashboard and API can slice costs per customer.
+2. **Sub-task correlation.** If your agent spawns helper tasks inside the same async context, their provider calls are automatically tagged with the same session id.
 
-## Config Layer
+See [Multi-tenant quickstart](/guide/multi-tenant-quickstart) for a worked example.
 
-VoiceGateway manages configuration from two sources: the `voicegw.yaml` file and a SQLite database (for models and projects created at runtime via the dashboard or MCP). At startup, the `ConfigManager` merges both sources. Changes made through the API or MCP are persisted to SQLite and merged on next `refresh_config()`.
+## What this page is not
 
-See: [voicegw.yaml Reference](/configuration/voicegw-yaml), [Environment Variables](/configuration/environment-variables)
+This page covers the framework-neutral core. For wiring, go to the seam pages. For limits and budget DSL, go to `guard()`. For config, go to the Configure section.
+
+<CardGroup cols={2}>
+  <Card title="attach() (observability)" icon="eye" href="/guide/attach">
+    Full signature, options, LiveKit and Pipecat wiring examples, and what each row records.
+  </Card>
+  <Card title="guard() (control)" icon="shield" href="/guide/guard">
+    Fallback chains, rate limiting, and spend caps with LiveKit and Pipecat examples.
+  </Card>
+  <Card title="Migrate to attach() + guard()" icon="arrow-right" href="/guide/migration-attach-guard">
+    Move off the deprecated factories to native providers plus the two seams.
+  </Card>
+  <Card title="Architecture overview" icon="building" href="/architecture/index">
+    How the seams, core, and sink layer fit together end-to-end.
+  </Card>
+</CardGroup>

--- a/docs/guide/guard.md
+++ b/docs/guide/guard.md
@@ -14,6 +14,11 @@ is the sole meter, so `guard(provider)` plus `attach(session)` never
 double-counts. The two seams never call each other; they coordinate only through
 the framework-neutral core (routing ContextVars and shared spend / limit state).
 
+<Note>
+For the conceptual model behind the two seams, see [Core Concepts](/guide/core-concepts).
+For the observe side, see [attach()](/guide/attach).
+</Note>
+
 ## Passive vs active
 
 This is the core distinction. An observer can capture cost and latency but can
@@ -55,65 +60,90 @@ voicegateway.guard(
   `BudgetExceededError` when it is at or over the cap. Budget enforcement depends
   on the cost data `attach()` writes, which closes the measure-then-enforce loop.
 
-## LiveKit
+## Wiring
 
-`guard()` returns a subclass of the LiveKit base (`livekit.agents.{llm,stt,tts}`)
-so the result slots into an `AgentSession` unchanged:
+<Tabs>
+  <Tab title="LiveKit">
+    `guard()` returns a subclass of the LiveKit base (`livekit.agents.{llm,stt,tts}`)
+    so the result slots into an `AgentSession` unchanged:
 
-```python
-from livekit.agents import Agent, AgentSession
-from livekit.plugins import deepgram, openai, cartesia
+    ```python
+    from livekit.agents import Agent, AgentSession
+    from livekit.plugins import deepgram, openai, cartesia
 
-import voicegateway
+    import voicegateway
 
 
-async def entrypoint(ctx):
-    await ctx.connect()
+    async def entrypoint(ctx):
+        await ctx.connect()
 
-    session = AgentSession(
-        stt=deepgram.STT(model="nova-3"),
-        llm=voicegateway.guard(
-            openai.LLM(model="gpt-4o-mini"),
-            fallback=[openai.LLM(model="gpt-4o")],
-            rate_limit="60/min",
-            budget="$5.00/day",
-        ),
-        tts=cartesia.TTS(model="sonic-3"),
+        session = AgentSession(
+            stt=deepgram.STT(model="nova-3"),
+            llm=voicegateway.guard(
+                openai.LLM(model="gpt-4o-mini"),
+                fallback=[openai.LLM(model="gpt-4o")],
+                rate_limit="60/min",
+                budget="$5.00/day",
+            ),
+            tts=cartesia.TTS(model="sonic-3"),
+        )
+
+        voicegateway.attach(session, project="my-agent")  # the single meter
+        await session.start(agent=Agent(instructions="Be helpful."), room=ctx.room)
+    ```
+
+    <Tip>
+    You can guard any combination of modalities independently. Guard only the
+    providers where you actually need fallback or limits; leave the others as plain
+    native plugins.
+    </Tip>
+  </Tab>
+  <Tab title="Pipecat">
+    The API is identical. Pass a native Pipecat service; `guard()` returns a
+    wrapped service you place in the pipeline where the original went:
+
+    ```python
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.task import PipelineParams, PipelineTask
+    from pipecat.services.deepgram.stt import DeepgramSTTService
+    from pipecat.services.openai.llm import OpenAILLMService
+    from pipecat.services.cartesia.tts import CartesiaTTSService
+
+    import voicegateway
+
+    stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
+    guarded_llm = voicegateway.guard(
+        OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini"),
+        fallback=[OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o")],
+        rate_limit="60/min",
+        budget="$5.00/day",
+    )
+    tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
+
+    pipeline = Pipeline([transport.input(), stt, guarded_llm, tts, transport.output()])
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
     )
 
-    voicegateway.attach(session, project="my-agent")  # the single meter
-    await session.start(agent=Agent(instructions="Be helpful."), room=ctx.room)
-```
+    voicegateway.attach(task, project="my-agent")
+    ```
 
-## Pipecat
+    ### Pipecat fallback scope
 
-The API is identical. Pass a native Pipecat service; `guard()` returns a wrapped
-service you place in the pipeline where the original went:
+    Fallback on the Pipecat path switches providers **before the first output frame**.
+    If the primary service fails to produce its first frame, `guard()` tries the next
+    provider. Once the primary has started streaming output, there is **no mid-stream
+    recovery**: a failure partway through a response is surfaced, not silently
+    patched over by swapping to a fallback.
 
-```python
-from pipecat.services.openai.llm import OpenAILLMService
-
-import voicegateway
-
-guarded_llm = voicegateway.guard(
-    OpenAILLMService(model="gpt-4o-mini"),
-    fallback=[OpenAILLMService(model="gpt-4o")],
-    rate_limit="60/min",
-    budget="$5.00/day",
-)
-
-pipeline = Pipeline([transport.input(), stt, guarded_llm, tts, transport.output()])
-```
-
-### Pipecat fallback scope
-
-Fallback on the Pipecat path switches providers **before the first output frame**.
-If the primary service fails to produce its first frame, `guard()` tries the next
-provider. Once the primary has started streaming output, there is **no mid-stream
-recovery**: a failure partway through a response is surfaced, not silently
-patched over by swapping to a fallback. Size a Pipecat fallback for
-"primary is down / rejecting" rather than "primary died halfway through a token
-stream."
+    <Warning>
+    Size a Pipecat fallback for "primary is down / rejecting" rather than "primary
+    died halfway through a token stream." Mid-stream failures are not recoverable on
+    the Pipecat path.
+    </Warning>
+  </Tab>
+</Tabs>
 
 ## What guard() does not do
 
@@ -126,6 +156,7 @@ stream."
 
 ## See also
 
+- [Core Concepts](/guide/core-concepts): the two-seam model and how guard and attach coordinate.
 - [attach()](/guide/attach): the passive meter guard composes with.
 - [Frameworks and extras](/guide/frameworks): the framework-neutral core.
 - [Migration guide](/guide/migration-attach-guard): moving fallback and limits off

--- a/docs/guide/migration-attach-guard.md
+++ b/docs/guide/migration-attach-guard.md
@@ -11,6 +11,12 @@ The `voicegateway.LLM("openai/gpt-4o")` / `STT(...)` / `TTS(...)` factories are
 to the framework-neutral shape: **native providers + `attach()`**, plus
 [`guard()`](/guide/guard) where you had fallback or limits.
 
+<Note>
+The deprecated factories were part of the old `voicegateway.inference` module.
+If you imported from there, the same migration applies: replace factory calls
+with native providers and wire `attach()` once per session.
+</Note>
+
 ## Why the change
 
 - **No more double-count.** The old factories and `attach()` both subscribed to
@@ -40,9 +46,9 @@ you guard.
 
 ## LiveKit
 
-Before:
+<CodeGroup>
 
-```python
+```python Before
 from livekit.agents import Agent, AgentSession
 from voicegateway import LLM, STT, TTS  # deprecated
 
@@ -54,9 +60,7 @@ session = AgentSession(
 await session.start(agent=Agent(instructions="Be helpful."), room=ctx.room)
 ```
 
-After:
-
-```python
+```python After
 from livekit.agents import Agent, AgentSession
 from livekit.plugins import deepgram, openai, cartesia
 
@@ -74,7 +78,9 @@ voicegateway.attach(session, project="my-agent")
 await session.start(agent=Agent(instructions="Be helpful."), room=ctx.room)
 ```
 
-If a modality had fallback or limits, wrap just that provider:
+</CodeGroup>
+
+If a modality had fallback or limits, wrap just that provider with `guard()`:
 
 ```python
 llm=voicegateway.guard(
@@ -91,7 +97,14 @@ The old factories were LiveKit-only. On Pipecat you construct native
 `pipecat.services.*` and observe them the same way. Enable Pipecat's metrics so
 there is usage for `attach()` to record:
 
-```python
+<CodeGroup>
+
+```python Before (no native Pipecat support existed)
+# The old factories did not support Pipecat. You had no VoiceGateway metering
+# unless you imported from voicegateway.inference and ran LiveKit-only code.
+```
+
+```python After
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.services.deepgram.stt import DeepgramSTTService
@@ -117,6 +130,8 @@ task = PipelineTask(
 voicegateway.attach(task, project="my-agent")
 ```
 
+</CodeGroup>
+
 ## Install the right extra
 
 The factories pulled `livekit` implicitly. Now install the extra for the
@@ -141,8 +156,14 @@ import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="voicegateway")
 ```
 
+<Tip>
+Remove the filter as soon as you have migrated all call sites. The filter hides
+real warnings if you leave it in.
+</Tip>
+
 ## See also
 
+- [Core Concepts](/guide/core-concepts): the two-seam model and why metering and control are separate.
 - [attach()](/guide/attach): the single meter.
 - [guard()](/guide/guard): fallback, rate limits, and spend caps.
 - [Frameworks and extras](/guide/frameworks): the framework-neutral core and


### PR DESCRIPTION
## Summary

- **guide/core-concepts.md**: full rewrite as the conceptual anchor for the Self-Host tab. Covers the two-seam model (attach observes / guard controls), RequestRecord and Sink, projects, cost via voice-prices, and ContextVars for session/tenant correlation. Ends with a CardGroup linking into attach, guard, migration, and architecture. No `voicegateway.inference` references (rule 5 clean).
- **guide/attach.md**: consistency pass. Adds `<Tabs>` for LiveKit and Pipecat wiring, `<Note>`/`<Tip>`/`<Warning>` callouts, and cross-links to core-concepts. All signatures and options preserved.
- **guide/guard.md**: consistency pass. Adds `<Tabs>` for LiveKit and Pipecat, `<Tip>`/`<Warning>`, and cross-links to core-concepts. Pipecat fallback scope caveat preserved.
- **guide/migration-attach-guard.md**: consistency pass. Replaces plain before/after blocks with `<CodeGroup>`, adds a `<Note>` clarifying the `voicegateway.inference` origin, `<Tip>` on filter cleanup, and cross-links to core-concepts. All deprecated-factory references retained (this is the one page where they are allowed).

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 4 scoped)
```

`python3 docs/_check_docs.py guide/core-concepts guide/attach guide/guard guide/migration-attach-guard` exits 0.