### PR TITLE
docs(advanced): rewrite Advanced group (P5)

### DIFF
--- a/docs/guide/agency-quickstart.md
+++ b/docs/guide/agency-quickstart.md
@@ -1,21 +1,27 @@
 ---
 title: Agency quickstart
-description: Provision a downstream customer project end-to-end with cross-modality routing and per-project white-label branding.
+description: Run one VoiceGateway deployment for many downstream clients, each with its own project, routing roster, budget, and white-label dashboard.
 ---
 
 # Agency quickstart
 
-VoiceGateway supports the agency rung of the buyer ladder: cross-modality routing and per-project white-label branding. This guide walks an agency operator through provisioning a downstream customer project end-to-end.
+An agency runs one VoiceGateway deployment and provisions a separate project for each downstream client. Each project gets its own routing roster, latency budget, spend cap, and white-label dashboard branding. Cost data stays separated by project, so you can pull a per-client cost report without manual filtering.
+
+This guide walks the end-to-end provisioning flow for one new client.
+
+<Note>
+Projects separate cost and routing at the client level. Tenants (covered in [Multi-tenant quickstart](/guide/multi-tenant-quickstart)) separate cost within a project at the end-user level. The two are composable: pass `project=` and `tenant_id=` together in `attach()` when you need both levels.
+</Note>
 
 ## Prerequisites
 
 - VoiceGateway installed (`voicegw --version`).
-- Daemon running (started by `voicegw onboard` or `voicegw serve`). The daemon serves the dashboard at the daemon URL (default `http://127.0.0.1:8080`).
-- `voicegw.yaml` configured with at least one project (operators usually have a `default` plus one per customer).
+- Daemon running (`voicegw serve` or `voicegw onboard`).
+- `voicegw.yaml` with at least one project configured. See [Configuration: projects](/configuration/projects) for the full schema.
 
-## 1. Configure routing rosters and budget
+## Step 1: add the client project to voicegw.yaml
 
-Open `voicegw.yaml` and add a `routing:` block under the customer's project. The router will only pick providers that appear in the rosters; order is preference (earlier first when two candidates tie on predicted latency).
+Open `voicegw.yaml` and add a `projects` entry for the client. Set a `daily_budget` to cap spend automatically and a `routing` block to constrain which providers the router may choose.
 
 ```yaml
 projects:
@@ -23,8 +29,7 @@ projects:
     name: Acme Voice
     daily_budget: 25.0
     routing:
-      # 1500 ms is the typical conversational target.
-      budget_ms: 1200          # Agency wants tighter than default.
+      budget_ms: 1200
       fallback_to_fastest: true
       rosters:
         stt: [deepgram, assemblyai]
@@ -32,15 +37,15 @@ projects:
         tts: [cartesia, elevenlabs]
 ```
 
-After editing, restart the gateway. The next session start picks providers from the new rosters; in-flight sessions keep their pre-existing triple.
+Provider order within each roster is preference: the router picks the first provider that fits the latency budget. Restart the daemon after saving. In-flight sessions keep their original provider triple; the new roster applies from the next session start.
 
-### Pick a budget
+<Tip>
+The default `budget_ms` is 1500 ms (a typical conversational target). Tighten to 800-1000 ms for high-energy customer-service scenarios. The Routing view in the dashboard shows observed p50 per provider so you can right-size after a few hundred sessions.
+</Tip>
 
-The default 1500 ms covers a typical conversational voice agent: caller stops talking, agent's first audible reply lands in ≈1.5 seconds. Agencies serving high-energy customer-service scenarios often tighten to 800–1000 ms; agencies serving deliberative legal or medical scenarios may relax to 2000 ms. The dashboard's Routing view shows actual observed latency per provider so an operator can right-size after a few hundred sessions.
+## Step 2: verify the router before traffic lands
 
-## 2. Verify the router will pick what you expect
-
-The CLI's `route` subgroup is read-only and useful for sanity-checking before traffic lands.
+The `route` CLI subgroup is read-only. Use it to confirm the config is correct before the first real call.
 
 ```bash
 voicegw route show acme
@@ -50,8 +55,6 @@ voicegw route show acme
 #   stt   deepgram, assemblyai
 #   llm   groq, openai
 #   tts   cartesia, elevenlabs
-#
-# (no observations yet; router will fall back to provider_baselines.json)
 ```
 
 ```bash
@@ -65,22 +68,89 @@ voicegw route simulate acme
 ```
 
 ```bash
-voicegw route simulate acme --llm openai  # Override LLM specifically.
+# Override one modality to compare.
+voicegw route simulate acme --llm openai
 # LLM: openai (300 ms baseline)
 # Predicted total: 700 ms
 ```
 
-After production traffic accrues, the rollup worker (every 15 minutes) populates `latency_observations` and the router prefers observed p50 over the curated baselines. `voicegw route show acme` then prints the live observations table.
+After production traffic accrues, the rollup worker (runs every 15 minutes) fills `latency_observations` and the router prefers observed p50 over the curated baselines.
 
-## 3. Upload the customer's logo and brand
+## Step 3: wire the agent to the project
 
