### PR TITLE
docs(config): rewrite Configure group (P4)

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -18,19 +18,18 @@ VoiceGateway reads environment variables for configuration overrides, secret mat
 | `VOICEGW_SECRET` | Fernet key for encrypting managed-provider API keys before they land in SQLite. Generate with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`. | (44-char base64 string) |
 | `VOICEGW_SECRET_FALLBACK` | Comma-separated previous Fernet keys for rotation. Lets `voicegw rotate-secret` re-encrypt rows stored under an older key. | (44-char base64 string) |
 | `VOICEGW_MCP_TOKEN` | Bearer token for authenticating MCP server requests when running over HTTP/SSE. | `mcp-secret-token` |
-| `VOICEGW_ACTIVE_PROJECT` | Override the active project for the current process. Lower precedence than `attach()` metadata, higher than `default_project`. | `customer-support` |
+| `VOICEGW_ACTIVE_PROJECT` | Active project for the deprecated `voicegateway.LLM/STT/TTS` factories only (resolution: ContextVar, then this env var, then `default_project`). `attach()` takes its project from the `project=` argument, not this variable. | `customer-support` |
 
 ## Cloud ingest variables
 
-These three variables configure the agent-side remote sink that pushes telemetry to VoiceGateway Cloud (or a self-hosted collector):
+These variables configure the agent-side remote sink that pushes telemetry to VoiceGateway Cloud (or a self-hosted collector):
 
 | Variable | Purpose |
 |---|---|
 | `VOICEGW_COLLECTOR_URL` | Full URL of the ingest endpoint, e.g. `https://collect.voicegateway.dev/v1/ingest` |
 | `VOICEGW_API_KEY` | Virtual API key (`vk_...`) that authenticates the agent to the collector |
-| `VOICEGW_PROJECT` | Project slug to attribute telemetry to (e.g. `customer-support`) |
 
-Set all three in the agent's environment. The SDK's remote sink reads them automatically and requires no additional config. See [Hosted quickstart](/hosted/quickstart) for the full setup flow.
+Set both in the agent's environment. `attach()` reads them automatically. Pass the project name in your `attach(target, project="...")` call (there is no project env var for `attach()`). See [Hosted quickstart](/hosted/quickstart) for the full setup flow.
 
 ## Provider API keys
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -1,32 +1,40 @@
 ---
 title: Environment variables
-description: Every environment variable VoiceGateway reads (config path, database path, daemon bind, Fernet keys, MCP token) and how ${VAR_NAME} substitution works in voicegw.yaml.
+description: Every environment variable VoiceGateway reads (config path, database, daemon bind, Fernet keys, MCP token, cloud ingest) and how ${VAR_NAME} substitution works in voicegw.yaml.
 ---
 
 # Environment variables
 
-VoiceGateway reads environment variables for configuration
-overrides, daemon binding, secret material, and provider API keys.
-Variables can also be referenced in `voicegw.yaml` using
-`${VAR_NAME}` syntax.
+VoiceGateway reads environment variables for configuration overrides, secret material, and daemon binding. Variables can also be referenced in `voicegw.yaml` using `${VAR_NAME}` syntax.
 
 ## VoiceGateway variables
 
 | Variable | Purpose | Example |
 |---|---|---|
-| `VOICEGW_CONFIG` | Override the config file path. Skips the default search order. | `/opt/voicegw/config.yaml` |
+| `VOICEGW_CONFIG` | Override the config file path. Skips the default discovery order. | `/opt/voicegw/config.yaml` |
 | `VOICEGW_DB_PATH` | Override the SQLite database path. Also enables cost tracking when set. | `~/.config/voicegateway/voicegw.db` |
 | `VOICEGW_HOST` | Bind host for `python -m voicegateway.server.main` (the Docker entrypoint). The CLI uses `serve.host` from the config; this var is for module invocations. | `127.0.0.1` |
 | `VOICEGW_PORT` | Bind port for `python -m voicegateway.server.main`. Same scope as `VOICEGW_HOST`. | `8080` |
 | `VOICEGW_SECRET` | Fernet key for encrypting managed-provider API keys before they land in SQLite. Generate with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`. | (44-char base64 string) |
-| `VOICEGW_SECRET_FALLBACK` | Comma-separated previous Fernet keys for rotation. Lets `voicegw rotate-secret` re-encrypt rows that were stored under an older key. | (44-char base64 string) |
+| `VOICEGW_SECRET_FALLBACK` | Comma-separated previous Fernet keys for rotation. Lets `voicegw rotate-secret` re-encrypt rows stored under an older key. | (44-char base64 string) |
 | `VOICEGW_MCP_TOKEN` | Bearer token for authenticating MCP server requests when running over HTTP/SSE. | `mcp-secret-token` |
+| `VOICEGW_ACTIVE_PROJECT` | Override the active project for the current process. Lower precedence than `attach()` metadata, higher than `default_project`. | `customer-support` |
+
+## Cloud ingest variables
+
+These three variables configure the agent-side remote sink that pushes telemetry to VoiceGateway Cloud (or a self-hosted collector):
+
+| Variable | Purpose |
+|---|---|
+| `VOICEGW_COLLECTOR_URL` | Full URL of the ingest endpoint, e.g. `https://collect.voicegateway.dev/v1/ingest` |
+| `VOICEGW_API_KEY` | Virtual API key (`vk_...`) that authenticates the agent to the collector |
+| `VOICEGW_PROJECT` | Project slug to attribute telemetry to (e.g. `customer-support`) |
+
+Set all three in the agent's environment. The SDK's remote sink reads them automatically and requires no additional config. See [Hosted quickstart](/hosted/quickstart) for the full setup flow.
 
 ## Provider API keys
 
-Each cloud provider reads its API key from a standard environment
-variable. These are referenced in `voicegw.yaml` via `${VAR_NAME}`
-substitution.
+Each cloud provider reads its API key from a standard environment variable. Reference these in `voicegw.yaml` via `${VAR_NAME}` substitution.
 
 | Variable | Provider | Required for |
 |---|---|---|
@@ -40,8 +48,7 @@ substitution.
 
 ## How substitution works
 
-In `voicegw.yaml`, any string value can reference an environment
-variable using `${VAR_NAME}`:
+Any string value in `voicegw.yaml` can reference an environment variable with `${VAR_NAME}`:
 
 ```yaml
 providers:
@@ -52,10 +59,7 @@ providers:
     base_url: ${OPENAI_BASE_URL}
 ```
 
-VoiceGateway substitutes these at config load time. If the
-environment variable is not set, it resolves to an empty string.
-Substitution works recursively through all dicts and lists in the
-config.
+VoiceGateway substitutes these at config load time from `os.environ`. Substitution works recursively through all dicts and lists. If a variable is not set, it resolves to an empty string.
 
 ## Setting environment variables
 
@@ -69,12 +73,9 @@ export VOICEGW_DB_PATH="~/.config/voicegateway/voicegw.db"
 
 ### `.env` file
 
-VoiceGateway does not load `.env` files automatically. Use a tool
-like `direnv` or `dotenv` if you prefer file-based env var
-management:
+VoiceGateway does not load `.env` files automatically. Use `direnv` or a similar tool if you prefer file-based management:
 
 ```bash
-# With direnv
 echo 'export DEEPGRAM_API_KEY="your-key"' >> .envrc
 direnv allow
 ```
