### PR TITLE
docs(deploy): rewrite Deploy group (P6)

### DIFF
--- a/docs/deployment/auto-update.md
+++ b/docs/deployment/auto-update.md
@@ -1,50 +1,50 @@
 ---
-title: "Auto-update the collector"
-description: "Keep a self-hosted fleet collector on the latest patch release automatically, with rolling Postgres backups and effectively no interruption to your agents."
+title: "Auto-update the daemon"
+description: "Keep a self-hosted VoiceGateway daemon on the latest patch release automatically, with rolling Postgres backups and effectively no interruption to your agents."
 ---
 
-# Auto-update the collector
+# Auto-update the daemon
 
-Once the collector runs on your own box (see [Deploy to a VPS](/deployment/vps)), you can have it pull and apply new patch releases on its own. This page sets that up with an opt-in Compose overlay that adds a release-channel pin, [Watchtower](https://containrrr.dev/watchtower/), and rolling Postgres backups.
+Once the daemon runs on your own box (see [Deploy to a VPS](/deployment/vps)), you can have it pull and apply new patch releases on its own. This page sets that up with an opt-in Compose overlay that adds a release-channel pin, [Watchtower](https://containrrr.dev/watchtower/), and rolling Postgres backups.
 
 ## Is it really "no interruption"?
 
-For your **agents**, effectively yes. The SDK's `RemoteCollectorSink` buffers telemetry in memory and retries with backoff, and treats HTTP 429 as backpressure. During the few-second container swap of an update, agents buffer and re-send, so no agent call fails.
+For your agents, effectively yes. The SDK's `RemoteCollectorSink` buffers telemetry in memory and retries with backoff, and treats HTTP 429 as backpressure. During the few-second container swap of an update, agents buffer and re-send, so no agent call fails.
 
 Two honest caveats:
 
-- Cost telemetry is **best-effort by design** (it is not billing-of-record). A *long* collector outage can drop some rows; a fast update swap does not.
-- On a **single node**, a container recreate is not literally zero-downtime: the ingest endpoint and dashboard are unavailable for a few seconds. For true zero-downtime you need two collector replicas behind a reverse proxy doing rolling restarts against shared Postgres (and migrations kept backward-compatible across the rollout). That is overkill for one box.
+- Cost telemetry is best-effort by design (it is not billing-of-record). A long daemon outage can drop some rows; a fast update swap does not.
+- On a single node, a container recreate is not literally zero-downtime: the ingest endpoint and dashboard are unavailable for a few seconds. For true zero-downtime you need two daemon replicas behind a reverse proxy doing rolling restarts against shared Postgres (and migrations kept backward-compatible across the rollout). That is overkill for one box.
 
 ## The release channel: pin to a minor, never `:latest`
 
-The release workflow publishes three Docker tags per version, for example `0.10.0`, `0.10`, and `latest`. The overlay pins the collector to the **minor channel** `:0.10`:
+The release workflow publishes three Docker tags per version, for example `0.10.0`, `0.10`, and `latest`. The overlay pins the daemon to the minor channel `:0.10`:
 
-- `:0.10` auto-gets bug-fix patches (`0.10.1`, `0.10.2`, ...) but **never a breaking major**. You move to `:0.11` deliberately.
+- `:0.10` auto-gets bug-fix patches (`0.10.1`, `0.10.2`, ...) but never a breaking major. You move to `:0.11` deliberately.
 - `:latest` would auto-pull the next major and run its migrations unattended. Do not auto-track `:latest` in production.
 
 <Note>
-The `:0.10` channel exists once **v0.10.0** is published. Until then, pin to the highest released minor.
+The `:0.10` channel exists once v0.10.0 is published. Until then, pin to the highest released minor.
 </Note>
 
 ## Turn it on
 
-The overlay ([`docker-compose.autoupdate.yml`](https://github.com/mahimailabs/voicegateway/blob/main/docker-compose.autoupdate.yml)) layers on top of the collector stack. From your deploy directory:
+The overlay ([`docker-compose.autoupdate.yml`](https://github.com/mahimailabs/voicegateway/blob/main/docker-compose.autoupdate.yml)) layers on top of the daemon stack. From your deploy directory:
 
 ```bash
 curl -fsSLO https://raw.githubusercontent.com/mahimailabs/voicegateway/main/docker-compose.autoupdate.yml
 docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml up -d
 ```
 
-That starts three things alongside the collector:
+That starts three things alongside the daemon:
 
 | Service | What it does |
 | :-- | :-- |
 | `collector` (relabeled) | Now tracks `mahimairaja/voicegateway:0.10` and carries the Watchtower-enable label. |
-| `watchtower` | Checks hourly and recreates **only the labeled collector** when `:0.10` advances, then removes the old image. Postgres and the backup sidecar are never auto-updated. |
+| `watchtower` | Checks hourly and recreates only the labeled daemon when `:0.10` advances, then removes the old image. Postgres and the backup sidecar are never auto-updated. |
 | `db-backup` | A `postgres:16-alpine` sidecar that dumps the database on a schedule (matching server version, so `pg_dump` never refuses), keeping the most recent N dumps in a named volume. |
 
-Always pass **both** `-f` files together for later `up`, `down`, and `logs`, so Compose keeps the merged definition.
+Always pass both `-f` files together for later `up`, `down`, and `logs`, so Compose keeps the merged definition.
 
 ## Tuning
 
@@ -61,30 +61,47 @@ Watchtower's cadence is `WATCHTOWER_POLL_INTERVAL` (default `3600`, hourly) in t
 
 Dumps live in the `voicegw-backups` volume as `voicegw-<timestamp>.sql`. To roll back after a bad update:
 
-```bash
-# 1. Stop the collector so nothing writes during the restore.
-docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml stop collector watchtower
+<Steps>
 
-# 2. List available dumps (newest first).
+### Stop the daemon
+
+Stop the daemon so nothing writes during the restore.
+
+```bash
+docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml stop collector watchtower
+```
+
+### List available dumps
+
+```bash
 docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml \
   exec db-backup sh -c 'ls -1t /backups/voicegw-*.sql'
+```
 
-# 3. Restore the chosen dump into Postgres.
+### Restore the chosen dump
+
+```bash
 docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml \
   exec -T db-backup sh -c 'psql -h postgres -U voicegw -d voicegw < /backups/voicegw-<timestamp>.sql'
+```
 
-# 4. Pin the collector back to the known-good version, then bring it up.
-#    (edit the image tag in docker-compose.autoupdate.yml, e.g. :0.10.1)
+### Pin to the known-good version and restart
+
+Edit the image tag in `docker-compose.autoupdate.yml` (for example `:0.10.1`), then bring the stack up:
+
+```bash
 docker compose -f docker-compose.collector.yml -f docker-compose.autoupdate.yml up -d
 ```
 
+</Steps>
+
 <Warning>
-Migrations run on collector startup and are forward-only. The Compose healthcheck gates a bad boot, but the database is shared state: keep the backups (and ideally a periodic host-level snapshot of the box) so a migration regression is always recoverable.
+Migrations run on daemon startup and are forward-only. The Compose healthcheck gates a bad boot, but the database is shared state: keep the backups (and ideally a periodic host-level snapshot of the box) so a migration regression is always recoverable.
 </Warning>
 
 ## Opting back out
 
-Bring the stack up with only the base file to drop Watchtower and the backup sidecar and return to a manually-pinned collector:
+Bring the stack up with only the base file to drop Watchtower and the backup sidecar and return to a manually-pinned daemon:
 
 ```bash
 docker compose -f docker-compose.collector.yml up -d

--- a/docs/deployment/distributed-sfu.md
+++ b/docs/deployment/distributed-sfu.md
@@ -1,19 +1,19 @@
 ---
-title: Distributed SFU probers
-description: Load-test a LiveKit SFU concurrently from several regions using a coordinator and per-region prober containers.
+title: "Distributed SFU probers"
+description: "Load-test a LiveKit SFU concurrently from several regions using a coordinator and per-region prober containers."
 ---
 
 # Distributed SFU probers
 
-`voicegw livekit sfu --load` measures SFU capacity from a single host. That answers "what can this one machine push," not "does my SFU hold up when clients from several regions join the same room at once." Distributed mode answers the second question: one **coordinator** synchronizes N **probers**, each running from a different region, all ramping the same room together.
+`voicegw livekit sfu --load` measures SFU capacity from a single host. That answers "what can this one machine push," not "does my SFU hold up when clients from several regions join the same room at once." Distributed mode answers the second question: one coordinator synchronizes N probers, each running from a different region, all ramping the same room together.
 
 See the [`voicegw livekit sfu`](/cli/livekit#voicegw-livekit-sfu) reference for the combined-report format. This page covers deploying the probers.
 
 ## How it works
 
-1. The **coordinator** (`sfu --coordinator --expect N`) serves a small HTTP barrier. It hands every prover the same job (room, ramp tiers, duration, thresholds) and a shared `start_at` timestamp once all N have registered.
-2. Each **prober** (`sfu --report-to <url> --vantage <label>`) registers, waits for the barrier so all vantages start at the same instant, ramps the shared room, and posts its per-tier measurements back.
-3. When every prover has reported, the coordinator aggregates (summing clients per tier, taking the worst rtt / loss / quality), prints the combined capacity, and deletes the shared rooms.
+1. The coordinator (`sfu --coordinator --expect N`) serves a small HTTP barrier. It hands every prober the same job (room, ramp tiers, duration, thresholds) and a shared `start_at` timestamp once all N have registered.
+2. Each prober (`sfu --report-to <url> --vantage <label>`) registers, waits for the barrier so all vantages start at the same instant, ramps the shared room, and posts its per-tier measurements back.
+3. When every prober has reported, the coordinator aggregates (summing clients per tier, taking the worst rtt / loss / quality), prints the combined capacity, and deletes the shared rooms.
 
 The coordinator needs the `[server]` extra (`pip install 'voicegateway[server]'`) for its HTTP layer. Probers need only the base install.
 
@@ -36,18 +36,32 @@ It blocks until all three probers report, then prints the combined report and ex
 
 The `deploy/prober/` directory ships a `Dockerfile` and an example `fly.toml`. The image is a run-to-completion job that runs one prober and exits.
 
+<Steps>
+
+### Create the Fly app
+
 ```bash
 cd deploy/prober
-
 fly apps create vg-sfu-prober
+```
+
+### Set secrets
+
+```bash
 fly secrets set -a vg-sfu-prober \
     LIVEKIT_URL=wss://your.livekit.cloud \
     LIVEKIT_API_KEY=... LIVEKIT_API_SECRET=... \
     COORDINATOR_URL=http://<coordinator-host>:8787
+```
 
+### Deploy and scale across regions
+
+```bash
 fly deploy -a vg-sfu-prober
 fly scale count 3 --region iad,sjc,lhr -a vg-sfu-prober
 ```
+
+</Steps>
 
 Each machine reads its region from Fly's `FLY_REGION` and reports it as its vantage label, so a machine in `sjc` shows up as the `sjc` vantage with no per-region config. The ramp and duration are dictated by the coordinator (every vantage runs the same job), so there is nothing to set for them on the prober.
 
@@ -55,9 +69,9 @@ Any host that can run a container works the same way: set `COORDINATOR_URL`, the
 
 ## Limitations
 
-- **The coordinator endpoint is unauthenticated.** `/register`, `/report`, and `/result` have no auth, so anyone who can reach the port can inject fake reports or read the result. Run the coordinator on a private network the probers can reach (a VPC, Fly private networking, an SSH tunnel), not a public interface, and only for the duration of the run.
-- **Per-tier concurrency drifts after the first tier.** The barrier synchronizes only the shared start; each vantage then advances to its next ramp tier as soon as its own measurement finishes. Vantages stay aligned at the first tier, but faster ones run ahead on later tiers, so the combined per-tier client sums are exact at tier one and an upper bound thereafter. Read the combined knee as approximate, and lean on the baseline and first-tier numbers for the tightest signal.
-- **If a prober dies, the run degrades rather than hangs.** The coordinator stops after its timeout (default 10 minutes) and aggregates whatever reported; a prober that never clears the barrier gives up after its own timeout. A missing vantage shows up under `dropped` in the report.
+- The coordinator endpoint is unauthenticated. `/register`, `/report`, and `/result` have no auth, so anyone who can reach the port can inject fake reports or read the result. Run the coordinator on a private network the probers can reach (a VPC, Fly private networking, an SSH tunnel), not a public interface, and only for the duration of the run.
+- Per-tier concurrency drifts after the first tier. The barrier synchronizes only the shared start; each vantage then advances to its next ramp tier as soon as its own measurement finishes. Vantages stay aligned at the first tier, but faster ones run ahead on later tiers, so the combined per-tier client sums are exact at tier one and an upper bound thereafter. Read the combined knee as approximate, and lean on the baseline and first-tier numbers for the tightest signal.
+- If a prober dies, the run degrades rather than hangs. The coordinator stops after its timeout (default 10 minutes) and aggregates whatever reported; a prober that never clears the barrier gives up after its own timeout. A missing vantage shows up under `dropped` in the report.
 
 ## Cost and safety
 
@@ -66,4 +80,4 @@ Distributed probing opens real SFU connections from many hosts at once. Unlike `
 ## Related
 
 - [`voicegw livekit sfu`](/cli/livekit#voicegw-livekit-sfu): the command reference and combined-report format.
-- [Deploy on Fly.io](/deployment/fly): deploying the VoiceGateway engine itself.
+- [Deploy on Fly.io](/deployment/fly): deploying the VoiceGateway daemon itself.

--- a/docs/deployment/fly.md
+++ b/docs/deployment/fly.md
@@ -1,11 +1,11 @@
 ---
 title: "Deploy to Fly.io"
-description: "Run the VoiceGateway fleet collector on Fly.io with managed Postgres, automatic HTTPS, and multi-region placement."
+description: "Run the VoiceGateway daemon on Fly.io with managed Postgres, automatic HTTPS, and multi-region placement."
 ---
 
 # Deploy to Fly.io
 
-Low ops; automatic HTTPS; deploy in multiple regions to sit near your agents.
+Low ops. Automatic HTTPS. Deploy in multiple regions to sit near your agents.
 
 <Tip>
 Deploy in a region close to where your agents run to cut ingest latency. Fly lets you place machines in specific regions with `--region` on `fly deploy` or via the `primary_region` key in `fly.toml`.
@@ -16,7 +16,9 @@ Deploy in a region close to where your agents run to cut ingest latency. Fly let
 - [`flyctl`](https://fly.io/docs/hands-on/install-flyctl/) installed
 - A Fly account: `fly auth login`
 
-## Configure
+<Steps>
+
+### Create fly.toml
 
 Create `fly.toml` in a working directory:
 
@@ -33,7 +35,7 @@ app = "<your-app-name>"
   min_machines_running = 1
 ```
 
-## Add Postgres
+### Add Postgres
 
 **Option A: Fly Postgres (unmanaged)**
 
@@ -42,13 +44,13 @@ fly postgres create --name <pg-app-name>
 fly postgres attach <pg-app-name> --app <your-app-name>
 ```
 
-`fly postgres attach` sets `DATABASE_URL` on your app automatically (in `postgres://...` form).
+`fly postgres attach` sets `DATABASE_URL` on your app automatically in `postgres://...` form.
 
 **Option B: Neon or another managed provider**
 
 Skip `fly postgres create` and supply the connection string directly in the next step.
 
-## Set secrets
+### Set secrets
 
 <Warning>
 Fly's `DATABASE_URL` (from `fly postgres attach`) uses the `postgres://` scheme. VoiceGateway requires `postgresql+asyncpg://`. Copy the connection string and rewrite the scheme; everything after `://` stays the same.
@@ -62,7 +64,7 @@ fly secrets set \
 
 `VOICEGW_API_KEY` must not start with `vk_`. Generate it with `openssl rand -hex 32`. No volume is needed since data is stored in Postgres.
 
-## Deploy
+### Deploy
 
 ```bash
 fly deploy
@@ -70,10 +72,12 @@ fly deploy
 
 HTTPS is automatic at `https://<your-app-name>.fly.dev`.
 
+</Steps>
+
 ## Verify
 
-Follow the steps at [Verify](/deployment#verify), using `https://<your-app-name>.fly.dev` as the collector URL and `VOICEGW_API_KEY` as the key.
+Follow the steps at [Verify](/deployment/index#verify), using `https://<your-app-name>.fly.dev` as the daemon URL and `VOICEGW_API_KEY` as the key.
 
 ## Connect your agent
 
-See [Connect your agent](/deployment#connect-your-agent). Use `https://<your-app-name>.fly.dev` as `collector_url` and `VOICEGW_API_KEY` as `api_key`.
+See [Connect your agent](/deployment/index#connect-your-agent). Use `https://<your-app-name>.fly.dev` as `collector_url` and `VOICEGW_API_KEY` as `api_key`.

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -1,49 +1,79 @@
 ---
-title: "Deployment"
-description: "Self-host the VoiceGateway fleet collector on a VPS, Railway, or Fly.io: Postgres-backed, HTTPS ingest, dashboard."
+title: "Deploy VoiceGateway"
+description: "Ship the self-hosted VoiceGateway daemon to production: HTTP API and dashboard on one port, backed by Postgres or SQLite."
 ---
 
-# Deploy the fleet collector
+# Deploy VoiceGateway
 
-The collector is a single container that serves `POST /v1/ingest` (agents push cost telemetry, Bearer-keyed), the dashboard, and the cost API on port 8080. It needs Postgres, a public HTTPS URL, and an ingest key you create.
+The VoiceGateway daemon is a single container that serves:
 
-Request flow: `agent -> POST /v1/ingest (Bearer key) -> collector -> Postgres -> dashboard`.
+- `POST /v1/ingest` (agents push cost telemetry, Bearer-keyed)
+- The web dashboard
+- The cost and analytics API
+
+Everything runs on port 8080. Your agents push to it; you read costs from the dashboard.
+
+Request flow: `agent -> POST /v1/ingest (Bearer key) -> daemon -> database -> dashboard`.
+
+## Prerequisites
+
+- A server or managed platform with outbound internet access
+- Docker (for VPS) or a platform account (Railway, Fly.io)
+- A Postgres database (or SQLite for single-user local use)
+- A public HTTPS URL so agents can reach `/v1/ingest`
+
+The ingest key you create must not start with `vk_`. Generate one with:
+
+```bash
+openssl rand -hex 32
+```
 
 ## Pick a platform
 
-| Platform | Ops effort | HTTPS | Postgres | Cost | Best when |
-|---|---|---|---|---|---|
-| [VPS](/deployment/vps) | Highest (you run TLS) | You set up (Caddy) | Self-run or Neon | Cheapest | You already run a box (e.g. your LiveKit server) |
-| [Railway](/deployment/railway) | Lowest | Automatic | One-click managed | Higher | You want zero ops |
-| [Fly.io](/deployment/fly) | Low | Automatic | Fly Postgres or Neon | Low | Multi-region, near your agents |
+<CardGroup cols={3}>
+  <Card title="Fly.io" icon="rocket" href="/deployment/fly">
+    Low ops. Automatic HTTPS. Multi-region placement to sit near your agents.
+  </Card>
+  <Card title="Railway" icon="train" href="/deployment/railway">
+    Zero ops. One-click Postgres. Automatic HTTPS and public URL.
+  </Card>
+  <Card title="VPS (systemd)" icon="server" href="/deployment/vps">
+    Cheapest. Full control. Ideal for co-locating with a self-hosted LiveKit server.
+  </Card>
+</CardGroup>
+
+<CardGroup cols={2}>
+  <Card title="Auto-update" icon="arrows-rotate" href="/deployment/auto-update">
+    Keep your self-hosted daemon on the latest patch release automatically.
+  </Card>
+  <Card title="Distributed SFU probers" icon="globe" href="/deployment/distributed-sfu">
+    Load-test your LiveKit SFU from multiple regions simultaneously.
+  </Card>
+</CardGroup>
 
 For a single-node / SQLite setup (just yourself, no fleet), see [Docker deployment](/examples/docker-deployment) instead.
 
 ## Connect your agent
 
-Once the collector has a public HTTPS URL and you have the ingest key, point your agents at it. The explicit form:
+Once the daemon has a public HTTPS URL and you have the ingest key, point your agents at it. The explicit form:
 
 ```python
-from openrtc import AgentPool
-from voicegateway.openrtc import VoiceGatewayObserver
+from voicegateway import attach
 
-pool = AgentPool(observers=[VoiceGatewayObserver(
-    project="prod",
-    collector_url="https://<your-collector-url>",
-    api_key="<your-ingest-key>",
-)])
+# In your LiveKit agent session handler:
+await attach(session, collector_url="https://<your-daemon-url>", api_key="<your-ingest-key>")
 ```
 
-The env-var form: set `VOICEGW_COLLECTOR_URL` and `VOICEGW_API_KEY` in the agent's environment and use `VoiceGatewayObserver(project="prod")`. Non-OpenRTC agents call `voicegateway.attach(session, collector_url=..., api_key=...)` instead.
+The env-var form: set `VOICEGW_COLLECTOR_URL` and `VOICEGW_API_KEY` in the agent's environment, then call `attach(session)` with no extra arguments. The project is passed as `attach(session, project="prod")`.
 
 ## Verify
 
-Replace `<url>` and `<key>` with your collector's public URL and ingest key:
+Replace `<url>` and `<key>` with your daemon's public URL and ingest key:
 
 ```bash
 curl -fsS https://<url>/health && echo                 # -> ok
 
-# auth gates ingest: no key is rejected, the key is accepted
+# Auth gates ingest: no key is rejected, the key is accepted.
 curl -s -o /dev/null -w "no-key:  %{http_code}  (expect 401/403)\n" \
   -X POST https://<url>/v1/ingest -H 'content-type: application/json' -d '[]'
 curl -s -o /dev/null -w "with-key: %{http_code}  (expect 2xx)\n" \
@@ -51,10 +81,8 @@ curl -s -o /dev/null -w "with-key: %{http_code}  (expect 2xx)\n" \
   -H 'Authorization: Bearer <key>' -d '[]'
 ```
 
-Then open the collector URL in a browser for the dashboard.
-
-## Notes
+Then open the daemon URL in a browser for the dashboard.
 
 <Note>
-The Postgres collector path works as of v0.9.2 (pin `>= 0.9.2`; the image is `mahimairaja/voicegateway:0.9.2`). The ingest key must not start with `vk_`. Only `/v1/ingest` and `/health` need to be public; all other endpoints can be firewall-restricted to your internal network.
+The Postgres-backed daemon path works as of v0.9.2 (pin `>= 0.9.2`; the image is `mahimairaja/voicegateway:0.9.2`). The ingest key must not start with `vk_`. Only `/v1/ingest` and `/health` need to be public; all other endpoints can be firewall-restricted to your internal network.
 </Note>

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploy to Railway"
-description: "Run the VoiceGateway fleet collector on Railway with managed Postgres and automatic HTTPS."
+description: "Run the VoiceGateway daemon on Railway with managed Postgres and automatic HTTPS."
 ---
 
 # Deploy to Railway
@@ -15,17 +15,19 @@ This is the least-ops path. Cost is usage-based and higher than a self-managed V
 
 - A [Railway](https://railway.com) account
 
-## Create the service
+<Steps>
+
+### Create the service
 
 1. In your Railway project, click **New** and choose **Docker Image**.
 2. Enter `mahimairaja/voicegateway:0.9.2` as the image.
 3. In the service settings, set the **exposed port** (also shown as "Port" or "Target Port") to `8080`.
 
-## Add Postgres
+### Add Postgres
 
 Click **New** in the same project and add the **PostgreSQL** plugin. Railway provisions a managed Postgres instance and injects a `DATABASE_URL` environment variable (in `postgres://...` form) into services in the project.
 
-## Configure
+### Configure environment variables
 
 In the collector service's **Variables** tab, add:
 
@@ -45,14 +47,16 @@ VOICEGW_DB_URL=postgresql+asyncpg://<user>:<pass>@<host>:<port>/<db>
 
 `VOICEGW_API_KEY` registers a wildcard ingest key without needing a mounted `voicegw.yaml`.
 
-## Deploy
+### Deploy
 
-Redeploy the service after setting variables. Railway builds and starts the container; HTTPS is automatic at `https://<your-service>.<your-project>.up.railway.app`. You can also attach a custom domain in the service's **Settings** tab.
+Redeploy the service after setting variables. Railway builds and starts the container. HTTPS is automatic at `https://<your-service>.<your-project>.up.railway.app`. You can also attach a custom domain in the service's **Settings** tab.
+
+</Steps>
 
 ## Verify
 
-Follow the steps at [Verify](/deployment#verify), using your Railway service URL as the collector URL and `VOICEGW_API_KEY` as the key.
+Follow the steps at [Verify](/deployment/index#verify), using your Railway service URL as the daemon URL and `VOICEGW_API_KEY` as the key.
 
 ## Connect your agent
 
-See [Connect your agent](/deployment#connect-your-agent). Use the Railway URL as `collector_url` and `VOICEGW_API_KEY` as `api_key`.
+See [Connect your agent](/deployment/index#connect-your-agent). Use the Railway URL as `collector_url` and `VOICEGW_API_KEY` as `api_key`.

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploy to a VPS"
-description: "Run the VoiceGateway fleet collector on your own server with Docker Compose and Caddy for automatic HTTPS."
+description: "Run the VoiceGateway daemon on your own server with Docker Compose and Caddy for automatic HTTPS."
 ---
 
 # Deploy to a VPS
@@ -38,14 +38,23 @@ The ingest key is printed to your terminal and saved to the deploy directory (`/
 
 Prerequisites: Docker and Compose installed (`curl -fsSL https://get.docker.com | sh`).
 
+<Steps>
+
+### Download Compose file and generate secrets
+
 ```bash
 mkdir -p ~/voicegw && cd ~/voicegw
 curl -fsSLO https://raw.githubusercontent.com/mahimailabs/voicegateway/main/docker-compose.collector.yml
 sed -i 's#mahimairaja/voicegateway:latest#mahimairaja/voicegateway:0.9.2#' docker-compose.collector.yml
 
 printf 'VOICEGW_PG_PASSWORD=%s\n' "$(openssl rand -hex 24)" > .env
+```
 
-# Ingest key the agents will present (must NOT start with vk_).
+### Create the ingest key
+
+The ingest key must not start with `vk_`.
+
+```bash
 INGEST_KEY="$(openssl rand -hex 32)"
 cat > voicegw.yaml <<EOF
 auth:
@@ -55,7 +64,11 @@ auth:
       scopes: [write]
 EOF
 echo "AGENT KEY (use as the agent api_key): ${INGEST_KEY}"
+```
 
+### Start the stack
+
+```bash
 docker compose -f docker-compose.collector.yml up -d
 sleep 10 && curl -fsS http://localhost:8080/health && echo     # -> ok
 ```
@@ -64,7 +77,9 @@ sleep 10 && curl -fsS http://localhost:8080/health && echo     # -> ok
 Run the above exactly once. Re-running it regenerates the Postgres password but the existing volume keeps the old one, causing authentication failures. If you need to re-run, bring the stack down first and remove the volume: `docker compose down -v`. The one-line installer avoids this footgun by persisting secrets across runs.
 </Warning>
 
-Postgres runs as a service in this Compose (self-hosted). To use a managed database instead, drop the `postgres` service and set `VOICEGW_DB_URL=postgresql+asyncpg://...` (e.g. a Neon URL) on the `collector` service.
+Postgres runs as a service in this Compose (self-hosted). To use a managed database instead, drop the `postgres` service and set `VOICEGW_DB_URL=postgresql+asyncpg://...` (for example a Neon URL) on the `collector` service.
+
+</Steps>
 
 ## Expose over HTTPS
 
@@ -96,11 +111,11 @@ sudo systemctl reload caddy
 sudo ufw allow 80,443/tcp
 ```
 
-For safety, bind the collector to localhost only by changing the compose port mapping to `127.0.0.1:8080:8080` so only Caddy is internet-facing. Point a DNS A record `collector.<your-domain>` at the VPS IP.
+For safety, bind the daemon to localhost only by changing the compose port mapping to `127.0.0.1:8080:8080` so only Caddy is internet-facing. Point a DNS A record `collector.<your-domain>` at the VPS IP.
 
 ### Reuse an existing reverse proxy
 
-If the box already runs a reverse proxy on 80/443 (for example a self-hosted LiveKit server whose Caddy runs with host networking), that proxy reaches the collector at `localhost:8080` with no extra wiring. The collector publishes 8080 on the host; a host-networked proxy shares the host's network namespace. Add a vhost or TLS-SNI route for `collector.<your-domain>` pointing to `localhost:8080`. Back up the proxy config first and reload it gracefully.
+If the box already runs a reverse proxy on 80/443 (for example a self-hosted LiveKit server whose Caddy runs with host networking), that proxy reaches the daemon at `localhost:8080` with no extra wiring. The daemon publishes 8080 on the host; a host-networked proxy shares the host's network namespace. Add a vhost or TLS-SNI route for `collector.<your-domain>` pointing to `localhost:8080`. Back up the proxy config first and reload it gracefully.
 
 For LiveKit's layer-4 Caddy (structured `caddy.yaml`), add a TLS-SNI route and include the hostname in `apps.tls.certificates.automate`:
 
@@ -125,8 +140,8 @@ Only `/v1/ingest` and `/health` need to be public. Put the dashboard and `/v1/ap
 
 ## Verify
 
-Follow the steps at [Verify](/deployment#verify), using `https://collector.<your-domain>` as the collector URL and the ingest key printed during setup.
+Follow the steps at [Verify](/deployment/index#verify), using `https://collector.<your-domain>` as the daemon URL and the ingest key printed during setup.
 
 ## Connect your agent
 
-See [Connect your agent](/deployment#connect-your-agent). Use `https://collector.<your-domain>` as `collector_url` and the ingest key as `api_key`.
+See [Connect your agent](/deployment/index#connect-your-agent). Use `https://collector.<your-domain>` as `collector_url` and the ingest key as `api_key`.


### PR DESCRIPTION
## Summary

- Rewrites all six deployment pages as a consistent self-host group for the VoiceGateway daemon (HTTP API + dashboard on port 8080)
- Landing page (`deployment/index`) now describes the daemon clearly with a `<CardGroup>` linking into all five sub-pages
- `fly.md`, `railway.md`, `vps.md` converted to `<Steps>` sequences; VPS page adds a three-step manual-setup flow
- `auto-update.md` converts the restore procedure to `<Steps>` and updates "collector" references to "daemon" throughout
- `distributed-sfu.md` converts the Fly deploy sequence to `<Steps>`
- Fixes all broken internal links: `/deployment` -> `/deployment/index#verify` and `/deployment/index#connect-your-agent` across fly, railway, and vps pages

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 6 scoped)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guides to consistently describe the VoiceGateway daemon.
  * Added clearer prerequisites, platform choices, and step-by-step setup instructions.
  * Improved Docker, Fly.io, Railway, VPS, and distributed SFU deployment guidance.
  * Clarified daemon auto-updates, release pinning, backup restoration, and opting out.
  * Updated agent connection and verification instructions, including current URLs and API key usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->