-Open the dashboard at `http://127.0.0.1:8080/projects` (the daemon's serve port), find the `acme` card, click **Brand**, and fill the modal:
+In the agent code, pass `project="acme"` to `attach()`. Every record written during that session is tagged with the project id.
 
-- **Product name**: e.g. `AcmeVoice` (up to 64 chars; appears in the sidebar in place of "VoiceGateway").
-- **Accent color**: `#FF6633` or any valid hex (the dashboard offers a native color picker too).
-- **Logo**: a PNG or SVG file. Maximum 256 KB, max dimensions 512x512 px for PNG (SVG is vector, no dimension check). Saved under `src/dashboard/api/static/branding/acme.{png,svg}` and served at `/static/branding/acme.png`.
+<Tabs>
+  <Tab title="LiveKit">
+    ```python
+    from livekit.agents import Agent, AgentSession, JobContext
+    from livekit.plugins import deepgram, openai, cartesia
 
-For scripted provisioning, the CLI's `brand` subgroup hits the same endpoints:
+    from voicegateway import attach
+
+
+    async def entrypoint(ctx: JobContext):
+        await ctx.connect()
+
+        session = AgentSession(
+            stt=deepgram.STT(model="nova-3"),
+            llm=openai.LLM(model="gpt-4o-mini"),
+            tts=cartesia.TTS(model="sonic-3"),
+        )
+
+        attach(session, project="acme")
+
+        await session.start(
+            agent=Agent(instructions="Be the Acme support agent."),
+            room=ctx.room,
+        )
+    ```
+  </Tab>
+  <Tab title="Pipecat">
+    ```python
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.task import PipelineParams, PipelineTask
+    from pipecat.services.deepgram.stt import DeepgramSTTService
+    from pipecat.services.openai.llm import OpenAILLMService
+    from pipecat.services.cartesia.tts import CartesiaTTSService
+
+    from voicegateway import attach
+
+
+    async def run_acme_agent():
+        stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
+        llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini")
+        tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
+
+        pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])
+        task = PipelineTask(
+            pipeline,
+            params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        )
+
+        attach(task, project="acme")
+
+        runner = PipelineRunner()
+        await runner.run(task)
+    ```
+  </Tab>
+</Tabs>
+
+If you also need per-end-user attribution within the Acme project, add `tenant_id=` as well:
+
+```python
+attach(session, project="acme", tenant_id=caller_id)
+```
+
+## Step 4: upload client branding
+
+Open the dashboard at `http://127.0.0.1:8080/projects`, find the `acme` card, click **Brand**, and fill the modal:
+
+- **Product name**: e.g. `AcmeVoice` (up to 64 characters; replaces "VoiceGateway" in the sidebar).
+- **Accent color**: any valid hex, e.g. `#FF6633`.
+- **Logo**: PNG or SVG, max 256 KB. PNG max 512x512 px.
+
+For scripted provisioning, the `brand` CLI subgroup hits the same endpoint:
 
 ```bash
 voicegw brand set \
@@ -94,51 +164,44 @@ voicegw brand set \
 #   Product name: AcmeVoice
 ```
 
-Set `VOICEGW_API_KEY=...` to pass the static-key Bearer header when the dashboard requires auth.
+Set `VOICEGW_API_KEY` when your dashboard requires auth.
 
-## 4. Send the customer a branded link
+## Step 5: share a branded dashboard link
 
-Branding is per-project; the dashboard picks up the active project from the URL query parameter. Share `https://your-gateway/sessions?project=acme` with the customer and they see the AcmeVoice brand: sidebar logo, accent color on interactive elements, page title and favicon. Without `?project=acme` the default VoiceGateway brand renders.
+Branding is per-project. Share `https://your-gateway/sessions?project=acme` with the client and they see the AcmeVoice brand: sidebar logo, accent color on interactive elements, page title and favicon. Without `?project=acme` the default VoiceGateway brand renders.
 
-The branding cache is per-mount: a customer who has the dashboard open during a brand change sees the new look on next page navigation, not in real time.
+## Step 6: monitor per-client cost and routing
 
-## 5. Watch the Routing view as traffic lands
+Open `/routing` in the dashboard. The page shows per-provider p50/p95 and sample count per project. Sort by p50 ascending to find the fastest provider in each modality, or by sample count to gauge confidence.
 
-Open `/routing` in the dashboard. The page shows per-provider p50/p95 and sample count for every project the gateway has seen sessions for. Use the column headers to sort by p50 ascending to spot the fastest provider in each modality, or by sample count to gauge confidence.
+From the Sessions page, click any row to open the SessionDetail modal. The routing strip shows:
 
-The page auto-refreshes every hour. The rollup worker behind the scenes refreshes every 15 minutes; the FE cadence is the page-side refresh, not the data freshness.
-
-NULL p50 renders as "no observations yet" rather than zero so it's obvious which entries the router is still relying on baselines for.
-
-## 6. Inspect the routing decision per session
-
-From the Sessions page, click any row to open the SessionDetail modal. The new routing strip shows:
-
-- **STT / LLM / TTS** picked for the session.
-- **Budget** that was in effect when the session started.
-- **Actual end-to-end latency** when the close-session hook populated `budget_ms_used` (otherwise omitted).
-- **budget_overrun chip** (yellow) when the router fell back to fastest because nothing fit the budget.
+- STT, LLM, and TTS picked for that session.
+- The latency budget in effect at session start.
+- Actual end-to-end latency when the close-session hook has populated `budget_ms_used`.
+- A yellow `budget_overrun` chip when the router fell back to fastest because nothing fit the budget.
 
 ## Known limitations
 
-A few capabilities are deliberately out of scope. Plan accordingly.
-
-- **No mid-call routing.** Pick-at-start only. If a provider degrades mid-call, the session keeps that provider until close.
-- **No adaptive learning.** The roll-up is static aggregation; there's no ML on in-call telemetry feeding back into pick scores.
-- **No custom-domain dashboard hosting.** White-label sits at the gateway's own host; agencies pointing `dashboard.theirfirm.com` at the gateway with their own TLS cert is future scope.
-- **No per-tenant branding inside one project.** White-label is per-project. An agency running multiple downstream tenants in one project shares one brand.
-- **No email or exported-report branding.** Dashboard chrome only.
-- **No cost-aware routing.** The router picks on latency; cost is observed via the existing per-modality dashboards but doesn't feed back into the picker.
+- **No mid-call routing.** Provider is chosen at session start. Mid-call degradation keeps the original provider.
+- **No per-tenant branding inside one project.** White-label is per-project only.
+- **No cost-aware routing.** The router picks on latency; cost is tracked but does not feed back into the picker.
 - **No multi-region routing.**
-- **No latency-budget enforcement in flight.** The budget is a router input at start, not a runtime kill switch.
-- **No performance SLAs from the gateway to the operator.** Best-effort prediction; the gap between prediction and reality is visible in the Routing view so operators can tune.
+- **No custom-domain dashboard hosting.** White-label sits at the gateway's own host.
 
-## Where the design lives
+## See also
 
-- **Migration**: `src/voicegateway/storage/migrations/0006_routing_and_branding.py`.
-- **Router**: `src/voicegateway/middleware/router.py` + `latency_observations_worker.py`.
-- **Baselines**: `src/voicegateway/core/provider_baselines.json`.
-- **Storage**: `src/voicegateway/storage/latency_observations_repo.py`.
-- **Dashboard API**: `src/dashboard/api/main.py` (search for `/api/routing` and `/api/projects/{id}/branding`).
-- **Frontend**: `src/dashboard/frontend/src/pages/Routing.tsx`, `lib/branding.ts`, `pages/Sessions.tsx` (`RoutingStrip`), `pages/Projects.tsx` (`BrandingModal`).
-- **CLI**: `src/voicegateway/cli/route.py`, `src/voicegateway/cli/brand.py`.
+<CardGroup>
+  <Card title="Configuration: projects" href="/configuration/projects">
+    Full projects schema: budgets, rosters, guardrails, and stale-key settings.
+  </Card>
+  <Card title="Multi-tenant quickstart" href="/guide/multi-tenant-quickstart">
+    Add per-end-user cost attribution within a project.
+  </Card>
+  <Card title="Budget enforcement example" href="/examples/budget-enforcement">
+    Code example for daily_budget enforcement with guard().
+  </Card>
+  <Card title="Cost reconciliation" href="/guide/cost-reconciliation">
+    Verify recorded per-project totals against provider invoices.
+  </Card>
+</CardGroup>

--- a/docs/guide/cost-reconciliation.md
+++ b/docs/guide/cost-reconciliation.md
@@ -1,47 +1,30 @@
 ---
-title: Cost Reconciliation
-description: How to compare VoiceGateway's recorded costs against your provider invoices using voicegw reconcile.
+title: Cost reconciliation
+description: Verify VoiceGateway's recorded costs against your provider invoices using voicegw export-costs and voicegw reconcile.
 ---
 
-# Cost Reconciliation
+# Cost reconciliation
 
-VoiceGateway records what it thinks you spent. Your provider records
-what they actually charged. These numbers should agree. They will not
-agree exactly, and that is by design: VoiceGateway estimates costs
-from per-request unit counts at a snapshot rate, while your provider
-bills against their authoritative meter and applies any discounts,
-plan tiers, or post-hoc credits.
+VoiceGateway records what it estimates you spent. Your provider records what they actually charged. These numbers should be close. They will not match exactly, and that is by design: VoiceGateway estimates from per-request unit counts at a snapshot rate, while the provider bills against their authoritative meter and applies discounts, plan tiers, or post-hoc credits.
 
-This page walks through reconciling the two numbers. The expected
-drift is up to about 5% on LLM costs (per `voice-prices`)
-and lower on STT and TTS, where unit-of-billing maps directly to what
-VoiceGateway records.
+The expected drift is up to about 5% on LLM costs (because rate sheets change frequently) and lower on STT and TTS, where the unit of billing maps directly to what VoiceGateway records.
 
 ## When to reconcile
 
 Run reconciliation:
 
-- **Once during the first 30 days after deployment.** Catches setup
-  errors (wrong rate sheet, miscounted units) before they accumulate.
-- **After a provider rate change** (e.g., OpenAI ships a new model).
-  Confirms the catalog refreshed in time.
-- **Before sending invoices that aggregate AI costs to clients or
-  internal teams.** If you bill milestone-based, this is the moment
-  to verify VoiceGateway's number is defensible.
-- **When VG's number diverges from your dashboard by >5%.** That is
-  the gate that warrants investigation.
+- Once during the first 30 days after deployment, to catch setup errors (wrong rate sheet, miscounted units) before they accumulate.
+- After a provider rate change, to confirm the catalog refreshed in time.
+- Before sending invoices that aggregate AI costs to clients or internal teams.
+- When VoiceGateway's number diverges from your dashboard by more than 5%.
 
-You do not need to reconcile every billing period. The reconciliation
-flow is for spot-checks and incident response, not a monthly ritual.
+You do not need to reconcile every billing period. The reconciliation flow is for spot-checks and incident response.
 
 ## Prerequisites
 
-- VoiceGateway recording requests against a SQLite store
-  (`storage.path` set in `voicegw.yaml`).
-- A provider usage export covering the same time window. See
-  [Reconcile File Formats](/reference/reconcile-formats) for the
-  per-provider schema VoiceGateway expects.
-- The CLI installed and on your PATH:
+- VoiceGateway recording requests to a SQLite store (`storage.path` set in `voicegw.yaml`).
+- A provider usage export covering the same time window. See [Reconcile file formats](/reference/reconcile-formats) for the per-provider schema VoiceGateway expects.
+- The CLI on your PATH:
 
 ```bash
 voicegw --version
@@ -49,173 +32,123 @@ voicegw --version
 
 ## Workflow
 
-### 1. Pull the VoiceGateway side (optional inspection step)
+<Steps>
+  <Step title="Pull the VoiceGateway side">
+    Inspect what VoiceGateway recorded before running the diff. This step is optional but useful for a quick sanity check.
 
-If you want to see what VG recorded before running the diff:
+    ```bash
+    voicegw export-costs \
+      --start 2026-05-01 --end 2026-05-31 \
+      --format csv > vg-may-2026.csv
+    ```
+
+    `export-costs` writes one CSV row per request with timestamp, project, modality, provider, model, units, cost, pricing source, and status. Open it in any spreadsheet to spot-check unit counts before comparing.
+
+    The `reconcile` command reads the same database directly, so this step is not required for the diff.
+  </Step>
+  <Step title="Pull and convert the provider export">
+    Each provider's dashboard exposes a usage export. The exports are not in VoiceGateway's canonical format, so you convert once with a short Python snippet. The conversion scripts are documented per-provider on the [Reconcile file formats](/reference/reconcile-formats) page.
+
+    For OpenAI:
+
+    ```bash
+    # Download the CSV from platform.openai.com/usage for the period.
+    # Run the conversion snippet from reconcile-formats.
+    python convert-openai.py \
+      openai-may-2026.csv \
+      openai-vg-format-may-2026.csv
+    ```
+
+    For Deepgram, download from `console.deepgram.com/usage`. For Cartesia, download from `play.cartesia.ai`.
+  </Step>
+  <Step title="Run reconcile">
+    ```bash
+    voicegw reconcile \
+      --provider openai \
+      --start 2026-05-01 --end 2026-05-31 \
+      --provider-usage-file openai-vg-format-may-2026.csv
+    ```
+
+    Default output is a text table:
+
+    ```text
+    Model             VG tokens  Provider tokens    Δ%   VG cost  Prov cost       Δ$     Δ%
+    -----------------------------------------------------------------------------------------
+    gpt-4o-mini        1500000.0        1500000.0 +0.00%  $0.0225   $0.0225  $+0.000  +0.00%
+    gpt-4o              250000.0         260000.0 +3.85%  $1.2500   $1.3000  $+0.050  +3.85%
+    gpt-4o-staging      100000.0               0  +0.00%  $0.0050   $0.0000  $-0.005  +0.00% (no provider data)
+    ```
+
+    For machine-readable output, pass `--format csv` or `--format json`. JSON is useful when piping into a monitoring or alerting tool.
+  </Step>
+  <Step title="Interpret the diff">
+    Three columns carry the most signal:
+
+    - **Delta percent on units.** How far off VoiceGateway's unit count is from the provider's. This should be near zero. A non-zero unit-side diff means VoiceGateway missed events or counted differently than the provider.
+    - **Delta dollar on cost.** Absolute dollar gap between VoiceGateway's calculation and the provider's invoice line.
+    - **Delta percent on cost.** The headline number. See the tolerance table below.
+
+    | Modality | Expected | Investigate at |
+    |---|---|---|
+    | LLM | within ~5% | more than 5% on cost, or any % on units |
+    | STT | within ~1% | more than 2% on cost, or any % on units |
+    | TTS | within ~2% | more than 3% on cost, or any % on units |
+
+    LLM has wider tolerance because its rate sheet changes frequently. `voice-prices` tracks published changes, but a same-day reconcile after a price change can show several percent of drift until the catalog is refreshed and the pin is bumped.
+  </Step>
+</Steps>
+
+## Interpreting specific patterns
+
+### Units agree but cost diverges
+
+The provider's per-model rate has drifted relative to what VoiceGateway calculated. For LLM costs this means `voice-prices` has not yet caught up to the rate change, or your account has a discount (volume tier, BAA tier) the public catalog does not know about.
+
+Update `voice-prices` and re-run:
 
 ```bash
-voicegw export-costs \
-  --start 2026-05-01 --end 2026-05-31 \
-  --format csv > vg-may-2026.csv
+uv pip install --upgrade voice-prices
+# pip install --upgrade voice-prices
 ```
 
-`export-costs` writes one CSV row per request with timestamp,
-project, modality, provider, model, units, cost, pricing source,
-and status. Open in any spreadsheet to spot-check.
+If the gap persists after upgrading, your account is on a non-public rate and the gap reflects the discount you are receiving.
 
-This step is not required for `reconcile`; the diff command reads
-the same database directly.
+### Units disagree
 
-### 2. Pull and convert the provider's export
+VoiceGateway is counting differently than the provider regardless of cost. Two common causes:
 
-Each provider's dashboard exposes a usage export. The exports are
-not in VG's canonical format, so you convert once with a short
-Python snippet (the conversions are documented per-provider on the
-[reconcile-formats](/reference/reconcile-formats) page).
+1. **Missed events.** A streaming request dropped before VoiceGateway saw the `usage_collected` event. Check for warnings in `voicegw logs` matching `failed to record cost` or `incomplete usage`.
+2. **Unit-of-billing mismatch.** The provider bills realtime audio differently from pre-recorded audio (Deepgram), or audio tokens differently from text tokens (OpenAI), and VoiceGateway's catalog or model IDs do not split them correctly.
 
-For OpenAI:
+### A model appears on only one side
 
-```bash
-# 1. Download the CSV from platform.openai.com/usage for the period.
-# 2. Run the conversion snippet from reconcile-formats.md.
-python convert-openai.py \
-  openai-may-2026.csv \
-  openai-vg-format-may-2026.csv
-```
+`(no provider data)` means VoiceGateway logged requests for a model but the provider's invoice has no line for it. Either the provider's billing dashboard lags by 24-72 hours (wait and re-pull), or VoiceGateway is routing requests to the wrong model id.
 
-For Deepgram, similar pattern with `console.deepgram.com/usage`.
-For Cartesia, `play.cartesia.ai`.
-
-### 3. Run reconcile
-
-```bash
-voicegw reconcile \
-  --provider openai \
-  --start 2026-05-01 --end 2026-05-31 \
-  --provider-usage-file openai-vg-format-may-2026.csv
-```
-
-Default output is a text table:
-
-```text
-Model                                   VG tokens  Provider tokens     Δ%   VG cost  Prov cost        Δ$      Δ%
--------------------------------------------------------------------------------------------------------------
-gpt-4o-mini                              1500000.0       1500000.0  +0.00% $0.0225  $0.0225   $+0.0000  +0.00%
-gpt-4o                                    250000.0        260000.0  +3.85% $1.2500  $1.3000   $+0.0500  +3.85%
-gpt-4o-staging                            100000.0             0.0  +0.00% $0.0050  $0.0000   $-0.0050   +0.00% (no provider data)
-```
-
-Three columns deserve a closer read:
-
-- **Δ% on units.** How far off VG's unit count is from the provider's.
-  Should be near zero. A non-zero unit-side diff means VG missed
-  events (network drop during a streaming request, plugin event
-  format changed) or counted differently than the provider.
-- **Δ$ on cost.** Absolute dollar gap between VG's calculation and
-  the provider's invoice for that model. Read with Δ% on cost.
-- **Δ% on cost.** This is the headline number. The 5% guidance below
-  applies to this column.
-
-### Other output formats
-
-`--format csv` emits the diff schema for spreadsheet ingestion.
-`--format json` emits the same data as a JSON array, which is what
-you want when piping into a monitoring or alerting tool.
-
-## Interpreting the diff
-
-### When the units agree but the cost diverges
-
-The provider's per-model rate has drifted relative to what
-VoiceGateway calculated.
-
-For LLM costs, this means `voice-prices` has not yet caught
-up to the rate change, or the operator's account has a discount
-(volume tier, BAA tier) the public catalog does not know about.
-Update `voice-prices` (`uv pip install --upgrade voice-prices`) and
-re-run; if the gap persists, your account is on a non-public rate
-and the gap is the discount you are getting.
-
-For STT and TTS costs, this means `voice-prices` has not yet caught up
-to the provider's published rate (or is missing the model). Update
-`voice-prices` (or add the model upstream), bump the pin, and re-run;
-the same discount logic as LLM applies.
-
-### When the units disagree
-
-VoiceGateway is counting differently than the provider, regardless
-of cost. Two common causes:
-
-1. **Missed events.** A streaming request dropped before VG saw the
-   `usage_collected` event from the LiveKit plugin. Check for
-   warnings in `voicegw logs` matching `failed to record cost` or
-   `incomplete usage`.
-2. **Unit-of-billing mismatch.** The provider bills realtime audio
-   differently from pre-recorded audio (Deepgram), or audio tokens
-   differently from text tokens (OpenAI), and VG's catalog or model
-   IDs do not split them. Look at the `model_id` column in
-   `vg-may-2026.csv`; if the provider invoice has separate lines
-   for `gpt-4o-audio` and `gpt-4o-mini` and VG only shows
-   `gpt-4o-mini`, your `voicegw.yaml` is routing audio requests to
-   the wrong model id and recording them under the wrong rate.
-
-### When a model is on only one side
-
-`(no provider data)` means VG logged requests for a model but the
-provider's invoice has no line for it in the period. Two causes:
-either VG is generating phantom requests (unlikely; VG only logs
-requests that returned successfully, no retries logged), or the
-provider's billing dashboard does not yet include very recent usage
-(some providers lag 24-72 hours). Wait a day and re-pull.
-
-`(no vg data)` means the provider charged for a model VG did not
-record. This is the more interesting case: usually it means a
-non-VG client is sharing the same API key. Check whether someone
-else is hitting the API with the same credentials.
-
-### How much drift is normal
-
-| Modality | Expected | Investigate at |
-| --- | --- | --- |
-| LLM | within ~5% | >5% on cost, any % on units |
-| STT | within ~1% | >2% on cost, any % on units |
-| TTS | within ~2% | >3% on cost, any % on units |
-
-LLM has wider tolerance because its rate sheet is a moving target;
-`voice-prices` tracks published changes, but a same-day reconcile
-after a price change can show several percent of drift until the
-catalog is refreshed upstream and the pin is bumped.
-
-STT and TTS rates change rarely. A persistent gap there is more
-likely a missed-event or wrong-model-id issue than a stale rate.
+`(no vg data)` means the provider charged for a model VoiceGateway did not record. Usually this means a non-VoiceGateway client is sharing the same API key. Check whether another system is hitting the API with the same credentials.
 
 ## Why VoiceGateway estimates instead of mirroring
 
-We considered shipping a "real-time invoice mirroring" feature where
-VoiceGateway pulls each provider's billing API and stores the
-authoritative number. We did not, for three reasons:
+VoiceGateway uses fast estimates rather than pulling authoritative invoice data for three reasons:
 
-1. **Provider billing APIs lag the request.** Several providers do
-   not surface per-request cost until 24-72 hours after the request.
-   Real-time cost dashboards (which is most of why operators use VG)
-   need an immediate number, not a delayed one.
-2. **Maintenance cost.** Each provider's billing API has different
-   auth, format, and rate-limit shape. Maintaining seven of them
-   inside VG is an ongoing tax.
-3. **Reconciliation is the audit anyway.** The right model is "VG
-   gives you a fast, defensible estimate; you reconcile when it
-   matters." The reconcile command is the audit mechanism, and
-   `pricing_source` attribution on every record (Phase 2.4) tells
-   you exactly what catalog priced what.
+1. **Provider billing APIs lag the request.** Several providers do not surface per-request cost until 24-72 hours after the request. Real-time cost dashboards need an immediate number.
+2. **Maintenance cost.** Each provider's billing API has different auth, format, and rate-limit shape. Maintaining seven of them inside VoiceGateway is an ongoing tax.
+3. **Reconciliation is the audit anyway.** The right model is "VoiceGateway gives you a fast, defensible estimate; you reconcile when it matters."
 
-If your billing requirements are FinOps-grade (every dollar must
-match the invoice for accounting purposes), VoiceGateway is the
-wrong tool for the cost-of-record. Use it for real-time observability
-and reconcile against the provider invoice for the official number.
+If your billing requirements are FinOps-grade (every dollar must match the invoice for accounting purposes), use VoiceGateway for real-time observability and reconcile against the provider invoice for the official number.
 
 ## See also
 
-- [Reconcile File Formats](/reference/reconcile-formats): per-provider
-  schema VoiceGateway expects.
-- [`voicegw export-costs`](/cli/export-costs): inspect VG's per-request rows directly.
-- [`voicegw reconcile`](/cli/reconcile): the diff command itself.
+<CardGroup>
+  <Card title="voicegw reconcile" href="/cli/reconcile">
+    Full CLI flag reference for the reconcile command.
+  </Card>
+  <Card title="voicegw export-costs" href="/cli/export-costs">
+    Inspect VoiceGateway's per-request rows directly.
+  </Card>
+  <Card title="Reconcile file formats" href="/reference/reconcile-formats">
+    Per-provider schema and conversion snippets.
+  </Card>
+  <Card title="voicegw costs" href="/cli/costs">
+    Quick cost summary without a provider comparison.
+  </Card>
+</CardGroup>

--- a/docs/guide/guardrails.md
+++ b/docs/guide/guardrails.md
@@ -1,17 +1,21 @@
 ---
 title: Voice-specific guardrails
-description: Project-scoped, LLM-side guardrails for voice agents, injected through the inference.LLM(...) drop-in path.
+description: Project-scoped, LLM-side guardrails for voice agents, injected through the attach() path.
 ---
 
 # Voice-specific guardrails
 
-VoiceGateway provides project-scoped, LLM-side guardrails for voice agents. Guardrails are injected through the existing `voicegateway.inference.LLM(...)` drop-in path, so agent code keeps the same LiveKit construction pattern.
+VoiceGateway provides project-scoped, LLM-side guardrails for voice agents. Guardrails are injected through the existing `attach()` seam, so your agent code keeps the same native provider construction pattern.
 
-Guardrails do not create a proxy session service, do not inspect raw audio, and do not intercept arbitrary tool calls. They append a versioned system prompt block to the LiveKit chat context and register one reserved LiveKit function tool named `report_guardrail_action`.
+Guardrails do not create a proxy session service, do not inspect raw audio, and do not intercept arbitrary tool calls. They append a versioned system prompt block to the chat context and register one reserved function tool named `report_guardrail_action`.
+
+<Note>
+Guardrails are prompt-side controls, not a deterministic safety classifier. They depend on the selected LLM following instructions and calling the reserved tool. Use provider-native moderation, contractual compliance review, and reconciliation for higher-assurance workflows.
+</Note>
 
 ## Policy model
 
-Guardrail policies live per project. The default is disabled, with every category set to `off`.
+Guardrail policies live per project in `voicegw.yaml`. The default is disabled, with every category set to `off`.
 
 ```yaml
 projects:
@@ -27,20 +31,84 @@ projects:
         off_topic: off
 ```
 
-Categories:
+### Categories
 
-- `pii`
-- `financial`
-- `medical`
-- `prompt_injection`
-- `off_topic`
+- `pii`: personally identifiable information (names, phone numbers, account numbers).
+- `financial`: financial advice, account balances, transaction details.
+- `medical`: medical advice or diagnoses.
+- `prompt_injection`: attempts to override or escape the system prompt.
+- `off_topic`: requests outside the agent's declared scope.
 
-Actions:
+### Actions
 
 - `redact`: answer without repeating the sensitive detail.
 - `block`: decline the current turn with a brief, neutral response.
 - `alert`: continue normally and write an audit event.
-- `off`: disable that category.
+- `off`: disable that category entirely.
+
+## Wiring guardrails with attach()
+
+Enable guardrails in `voicegw.yaml` for the project, then call `attach()` as normal. VoiceGateway detects the active policy and injects the guardrail block automatically on the first guarded LLM chat in the session.
+
+<Tabs>
+  <Tab title="LiveKit">
+    ```python
+    from livekit.agents import Agent, AgentSession, JobContext
+    from livekit.plugins import deepgram, openai, cartesia
+
+    from voicegateway import attach
+
+
+    async def entrypoint(ctx: JobContext):
+        await ctx.connect()
+
+        session = AgentSession(
+            stt=deepgram.STT(model="nova-3"),
+            llm=openai.LLM(model="gpt-4o-mini"),
+            tts=cartesia.TTS(model="sonic-3"),
+        )
+
+        # Guardrails are injected automatically because the "support" project
+        # has guardrails.enabled: true in voicegw.yaml.
+        attach(session, project="support")
+
+        await session.start(
+            agent=Agent(instructions="Be the Acme support agent."),
+            room=ctx.room,
+        )
+    ```
+  </Tab>
+  <Tab title="Pipecat">
+    ```python
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.task import PipelineParams, PipelineTask
+    from pipecat.services.deepgram.stt import DeepgramSTTService
+    from pipecat.services.openai.llm import OpenAILLMService
+    from pipecat.services.cartesia.tts import CartesiaTTSService
+
+    from voicegateway import attach
+
+
+    async def run_agent():
+        stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
+        llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini")
+        tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
+
+        pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])
+        task = PipelineTask(
+            pipeline,
+            params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        )
+
+        # Guardrails are injected automatically because the "support" project
+        # has guardrails.enabled: true in voicegw.yaml.
+        attach(task, project="support")
+
+        runner = PipelineRunner()
+        await runner.run(task)
+    ```
+  </Tab>
+</Tabs>
 
 ## Runtime behavior
 
@@ -48,8 +116,8 @@ On the first guarded LLM chat in a session, VoiceGateway freezes the active proj
 
 When guardrails are active:
 
-- VoiceGateway appends a `<voicegateway_guardrails version="v0.6.0">` block after existing system/developer instructions.
-- VoiceGateway registers `report_guardrail_action(category, action, context_excerpt)`.
+- VoiceGateway appends a `<voicegateway_guardrails version="v0.6.0">` block after existing system or developer instructions.
+- VoiceGateway registers `report_guardrail_action(category, action, context_excerpt)` as a reserved function tool.
 - A user-defined tool with the same name is rejected for that session.
 - Audit rows are written to `guardrail_events` with `event_type = fired`.
 
@@ -64,18 +132,18 @@ This lets the dashboard distinguish "active policy, zero events" from "no guardr
 
 ## Bypass
 
-Use bypass only for trusted internal sessions where the operator intentionally wants no injection. VoiceGateway records a bypass audit event when the frozen policy would otherwise be active.
+Use bypass only for trusted internal sessions where you intentionally want no injection. VoiceGateway records a bypass audit event when the frozen policy would otherwise be active.
+
+Pass `bypass_guardrails=True` as a keyword argument to `attach()`:
 
 ```python