@@ -99,17 +100,17 @@ services:
       - VOICEGW_SECRET=${VOICEGW_SECRET}
 ```
 
-## Config search order
+## Config discovery order
 
-When `VOICEGW_CONFIG` is not set, VoiceGateway searches for config
-in this order:
+When `VOICEGW_CONFIG` is not set, VoiceGateway searches for config in this order:
 
 1. `./voicegw.yaml`
 2. `~/.config/voicegateway/voicegw.yaml`
 3. `/etc/voicegateway/voicegw.yaml`
 
-`voicegw onboard` writes to the second path by default.
+`voicegw init` writes to the second path by default.
 
-See [voicegw.yaml reference](/configuration/voicegw-yaml),
-[Providers](/configuration/providers),
-[Installation](/guide/installation).
+---
+
+See [voicegw.yaml reference](/configuration/voicegw-yaml) for all config keys.
+See [Providers](/configuration/providers) for per-provider credential blocks.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -1,13 +1,13 @@
 ---
 title: Models
-description: How VoiceGateway identifies every model with a provider/model string, including language and voice suffixes, custom aliases, and example STT, LLM, and TTS model IDs.
+description: How VoiceGateway identifies every model with a provider/model string, including language and voice suffixes, custom alias registration, and example model IDs for STT, LLM, and TTS.
 ---
 
 # Models
 
 ## Model ID format
 
-Every model in VoiceGateway is identified by a string in `provider/model` format.
+Every model in VoiceGateway is identified by a `provider/model` string:
 
 ```
 deepgram/nova-3
@@ -15,48 +15,42 @@ openai/gpt-4.1-mini
 cartesia/sonic-3
 ```
 
-### Language and voice suffixes
+### Language suffixes (STT)
 
-STT model IDs can include a language suffix separated by a colon:
+STT model IDs accept an optional language code after a colon:
 
 ```
 deepgram/nova-3:en
 deepgram/nova-3:es
 ```
 
-TTS model IDs can include a voice suffix:
+### Voice suffixes (TTS)
+
+TTS model IDs accept an optional voice ID after a colon:
 
 ```
 cartesia/sonic-3:narrator-male
 openai/tts-1:nova
 ```
 
-LLM model IDs preserve trailing colons verbatim, so Ollama tags survive:
+### Ollama tags (LLM)
+
+LLM model IDs preserve trailing colons verbatim, so Ollama version tags pass through intact:
 
 ```
 ollama/qwen2.5:3b
 ollama/llama3.2:3b
 ```
 
-This asymmetry mirrors `livekit.agents.inference`: STT and TTS strip the last colon segment, LLM does not.
+<Note>
+STT and TTS strip the last colon segment at parse time. LLM does not. This asymmetry mirrors how LiveKit agents handle the model string.
+</Note>
 
-### Using model IDs in code
+---
 
-```python
-from voicegateway import inference
+## Registering custom model aliases
 
-# Pass model ID strings directly to inference factories.
-stt = inference.STT("deepgram/nova-3:en")          # :en parsed as language
-llm = inference.LLM("openai/gpt-4.1-mini")
-tts = inference.TTS("cartesia/sonic-3:narrator-male")  # :voice-id parsed as voice
-llm_local = inference.LLM("ollama/qwen2.5:3b")     # :3b kept as part of model name
-```
-
-## Registering custom models
-
-You can register model aliases in `voicegw.yaml` under the `models` section. The aliases surface in the dashboard and CLI for display purposes; the `voicegateway.inference` module parses `provider/model` strings directly from the factory call, so an alias does not change runtime behaviour. Aliases are organised by modality (stt, llm, tts).
-
-### Via YAML
+Register aliases under `models` in `voicegw.yaml`. Aliases surface in the dashboard and CLI. They group models by modality with an optional `default_voice` for TTS entries.
 
 ```yaml
 models:
@@ -66,7 +60,7 @@ models:
       model: nova-3
     accurate-stt:
       provider: assemblyai
-      model: best
+      model: universal-2
   llm:
     reasoning:
       provider: anthropic
@@ -84,21 +78,25 @@ models:
       model: en_US-lessac-medium
 ```
 
-Each model entry supports:
+Each entry supports:
 
-- `provider` (string, required) -- the provider identifier
-- `model` (string) -- the model name at the provider
-- `default_voice` (string, optional) -- default voice for TTS models
+| Field | Required | Description |
+|---|---|---|
+| `provider` | yes | Provider identifier (e.g. `deepgram`, `anthropic`) |
+| `model` | yes | Model name at the provider |
+| `default_voice` | no | Default voice for TTS model aliases |
 
 ### Via the dashboard
 
-Models can also be registered through the web dashboard at the daemon URL (default `http://localhost:8080`). Models added through the dashboard are persisted in the SQLite database and merged with the YAML config at startup.
+Models can also be registered through the web dashboard at the daemon URL (default `http://localhost:8080`). Dashboard-registered models are persisted in SQLite and merged with YAML config at startup.
 
 ### Via MCP
 
-If you have the MCP server running (`voicegw mcp`), you can register models through MCP tool calls from your IDE. See the MCP documentation for details.
+If the MCP server is running (`voicegw mcp`), you can register models through MCP tool calls from your IDE.
 
-## Model examples
+---
+
+## Model reference
 
 ### STT models
 
@@ -136,6 +134,10 @@ If you have the MCP server running (`voicegw mcp`), you can register models thro
 | `elevenlabs/eleven_turbo_v2` | ElevenLabs | Faster, English-focused |
 | `deepgram/aura-asteria-en` | Deepgram | Deepgram TTS |
 | `local/kokoro` | Kokoro (local) | Lightweight local TTS |
-| `local/piper:en_US-lessac-medium` | Piper (local) | Fast offline TTS (voice ID after `:`) |
+| `local/piper:en_US-lessac-medium` | Piper (local) | Fast offline TTS; voice ID after `:` |
 
-See: [Providers](/configuration/providers), [Stacks](/configuration/stacks), [voicegw.yaml Reference](/configuration/voicegw-yaml)
+---
+
+See [Providers](/configuration/providers) for which providers support each modality.
+See [Stacks](/configuration/stacks) for bundling model IDs into named tiers.
+See [voicegw.yaml reference](/configuration/voicegw-yaml) for the full config file shape.

--- a/docs/configuration/observability.md
+++ b/docs/configuration/observability.md
@@ -1,11 +1,11 @@
 ---
 title: Observability
-description: VoiceGateway's three built-in observability features (latency tracking, cost tracking, and request logging) that run as middleware around every provider call, and how to toggle each one.
+description: VoiceGateway's three built-in observability middleware flags (latency tracking, cost tracking, request logging) and the storage and latency tuning knobs that back them.
 ---
 
 # Observability
 
-VoiceGateway includes three built-in observability features that run as middleware around every provider call. All three are enabled by default and can be toggled independently.
+VoiceGateway runs three middleware features around every provider call. All three are enabled by default and can be toggled independently.
 
 ## Configuration
 