-from voicegateway import inference
+from voicegateway import attach
 
-session_id = inference.start_session(bypass_guardrails=True)
-
-# Or, when binding a custom LiveKit AgentSession:
-inference.attach_session(agent_session, bypass_guardrails=True)
+# Trusted internal session: skip guardrail injection.
+attach(session, project="support", bypass_guardrails=True)
 ```
 
-Bypass skips prompt/tool injection for the session. The bypass row has `event_type = bypassed`; `category` and `action` are `NULL`.
+Bypass skips prompt and tool injection for the session. The bypass row has `event_type = bypassed`; `category` and `action` are `NULL`.
 
 ## CLI
 
@@ -88,11 +156,9 @@ voicegw guardrails clear --project support
 voicegw guardrails dry-run --project support
 ```
 
-Use `VOICEGW_API_KEY` when your dashboard API requires auth.
+Set `VOICEGW_API_KEY` when your dashboard API requires auth.
 
-## API
-
-Server API:
+## HTTP API
 
 - `GET /v1/projects/{id}/guardrails`
 - `POST /v1/projects/{id}/guardrails`
@@ -103,6 +169,19 @@ Dashboard API mirrors these under `/api/...`.
 
 Aggregates count only `fired` rows. Event listings can include both `fired` and `bypassed`.
 
-## Caveats
+## See also
 
-These guardrails are prompt-side controls, not a deterministic safety classifier. They depend on the selected LLM following instructions and calling the reserved tool. Use provider-native moderation, contractual compliance review, and invoice/log reconciliation for higher-assurance workflows.
+<CardGroup>
+  <Card title="Guardrail prompts reference" href="/reference/guardrail-prompts">
+    The exact prompt blocks VoiceGateway injects per category and action.
+  </Card>
+  <Card title="attach()" href="/guide/attach">
+    Full signature and wiring reference for the attach() seam.
+  </Card>
+  <Card title="Configuration: projects" href="/configuration/projects">
+    Set guardrail policies per project in voicegw.yaml.
+  </Card>
+  <Card title="guard()" href="/guide/guard">
+    Active control: fallback, rate limiting, and spend caps.
+  </Card>
+</CardGroup>

--- a/docs/guide/guardrails.md
+++ b/docs/guide/guardrails.md
@@ -1,21 +1,29 @@
 ---
 title: Voice-specific guardrails
-description: Project-scoped, LLM-side guardrails for voice agents, injected through the attach() path.
+description: Project-scoped, LLM-side guardrails for voice agents. Configure categories and actions per project in voicegw.yaml; VoiceGateway injects a versioned guardrail block into the LLM chat context at runtime.
 ---
 
 # Voice-specific guardrails
 