@@ -16,17 +16,17 @@ observability:
   request_logging: true
 ```
 
-## The three flags
+---
 
-### `latency_tracking`
+## `latency_tracking`
 
 **Default:** `true`
 
-When enabled, VoiceGateway measures time-to-first-byte (TTFB) and total latency for every provider call. Latency data is stored in SQLite and available through the dashboard, CLI (`voicegw status`), and HTTP API (`/v1/metrics`).
+When enabled, VoiceGateway measures time-to-first-byte (TTFB) and total latency for every provider call. Latency data is stored in SQLite and available through the dashboard, `voicegw status`, and the HTTP API at `/v1/metrics`.
 
-When disabled, provider instances are returned without the latency monitoring wrapper. This reduces overhead slightly but removes all latency visibility.
+When disabled, providers are returned without the latency monitoring wrapper. This reduces overhead slightly but removes all latency visibility.
 
-Related config:
+### Latency thresholds
 
 ```yaml
 latency:
@@ -34,22 +34,24 @@ latency:
   percentiles: [50.0, 95.0, 99.0]
 ```
 
-- `ttfb_warning_ms` -- a warning is logged when TTFB exceeds this threshold
-- `percentiles` -- which percentiles to compute and report
+- `ttfb_warning_ms`: a warning is logged when TTFB exceeds this threshold (default `500.0` ms).
+- `percentiles`: which percentiles to compute and report.
 
-### `cost_tracking`
+---
+
+## `cost_tracking`
 
 **Default:** `true`
 
-When enabled, VoiceGateway estimates the cost of each provider call based on usage (tokens, characters, audio seconds) and records it in the SQLite database. Cost data powers the dashboard cost views, the `voicegw costs` CLI command, and per-project budget enforcement.
+When enabled, VoiceGateway estimates the cost of each provider call based on usage (tokens for LLM, characters for TTS, audio seconds for STT) and records it in SQLite. Cost data powers the dashboard cost views, the `voicegw costs` CLI command, and per-project budget enforcement.
 
-When disabled, no cost records are written. Budget enforcement (`budget_action`) will not trigger because there is no spend data to compare against.
+When disabled, no cost records are written and budget enforcement (`budget_action`) will not trigger.
 
 <Warning>
-Disabling `cost_tracking` also effectively disables budget enforcement for all projects, regardless of their `budget_action` setting.
+Disabling `cost_tracking` effectively disables budget enforcement for all projects, regardless of their `budget_action` setting.
 </Warning>
 
-Related config:
+### Storage settings
 
 ```yaml
 cost_tracking:
@@ -58,17 +60,35 @@ cost_tracking:
   daily_budget_alert: 100.00
 ```
 
-### `request_logging`
+- `enabled`: enable cost persistence (default `false`; also enabled when `VOICEGW_DB_PATH` is set).
+- `db_path`: path to the SQLite database file.
+- `daily_budget_alert`: global daily budget alert threshold in USD (optional).
+
+### Cost units per modality
+
+| Modality | Billing unit | Example |
+|---|---|---|
+| STT | Audio seconds | `deepgram/nova-3` billed per second |
+| LLM | Input + output tokens | `anthropic/claude-sonnet-4-5` per million tokens |
+| TTS | Characters | `cartesia/sonic-3` per character |
+
+Prices are looked up from `voice-prices` (a fork of `pydantic/genai-prices`) at request time. No manual price configuration is needed.
+
+---
+
+## `request_logging`
 
 **Default:** `true`
 
-When enabled, VoiceGateway logs metadata about each provider call: timestamp, provider, model, modality, project, latency, and cost. Logs are stored in SQLite and visible in the dashboard request log view and through the `voicegw logs` CLI command.
+When enabled, VoiceGateway logs metadata for each provider call: timestamp, provider, model, modality, project, latency, and cost. Logs are stored in SQLite and visible in the dashboard request log view and through the `voicegw logs` CLI command.
 
-When disabled, no request log entries are written. The dashboard log view will be empty.
+When disabled, no request log entries are written and the dashboard log view will be empty.
+
+---
 
 ## Disabling all observability
 
-To run VoiceGateway with zero overhead from observability middleware:
+To run VoiceGateway with zero middleware overhead (useful for benchmarking raw provider performance):
 
 ```yaml
 observability:
@@ -77,7 +97,7 @@ observability:
   request_logging: false
 ```
 
-This is useful for benchmarking raw provider performance or in environments where you handle monitoring externally.
+---
 
 ## Checking current settings
 
@@ -85,6 +105,10 @@ This is useful for benchmarking raw provider performance or in environments wher
 voicegw status
 ```
 
-The status output includes which observability features are enabled.
+The status output shows which observability features are currently enabled.
 
-See: [voicegw.yaml Reference](/configuration/voicegw-yaml), [Projects](/configuration/projects), [Environment Variables](/configuration/environment-variables)
+---
+
+See [voicegw.yaml reference](/configuration/voicegw-yaml) for the full config file shape.
+See [Projects](/configuration/projects) for `budget_action` and per-project budget configuration.
+See [Environment variables](/configuration/environment-variables) for `VOICEGW_DB_PATH`.

--- a/docs/configuration/projects.md
+++ b/docs/configuration/projects.md
@@ -1,15 +1,15 @@
 ---
 title: Projects
-description: Per-project cost tracking, budget enforcement, guardrails, and organizational grouping for attributing VoiceGateway costs to specific agents, teams, or customers.
+description: Per-project cost tracking, budget enforcement, provider key overrides, tags, and guardrail policies for attributing VoiceGateway costs to specific agents, teams, or customers.
 ---
 
 # Projects
 
-Projects provide per-project cost tracking, budget enforcement, and organizational grouping. They are the primary mechanism for attributing costs to specific agents, teams, or customers.
+Projects are the primary mechanism for attributing costs to specific agents, teams, or customers. Each project can carry a daily budget, override provider keys, and define guardrail policies.
 
 ## Defining projects
 
-Projects are defined in `voicegw.yaml` under the `projects` section. The key is the project ID used in code.
+Projects live under `projects:` in `voicegw.yaml`. The key is the project ID used everywhere (CLI, API, dashboard).
 
 ```yaml
 projects:
@@ -44,21 +44,21 @@ default_project: customer-support
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `name` | string | required | Human-readable project name |
-| `description` | string | `""` | Description of the project's purpose |
+| `description` | string | `""` | Free-text description |
 | `daily_budget` | float | `0.0` | Daily spending limit in USD. `0.0` means no limit. |
-| `budget_action` | string | `"warn"` | What to do when budget is exceeded: `warn`, `throttle`, or `block` |
+| `budget_action` | string | `"warn"` | Action when budget is exceeded: `warn`, `throttle`, or `block` |
 | `tags` | list of strings | `[]` | Arbitrary tags for filtering and dashboard display |
-| `providers` | mapping | `{}` | Per-project provider keys. Wins over the top-level `providers:` block when set. |
-| `default_stack` | string | `""` | Optional dashboard / display hint. Not used by the inference module. |
-| `guardrails` | mapping | all categories `off` | Optional LLM-side guardrail policy. |
+| `providers` | mapping | `{}` | Per-project provider keys. Overrides the top-level `providers:` block for this project. |
+| `default_stack` | string | `""` | Dashboard display hint. See [Stacks](/configuration/stacks). |
+| `guardrails` | mapping | all off | Optional per-project LLM guardrail policy. |
 
 ## Budget actions
 
-The `budget_action` field controls what happens when a project's daily spend exceeds its `daily_budget`:
+The `budget_action` field controls what happens when a project's daily spend exceeds `daily_budget`:
 
-- **`warn`** -- a warning is logged but requests continue normally. Use this for development and low-risk projects where you want visibility without disruption.
-- **`throttle`** -- requests are artificially slowed down to reduce consumption rate. Use this when you want to discourage overuse without hard-blocking.
-- **`block`** -- requests are rejected entirely until the next day when the budget resets. Use this for strict cost controls on production projects.
+- `warn`: a warning is logged but requests continue. Use for development or low-risk projects.
+- `throttle`: requests are artificially slowed to reduce the consumption rate.
+- `block`: requests are rejected until the next calendar day when the budget resets.
 
 ```yaml
 projects:
@@ -68,32 +68,24 @@ projects:
     budget_action: block
 ```
 
-## Selecting a project from code
+<Warning>
+Budget enforcement requires `cost_tracking: true` in the `observability` block. If cost tracking is disabled, `budget_action` never triggers because there is no spend data to compare against.
+</Warning>
 
-The active project resolves in this order:
+## Active project resolution
 
-1. `inference.set_project(name)` in the current async context.
+The active project for a call resolves in this order:
+
+1. The `tenant_id` carried in the `attach()` call or agent metadata.
 2. `VOICEGW_ACTIVE_PROJECT` environment variable.
-3. `default_project` field in `voicegw.yaml`.
+3. `default_project` in `voicegw.yaml`.
 4. The literal `"default"` (auto-created on first run).
 
-```python
-from voicegateway import inference
-
-# Either rely on default_project: customer-support in voicegw.yaml,
-# or pick the project explicitly per call context:
-inference.set_project("customer-support")
-
-stt = inference.STT("deepgram/nova-3")
-llm = inference.LLM("anthropic/claude-sonnet-4-20250514")
-tts = inference.TTS("cartesia/sonic-3")
-```
-
-`inference.set_project` is scoped to the current `asyncio` context; sibling tasks each manage their own project state without leaking.
+See [attach()](/guide/attach) for how to bind a tenant to a call.
 
 ## Guardrails
 
-Guardrails are optional per-project policies injected into `voicegateway.inference.LLM.chat(...)`.
+Per-project guardrails are optional policies applied to LLM calls.
 
 ```yaml
 projects:
@@ -109,7 +101,10 @@ projects:
         off_topic: off
 ```
 
-Supported categories are `pii`, `financial`, `medical`, `prompt_injection`, and `off_topic`. Supported actions are `redact`, `block`, `alert`, and `off`. See [Voice-specific guardrails](/guide/guardrails) for runtime behavior, bypass, and audit events.
+Supported categories: `pii`, `financial`, `medical`, `prompt_injection`, `off_topic`.
+Supported actions: `redact`, `block`, `alert`, `off`.
+
+Use `guard()` in agent code to enforce these policies at the call layer. See [guard()](/guide/guard) for runtime behavior and audit events.
 
 ## Querying project data
 
@@ -118,8 +113,8 @@ Supported categories are `pii`, `financial`, `medical`, `prompt_injection`, and 
 ```bash
 voicegw projects                         # list all projects
 voicegw project customer-support         # project details
-voicegw costs --project customer-support # project costs today
-voicegw logs --project customer-support  # recent requests for the project
+voicegw costs --project customer-support # costs today
+voicegw logs --project customer-support  # recent requests
 ```
 
 ### From the HTTP API
@@ -135,29 +130,19 @@ The web dashboard (`voicegw dashboard`) shows per-project cost breakdowns, daily
 
 ## Tags
 
-Tags are arbitrary strings used for filtering and visual organization. The dashboard uses the first tag to determine accent colors:
+Tags are arbitrary strings for filtering and visual organization. The dashboard uses the first tag to choose an accent color:
 
-- Tags containing `prod` render with a green accent
-- Tags containing `stag` render with a yellow accent
-- Tags containing `dev` or `test` render with a blue accent
-- All other tags render with a pink accent
-
-```yaml
-projects:
-  staging-bot:
-    name: Staging Bot
-    tags: [staging, v2]
-    # Renders with yellow accent in dashboard
-```
+- Tags containing `prod`: green accent
+- Tags containing `stag`: yellow accent
+- Tags containing `dev` or `test`: blue accent
+- All other tags: pink accent
 
 ## Runtime project management
 
-Projects can also be created and managed at runtime through:
+Projects can also be created at runtime through the dashboard, the MCP server (`voicegw mcp`), or the HTTP API (`/v1/projects`). Runtime-created projects are persisted in SQLite and merged with YAML-defined projects on startup. YAML-defined projects take precedence on conflicts.
 
-- The **dashboard** web UI
-- The **MCP server** (`voicegw mcp`)
-- The **HTTP API** (`/v1/projects`)
+---
 
-Projects created at runtime are persisted in the SQLite database and merged with YAML-defined projects on startup. YAML-defined projects take precedence if there is a conflict.
-
-See: [Stacks](/configuration/stacks), [Observability](/configuration/observability), [voicegw.yaml Reference](/configuration/voicegw-yaml)
+See [Stacks](/configuration/stacks) for the `default_stack` field.
+See [Observability](/configuration/observability) for `cost_tracking` and budget enforcement.
+See [voicegw.yaml reference](/configuration/voicegw-yaml) for the full config file shape.

--- a/docs/configuration/providers.md
+++ b/docs/configuration/providers.md
@@ -1,26 +1,31 @@
 ---
 title: Providers
-description: All 11 providers VoiceGateway supports, with modality coverage, recommended models, and per-provider config notes.
+description: All 11 providers VoiceGateway supports, with modality coverage, recommended models, per-provider config blocks, and project-level key overrides.
 ---
 
 # Providers
 
-VoiceGateway supports 11 providers across cloud and local
-deployments. Each provider extends the `BaseProvider` interface and
-is instantiated lazily on first use.
+VoiceGateway supports 11 providers across cloud and local deployments. Each provider extends the `BaseProvider` interface and is instantiated lazily on first use.
+
+## Common fields
+
+Every provider block supports these fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | string | `""` | API key, typically via `${ENV_VAR}` substitution |
+| `base_url` | string | provider default | Override the default API endpoint |
+| `enabled` | bool | `true` | Disable a provider without removing its config |
+
+---
 
 ## Cloud providers
 
 ### Deepgram
 
-- **Modalities:** STT, TTS
-- **Required config:** `api_key`
-- **Recommended models:**
-  - STT: `deepgram/nova-3` (best accuracy), `deepgram/nova-2` (lower cost)
-  - TTS: `deepgram/aura-asteria-en`
-- **Pricing notes:** Pay-per-second for STT, pay-per-character for
-  TTS. Nova-3 is priced higher than Nova-2 but offers better
-  accuracy.
+Modalities: STT, TTS. Required: `api_key`.
+
+Recommended models: `deepgram/nova-3` (best accuracy), `deepgram/nova-2` (lower cost), `deepgram/aura-asteria-en` (TTS).
 
 ```yaml
 providers:
@@ -30,16 +35,9 @@ providers:
 
 ### OpenAI
 