-VoiceGateway provides project-scoped, LLM-side guardrails for voice agents. Guardrails are injected through the existing `attach()` seam, so your agent code keeps the same native provider construction pattern.
+VoiceGateway provides project-scoped, LLM-side guardrails for voice agents. A
+guardrail policy appends a versioned system-prompt block to the chat context and
+registers one reserved function tool named `report_guardrail_action`, so the
+model can flag when a category fires.
 
-Guardrails do not create a proxy session service, do not inspect raw audio, and do not intercept arbitrary tool calls. They append a versioned system prompt block to the chat context and register one reserved function tool named `report_guardrail_action`.
+Guardrails do not create a proxy session service, do not inspect raw audio, and
+do not intercept arbitrary tool calls. They are prompt-side controls.
 
 <Note>
-Guardrails are prompt-side controls, not a deterministic safety classifier. They depend on the selected LLM following instructions and calling the reserved tool. Use provider-native moderation, contractual compliance review, and reconciliation for higher-assurance workflows.
+Guardrails are prompt-side controls, not a deterministic safety classifier. They
+depend on the selected LLM following instructions and calling the reserved tool.
+Use provider-native moderation, contractual compliance review, and reconciliation
+for higher-assurance workflows.
 </Note>
 
 ## Policy model
 
-Guardrail policies live per project in `voicegw.yaml`. The default is disabled, with every category set to `off`.
+Guardrail policies live per project in `voicegw.yaml`. The default is disabled,
+with every category set to `off`.
 
 ```yaml
 projects:
@@ -46,78 +54,39 @@ projects:
 - `alert`: continue normally and write an audit event.
 - `off`: disable that category entirely.
 
-## Wiring guardrails with attach()
+## How guardrails are applied
 
-Enable guardrails in `voicegw.yaml` for the project, then call `attach()` as normal. VoiceGateway detects the active policy and injects the guardrail block automatically on the first guarded LLM chat in the session.
+Guardrail injection happens inside VoiceGateway's instrumented LLM wrapper. When a
+project has an enabled policy, that wrapper rewrites the chat context on the first
+guarded LLM turn: it appends the guardrail block and registers the reserved tool
+before delegating to the underlying provider.
 
-<Tabs>
-  <Tab title="LiveKit">
-    ```python
-    from livekit.agents import Agent, AgentSession, JobContext
-    from livekit.plugins import deepgram, openai, cartesia
+<Warning>
+Guardrail injection runs through the instrumented LLM path (the
+`voicegateway.LLM(...)` provider wrapper). The passive [`attach()`](/guide/attach)
+seam meters cost and latency but does not modify prompts, so `attach()` alone does
+not inject guardrails. [`guard()`](/guide/guard) is control-only (fallback, rate
+limiting, budgets) and does not inject them either. Route your LLM through the
+gateway's LLM wrapper for the policy to take effect. If your agent uses only
+native providers plus `attach()`, the policy is recorded as active but no block is
+injected.
+</Warning>
 