-- **Modalities:** STT, LLM, TTS
-- **Required config:** `api_key`
-- **Recommended models:**
-  - STT: `openai/whisper-1`
-  - LLM: `openai/gpt-4.1-mini` (balanced), `openai/gpt-4.1` (best
-    quality)
-  - TTS: `openai/tts-1` (fast), `openai/tts-1-hd` (high quality)
-- **Pricing notes:** Different pricing tiers per model.
-  GPT-4.1-mini offers a good cost / quality balance for voice
-  agents.
+Modalities: STT, LLM, TTS. Required: `api_key`.
+
+Recommended models: `openai/whisper-1` (STT), `openai/gpt-4.1-mini` (LLM, balanced), `openai/gpt-4.1` (LLM, best quality), `openai/tts-1` (TTS, fast), `openai/tts-1-hd` (TTS, high quality).
 
 ```yaml
 providers:
@@ -49,13 +47,9 @@ providers:
 
 ### Anthropic
 
-- **Modalities:** LLM
-- **Required config:** `api_key`
-- **Recommended models:**
-  - LLM: `anthropic/claude-sonnet-4-5` (balanced),
-    `anthropic/claude-opus-4-1` (highest quality)
-- **Pricing notes:** Per-token pricing. Check Anthropic's pricing
-  page for current rates.
+Modalities: LLM. Required: `api_key`.
+
+Recommended models: `anthropic/claude-sonnet-4-5` (balanced), `anthropic/claude-opus-4-1` (highest quality).
 
 ```yaml
 providers:
@@ -65,14 +59,9 @@ providers:
 
 ### Groq
 
-- **Modalities:** STT, LLM
-- **Required config:** `api_key`
-- **Recommended models:**
-  - STT: `groq/whisper-large-v3`
-  - LLM: `groq/llama-3.3-70b-versatile`, `groq/llama-3.1-8b-instant`
-- **Pricing notes:** Very fast inference at competitive pricing.
-  The Whisper endpoint is significantly cheaper than OpenAI's
-  hosted Whisper.
+Modalities: STT, LLM. Required: `api_key`.
+
+Recommended models: `groq/whisper-large-v3` (STT), `groq/llama-3.3-70b-versatile`, `groq/llama-3.1-8b-instant` (LLM).
 
 ```yaml
 providers:
@@ -82,12 +71,9 @@ providers:
 
 ### Cartesia
 
-- **Modalities:** TTS
-- **Required config:** `api_key`
-- **Recommended models:**
-  - TTS: `cartesia/sonic-3` (latest, best quality)
-- **Pricing notes:** Pay-per-character. Known for low-latency
-  streaming TTS.
+Modalities: TTS. Required: `api_key`.
+
+Recommended models: `cartesia/sonic-3` (latest, best quality, low latency).
 
 ```yaml
 providers:
@@ -97,13 +83,9 @@ providers:
 
 ### ElevenLabs
 
-- **Modalities:** TTS
-- **Required config:** `api_key`
-- **Recommended models:**
-  - TTS: `elevenlabs/eleven_multilingual_v2`,
-    `elevenlabs/eleven_turbo_v2_5`
-- **Pricing notes:** Per-character pricing with monthly quotas
-  depending on plan. Multilingual v2 supports 29 languages.
+Modalities: TTS. Required: `api_key`.
+
+Recommended models: `elevenlabs/eleven_multilingual_v2` (29 languages), `elevenlabs/eleven_turbo_v2_5`.
 
 ```yaml
 providers:
@@ -113,12 +95,9 @@ providers:
 
 ### AssemblyAI
 
-- **Modalities:** STT
-- **Required config:** `api_key`
-- **Recommended models:**
-  - STT: `assemblyai/universal-2` (single-tier model)
-- **Pricing notes:** Per-second pricing. Offers real-time streaming
-  and batch transcription.
+Modalities: STT. Required: `api_key`.
+
+Recommended models: `assemblyai/universal-2` (single-tier, streaming and batch).
 
 ```yaml
 providers:
@@ -130,19 +109,13 @@ providers:
 
 ## Local providers
 
-Local providers run on your own hardware with no API keys required.
-They are useful for development, privacy-sensitive deployments, and
-offline operation.
+Local providers run on your own hardware with no API keys required. They suit development, privacy-sensitive deployments, and offline operation.
 
 ### Whisper
 
-- **Modalities:** STT
-- **Required config:** None (downloads model on first use)
-- **Recommended models:**
-  - STT: `local/whisper-large-v3` (best accuracy),
-    `local/whisper-base` (fastest)
-- **Notes:** Runs OpenAI Whisper locally via faster-whisper.
-  Requires a capable CPU or GPU.
+Modalities: STT. No API key required; model weights download on first use.
+
+Recommended models: `local/whisper-large-v3` (best accuracy), `local/whisper-base` (fastest). Requires a capable CPU or GPU.
 
 ```yaml
 providers:
@@ -152,15 +125,9 @@ providers:
 
 ### Ollama
 
-- **Modalities:** LLM
-- **Required config:** `base_url` (defaults to
-  `http://localhost:11434`)
-- **Recommended models:**
-  - LLM: `ollama/llama3.2:3b`, `ollama/mistral:7b`,
-    `ollama/phi3:mini`
-- **Notes:** Requires a running Ollama server. Models are pulled on
-  first use. Use `docker compose --profile local up -d` to start
-  Ollama alongside VoiceGateway.
+Modalities: LLM. Required: a running Ollama server.
+
+Recommended models: `ollama/llama3.2:3b`, `ollama/mistral:7b`, `ollama/phi3:mini`. Use `docker compose --profile local up -d` to start Ollama alongside VoiceGateway.
 
 ```yaml
 providers:
@@ -170,12 +137,9 @@ providers:
 
 ### Kokoro
 
-- **Modalities:** TTS
-- **Required config:** None
-- **Recommended models:**
-  - TTS: `local/kokoro`
-- **Notes:** Lightweight local TTS. Good for development and
-  testing.
+Modalities: TTS. No API key required.
+
+Recommended models: `local/kokoro`. Lightweight local TTS, good for development and testing.
 
 ```yaml
 providers:
@@ -185,13 +149,9 @@ providers:
 
 ### Piper
 
-- **Modalities:** TTS
-- **Required config:** None
-- **Recommended models:**
-  - TTS: `local/piper:en_US-lessac-medium`,
-    `local/piper:en_US-amy-low` (voice id after `:`)
-- **Notes:** Fast offline TTS using ONNX models. Supports multiple
-  languages and voices. Voice models are downloaded on first use.
+Modalities: TTS. No API key required; ONNX voice models download on first use.
+
+Recommended models: `local/piper:en_US-lessac-medium`, `local/piper:en_US-amy-low`. The voice ID follows the colon.
 
 ```yaml
 providers:
@@ -217,11 +177,11 @@ providers:
 | Kokoro | -- | -- | Yes | Local |
 | Piper | -- | -- | Yes | Local |
 
+---
+
 ## Per-project provider keys
 
-The top-level `providers` block sets the default keys. Each project
-under `projects:` can override the providers it uses by declaring
-its own `providers` block:
+The top-level `providers` block sets the default keys. Each project can override the keys it uses with its own `providers` block:
 
 ```yaml
 providers:
@@ -233,31 +193,18 @@ projects:
     name: Tony's Pizza
     providers:
       openai:
-        api_key: ${TONYS_OPENAI_KEY}  # overrides for this project
+        api_key: ${TONYS_OPENAI_KEY}
 ```
 
-The inference factories pick the right key automatically based on
-the active project (set via `default_project`, the `set_project`
-helper from `voicegateway.core.active_project`, or a virtual key's
-project binding).
+The router picks the right key automatically based on the active project. See [Projects](/configuration/projects) for how the active project is resolved.
+
+---
 
 ## DB-managed providers
 
-Beyond YAML, providers can be added at runtime via the MCP server
-or the dashboard. These rows live in the `managed_providers` table
-with their API keys Fernet-encrypted by `VOICEGW_SECRET`. The
-runtime resolution order is: YAML providers (top-level + per-project)
-first, then DB-managed providers for any missing entries.
+Beyond YAML, providers can be added at runtime via the MCP server or the dashboard. These rows live in the `managed_providers` table with their API keys Fernet-encrypted by `VOICEGW_SECRET`. The resolution order is: YAML providers (top-level + per-project) first, then DB-managed providers for any missing entries.
 
-## Common configuration options
+---
 
-All providers support these shared fields:
-
-- `api_key` (string): API key, typically via `${ENV_VAR}`
-  substitution.
-- `base_url` (string): override the default API endpoint.
-- `enabled` (bool, default `true`): disable a provider without
-  removing its config.
-
-See [voicegw.yaml reference](/configuration/voicegw-yaml),
-[Models](/configuration/models).
+See [voicegw.yaml reference](/configuration/voicegw-yaml) for the full config file shape.
+See [Models](/configuration/models) for the `provider/model` string format.

--- a/docs/configuration/stacks.md
+++ b/docs/configuration/stacks.md
@@ -1,11 +1,15 @@
 ---
 title: Stacks
-description: Named YAML bundles that map a single name to one STT, one LLM, and one TTS model, used as a documentation and dashboard hint for VoiceGateway projects.
+description: Named YAML bundles that map one name to an STT, LLM, and TTS model ID, used as quality-tier presets for the dashboard and team documentation.
 ---
 
 # Stacks
 
-Stacks are named YAML bundles that map a single name to one STT model, one LLM model, and one TTS model. They are a documentation and dashboard hint only: the `voicegateway.inference` module does not consume them. The dashboard uses `default_stack` on a project to render a recommended-stack badge; the rest of the gateway ignores the field.
+Stacks are named YAML bundles that map one name to an STT model ID, one LLM model ID, and one TTS model ID. They serve as quality-tier presets: you reference a stack name on a project, and the dashboard renders it as a recommended-configuration badge.
+
+<Note>
+Stacks are a dashboard and documentation hint. Wire your native LiveKit or Pipecat providers directly using `attach()` and pass the model ID you want. No code reads `default_stack` at runtime to construct providers.
+</Note>
 
 ## Defining stacks
 
@@ -25,9 +29,19 @@ stacks:
     tts: local/kokoro
 ```
 
-A project can carry an optional `default_stack` that points at one of these names:
+Each stack entry has exactly three keys: `stt`, `llm`, and `tts`. Values are `provider/model` strings in the standard format.
+
+## Referencing a stack from a project
+
+Add `default_stack` to any project. The value must match a key under `stacks:`.
 
 ```yaml
+stacks:
+  premium:
+    stt: deepgram/nova-3
+    llm: anthropic/claude-sonnet-4-5
+    tts: cartesia/sonic-3
+
 projects:
   production:
     name: Production
@@ -36,24 +50,44 @@ projects:
     budget_action: throttle
 ```
 
-The dashboard's project page renders the stack name next to the project. No code reads the stack to construct factories: pick the model id you want and pass it to `inference.STT/LLM/TTS` directly.
+The dashboard project page renders the stack name alongside the project. No additional runtime behavior is attached to this field.
 
-## Using stacks from code
+## Wiring providers in agent code
 
+Pick the model IDs from your chosen stack and pass them to your framework's native provider constructors. Wrap with `attach()` to meter cost.
+
+<Tabs>
+  <Tab title="LiveKit">
 ```python
-from voicegateway.inference import STT, LLM, TTS
+from livekit.agents import Agent, AgentSession
+from livekit.plugins import deepgram, anthropic, cartesia
+from voicegateway import attach
 
-# Construct each modality explicitly with the model id from the
-# stack you want. There is no Gateway.stack(...) helper.
-stt = STT("deepgram/nova-3")
-llm = LLM("anthropic/claude-sonnet-4-5")
-tts = TTS("cartesia/sonic-3")
+session = AgentSession(
+    stt=attach(deepgram.STT(model="nova-3")),
+    llm=attach(anthropic.LLM(model="claude-sonnet-4-5")),
+    tts=attach(cartesia.TTS(model="sonic-3")),
+)
 ```
+  </Tab>
+  <Tab title="Pipecat">
+```python
+from pipecat.services.deepgram import DeepgramSTTService
+from pipecat.services.anthropic import AnthropicLLMService
+from pipecat.services.cartesia import CartesiaTTSService
+from voicegateway import attach
 
-If you find yourself repeating the same triple across agents, define a small Python helper in your own code that returns the three calls. The gateway does not need a built-in for it.
+stt = attach(DeepgramSTTService(model="nova-3"))
+llm = attach(AnthropicLLMService(model="claude-sonnet-4-5"))
+tts = attach(CartesiaTTSService(model="sonic-3"))
+```
+  </Tab>
+</Tabs>
 
-## Roadmap
+If you find yourself repeating the same triple across agents, define a small helper in your own code that returns the three attached providers. See [attach()](/guide/attach) for the full API.
 
-A future release may bring back a one-line `inference.stack("premium")` shortcut once the trade-offs (per-project key resolution, fallback chains, model-id validation) are sorted. For now stacks live in YAML for dashboard display and team-internal documentation.
+---
 
-See: [Projects](/configuration/projects), [Models](/configuration/models), [voicegw.yaml Reference](/configuration/voicegw-yaml)
+See [Projects](/configuration/projects) for the `default_stack` field and budget configuration.
+See [Models](/configuration/models) for the `provider/model` string format.
+See [voicegw.yaml reference](/configuration/voicegw-yaml) for the full config file shape.

--- a/docs/configuration/voicegw-yaml.md
+++ b/docs/configuration/voicegw-yaml.md
@@ -1,37 +1,39 @@
 ---
 title: voicegw.yaml reference
-description: Every top-level section and key in the VoiceGateway config file. Validated with pydantic extra=forbid so typos fail fast at startup.
+description: Every top-level section and key in the VoiceGateway config file, validated with pydantic extra=forbid so typos fail fast at startup.
 ---
 
 # voicegw.yaml reference
 
-The `voicegw.yaml` file is the central configuration for
-VoiceGateway. It is validated at startup using a Pydantic schema
-with `extra="forbid"`, which means any typo or unknown key produces
-a clear error message before your gateway starts.
+`voicegw.yaml` is the central config file for VoiceGateway. It is validated at startup using a Pydantic schema with `extra="forbid"`, so any typo or unknown key produces a clear error before your gateway starts.
 
-VoiceGateway searches for the config file in this order:
+## Discovery order
+
+VoiceGateway searches for the file in this order:
 
 1. `./voicegw.yaml` (current directory)
 2. `~/.config/voicegateway/voicegw.yaml`
 3. `/etc/voicegateway/voicegw.yaml`
 
-You can override this with the `VOICEGW_CONFIG` environment
-variable. See [Environment variables](/configuration/environment-variables).
+Override this entirely by setting `VOICEGW_CONFIG` to an absolute path. See [Environment variables](/configuration/environment-variables).
+
+<Tip>
+Run `voicegw init` to write a starter config to `~/.config/voicegateway/voicegw.yaml` with every section commented in.
+</Tip>
 
 ## Top-level sections
 
-The config file has thirteen top-level sections. All are optional.
+All sections are optional. Omitted sections use defaults.
 
 | Section | Purpose |
 |---|---|
 | `providers` | API keys and settings for each provider |
-| `models` | Register custom model aliases |
-| `stacks` | Named bundles of STT + LLM + TTS models |
+| `models` | Register custom model aliases by modality |
+| `stacks` | Named STT + LLM + TTS bundles |
 | `projects` | Per-project tracking and budgets |
 | `fallbacks` | Ordered fallback chains per modality |
 | `observability` | Toggle latency, cost, and logging middleware |
-| `cost_tracking` | SQLite database settings for cost persistence |
+| `cost_tracking` | SQLite storage settings |
 | `latency` | TTFB warning thresholds and percentile config |
 | `rate_limits` | Per-provider request rate limits |
 | `ingest` | Rate limits for the fleet collector ingest endpoint |
@@ -43,9 +45,7 @@ The config file has thirteen top-level sections. All are optional.
 
 ## `providers`
 
-Configure credentials and settings for each provider. Keys are
-provider names matching VoiceGateway's built-in provider
-identifiers.
+Configure credentials for each provider. String values support `${ENV_VAR}` substitution.
 
 ```yaml
 providers:
@@ -73,23 +73,13 @@ providers:
     enabled: true
 ```
 
-Each provider supports at minimum:
-
-- `api_key` (string): API key, typically via `${ENV_VAR}` substitution.
-- `base_url` (string): override the default API endpoint.
-- `enabled` (bool, default `true`): disable a provider without
-  removing its config.
-
-See [Providers](/configuration/providers) for per-provider
-details.
+All providers support `api_key`, `base_url`, and `enabled` (bool, default `true`). See [Providers](/configuration/providers).
 
 ---
 
 ## `models`
 
-Register custom model aliases organised by modality. Each entry
-maps an alias to a `provider` and `model` name, with optional
-defaults.
+Register named aliases per modality. Each alias maps to a `provider` and `model`.
 
 ```yaml
 models:
@@ -117,8 +107,7 @@ See [Models](/configuration/models).
 
 ## `stacks`
 
-Named bundles that map to one STT, one LLM, and one TTS model. Use
-stacks to define preset quality / cost tiers.
+Named bundles that map one name to an STT, LLM, and TTS model ID. Reference a stack from a project with `default_stack`.
 
 ```yaml
 stacks:
@@ -142,8 +131,7 @@ See [Stacks](/configuration/stacks).
 
 ## `projects`
 
-Define projects for cost attribution and budget enforcement. Each
-project can override providers per-key.
+Define projects for cost attribution and budget enforcement.
 
 ```yaml
 projects:
@@ -161,7 +149,6 @@ projects:
         api_key: ${SUPPORT_ANTHROPIC_KEY}
   internal-qa:
     name: Internal QA Bot
-    description: Testing and QA agent
     default_stack: budget
     daily_budget: 10.00
     budget_action: warn
@@ -170,19 +157,13 @@ projects:
 default_project: customer-support
 ```
 
-`budget_action` is one of `warn`, `throttle`, or `block`. Project-
-scoped `providers` override the top-level `providers` for that
-project; otherwise the top-level keys apply.
-
-See [Projects](/configuration/projects).
+`budget_action` is one of `warn`, `throttle`, or `block`. Project-level `providers` override the top-level block for that project. See [Projects](/configuration/projects).
 
 ---
 
 ## `fallbacks`
 
-Ordered lists of model ids per modality. Used as a resolver-time
-hint: walk the list at startup and pick the first model whose
-provider plugin imports cleanly.
+Ordered model IDs per modality. The router walks the list at startup and picks the first model whose provider imports cleanly.
 
 ```yaml
 fallbacks:
@@ -204,8 +185,7 @@ fallbacks:
 
 ## `observability`
 
-Three boolean flags that control which middleware runs. All default
-to `true`.
+Three boolean flags that control which middleware runs. All default to `true`.
 
 ```yaml
 observability:
@@ -229,11 +209,9 @@ cost_tracking:
   daily_budget_alert: 100.00
 ```
 
-- `enabled` (bool, default `false`): enable cost persistence. Also
-  enabled automatically if `VOICEGW_DB_PATH` is set.
+- `enabled` (bool, default `false`): enable cost persistence. Also enabled automatically when `VOICEGW_DB_PATH` is set.
 - `db_path` (string): path to the SQLite database file.
-- `daily_budget_alert` (float, optional): global daily budget alert
-  threshold.
+- `daily_budget_alert` (float, optional): global daily budget alert threshold in USD.
 
 ---
 
@@ -247,10 +225,8 @@ latency:
   percentiles: [50.0, 95.0, 99.0]
 ```
 
-- `ttfb_warning_ms` (float, default `500.0`): time-to-first-byte
-  warning threshold in milliseconds.
-- `percentiles` (list of floats): which percentiles to track and
-  report.
+- `ttfb_warning_ms` (float, default `500.0`): time-to-first-byte warning threshold in milliseconds.
+- `percentiles` (list of floats): which percentiles to track and report.
 
 ---
 
@@ -266,16 +242,13 @@ rate_limits:
     requests_per_minute: 60
 ```
 
-- `requests_per_minute` (int): maximum requests per minute for the
-  given provider.
+- `requests_per_minute` (int): maximum requests per minute for the provider.
 
 ---
 
 ## `ingest`
 
-Rate limiting for the fleet collector ingest endpoint (`POST /v1/ingest`),
-where remote agents push telemetry. Limiting is a per-caller token bucket
-keyed by virtual key (then static API key, then client IP).
+Rate limiting for the fleet collector ingest endpoint (`POST /v1/ingest`). Limiting uses a per-caller token bucket keyed by virtual key, then static API key, then client IP.
 
 ```yaml
 ingest:
@@ -286,24 +259,17 @@ ingest:
 ```
 
 - `enabled` (bool, default `true`): turn ingest rate limiting on or off.
-- `requests_per_minute` (int, default `120`): sustained per-caller request
-  rate. Set to `0` to disable limiting (unlimited).
-- `burst` (int, default `240`): token-bucket ceiling, the largest burst a
-  caller can send before being throttled.
-- `max_batch_size` (int, default `1000`): maximum records in one POST. A
-  larger batch is rejected with `413` before any database write.
+- `requests_per_minute` (int, default `120`): sustained per-caller rate. Set to `0` to disable.
+- `burst` (int, default `240`): token-bucket ceiling.
+- `max_batch_size` (int, default `1000`): maximum records per POST. Larger batches are rejected with `413`.
 
-Over-limit requests get `429` with a `Retry-After` header (integer seconds).
-The library's remote sink honors `Retry-After` and retries without dropping the
-batch, so transient throttling never loses telemetry.
+Over-limit requests receive `429` with a `Retry-After` header. The remote sink honors `Retry-After` and retries without dropping data.
 
 ---
 
 ## `retention`
 
-Hard-delete aged rows from the collector database. A background worker prunes,
-per project, sessions and their dependent rows (replay, turns, dead-air,
-guardrail) by `ended_at`, and requests by `timestamp`, in batches.
+Hard-delete aged rows from the collector database. A background worker prunes sessions and their dependent rows by `ended_at`, and requests by `timestamp`, in batches.
 
 ```yaml
 retention:
@@ -312,18 +278,13 @@ retention:
 ```
 
 - `enabled` (bool, default `true`): turn retention pruning on or off.
-- `default_days` (int, default `90`): age after which a project's rows are
-  deleted. Applies to every project that has data.
+- `default_days` (int, default `90`): age in days after which rows are deleted.
 
 ---
 
 ## `workers`
 
-Cadence for the collector's background workers: the latency and agent rollups,
-and the retention prune. Workers run in-process and are started by the server.
-In a multi-replica deployment, set `enabled: false` on every replica except the
-one chosen to run them (rollups and prunes are idempotent, but running them on
-every replica is wasteful).
+Cadence for background workers: latency and agent rollups, and the retention prune. Workers run in-process and are started by the server. In a multi-replica deployment, set `enabled: false` on every replica except one.
 
 ```yaml
 workers:
@@ -332,19 +293,15 @@ workers:
   retention_interval_seconds: 3600
 ```
 
-- `enabled` (bool, default `true`): start the background workers. When `false`,
-  no workers run (the rollup tables stay stale and retention does not prune).
-- `rollup_interval_seconds` (int, default `900`): how often the latency and
-  agent rollups refresh. The Agents dashboard list serves this 24h rollup.
+- `enabled` (bool, default `true`): start the background workers.
+- `rollup_interval_seconds` (int, default `900`): how often the latency and agent rollups refresh.
 - `retention_interval_seconds` (int, default `3600`): how often retention runs.
 
 ---
 
 ## `serve`
 
-Bind host and port for the daemon. The daemon serves the HTTP API
-(`/v1/*`), the dashboard API (`/api/*`), and the React SPA (`/`)
-all on this single port.
+Bind host and port for the daemon. The daemon serves the HTTP API (`/v1/*`), dashboard API (`/api/*`), and the React SPA (`/`) on this single port.
 
 ```yaml
 serve:
@@ -352,25 +309,36 @@ serve:
   port: 8080
 ```
 
-- `host` (string, default `0.0.0.0`): bind address. Use `127.0.0.1`
-  to restrict to localhost.
-- `port` (int, default `8080`): port number. The wizard collects
-  this as question 4 of [`voicegw onboard`](/cli/onboard).
+- `host` (string, default `0.0.0.0`): bind address. Use `127.0.0.1` to restrict to localhost.
+- `port` (int, default `8080`): port number.
 
 ---
 
 ## Environment variable substitution
 
-Any string value in the config can use `${ENV_VAR}` syntax.
-VoiceGateway substitutes these at load time using `os.environ`.
+Any string value in the config can use `${VAR_NAME}` syntax. VoiceGateway substitutes these at load time from `os.environ`. If the variable is not set, the value resolves to an empty string. See [Environment variables](/configuration/environment-variables).
 
-```yaml
-providers:
-  deepgram:
-    api_key: ${DEEPGRAM_API_KEY}
-```
+---
 
-If the environment variable is not set, it resolves to an empty
-string.
+## Explore each section
 
-See [Environment variables](/configuration/environment-variables).
+<CardGroup cols={3}>
+  <Card title="Providers" href="/configuration/providers">
+    API keys, base URL overrides, and per-project provider blocks for all 11 providers.
+  </Card>
+  <Card title="Models" href="/configuration/models">
+    Model ID format, language and voice suffixes, and custom alias registration.
+  </Card>
+  <Card title="Stacks" href="/configuration/stacks">
+    Named STT + LLM + TTS bundles for quality tiers.
+  </Card>
+  <Card title="Projects" href="/configuration/projects">
+    Cost attribution, budget enforcement, and per-project provider keys.
+  </Card>
+  <Card title="Environment variables" href="/configuration/environment-variables">
+    All VOICEGW_ and provider API key variables, plus substitution rules.
+  </Card>
+  <Card title="Observability" href="/configuration/observability">
+    Latency tracking, cost recording, and request logging middleware.
+  </Card>
+</CardGroup>

--- a/docs/guide/decision-tree.md
+++ b/docs/guide/decision-tree.md
@@ -15,7 +15,7 @@ This page helps you pick the right combination before you write any code. Two de
 | Storage | SQLite, single process | ClickHouse, multi-tenant |
 | Ingest | local sink (no network hop) | push to `VOICEGW_COLLECTOR_URL` |
 | Dashboard | `voicegw dashboard` (port 9090) | `dash.voicegateway.dev` |
-| Setup | `pip install voicegateway` + `voicegw.yaml` | 3 env vars (`VOICEGW_COLLECTOR_URL`, `VOICEGW_API_KEY`, `VOICEGW_PROJECT`) |
+| Setup | `pip install voicegateway` + `voicegw.yaml` | 2 env vars (`VOICEGW_COLLECTOR_URL`, `VOICEGW_API_KEY`) + `project=` in your `attach()` call |
 | Horizontal scale | single instance | managed, no ops |
 | Right for | local dev, small teams, self-managed infra | multi-agent fleets, SaaS products, agency work |
 
@@ -81,7 +81,7 @@ flowchart TD
     Install the OSS package, write a voicegw.yaml, and attach to your first agent.
   </Card>
   <Card title="Hosted Cloud" icon="cloud" href="/hosted/quickstart">
-    Three env vars and your agent is sending data to the cloud dashboard.
+    Two env vars plus one `attach()` call and your agent is sending data to the cloud dashboard.
   </Card>
   <Card title="attach() reference" icon="eye" href="/guide/attach">
     Full signature, options, and LiveKit / Pipecat examples.


### PR DESCRIPTION
## Summary

- Rewrote all seven configuration pages (`voicegw-yaml`, `providers`, `models`, `stacks`, `projects`, `environment-variables`, `observability`) into a consistent config-reference group for self-hosters.
- Removed all `voicegateway.inference` usage from pages where it was banned (models, stacks, projects); replaced with `attach()`/`guard()` patterns and LiveKit + Pipecat `<Tabs>` where agent wiring was shown.
- Added the cloud ingest env vars (`VOICEGW_COLLECTOR_URL` / `VOICEGW_API_KEY` / `VOICEGW_PROJECT`) to the environment-variables page.
- Added a `<CardGroup>` nav at the bottom of `voicegw-yaml.md` pointing into the other six pages.
- Added per-modality cost-unit table to observability; added budget enforcement / cost_tracking warning to projects.

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 7 scoped)
```