-    from voicegateway import attach
-
-
-    async def entrypoint(ctx: JobContext):
-        await ctx.connect()
-
-        session = AgentSession(
-            stt=deepgram.STT(model="nova-3"),
-            llm=openai.LLM(model="gpt-4o-mini"),
-            tts=cartesia.TTS(model="sonic-3"),
-        )
-
-        # Guardrails are injected automatically because the "support" project
-        # has guardrails.enabled: true in voicegw.yaml.
-        attach(session, project="support")
-
-        await session.start(
-            agent=Agent(instructions="Be the Acme support agent."),
-            room=ctx.room,
-        )
-    ```
-  </Tab>
-  <Tab title="Pipecat">
-    ```python
-    from pipecat.pipeline.pipeline import Pipeline
-    from pipecat.pipeline.task import PipelineParams, PipelineTask
-    from pipecat.services.deepgram.stt import DeepgramSTTService
-    from pipecat.services.openai.llm import OpenAILLMService
-    from pipecat.services.cartesia.tts import CartesiaTTSService
-
-    from voicegateway import attach
-
-
-    async def run_agent():
-        stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
-        llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini")
-        tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
-
-        pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])
-        task = PipelineTask(
-            pipeline,
-            params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
-        )
-
-        # Guardrails are injected automatically because the "support" project
-        # has guardrails.enabled: true in voicegw.yaml.
-        attach(task, project="support")
-
-        runner = PipelineRunner()
-        await runner.run(task)
-    ```
-  </Tab>
-</Tabs>
+This is a known gap: guardrail injection is not yet wired into the `attach()` /
+`guard()` seams. See [the migration guide](/guide/migration-attach-guard) for how
+the instrumented wrapper relates to the current API.
 
 ## Runtime behavior
 
-On the first guarded LLM chat in a session, VoiceGateway freezes the active project policy. Later dashboard or API edits affect new sessions only.
+On the first guarded LLM chat in a session, VoiceGateway freezes the active
+project policy. Later dashboard or API edits affect new sessions only.
 
 When guardrails are active:
 
-- VoiceGateway appends a `<voicegateway_guardrails version="v0.6.0">` block after existing system or developer instructions.
-- VoiceGateway registers `report_guardrail_action(category, action, context_excerpt)` as a reserved function tool.
+- VoiceGateway appends a `voicegateway_guardrails` block (version `v0.6.0`) after
+  existing system or developer instructions.
+- VoiceGateway registers `report_guardrail_action(category, action, context_excerpt)`
+  as a reserved function tool.
 - A user-defined tool with the same name is rejected for that session.
 - Audit rows are written to `guardrail_events` with `event_type = fired`.
 
@@ -128,22 +97,19 @@ Session detail responses include:
 - `guardrail_policy_snapshot`
 - `guardrail_events`
 
-This lets the dashboard distinguish "active policy, zero events" from "no guardrail audit".
+This lets the dashboard distinguish "active policy, zero events" from "no
+guardrail audit".
 
-## Bypass
+## Disabling and bypass
 
-Use bypass only for trusted internal sessions where you intentionally want no injection. VoiceGateway records a bypass audit event when the frozen policy would otherwise be active.
+To turn a policy off, set `enabled: false` for the project, or set individual
+categories to `off`. Both take effect for new sessions (the policy is frozen per
+session at the first guarded turn).
 
-Pass `bypass_guardrails=True` as a keyword argument to `attach()`:
-
-```python
-from voicegateway import attach
-
-# Trusted internal session: skip guardrail injection.
-attach(session, project="support", bypass_guardrails=True)
-```
-
-Bypass skips prompt and tool injection for the session. The bypass row has `event_type = bypassed`; `category` and `action` are `NULL`.
+A per-session bypass path exists internally for trusted sessions and writes a
+`bypassed` audit event when the frozen policy would otherwise be active. It is not
+part of the public `attach()` / `guard()` surface; use the policy config above to
+control guardrails from your agent.
 
 ## CLI
 
@@ -165,9 +131,10 @@ Set `VOICEGW_API_KEY` when your dashboard API requires auth.
 - `GET /v1/guardrails/events`
 - `GET /v1/guardrails/aggregate`
 
-Dashboard API mirrors these under `/api/...`.
+The dashboard API mirrors these under `/api/...`.
 
-Aggregates count only `fired` rows. Event listings can include both `fired` and `bypassed`.
+Aggregates count only `fired` rows. Event listings can include both `fired` and
+`bypassed`.
 
 ## See also
 
@@ -175,13 +142,13 @@ Aggregates count only `fired` rows. Event listings can include both `fired` and 
   <Card title="Guardrail prompts reference" href="/reference/guardrail-prompts">
     The exact prompt blocks VoiceGateway injects per category and action.
   </Card>
-  <Card title="attach()" href="/guide/attach">
-    Full signature and wiring reference for the attach() seam.
-  </Card>
   <Card title="Configuration: projects" href="/configuration/projects">
     Set guardrail policies per project in voicegw.yaml.
   </Card>
-  <Card title="guard()" href="/guide/guard">
-    Active control: fallback, rate limiting, and spend caps.
+  <Card title="attach()" href="/guide/attach">
+    The passive metering seam (does not inject guardrails).
+  </Card>
+  <Card title="Migration guide" href="/guide/migration-attach-guard">
+    How the instrumented LLM wrapper relates to the current API.
   </Card>
 </CardGroup>

--- a/docs/guide/multi-tenant-quickstart.md
+++ b/docs/guide/multi-tenant-quickstart.md
@@ -1,114 +1,121 @@
 ---
 title: Multi-tenant quickstart
-description: Tag voice sessions with a tenant id, issue scoped virtual API keys, and view or export per-tenant costs from a single deployment.
+description: Tag every voice session with a tenant id so a single deployment can attribute cost to each customer separately.
 ---
 
 # Multi-tenant quickstart
 
-VoiceGateway tags every voice session with an optional `tenant_id` so a single deployment can serve many customers and account for each one separately. This guide walks an operator through the four moves the multi-tenant surface enables:
+One VoiceGateway deployment can serve many customers. Pass `tenant_id` to `attach()` and every STT, LLM, and TTS record is stamped with that customer's identifier. The dashboard and API can then filter, group, and export by tenant so you see per-customer cost without running separate deployments.
 
-1. Tag a session with a tenant at session-create.
-2. Issue a virtual API key scoped to that tenant.
-3. View per-tenant costs, metrics, and replay in the dashboard.
-4. Export per-tenant data for billing or analysis.
-
-If you only need to filter the dashboard, jump straight to [Step 3](#3-view-per-tenant-costs-and-metrics).
+<Note>
+This page covers the agent-side wiring. For project-level grouping (one project per agency client), see [Agency quickstart](/guide/agency-quickstart). The two are composable: you can pass both `project=` and `tenant_id=` to `attach()`.
+</Note>
 
 ## Prerequisites
 
 - VoiceGateway installed (`voicegw --version` to confirm).
-- Daemon running (started by `voicegw onboard` or `voicegw serve`). The daemon serves the dashboard at the daemon URL (default `http://127.0.0.1:8080`).
-- A `voicegw.yaml` with `cost_tracking.db_path` set (the dashboard reads the same SQLite database the gateway writes to).
+- A running gateway daemon (`voicegw serve` or `voicegw onboard`).
+- `voicegw.yaml` with `storage.path` pointing to your SQLite database.
 
-## 1. Tag a session with a tenant
+## How tenant attribution works
 
-Three independent surfaces, listed in order of "least to most operator coupling." Pick whichever fits your deployment.
+`attach()` accepts a `tenant_id` keyword argument. Every cost and latency record written during that session carries the value you pass. Sub-tenants or per-call overrides can be stamped via `metadata.tenant_id` on the record after it is created.
 
-### Option A: pass `tenant_id` to `attach_session`
+The tenant id is bounded at 128 UTF-8 characters. Unicode is allowed.
 
-The cleanest path when your worker code knows the tenant. Refer to the [Python SDK reference](/api/python-sdk#1-attach_session-tenant_id) for the full signature.
+Sessions where `tenant_id` is not set store `NULL` and appear as "unattributed" in the dashboard.
+
+## Step 1: wire attach() with a tenant id
+
+Your agent code knows the caller's tenant at connection time (from room metadata, a custom JWT claim, or a header). Pass it straight into `attach()`.
+
+<Tabs>
+  <Tab title="LiveKit">
+    ```python
+    from livekit.agents import Agent, AgentSession, JobContext
+    from livekit.plugins import deepgram, openai, cartesia
+
+    from voicegateway import attach
+
+
+    async def entrypoint(ctx: JobContext):
+        await ctx.connect()
+
+        # Resolve the tenant from room metadata or a JWT claim.
+        tenant_id = ctx.room.metadata  # e.g. "acme"
+
+        session = AgentSession(
+            stt=deepgram.STT(model="nova-3"),
+            llm=openai.LLM(model="gpt-4o-mini"),
+            tts=cartesia.TTS(model="sonic-3"),
+        )
+
+        # Every record from this session is stamped with tenant_id.
+        attach(session, project="support", tenant_id=tenant_id)
+
+        await session.start(
+            agent=Agent(instructions="Be helpful."),
+            room=ctx.room,
+        )
+    ```
+  </Tab>
+  <Tab title="Pipecat">
+    ```python
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.task import PipelineParams, PipelineTask
+    from pipecat.services.deepgram.stt import DeepgramSTTService
+    from pipecat.services.openai.llm import OpenAILLMService
+    from pipecat.services.cartesia.tts import CartesiaTTSService
+
+    from voicegateway import attach
+
+
+    async def run_agent(tenant_id: str):
+        stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
+        llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini")
+        tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
+
+        pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])
+        task = PipelineTask(
+            pipeline,
+            params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        )
+
+        # Every record from this pipeline is stamped with tenant_id.
+        attach(task, project="support", tenant_id=tenant_id)
+
+        runner = PipelineRunner()
+        await runner.run(task)
+    ```
+  </Tab>
+</Tabs>
+
+## Step 2: carry a sub-tenant via metadata
+
+Some deployments nest sub-tenants below the top-level tenant (for example, a platform serving agencies that each have end clients). The record's `metadata` field lets you attach an additional `tenant_id` for downstream analysis without changing the top-level attribution.
 
 ```python
-from voicegateway import inference
-
-async def handle_call(tenant_id: str):
-    agent_session = AgentSession(...)
-    inference.attach_session(agent_session, tenant_id=tenant_id)
-    await agent_session.start(...)
+# After attach(), stamp sub-tenant data in metadata before the session starts.
+session_id = attach(session, project="platform", tenant_id="agency-acme")
+# The sub-tenant is carried on the wire via record metadata.
+# See the Fleet Collector ingest flow for how metadata.tenant_id is routed.
 ```
 
-Use this when the LiveKit dispatcher hands your worker a context that already names the tenant (room metadata, a custom claim, a header passed through to the worker, etc.).
+<Tip>
+If you are sending data to the VoiceGateway Cloud collector, pass `metadata.tenant_id` in the ingest payload. The collector routes it alongside the top-level `tenant_id` so both levels appear in the dashboard. See [Hosted quickstart](/hosted/quickstart) for the collector env vars.
+</Tip>
 
-### Option B: `inference.set_tenant("…")`
+## Step 3: view per-tenant costs in the dashboard
 
-The ContextVar escape hatch for code that does not own the `AgentSession` construction. Sets `tenant_id_ctx` for the rest of the async context; subsequent factory calls inherit the scope.
+Open the dashboard at `http://127.0.0.1:8080` (your daemon's serve port).
 
-```python
-from voicegateway import inference
+Every cost, session, and metrics page respects the **Tenant** filter in the top-right filter strip. Type a tenant id to scope the page, or choose **Unattributed** to audit sessions with no `tenant_id`. The filter value lives in the URL so it persists across navigation.
 
-inference.set_tenant("acme")
-stt = inference.STT("deepgram/nova-3")
-llm = inference.LLM("openai/gpt-4o-mini")
-# Every request from this point in the async context tags 'acme'.
-```
+The Sessions page shows a **Tenant** column. Clicking the tenant pill on any row scopes the whole page to that tenant immediately.
 
-Tenant ids are bounded at 128 UTF-8 characters. Unicode is allowed. Pass `None` to leave the ContextVar untouched (it does **not** clear a previously-set tenant). Use `inference.reset_tenant_id()` to clear it explicitly between sessions in long-lived tasks.
+## Step 4: export per-tenant data
 
-### Option C: scoped virtual API keys
-
-When the caller is not your own agent code (a partner integration, a third-party voicebot) but you can give them a unique API key, issue a virtual key scoped to their tenant. The auth middleware auto-tags every session that arrives bearing that key. See [Step 2](#2-issue-a-virtual-api-key) for the workflow.
-
-### Sessions without a tenant: the "unattributed" bucket
-
-Sessions where none of the three surfaces set a tenant get `tenant_id = NULL` in storage. The dashboard renders these as a muted **unattributed** pill. The dashboard's tenant filter has a dedicated entry for the unattributed bucket so you can audit which sessions slipped through.
-
-## 2. Issue a virtual API key
-
-The dashboard is the only surface that issues virtual keys. The CLI is read-only by design: a CLI that printed the plaintext key would leak it via shell history and scrollback.
-
-1. Open the dashboard at `http://127.0.0.1:8080/api-keys` (the daemon's serve port).
-2. Click **+ Issue Key**.
-3. Fill in:
-    - **Name** (required): a human label, e.g. `acme-prod`.
-    - **Tenant scope** (optional): the tenant id you want auto-attached. Leave blank for an unscoped key.
-    - **Issued by** (optional): free-form audit string.
-4. Hit **Issue Key**. The next modal shows the full key **exactly once**. Copy it into your secret store before closing.
-
-The key looks like `vk_AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPP` (35 characters: `vk_` + 32 base32). The first 8 characters (`vk_AABBC`) persist as the visible prefix so you can identify a key in the list without exposing the secret; the whole key is bcrypt-hashed before storage.
-
-Ship the key to the caller as `Authorization: Bearer vk_…`. From that point:
-
-- Scoped keys auto-tag every session. A body-level `tenant_id` that disagrees with the key's scope returns `403`.
-- Unscoped keys allow the body to declare any tenant.
-- Static API keys (the `auth.api_keys` block in `voicegw.yaml`) never set a tenant.
-
-### Revoke
-
-The same API Keys page exposes a **Revoke** action per row. Revocation is soft: the row stays for audit and the stale-key surface, but verification rejects further requests bearing the key within ~30 seconds.
-
-### Stale-key detection
-
-Keys whose `last_used_at` (or `issued_at`, for never-used keys) is older than `api_key_stale_days` (default 90, per-project overridable in `voicegw.yaml`) surface with a yellow **stale** badge. Hide revoked rows with the toggle at the top of the page when triaging.
-
-## 3. View per-tenant costs and metrics
-
-Every cost, log, sessions, metrics, and replay page in the dashboard now respects the `tenant` URL parameter.
-
-- Use the **Tenant** typeahead in the filter strip (top-right of each page) to scope to one tenant, or pick **Unattributed** to see only sessions without attribution.
-- The filter persists across navigation: switching from Costs to Sessions to Metrics keeps the same tenant in scope because the value lives in the URL.
-- Selecting **All tenants** clears the filter without losing project or time-range scope.
-
-### The Tenants tab
-
-`GET /api/tenants` (consumed by the typeahead) returns the index of every tenant the gateway has seen, ordered by most recent activity. Each entry carries the session count, total cost, and first/last-seen timestamps. The unattributed bucket appears as a separate entry below the list.
-
-### Per-session attribution
-
-The Sessions page has a **Tenant** column that renders the row's `tenant_id` as a clickable pill: clicking it scopes the page to that tenant immediately. The SessionDetail modal also shows the tenant pill next to the session id so you can verify attribution without leaving the row.
-
-## 4. Export per-tenant data
-
-For billing exports or third-party analysis, two paths.
+For billing exports or downstream analysis, use the CLI or direct SQL.
 
 ### CLI
 
@@ -117,40 +124,48 @@ voicegw tenant list --json
 voicegw tenant show acme --json
 ```
 
-Both commands emit JSON with the same shape `/api/tenants` returns. `tenant show` exits 1 when the tenant has no sessions so CI scripts can branch.
+`tenant show` exits 1 when the tenant has no sessions, so CI scripts can branch on it.
 
-The `voicegw costs` command does **not** accept a `--tenant` flag. The dashboard's `/api/costs?tenant=…` endpoint is the canonical per-tenant cost source.
-
-### Direct SQL
+### SQL
 
 The `sessions` table carries `tenant_id`. For ad-hoc analysis:
 
 ```sql
-SELECT tenant_id,
-       COUNT(*) AS session_count,
-       SUM(total_cost_usd) AS total_cost
+SELECT
+    tenant_id,
+    COUNT(*)             AS session_count,
+    SUM(total_cost_usd)  AS total_cost
 FROM sessions
 WHERE started_at >= '2026-05-01'
 GROUP BY tenant_id
 ORDER BY total_cost DESC;
 ```
 
-The `requests`, `turns`, `dead_air_events`, and `replay_*` tables all carry the column too, so any join-and-aggregate workflow can add `tenant_id` to the GROUP BY without schema gymnastics.
+The `requests`, `turns`, and `guardrail_events` tables also carry `tenant_id`, so any join-and-aggregate query can group by tenant without schema changes.
 
 ## Known limitations
 
-A few operator workflows are deliberately out of scope. Plan accordingly.
+<Note>
+These are deliberate scope decisions, not bugs.
+</Note>
 
-- **No CLI issuance of virtual keys.** The plaintext surface is the dashboard's "show key once" modal; a CLI flow would leak via shell history.
-- **No `voicegw costs --tenant`.** The dashboard's `/api/costs?tenant=…` is the canonical per-tenant cost source.
-- **No re-tag affordance for already-attributed sessions.** Once a session has a non-NULL `tenant_id`, the dashboard cannot change it; the COALESCE rule in `log_request` only fills NULL slots.
-- **Virtual keys do not carry RBAC scopes.** A verified vk grants the same access a wildcard static key would.
+- **No `voicegw costs --tenant` flag.** Use the dashboard's `/api/costs?tenant=` endpoint for per-tenant cost totals.
+- **No re-tag affordance.** Once a session has a non-NULL `tenant_id`, it cannot be changed after the fact.
+- **Virtual keys do not carry RBAC scopes.** A verified virtual key grants the same access as a wildcard static key.
 
-## Where the design lives
+## See also
 
-- **Migration**: `src/voicegateway/storage/migrations/0005_tenant_attribution.py`.
-- **ContextVar**: `src/voicegateway/inference/_session_context.py`.
-- **Auth middleware**: `src/voicegateway/server/main.py::build_app` + `src/voicegateway/core/auth.py`.
-- **Repos**: `src/voicegateway/storage/api_keys_repo.py`, `src/voicegateway/storage/tenants_repo.py`.
-- **Dashboard API**: `src/dashboard/api/main.py` (search for `/api/tenants` and `/api/api_keys`).
-- **Frontend primitives**: `src/dashboard/frontend/src/components/{FilterBar,TenantFilter,TenantPill}.tsx`.
+<CardGroup>
+  <Card title="attach()" href="/guide/attach">
+    Full signature and wiring reference for LiveKit and Pipecat.
+  </Card>
+  <Card title="Agency quickstart" href="/guide/agency-quickstart">
+    One agency running many client projects, with per-client budgets.
+  </Card>
+  <Card title="Multi-project example" href="/examples/multi-project">
+    Code example using multiple projects and tenants side by side.
+  </Card>
+  <Card title="Configuration: projects" href="/configuration/projects">
+    Set daily budgets and routing rosters per project in voicegw.yaml.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Rewrites the four Advanced guide pages (multi-tenant-quickstart, agency-quickstart, cost-reconciliation, guardrails) into a consistent group for teams past the basics.
- Removes all `voicegateway.inference` references from `guardrails.md` (rule 5 violation); replaces with the current `attach()` / `guard()` API.
- Adds LiveKit + Pipecat `<Tabs>` wherever agent wiring appears across all four pages.
- Wraps the reconciliation workflow in `<Steps>`; adds `<CardGroup>` footers on all pages.
- Fixes `attach()` env-var accuracy: no invented `VOICEGW_PROJECT`; only `VOICEGW_COLLECTOR_URL`, `VOICEGW_API_KEY`, `VOICEGW_AGENT_ID`, `VOICEGW_DB_PATH`.
- All internal links resolve to valid nav pages; no `{#anchor}` heading ids; Mintlify-only frontmatter.

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 4 scoped)
```