### PR TITLE
docs(examples): rewrite Examples gallery (P7)

### DIFF
--- a/docs/examples/basic-voice-agent.md
+++ b/docs/examples/basic-voice-agent.md
@@ -1,13 +1,25 @@
+---
+title: Basic Voice Agent
+description: Build a minimal metered voice agent using LiveKit or Pipecat with VoiceGateway cost tracking.
+---
+
 # Basic Voice Agent
 
-Build a voice agent with LiveKit Agents using VoiceGateway to route STT, LLM, and TTS requests.
+The minimal setup to get a working, metered voice pipeline. Use `attach(session)` to add cost tracking to a session you build yourself with native provider plugins.
 
-## Prerequisites
+## Install
 
-```bash
-pip install voicegateway[openai,deepgram,cartesia]
+<CodeGroup>
+```bash uv
+uv add "voicegateway[openai,deepgram,cartesia]"
+uv add livekit-agents livekit-plugins-deepgram livekit-plugins-openai livekit-plugins-cartesia
+```
+
+```bash pip
+pip install "voicegateway[openai,deepgram,cartesia]"
 pip install livekit-agents livekit-plugins-deepgram livekit-plugins-openai livekit-plugins-cartesia
 ```
+</CodeGroup>
 
 ## Configuration
 
@@ -36,33 +48,14 @@ observability:
   latency_tracking: true
 ```
 
-## Basic Usage
+## Agent code
 
-```python
-from voicegateway import inference
-
-# Each factory returns a wrapped LiveKit plugin instance, ready to drop
-# into AgentSession. Cost, latency, and session correlation happen
-# transparently in the middleware.
-stt = inference.STT("deepgram/nova-3")
-llm = inference.LLM("openai/gpt-4.1-mini")
-tts = inference.TTS("cartesia/sonic-3")
-```
-
-If you already build your own LiveKit plugins, use the session observer instead:
-
-```python
-from voicegateway import attach
-
-session_id = attach(session)
-```
-
-## LiveKit Agent Integration
-
+<Tabs>
+  <Tab title="LiveKit">
 ```python
 from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
-from livekit.plugins import silero
-from voicegateway import inference
+from livekit.plugins import cartesia, deepgram, openai, silero
+from voicegateway import attach
 
 
 async def entrypoint(ctx: JobContext):
@@ -70,14 +63,17 @@ async def entrypoint(ctx: JobContext):
 
     session = AgentSession(
         vad=silero.VAD.load(),
-        stt=inference.STT("deepgram/nova-3"),
-        llm=inference.LLM("openai/gpt-4.1-mini"),
-        tts=inference.TTS("cartesia/sonic-3"),
+        stt=deepgram.STT(model="nova-3"),
+        llm=openai.LLM(model="gpt-4o-mini"),
+        tts=cartesia.TTS(model="sonic-3"),
     )
+
+    # Single passive meter: records cost, latency, and session id.
+    attach(session, project="voice-agent")
 
     await session.start(
         agent=Agent(
-            instructions="You are a helpful voice assistant. Be concise in your responses.",
+            instructions="You are a helpful voice assistant. Be concise.",
         ),
         room=ctx.room,
     )
@@ -86,61 +82,63 @@ async def entrypoint(ctx: JobContext):
 if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
 ```
-
-## Multiple agents in one process
-
-When one process serves multiple agents (e.g., one worker handling several entrypoints), set the active project per call context:
-
+  </Tab>
+  <Tab title="Pipecat">
 ```python
-from voicegateway import inference
+import os
 
-async def restaurant_entrypoint(ctx):
-    inference.set_project("restaurant-agent")
-    # all inference factories below charge the restaurant-agent project
-    ...
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.openai.llm import OpenAILLMService
+from voicegateway import attach
 
-async def support_entrypoint(ctx):
-    inference.set_project("support-agent")
-    # sibling tasks each have their own ContextVar; no leakage
-    ...
+
+def build_task(transport_input, transport_output):
+    stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+    llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4o-mini")
+    tts = CartesiaTTSService(api_key=os.environ["CARTESIA_API_KEY"])
+
+    pipeline = Pipeline([transport_input, stt, llm, tts, transport_output])
+
+    task = PipelineTask(
+        pipeline,
+        # Pipecat must emit usage frames for attach() to record them.
+        params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+    )
+
+    # Attach the single passive meter after task construction.
+    attach(task, project="voice-agent")
+    return task
+```
+  </Tab>
+</Tabs>
+
+## Run
+
+```bash
+python agent.py start
 ```
 
-## Checking Costs
+The standard `livekit-agents` worker CLI connects to your LiveKit server. Costs and latency land in the dashboard under the `voice-agent` project.
+
+## Check costs
 
 ```bash
 voicegw costs --project voice-agent
-voicegw logs --project voice-agent
-
-# Or open the dashboard in your browser (the daemon already serves it):
+voicegw logs  --project voice-agent
 voicegw dashboard
-# Default URL: http://localhost:8080
 ```
 
+Or via the HTTP API:
+
 ```bash
-# From the HTTP API:
 curl 'http://localhost:8080/v1/costs?period=today&project=voice-agent'
 ```
 
-## Monitoring Latency
+## Notes
 
-VoiceGateway automatically records TTFB and total latency for every request. View these metrics through the dashboard or the HTTP API:
-
-```bash
-curl http://localhost:8080/v1/metrics?period=today
-```
-
-The `latency.ttfb_warning_ms` config value (default 500ms) triggers a log warning when TTFB exceeds the threshold, useful for catching provider degradation early.
-
-## What Happens Under the Hood
-
-When you call `inference.STT("deepgram/nova-3")`:
-
-1. The factory parses `"deepgram/nova-3"` into provider `"deepgram"` and model `"nova-3"`.
-2. The active project is resolved (set_project / env / yaml default / `"default"`).
-3. The provider's API key is looked up: per-project entry first, then top-level `providers:`.
-4. The Registry lazily imports and instantiates `DeepgramProvider`.
-5. The provider creates a `livekit.plugins.deepgram.STT` instance.
-6. The instance is wrapped in `InstrumentedSTT` to track cost, latency, and the session id.
-7. You get back an object that behaves exactly like the underlying LK plugin instance.
-
-All of this is transparent: your LiveKit Agent code sees the same API surface whether it uses `voicegateway.inference` or direct plugin imports.
+- `attach()` is passive: it measures but never reroutes traffic.
+- To add fallback or a spend cap, wrap the LLM with [`guard()`](/guide/guard) before passing it to `AgentSession`.
+- For the full `attach` + `guard` worked example, see [LiveKit: attach + guard](/examples/livekit-attach-guard).

--- a/docs/examples/budget-enforcement.md
+++ b/docs/examples/budget-enforcement.md
@@ -1,8 +1,49 @@
+---
+title: Budget Enforcement
+description: Enforce a daily spend cap using guard(llm, budget="$5.00/day") with warn, throttle, and block modes.
+---
+
 # Budget Enforcement
 
-VoiceGateway supports per-project daily budgets with three enforcement modes: `warn`, `throttle`, and `block`. Budgets are enforced at request-completion time inside the cost tracker; the `inference` factories themselves never raise on budget. The `BudgetThrottleSignal` and `BudgetExceededError` types are available for callers that want to wire their own pre-request check (CLI / HTTP / dashboard).
+Use `guard()` to attach a daily budget to any provider. When the budget is exceeded, `guard()` can warn and continue, throttle to a cheaper fallback, or block the request outright.
+
+## The three modes
+
+```python
+from livekit.plugins import openai
+from voicegateway import guard
+
+# warn: log and continue (default when you pass budget= without budget_action)
+llm_warn = guard(
+    openai.LLM(model="gpt-4o-mini"),
+    budget="$5.00/day",
+    project="warn-demo",
+)
+
+# throttle: fall back to a cheaper provider when the budget is exceeded
+llm_throttle = guard(
+    openai.LLM(model="gpt-4o-mini"),
+    fallback=[openai.LLM(model="gpt-4o-mini")],   # swap in a local/cheaper model
+    budget="$5.00/day",
+    project="throttle-demo",
+)
+
+# block: raise BudgetExceededError when the budget is exceeded
+llm_block = guard(
+    openai.LLM(model="gpt-4o-mini"),
+    budget="$5.00/day",
+    project="block-demo",
+)
+```
+
+<Note>
+`guard()` returns the same type as the provider you pass in, so it is a
+drop-in replacement anywhere you use the provider directly.
+</Note>
 
 ## Configuration
+
+Set the budget and action per project in `voicegw.yaml`:
 
 ```yaml
 projects:
@@ -51,21 +92,9 @@ cost_tracking:
   enabled: true
 ```
 
-## Mode 1: Warn
+## Mode 1: warn
 
 The `warn` mode logs a warning when the budget is exceeded but allows all requests to proceed. Use this for visibility without disrupting service.
-
-```python
-from voicegateway.core.active_project import set_project
-from voicegateway.inference import STT, LLM, TTS
-
-set_project("warn-demo")
-# Requests proceed even after budget is exceeded.
-# Check your logs for: "Project 'warn-demo' exceeded daily budget: $X.XX / $1.00"
-stt = STT("deepgram/nova-3")
-llm = LLM("openai/gpt-4.1-mini")
-tts = TTS("cartesia/sonic-3")
-```
 
 **Log output when budget is exceeded:**
 
@@ -73,53 +102,64 @@ tts = TTS("cartesia/sonic-3")
 WARNING - Project 'warn-demo' exceeded daily budget: $1.23 / $1.00
 ```
 
-## Mode 2: Throttle (caller-driven)
+## Mode 2: throttle
 
-The inference factories do not raise `BudgetThrottleSignal` themselves. Wire a pre-flight check in your worker if you want the throttle path:
+With `fallback=` set, `guard()` switches to the fallback provider when the budget is exceeded instead of raising:
 
 ```python
-from voicegateway import inference
-from voicegateway.inference._factory import get_gateway
-from voicegateway.middleware.budget_enforcer import BudgetThrottleSignal
+from livekit.plugins import openai
+from livekit.plugins import silero
+from voicegateway import attach, guard
 
 
-async def stt_for(project: str):
-    gw = get_gateway()
-    try:
-        await gw._budget_enforcer.check_budget(project)
-    except BudgetThrottleSignal:
-        # Budget exceeded -- fall back to local Whisper.
-        inference.set_project(project)
-        return inference.STT("local/whisper-large-v3")
-    inference.set_project(project)
-    return inference.STT("deepgram/nova-3")
+async def entrypoint(ctx):
+    from livekit.agents import Agent, AgentSession
+
+    await ctx.connect()
+
+    session = AgentSession(
+        vad=silero.VAD.load(),
+        stt=...,
+        llm=guard(
+            openai.LLM(model="gpt-4o-mini"),
+            fallback=[openai.LLM(model="gpt-4o-mini")],  # local or cheaper model
+            budget="$1.00/day",
+            project="throttle-demo",
+        ),
+        tts=...,
+    )
+
+    attach(session, project="throttle-demo")
+    await session.start(agent=Agent(instructions="Be concise."), room=ctx.room)
 ```
 
-The `_budget_enforcer` reference is an internal handle today; a public `inference.check_budget()` helper is planned so callers no longer reach into a private attribute.
+## Mode 3: block
 
-## Mode 3: Block (caller-driven)
+When the budget is exhausted, `guard()` raises `BudgetExceededError`. Catch it in your worker:
 
 ```python
 import asyncio
 
-from voicegateway import inference
-from voicegateway.inference._factory import get_gateway
+from livekit.plugins import openai
+from voicegateway import attach, guard
 from voicegateway.middleware.budget_enforcer import BudgetExceededError
 
 
 async def main():
-    gw = get_gateway()
+    guarded_llm = guard(
+        openai.LLM(model="gpt-4o-mini"),
+        budget="$1.00/day",
+        project="block-demo",
+    )
     try:
-        await gw._budget_enforcer.check_budget("block-demo")
+        # guard() raises BudgetExceededError when the cap is hit.
+        result = await guarded_llm.chat(...)
     except BudgetExceededError as e:
         print(f"Request blocked: {e}")
         print(f"  Project: {e.project}")
         print(f"  Spent today: ${e.spent_usd:.2f}")
         print(f"  Daily budget: ${e.budget_usd:.2f}")
-        # Handle gracefully -- show user a message, queue for later, etc.
-    else:
-        inference.set_project("block-demo")
-        stt = inference.STT("deepgram/nova-3")
+        # Handle gracefully: show user a message, queue for later, etc.
 
 
 asyncio.run(main())
@@ -134,12 +174,11 @@ Request blocked: Project 'block-demo' exceeded daily budget: $1.23 / $1.00
   Daily budget: $1.00
 ```
 
-## Budget Status API
+## Budget status via the HTTP API
 
 Check budget status before making a request:
 
 ```python
-# Via the HTTP API
 import httpx
 
 resp = httpx.get("http://localhost:8080/v1/projects")
@@ -148,55 +187,31 @@ for project in resp.json()["projects"]:
     # "ok", "warning" (>80% spent), or "exceeded"
 ```
 
-The `BudgetEnforcer.get_budget_status()` method returns:
-
 | Status | Condition |
 |--------|-----------|
 | `"ok"` | Under 80% of budget |
 | `"warning"` | Between 80% and 100% of budget |
 | `"exceeded"` | At or over 100% of budget |
 
-## Cache Behavior
+## Cache behavior
 
-Budget checks are cached in memory with a **30-second TTL** to avoid hitting SQLite on every single request. This means:
+Budget checks are cached in memory with a **30-second TTL** to avoid hitting SQLite on every single request. A budget may be briefly exceeded before the cache refreshes. For high-throughput scenarios this tradeoff is usually acceptable.
 
-- A budget may be briefly exceeded before the cache refreshes
-- The maximum over-spend window is 30 seconds of requests
-- The TTL is configurable via `BudgetEnforcer(cache_ttl_seconds=30.0)`
+## Combining with fallback chains
 
-For high-throughput scenarios, this tradeoff between precision and performance is usually acceptable. If you need tighter enforcement, reduce the TTL:
-
-```python
-# In a custom Gateway subclass or direct instantiation
-enforcer = BudgetEnforcer(config, storage, cache_ttl_seconds=5.0)
-```
-
-## Combining with Fallback Chains
-
-The throttle path can be paired with the manual chain walk pattern from [Fallback Chains](/examples/fallback-chains): on `BudgetThrottleSignal`, walk a chain that ends in a local model.
+The throttle path pairs naturally with the chain walk pattern from [Fallback Chains](/examples/fallback-chains). Pass a local or cheaper model as the `fallback=` to `guard()` so throttled calls still resolve:
 
 ```yaml
+providers:
+  deepgram:
+    api_key: ${DEEPGRAM_API_KEY}
+  ollama:
+    base_url: http://localhost:11434
+  whisper: {}
+  kokoro: {}
+
 projects:
   prod:
     daily_budget: 50.00
     budget_action: throttle
-    providers:
-      deepgram:
-        api_key: ${DEEPGRAM_API_KEY}
-
-fallbacks:
-  stt:
-    - deepgram/nova-3
-    - local/whisper-large-v3
-```
-
-```python
-async def stt_for(project: str):
-    gw = get_gateway()
-    try:
-        await gw._budget_enforcer.check_budget(project)
-    except BudgetThrottleSignal:
-        # Walk the chain to land on the cheaper / local backup.
-        return first_resolvable("stt", ["deepgram/nova-3", "local/whisper-large-v3"])
-    return inference.STT("deepgram/nova-3")
 ```

--- a/docs/examples/claude-code-integration.md
+++ b/docs/examples/claude-code-integration.md
@@ -1,17 +1,27 @@
+---
+title: Claude Code Integration
+description: Use VoiceGateway's MCP server with Claude Code to manage providers, projects, and costs through natural language.
+---
+
 # Claude Code Integration
 
 VoiceGateway includes an MCP (Model Context Protocol) server that lets you manage providers, models, projects, and monitor costs directly from Claude Code using natural language.
 
 ## Setup
 
-### 1. Install the MCP Extra
-
-```bash
-pip install voicegateway[mcp]
+<Steps>
+  <Step title="Install the MCP extra">
+<CodeGroup>
+```bash uv
+uv add "voicegateway[mcp]"
 ```
 
-### 2. Configure Claude Code
-
+```bash pip
+pip install "voicegateway[mcp]"
+```
+</CodeGroup>
+  </Step>
+  <Step title="Configure Claude Code">
 Add VoiceGateway to your Claude Code MCP settings (`~/.claude/settings.json` or your project's `.mcp.json`):
 
 ```json
@@ -28,25 +38,24 @@ Add VoiceGateway to your Claude Code MCP settings (`~/.claude/settings.json` or 
 }
 ```
 
-### 3. Verify the Connection
-
+See [MCP setup](/mcp/setup) for the full configuration reference.
+  </Step>
+  <Step title="Verify the connection">
 Start Claude Code and ask it to check VoiceGateway status. The MCP server exposes 17 tools across four categories: providers, models, projects, and observability.
+  </Step>
+</Steps>
 
-## Prompt Examples
+## Prompt examples
 
-### 1. Check System Status
-
-**Prompt:**
+### Check system status
 
 ```
 What providers are configured in VoiceGateway? Show me the status of each one.
 ```
 
-Claude Code will call the `list_providers` tool and display all configured providers, their types (cloud vs. local), and whether they have valid credentials (API keys are shown masked, e.g., `sk-p...z789`).
+Claude Code calls the `list_providers` tool and displays all configured providers, their types (cloud vs. local), and whether they have valid credentials (API keys are shown masked).
 
-### 2. Add a New Provider
-
-**Prompt:**
+### Add a new provider
 
 ```
 Add a Groq provider to VoiceGateway with API key "gsk_abc123xyz789".
@@ -54,14 +63,12 @@ Then register the llama-3.3-70b-versatile model as an LLM.
 ```
 
 Claude Code will:
-1. Call `create_provider` with `provider_id="groq"`, `provider_type="groq"`, and the API key
-2. Call `register_model` with `model_id="groq/llama-3.3-70b-versatile"`, `modality="llm"`, `provider_id="groq"`
-3. The API key is encrypted with Fernet before storage
-4. Both actions are recorded in the audit log
+1. Call `create_provider` with `provider_id="groq"`, `provider_type="groq"`, and the API key.
+2. Call `register_model` with `model_id="groq/llama-3.3-70b-versatile"`, `modality="llm"`, `provider_id="groq"`.
+3. The API key is encrypted with Fernet before storage.
+4. Both actions are recorded in the audit log.
 
-### 3. Create a Project with Budget
-
-**Prompt:**
+### Create a project with budget
 
 ```
 Create a new project called "customer-support" with a $25 daily budget.
@@ -69,70 +76,53 @@ Set it to throttle mode so it falls back to local models when the budget is exce
 Tag it as "production" and "support".
 ```
 
-Claude Code will call `create_project` with:
-- `project_id`: `"customer-support"`
-- `name`: `"Customer Support"`
-- `daily_budget`: `25.00`
-- `budget_action`: `"throttle"`
-- `tags`: `["production", "support"]`
+Claude Code calls `create_project` with `project_id="customer-support"`, `daily_budget=25.00`, `budget_action="throttle"`, and `tags=["production", "support"]`.
 
-### 4. Monitor Costs
-
-**Prompt:**
+### Monitor costs
 
 ```
 Show me today's costs broken down by project and provider.
 Which model is costing us the most?
 ```
 
-Claude Code will call the `get_costs` tool with `period="today"` and present the results as a structured breakdown. It will also call `get_cost_by_project` to show per-project spending and identify the most expensive model.
+Claude Code calls `get_costs` with `period="today"` and presents the results as a structured breakdown, then calls `get_cost_by_project` to show per-project spending and identify the most expensive model.
 
-### 5. View Recent Requests and Latency
-
-**Prompt:**
+### View recent requests and latency
 
 ```
 Show me the last 20 requests to VoiceGateway. Are there any with high latency or errors?
 Flag any requests where TTFB exceeded 500ms.
 ```
 
-Claude Code will call `get_recent_requests` with `limit=20` and analyze the results, highlighting:
+Claude Code calls `get_recent_requests` with `limit=20` and analyzes the results, highlighting:
 - Requests with `status: "error"`
 - Requests where `ttfb_ms > 500`
-- Any fallback events (`fallback_from` is not null)
+- Any fallback events where `fallback_from` is not null
 
-### 6. Audit Configuration Changes
-
-**Prompt:**
+### Audit configuration changes
 
 ```
 Show me all configuration changes made to VoiceGateway in the last 24 hours.
 Who added or modified providers?
 ```
 
-Claude Code will call `get_audit_log` and display the history of changes, including:
-- What was changed (provider, model, or project)
-- What action was taken (create, update, delete)
-- The source of the change (api, mcp, dashboard)
-- What specifically changed (from the `changes_json` field)
+Claude Code calls `get_audit_log` and displays the history of changes, including what was changed, what action was taken, the source of the change (api, mcp, dashboard), and what specifically changed.
 
-### 7. Delete Unused Resources
-
-**Prompt:**
+### Delete unused resources
 
 ```
 List all models registered in VoiceGateway. Delete the ones that have had zero requests in the last 30 days.
 ```
 
 Claude Code will:
-1. Call `list_models` to get all registered models
-2. Call `get_costs` with `period="month"` to check usage
-3. Identify models with zero requests
-4. Call `delete_model` for each unused model (after confirming with you)
+1. Call `list_models` to get all registered models.
+2. Call `get_costs` with `period="month"` to check usage.
+3. Identify models with zero requests.
+4. Call `delete_model` for each unused model (after confirming with you).
 
-## Available MCP Tools
+## Available MCP tools
 
-### Provider Tools
+### Provider tools
 
 | Tool | Description |
 |------|-------------|
@@ -141,7 +131,7 @@ Claude Code will:
 | `create_provider` | Add a new provider with encrypted API key |
 | `delete_provider` | Remove a provider |
 
-### Model Tools
+### Model tools
 
 | Tool | Description |
 |------|-------------|
@@ -150,7 +140,7 @@ Claude Code will:
 | `register_model` | Register a new model for a provider |
 | `delete_model` | Remove a model registration |
 
-### Project Tools
+### Project tools
 
 | Tool | Description |
 |------|-------------|
@@ -159,7 +149,7 @@ Claude Code will:
 | `create_project` | Create a new project with budget settings |
 | `delete_project` | Remove a project |
 
-### Observability Tools
+### Observability tools
 
 | Tool | Description |
 |------|-------------|
@@ -188,7 +178,7 @@ The MCP server supports API key authentication. Set the `VOICEGW_MCP_API_KEY` en
 }
 ```
 
-## End-to-End Workflow
+## End-to-end workflow
 
 Here is a complete workflow you can run through Claude Code:
 

--- a/docs/examples/docker-deployment.md
+++ b/docs/examples/docker-deployment.md
@@ -1,16 +1,18 @@
+---
+title: Docker Deployment
+description: Production-ready Docker Compose configuration with health checks, persistent storage, and an optional Ollama sidecar.
+---
+
 # Docker Deployment
 
 Deploy VoiceGateway in production with Docker Compose. The
 daemon serves the HTTP API and the web dashboard on the same port,
-so one service is enough; the optional dashboard service in the
-compose file below is a convenience for operators who want the
-dashboard reachable on a different external port. Includes
-persistent storage, health checks, and an optional Ollama sidecar
-for local LLM inference.
+so one service is enough. Includes persistent storage, health checks,
+and an optional Ollama sidecar for local LLM inference.
 
-For hosting the collector on a VPS, Railway, or Fly.io, see [Deployment](/deployment).
+For hosting the collector on a VPS, Railway, or Fly.io, see [Deployment](/deployment/index).
 
-## Project Structure
+## Project structure
 
 ```
 your-project/
@@ -19,7 +21,7 @@ your-project/
   .env
 ```
 
-## Environment Variables
+## Environment variables
 
 Create a `.env` file with your provider API keys:
 
@@ -41,7 +43,7 @@ VOICEGW_SECRET=your-base64-fernet-key
 Never commit `.env` files to version control. Add `.env` to your `.gitignore`.
 </Warning>
 
-### Generating a Fernet Key
+### Generating a Fernet key
 
 If you do not set `VOICEGW_SECRET`, VoiceGateway auto-generates one on first run and stores it in the container. Since containers are ephemeral, set this explicitly for production:
 
@@ -68,46 +70,11 @@ providers:
   elevenlabs:
     api_key: ${ELEVENLABS_API_KEY}
 
-models:
-  stt:
-    deepgram/nova-3:
-      provider: deepgram
-      model: nova-3
-  llm:
-    openai/gpt-4.1-mini:
-      provider: openai
-      model: gpt-4.1-mini
-    anthropic/claude-sonnet-4-20250514:
-      provider: anthropic
-      model: claude-sonnet-4-20250514
-  tts:
-    cartesia/sonic-3:
-      provider: cartesia
-      model: sonic-3
-      default_voice: 794f9389-aac1-45b6-b726-9d9369183238
-
-stacks:
-  premium:
-    stt: deepgram/nova-3
-    llm: openai/gpt-4.1-mini
-    tts: cartesia/sonic-3
-
-fallbacks:
-  stt:
-    - deepgram/nova-3
-  llm:
-    - openai/gpt-4.1-mini
-    - anthropic/claude-sonnet-4-20250514
-  tts:
-    - cartesia/sonic-3
-    - elevenlabs/turbo-v2.5
-
 projects:
   prod:
     name: Production
     daily_budget: 100.00
     budget_action: throttle
-    default_stack: premium
     tags: [production]
 
 cost_tracking:
@@ -157,10 +124,6 @@ services:
     networks:
       - voicegw-net
 
-  # The dashboard runs inside the voicegateway service: the daemon
-  # mounts the React SPA at / and the dashboard API at /api/* on
-  # the same port as the public HTTP API. No second service needed.
-
   # Optional: local LLM via Ollama
   ollama:
     image: ollama/ollama:latest
@@ -186,7 +149,7 @@ networks:
     driver: bridge
 ```
 
-## Starting the Services
+## Starting the services
 
 ### Cloud-only (API + Dashboard)
 
@@ -194,11 +157,10 @@ networks:
 docker compose up -d
 ```
 
-This starts:
-- **voicegateway** on port 8080 (HTTP API)
-- **dashboard** on port 9090 (Web UI)
+This starts the **voicegateway** service on port 8080. The daemon serves both
+the HTTP API and the React dashboard SPA on the same port.
 
-### With Local Ollama
+### With local Ollama
 
 ```bash
 docker compose --profile local up -d
@@ -206,9 +168,6 @@ docker compose --profile local up -d
 # Pull a model into Ollama
 docker exec voicegateway-ollama ollama pull qwen2.5:3b
 ```
-
-This adds:
-- **ollama** on port 11434
 
 Update `voicegw.yaml` to use the container hostname:
 
@@ -221,22 +180,16 @@ providers:
 ### Fleet collector (Postgres)
 
 To run the self-hosted collector that many LiveKit agents push telemetry to,
-use the Postgres-backed stack. The same container serves `POST /v1/ingest`, the
-dashboard API, and the SPA on port 8080.
+use the Postgres-backed stack:
 
 ```bash
 docker compose -f docker-compose.collector.yml up -d
 ```
 
 This starts a `postgres` service and a `collector` service. The collector reads
-its database from `VOICEGW_DB_URL`; setting that enables storage automatically,
-so `cost_tracking` does not need to be turned on by hand. The image ships the
-`postgres` extra (asyncpg) and the migrations, so it builds its schema on first
-start. Provide a `voicegw.yaml` next to the compose file (the collector mainly
-needs `auth.api_keys` for the agents' virtual keys), and set
-`VOICEGW_PG_PASSWORD` for anything beyond a local trial.
-
-Point the official image at any Postgres directly without compose:
+its database from `VOICEGW_DB_URL` and builds its schema on first start.
+Set `VOICEGW_PG_PASSWORD` for anything beyond a local trial. Point the official
+image at any Postgres directly without compose:
 
 ```bash
 docker run -p 8080:8080 \
@@ -246,11 +199,10 @@ docker run -p 8080:8080 \
   mahimairaja/voicegateway:latest
 ```
 
-## Verifying the Deployment
-
-### Health Check
+## Verifying the deployment
 
 ```bash
+# Health check
 curl http://localhost:8080/health
 ```
 
@@ -262,38 +214,29 @@ curl http://localhost:8080/health
 }
 ```
 
-### Provider Status
-
 ```bash
+# Provider status
 curl http://localhost:8080/v1/status
+
+# Open the dashboard
+open http://localhost:8080
 ```
 
-### Dashboard
+## Production considerations
 
-Open http://localhost:8080 in your browser to see the dashboard with cost charts, latency metrics, and request logs. The daemon serves both the React UI and the dashboard API at this port.
+### Persistent storage
 
-## Production Considerations
-
-### Persistent Storage
-
-The `voicegw-data` volume stores the SQLite database. This persists across container restarts and rebuilds. To back up:
+The `voicegw-data` volume stores the SQLite database. To back up:
 
 ```bash
-# Copy the database out of the volume
 docker cp voicegateway:/data/voicegw.db ./backup-$(date +%Y%m%d).db
 ```
 
-### Encryption Key Persistence
+### Encryption key persistence
 
-If you do not set `VOICEGW_SECRET`, a new Fernet key is generated on first run and stored in the container filesystem (not the volume). This means:
+**Always set `VOICEGW_SECRET` in production.** If you do not set it, a new Fernet key is generated on first run and stored in the container filesystem. Rebuilding the container loses the key, making encrypted API keys in the database unreadable.
 
-- Rebuilding the container loses the key
-- Encrypted API keys in the database become undecryptable
-- You will need to re-add managed providers
-
-**Always set `VOICEGW_SECRET` in production** via the `.env` file or a secrets manager.
-
-### Reverse Proxy
+### Reverse proxy
 
 For TLS termination, put Nginx or Caddy in front:
 
@@ -307,14 +250,11 @@ For TLS termination, put Nginx or Caddy in front:
       - ./certs:/etc/nginx/certs:ro
     depends_on:
       - voicegateway
-      - dashboard
     networks:
       - voicegw-net
 ```
 
-### Resource Limits
-
-For production deployments, add resource constraints:
+### Resource limits
 
 ```yaml
   voicegateway:
@@ -330,8 +270,6 @@ For production deployments, add resource constraints:
 
 ### Logging
 
-VoiceGateway logs to stdout. Use Docker's logging driver to ship logs:
-
 ```yaml
   voicegateway:
     logging:
@@ -341,41 +279,11 @@ VoiceGateway logs to stdout. Use Docker's logging driver to ship logs:
         max-file: "3"
 ```
 
-## Connecting Your Application
-
-From your voice agent application, point inference factories at the deployed VoiceGateway by sharing the same `voicegw.yaml`:
-
-```python
-import os
-os.environ["VOICEGW_CONFIG"] = "/path/to/voicegw.yaml"
-
-from voicegateway import inference
-
-stt = inference.STT("deepgram/nova-3")
-```
-
-For pure observability calls (status, costs, logs), hit the HTTP API:
-
-```python
-import httpx
-resp = httpx.get("http://localhost:8080/v1/status")
-```
-
-If your application runs in a separate container on the same Docker network, use the service name:
-
-```python
-# From another container on voicegw-net
-resp = httpx.get("http://voicegateway:8080/v1/status")
-```
-
 ## Updating
 
 ```bash
-# Pull latest code and rebuild
 git pull
 docker compose build
 docker compose up -d
-
-# The SQLite database auto-migrates on startup
-# No manual migration steps needed
+# The SQLite database auto-migrates on startup.
 ```

--- a/docs/examples/fallback-chains.md
+++ b/docs/examples/fallback-chains.md
@@ -1,13 +1,17 @@
+---
+title: Fallback Chains
+description: Startup-time provider selection using guard() with fallback= so the first available provider wins.
+---
+
 # Fallback Chains
 
-Resolver-time fallback at agent startup: walk a chain of model ids and pass the first one whose `inference.STT/LLM/TTS` factory builds cleanly into `AgentSession`. Useful when a primary provider's credentials are temporarily wrong, its plugin SDK is missing, or its initialization handshake fails.
+Use `guard(primary, fallback=[backup1, backup2])` to wire a chain of providers at startup. If the primary is unavailable or fails, `guard()` advances to the next provider in the list.
 
-Once a model is wired into a LiveKit `AgentSession`, that resolved model is used for the entire call. VoiceGateway does not swap providers mid-call. For runtime failover when a provider degrades during an active call, compose LiveKit's `FallbackAdapter` around VG `inference.*` instances; see [LiveKit FallbackAdapter integration](/examples/livekit-fallback-adapter).
-
-VoiceGateway does not run an automatic fallback middleware. The
-chain in `voicegw.yaml` (under `fallbacks:`) is a documentation +
-walk-pattern convention: enumerate the chain at startup and pick
-the first model whose factory builds.
+<Note>
+Resolver-time fallback handles startup selection. Once a session is live,
+providers are not swapped mid-call. For runtime failover during an active call,
+see [LiveKit FallbackAdapter integration](/examples/livekit-fallback-adapter).
+</Note>
 
 ## Configuration
 
@@ -31,113 +35,85 @@ projects:
 
 default_project: prod
 
-# Fallback chains: first model is primary, rest are backups. The
-# YAML chain is documentation; the manual walk below picks the
-# first model whose factory builds.
-fallbacks:
-  stt:
-    - deepgram/nova-3              # Primary: fastest, best accuracy
-    - openai/whisper-1             # Backup: good accuracy, higher latency
-    - local/whisper-large-v3       # Last resort: local, no API dependency
-  llm:
-    - openai/gpt-4.1-mini          # Primary: best quality
-    - groq/llama-3.3-70b-versatile # Backup: fast, good quality
-    - ollama/qwen2.5:3b            # Last resort: local
-  tts:
-    - cartesia/sonic-3             # Primary: lowest latency
-    - elevenlabs/turbo-v2.5        # Backup: highest quality
-    - local/kokoro                 # Last resort: local
-
 cost_tracking:
   enabled: true
 ```
 
-## Using Fallback Chains
+## Wiring chains with guard()
 
 ```python
-from voicegateway import inference
+from livekit.plugins import cartesia, deepgram, elevenlabs, openai
+from livekit.plugins import groq as groq_plugin
+from voicegateway import attach, guard
 
 
-def first_resolvable(modality: str, chain: list[str]):
-    """Walk the chain, return the first inference instance that builds.
+def build_session():
+    from livekit.agents import AgentSession
+    from livekit.plugins import silero
 
-    Raises the last error if every model fails.
-    """
-    factory = {
-        "stt": inference.STT,
-        "llm": inference.LLM,
-        "tts": inference.TTS,
-    }[modality]
-    last_error: Exception | None = None
-    for model_id in chain:
-        try:
-            return factory(model_id)
-        except Exception as exc:  # noqa: BLE001
-            last_error = exc
-    assert last_error is not None
-    raise last_error
-
-
-STT_CHAIN = ["deepgram/nova-3", "openai/whisper-1", "local/whisper-large-v3"]
-LLM_CHAIN = [
-    "openai/gpt-4.1-mini",
-    "groq/llama-3.3-70b-versatile",
-    "ollama/qwen2.5:3b",
-]
-TTS_CHAIN = ["cartesia/sonic-3", "elevenlabs/turbo-v2.5", "local/kokoro"]
-
-stt = first_resolvable("stt", STT_CHAIN)
-llm = first_resolvable("llm", LLM_CHAIN)
-tts = first_resolvable("tts", TTS_CHAIN)
+    return AgentSession(
+        vad=silero.VAD.load(),
+        stt=guard(
+            deepgram.STT(model="nova-3"),
+            fallback=[
+                openai.STT(model="whisper-1"),
+            ],
+            project="prod",
+        ),
+        llm=guard(
+            openai.LLM(model="gpt-4o-mini"),
+            fallback=[
+                groq_plugin.LLM(model="llama-3.3-70b-versatile"),
+            ],
+            project="prod",
+        ),
+        tts=guard(
+            cartesia.TTS(model="sonic-3"),
+            fallback=[
+                elevenlabs.TTS(model="turbo-v2.5"),
+            ],
+            project="prod",
+        ),
+    )
 ```
 
-## How Fallback Works
+`guard()` returns the same type as the primary, so it is a drop-in replacement
+anywhere you would use the provider directly.
 
-The factory walk runs once at construction time:
-
-```mermaid
-graph TD
-    A["first_resolvable('stt', chain)"] --> B["inference.STT('deepgram/nova-3')"]
-    B -->|Success| C["Return DeepgramSTT instance"]
-    B -->|ImportError / init error| D["Catch and continue"]
-    D --> E["inference.STT('openai/whisper-1')"]
-    E -->|Success| F["Return OpenAI Whisper instance"]
-    E -->|Init error| G["inference.STT('local/whisper-large-v3')"]
-    G -->|Success| H["Return local Whisper instance"]
-    G -->|Init error| I["raise (last error)"]
-```
-
-Errors during an `AgentSession` are not in this picture; they propagate to the caller.
-
-## LiveKit Agent with Fallback
+## Full LiveKit agent with fallback
 
 ```python
 from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
-from livekit.plugins import silero
-from voicegateway import inference
+from livekit.plugins import cartesia, deepgram, elevenlabs, openai, silero
+from livekit.plugins import groq as groq_plugin
+from voicegateway import attach, guard
 
-
-# (paste first_resolvable / STT_CHAIN / LLM_CHAIN / TTS_CHAIN from above)
+PROJECT = "prod"
 
 
 async def entrypoint(ctx: JobContext):
     await ctx.connect()
 
-    try:
-        stt = first_resolvable("stt", STT_CHAIN)
-        llm = first_resolvable("llm", LLM_CHAIN)
-        tts = first_resolvable("tts", TTS_CHAIN)
-    except Exception as e:
-        # Every model in every chain failed to resolve at startup.
-        print(f"Cannot start voice agent: {e}")
-        return
-
     session = AgentSession(
         vad=silero.VAD.load(),
-        stt=stt,
-        llm=llm,
-        tts=tts,
+        stt=guard(
+            deepgram.STT(model="nova-3"),
+            fallback=[openai.STT(model="whisper-1")],
+            project=PROJECT,
+        ),
+        llm=guard(
+            openai.LLM(model="gpt-4o-mini"),
+            fallback=[groq_plugin.LLM(model="llama-3.3-70b-versatile")],
+            project=PROJECT,
+        ),
+        tts=guard(
+            cartesia.TTS(model="sonic-3"),
+            fallback=[elevenlabs.TTS(model="turbo-v2.5")],
+            project=PROJECT,
+        ),
     )
+
+    attach(session, project=PROJECT)
 
     await session.start(
         agent=Agent(instructions="You are a helpful voice assistant."),
@@ -149,21 +125,47 @@ if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
 ```
 
-## Cloud-to-Local Fallback Strategy
+## Cloud-to-local fallback strategy
 
-A common pattern is cloud models as primaries with local models as the final fallback. This guarantees an agent can come up even when every cloud provider is unreachable:
+A common pattern is cloud models as primaries with local models as the final fallback. This keeps the agent alive even if every cloud provider is unreachable:
+
+```python
+from livekit.plugins import cartesia, deepgram, openai
+from voicegateway import guard
+
+# Local fallback imports come from the voicegateway providers, not livekit.plugins.
+# Use a guard() chain ending in whichever local provider you have configured.
+stt = guard(
+    deepgram.STT(model="nova-3"),
+    fallback=[openai.STT(model="whisper-1")],
+    project="prod",
+)
+```
 
 ```yaml
+# voicegw.yaml: document your fallback intention alongside the config
 fallbacks:
   stt:
     - deepgram/nova-3
+    - openai/whisper-1
     - local/whisper-large-v3
   llm:
-    - openai/gpt-4.1-mini
+    - openai/gpt-4o-mini
+    - groq/llama-3.3-70b-versatile
     - ollama/qwen2.5:3b
   tts:
     - cartesia/sonic-3
+    - elevenlabs/turbo-v2.5
     - local/kokoro
 ```
 
-This handles the cold-start case: every cloud provider unreachable when the agent starts means the local model is selected and the agent comes up. It does not handle the warm-failure case: if Deepgram is healthy at startup and starts returning 500s mid-call, VG keeps the Deepgram instance for the rest of the call. For warm failover, see [LiveKit FallbackAdapter integration](/examples/livekit-fallback-adapter).
+<Tip>
+Anchor every chain with a local model as the last entry. A single local fallback
+gives you true outage coverage at the cost of degraded quality during the
+outage.
+</Tip>
+
+This handles the cold-start case: every cloud provider unreachable when the agent
+starts means the local model is selected and the agent comes up. For warm failover
+(a provider that starts returning errors mid-call), see [LiveKit FallbackAdapter
+integration](/examples/livekit-fallback-adapter).

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,21 +1,23 @@
+---
+title: Examples
+description: Runnable examples showing how to use VoiceGateway with LiveKit, Pipecat, Docker, and more.
+---
+
 # Examples
 
-Practical examples showing how to use VoiceGateway in real-world scenarios. Each example includes runnable code and a complete `voicegw.yaml` configuration.
-
-## Getting Started
+Practical, runnable examples for common VoiceGateway use cases. Each example includes working code and the configuration it needs.
 
 Before running any example, install VoiceGateway with the providers you need:
 
-```bash
-# Install with cloud providers
-pip install voicegateway[openai,deepgram,cartesia]
-
-# Install with local providers
-pip install voicegateway[whisper,kokoro]
-
-# Install everything
-pip install voicegateway[all,dev]
+<CodeGroup>
+```bash uv
+uv add "voicegateway[openai,deepgram,cartesia]"
 ```
+
+```bash pip
+pip install "voicegateway[openai,deepgram,cartesia]"
+```
+</CodeGroup>
 
 Then create a config file:
 
@@ -23,40 +25,38 @@ Then create a config file:
 voicegw init
 ```
 
-## Examples
-
-### [Basic Voice Agent](./basic-voice-agent)
-
-Build a simple voice agent using LiveKit Agents with VoiceGateway routing STT, LLM, and TTS requests. The minimal setup to get a working voice pipeline.
-
-### [LiveKit: attach() + guard()](./livekit-attach-guard)
-
-The framework-neutral shape on LiveKit: native `livekit.plugins` providers, metered by `attach(session)` (the single passive meter), with one `guard()` wrapper adding fallback, rate limit, and a daily spend cap.
-
-### [Pipecat: attach() + guard()](./pipecat-attach-guard)
-
-The same public surface on Pipecat: native `pipecat.services`, metered by an `Observer` (or `attach(task)`), with one `guard()` wrapper for fallback and a spend cap. Includes enabling Pipecat metrics and the fallback scope note.
-
-### [Multi-Project Setup](./multi-project)
-
-Configure three separate projects (production, staging, dev) with different model stacks, budgets, and tags. Shows how to isolate cost tracking across teams and environments.
-
-### [Budget Enforcement](./budget-enforcement)
-
-Demonstrate all three budget modes: `warn` (log and continue), `throttle` (fall back to local models), and `block` (reject requests). Includes handling `BudgetExceededError` and `BudgetThrottleSignal`.
-
-### [Fallback Chains](./fallback-chains)
-
-Configure primary/backup model chains so that if Deepgram's STT is down, traffic automatically falls back to OpenAI Whisper, then to local Whisper. Includes monitoring fallback events.
-
-### [Local-Only Deployment](./local-only)
-
-Run VoiceGateway with zero cloud dependencies using Ollama for LLM, Whisper for STT, and Kokoro for TTS. Useful for air-gapped environments or development without API keys.
-
-### [Claude Code Integration](./claude-code-integration)
-
-Use VoiceGateway's MCP server with Claude Code to manage providers, models, projects, and monitor costs through natural language. Includes 5+ end-to-end prompt examples.
-
-### [Docker Deployment](./docker-deployment)
-
-Production-ready `docker-compose.yml` with the API server, dashboard, persistent storage, health checks, and optional Ollama sidecar.
+<CardGroup cols={2}>
+  <Card title="Basic Voice Agent" icon="microphone" href="/examples/basic-voice-agent">
+    Minimal metered agent using LiveKit and Pipecat side by side.
+  </Card>
+  <Card title="LiveKit: attach + guard" icon="shield-check" href="/examples/livekit-attach-guard">
+    Native LiveKit plugins metered by `attach(session)` with a guarded LLM.
+  </Card>
+  <Card title="Pipecat: attach + guard" icon="shield-check" href="/examples/pipecat-attach-guard">
+    Native Pipecat services metered by an Observer with a guarded LLM.
+  </Card>
+  <Card title="Budget Enforcement" icon="dollar-sign" href="/examples/budget-enforcement">
+    Enforce a daily spend cap with `guard(llm, budget="$5.00/day")`.
+  </Card>
+  <Card title="Fallback Chains" icon="arrow-right-arrow-left" href="/examples/fallback-chains">
+    Startup-time provider selection: walk a chain and pick the first that builds.
+  </Card>
+  <Card title="LiveKit FallbackAdapter" icon="rotate" href="/examples/livekit-fallback-adapter">
+    Runtime error-driven failover using LiveKit's built-in FallbackAdapter.
+  </Card>
+  <Card title="Local-Only Deployment" icon="server" href="/examples/local-only">
+    Zero cloud dependencies: Whisper + Ollama + Kokoro, no API keys.
+  </Card>
+  <Card title="Multi-Project" icon="folder-open" href="/examples/multi-project">
+    Per-project cost attribution with `attach(..., project=...)`.
+  </Card>
+  <Card title="Docker Deployment" icon="docker" href="/examples/docker-deployment">
+    Production-ready Docker Compose with health checks and optional Ollama.
+  </Card>
+  <Card title="Claude Code Integration" icon="robot" href="/examples/claude-code-integration">
+    Manage providers, projects, and costs from Claude Code via the MCP server.
+  </Card>
+  <Card title="OpenRTC Multi-Agent" icon="users" href="/examples/openrtc-multi-agent">
+    Track every agent in one worker with the OpenRTC SessionObserver seam.
+  </Card>
+</CardGroup>

--- a/docs/examples/livekit-attach-guard.md
+++ b/docs/examples/livekit-attach-guard.md
@@ -1,8 +1,13 @@
-# LiveKit: attach() + guard()
+---
+title: "LiveKit: attach + guard"
+description: Native LiveKit plugins metered by attach(session) with a guarded LLM providing fallback, rate limiting, and a daily spend cap.
+---
+
+# LiveKit: attach + guard
 
 A minimal LiveKit agent built from native `livekit.plugins` providers, metered
-by [`voicegateway.attach(session)`](/guide/attach) (the single passive meter) and
-controlled by one [`voicegateway.guard(...)`](/guide/guard) wrapper around the
+by [`attach(session)`](/guide/attach) (the single passive meter) and
+controlled by one [`guard()`](/guide/guard) wrapper around the
 LLM (fallback, rate limit, and a daily spend cap).
 
 The full runnable file lives at
@@ -10,8 +15,17 @@ The full runnable file lives at
 
 ## Install
 
-```bash
+<CodeGroup>
+```bash uv
+uv add "voicegateway[livekit,openai,deepgram,cartesia]"
+```
+
+```bash pip
 pip install "voicegateway[livekit,openai,deepgram,cartesia]"
+```
+</CodeGroup>
+
+```bash
 export OPENAI_API_KEY=... DEEPGRAM_API_KEY=... CARTESIA_API_KEY=...
 export LIVEKIT_URL=... LIVEKIT_API_KEY=... LIVEKIT_API_SECRET=...
 ```
@@ -76,4 +90,4 @@ the `livekit-demo` project.
 - The `livekit.plugins` imports are inside `build_session()` so importing the
   module never requires the plugin wheels; only running the agent does.
 - For the Pipecat version, see
-  [Pipecat: attach() + guard()](/examples/pipecat-attach-guard).
+  [Pipecat: attach + guard](/examples/pipecat-attach-guard).

--- a/docs/examples/livekit-fallback-adapter.md
+++ b/docs/examples/livekit-fallback-adapter.md
@@ -1,6 +1,11 @@
+---
+title: LiveKit FallbackAdapter Integration
+description: Compose VoiceGateway's attach() with LiveKit's built-in FallbackAdapter for runtime, error-driven provider failover during an active call.
+---
+
 # LiveKit FallbackAdapter Integration
 
-This page shows how to compose VoiceGateway's `inference` factories with LiveKit's `FallbackAdapter` to get runtime, error-driven failover during an active call. VoiceGateway's own resolver-time fallback (see [Fallback Chains](/examples/fallback-chains)) handles startup selection; the LiveKit Agents framework supplies the runtime piece.
+This page shows how to compose VoiceGateway's `attach()` with LiveKit's `FallbackAdapter` to get runtime, error-driven failover during an active call. VoiceGateway's own `guard()` fallback (see [Fallback Chains](/examples/fallback-chains)) handles startup selection; the LiveKit Agents framework supplies the runtime piece.
 
 ## Why LiveKit FallbackAdapter, not VG's own
 
@@ -10,14 +15,18 @@ LiveKit Agents ships `stt.FallbackAdapter`, `llm.FallbackAdapter`, and `tts.Fall
 2. The LiveKit team maintains and tests it alongside the rest of the agents framework.
 3. The adapter integrates with `AgentSession`'s `ErrorEvent` flow, which is the canonical way to surface a chain-exhausted state to the agent.
 
-The composition pattern below is the recommended way to deliver "primary provider down, fall back to a backup, keep the call alive" for a VG-routed agent.
+The composition pattern below is the recommended way to deliver "primary provider down, fall back to a backup, keep the call alive" for a VG-tracked agent.
 
 ## The composition
 
 ```python
 from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli, llm, stt, tts
-from livekit.plugins import silero
-from voicegateway import inference
+from livekit.plugins import cartesia, deepgram, elevenlabs, openai, silero
+from voicegateway import attach
+
+# Assumes voicegateway providers are wired for local fallback in voicegw.yaml.
+# Replace local/... with whatever local or secondary provider you configure.
+from livekit.plugins import openai as lk_openai
 
 
 async def entrypoint(ctx: JobContext):
@@ -26,21 +35,21 @@ async def entrypoint(ctx: JobContext):
     session = AgentSession(
         vad=silero.VAD.load(),
         stt=stt.FallbackAdapter([
-            inference.STT("deepgram/nova-3"),         # primary
-            inference.STT("groq/whisper-large-v3"),   # secondary cloud
-            inference.STT("local/whisper-large-v3"),  # local fallback
+            deepgram.STT(model="nova-3"),          # primary
+            openai.STT(model="whisper-1"),          # secondary cloud
         ]),
         llm=llm.FallbackAdapter([
-            inference.LLM("openai/gpt-4.1-mini"),
-            inference.LLM("anthropic/claude-sonnet-4-20250514"),
-            inference.LLM("ollama/qwen2.5:3b"),
+            openai.LLM(model="gpt-4o-mini"),
+            lk_openai.LLM(model="gpt-4o"),
         ]),
         tts=tts.FallbackAdapter([
-            inference.TTS("cartesia/sonic-3"),
-            inference.TTS("elevenlabs/eleven_turbo_v2_5"),
-            inference.TTS("local/kokoro"),
+            cartesia.TTS(model="sonic-3"),
+            elevenlabs.TTS(model="turbo-v2.5"),
         ]),
     )
+
+    # One meter for the whole session across all providers in each chain.
+    attach(session, project="prod")
 
     await session.start(
         agent=Agent(instructions="You are a helpful voice assistant."),
@@ -52,7 +61,7 @@ if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
 ```
 
-Each `inference.STT / LLM / TTS` call returns a native LiveKit plugin instance wrapped by VoiceGateway's instrumentation. `FallbackAdapter` accepts those instances directly: no extra adapter layer, no plugin shim. The active project resolves the same way it does for any other inference call (`set_project`, env var, or `default_project` in YAML).
+`FallbackAdapter` accepts native LiveKit plugin instances directly. `attach()` meters the session as a whole, not per-provider, so the single `attach()` call covers all providers in each chain.
 
 ## What triggers fallback
 
@@ -73,7 +82,7 @@ For voice agents specifically:
 - **Match modality strengths.** STT chains should put the lowest-latency provider first (Deepgram Nova for English-heavy voice agents). TTS chains should also put the lowest-latency provider first (Cartesia Sonic). LLM chains can prioritize quality over latency since reasoning latency is a smaller share of total turn time.
 - **Anchor with a local model.** Avoid all-cloud chains where a regional outage could take down every provider in the list. A single local fallback at the end of the chain gives you true outage coverage at the cost of degraded quality during the outage.
 
-## How VoiceGateway's cost tracking interacts
+## How VoiceGateway cost tracking interacts
 
 Each attempt VoiceGateway sees is logged as a separate `RequestRecord` in SQLite. If `FallbackAdapter` calls the primary and that call fails:
 
@@ -81,8 +90,6 @@ Each attempt VoiceGateway sees is logged as a separate `RequestRecord` in SQLite
 - When `FallbackAdapter` retries with the secondary, that call is logged separately with `status = "success"` (or another `error` if the secondary also fails).
 
 You can correlate the two records by timestamp clustering and project tag. The dashboard's request log view shows the status next to each row.
-
-The `fallback_from` field on `RequestRecord` is reserved for a future resolver-time fallback parameter on the inference factories, not for LiveKit's runtime `FallbackAdapter`: VG sees each attempt as an independent provider call. To trace runtime fallback events today, filter the request log by project and look for adjacent records with `status = "error"` followed by `status = "success"`.
 
 For project budget enforcement, every attempt counts against the project budget independently. A primary that fails and a secondary that succeeds will both be billed (the primary because the provider counts the failed request, the secondary because it served the actual response). This matches what your provider invoices will show.
 
@@ -99,16 +106,16 @@ def on_error(event):
         ...
 ```
 
-If `event.error.recoverable` is `True`, the chain advanced to the next provider successfully and the session continues. The event is informational; you can log it for later analysis but no intervention is required.
+If `event.error.recoverable` is `True`, the chain advanced to the next provider successfully and the session continues. The event is informational; log it for later analysis but no intervention is required.
 
 ## When this is not what you need
 
-- **You only want startup-time provider selection.** Use the manual chain walk pattern in [Fallback Chains](/examples/fallback-chains).
+- **You only want startup-time provider selection.** Use `guard()` with `fallback=` as shown in [Fallback Chains](/examples/fallback-chains).
 - **You only have one cloud provider configured.** `FallbackAdapter` is overkill. A single-provider config plus a circuit breaker outside the agent is simpler.
 - **You are on Node.js.** `stt.FallbackAdapter` is Python-only. `llm.FallbackAdapter` and `tts.FallbackAdapter` are available on Node.js per the [LiveKit reference](https://docs.livekit.io/reference/agents/events/); for STT failover on Node.js you need a different approach.
 
 ## Related
 
-- [Fallback Chains](/examples/fallback-chains): VoiceGateway's resolver-time fallback. Complementary to `FallbackAdapter`. Resolver-time picks the first available provider at agent startup; runtime fallback handles failures during a call.
+- [Fallback Chains](/examples/fallback-chains): `guard()` resolver-time fallback. Complementary to `FallbackAdapter`. Resolver-time picks the first available provider at agent startup; runtime fallback handles failures during a call.
 - [Quick Start](/guide/quick-start)
 - [LiveKit Agents events reference](https://docs.livekit.io/reference/agents/events/)

--- a/docs/examples/local-only.md
+++ b/docs/examples/local-only.md
@@ -1,11 +1,16 @@
+---
+title: Local-Only Deployment
+description: Run a voice agent with zero cloud dependencies using Whisper for STT, Ollama for LLM, and Kokoro for TTS.
+---
+
 # Local-Only Deployment
 
 Run VoiceGateway entirely on local hardware with zero cloud dependencies. Uses Ollama for LLM, Whisper for STT, and Kokoro for TTS. Ideal for air-gapped environments, development without API keys, or privacy-sensitive deployments.
 
 ## Prerequisites
 
-### Install Ollama
-
+<Steps>
+  <Step title="Install Ollama">
 ```bash
 # macOS / Linux
 curl -fsSL https://ollama.com/install.sh | sh
@@ -13,19 +18,21 @@ curl -fsSL https://ollama.com/install.sh | sh
 # Pull a model
 ollama pull qwen2.5:3b
 ```
-
-### Install VoiceGateway with Local Providers
-
-```bash
-pip install voicegateway[whisper,kokoro]
+  </Step>
+  <Step title="Install VoiceGateway with local providers">
+<CodeGroup>
+```bash uv
+uv add "voicegateway[whisper,kokoro]"
 ```
 
-Whisper requires `torch` and will download model weights on first use. Kokoro requires the `kokoro` package.
+```bash pip
+pip install "voicegateway[whisper,kokoro]"
+```
+</CodeGroup>
 
-## Configuration
-
-Create `voicegw.yaml`:
-
+Whisper requires `torch` and downloads model weights on first use. Kokoro requires the `kokoro` package.
+  </Step>
+  <Step title="Create voicegw.yaml">
 ```yaml
 providers:
   ollama:
@@ -33,76 +40,38 @@ providers:
   whisper: {}
   kokoro: {}
 
-models:
-  stt:
-    local/whisper-large-v3:
-      provider: whisper
-      model: large-v3
-    local/whisper-base:
-      provider: whisper
-      model: base
-  llm:
-    ollama/qwen2.5:3b:
-      provider: ollama
-      model: qwen2.5:3b
-    ollama/llama3.2:1b:
-      provider: ollama
-      model: llama3.2:1b
-  tts:
-    local/kokoro:
-      provider: kokoro
-
-stacks:
-  local:
-    stt: local/whisper-large-v3
-    llm: ollama/qwen2.5:3b
-    tts: local/kokoro
-  fast:
-    stt: local/whisper-base
-    llm: ollama/llama3.2:1b
-    tts: local/kokoro
-
-fallbacks:
-  stt:
-    - local/whisper-large-v3
-    - local/whisper-base
-  llm:
-    - ollama/qwen2.5:3b
-    - ollama/llama3.2:1b
-
 projects:
   local-dev:
     name: Local Development
-    daily_budget: 0  # Unlimited (local models are free)
+    daily_budget: 0   # local models are free
     tags: [development, local]
 
 default_project: local-dev
 
 cost_tracking:
-  enabled: true  # Still tracks requests, costs will be $0.00
+  enabled: true   # still records requests; costs will be $0.00
 
 observability:
   latency_tracking: true
 ```
+  </Step>
+</Steps>
 
-## Basic Usage
+## Agent code
 
-```python
-from voicegateway import inference
-
-# default_project: local-dev in voicegw.yaml means the inference
-# factories pick up local-dev automatically. All local, no API keys.
-stt = inference.STT("local/whisper-large-v3")
-llm = inference.LLM("ollama/qwen2.5:3b")
-tts = inference.TTS("local/kokoro")
-```
-
-## LiveKit Agent with Local Models
-
+<Tabs>
+  <Tab title="LiveKit">
 ```python
 from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
 from livekit.plugins import silero
-from voicegateway import inference
+from voicegateway import attach
+
+# Assumes voicegateway local providers are wired in voicegw.yaml.
+# The local Whisper and Kokoro providers expose the same plugin interface
+# as their cloud counterparts.
+from voicegateway.providers.whisper import WhisperSTT
+from voicegateway.providers.kokoro import KokoroTTS
+from voicegateway.providers.ollama import OllamaLLM
 
 
 async def entrypoint(ctx: JobContext):
@@ -110,15 +79,17 @@ async def entrypoint(ctx: JobContext):
 
     session = AgentSession(
         vad=silero.VAD.load(),
-        stt=inference.STT("local/whisper-large-v3"),
-        llm=inference.LLM("ollama/qwen2.5:3b"),
-        tts=inference.TTS("local/kokoro"),
+        stt=WhisperSTT(model="large-v3"),
+        llm=OllamaLLM(model="qwen2.5:3b"),
+        tts=KokoroTTS(),
     )
+
+    attach(session, project="local-dev")
 
     await session.start(
         agent=Agent(
             instructions=(
-                "You are a helpful voice assistant running entirely on local hardware. "
+                "You are a helpful voice assistant running on local hardware. "
                 "Be concise: local models work best with shorter responses."
             ),
         ),
@@ -129,6 +100,34 @@ async def entrypoint(ctx: JobContext):
 if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
 ```
+  </Tab>
+  <Tab title="Pipecat">
+```python
+import voicegateway
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+
+# Import local provider services (registered via voicegateway providers).
+from voicegateway.providers.whisper import WhisperSTTService
+from voicegateway.providers.kokoro import KokoroTTSService
+from voicegateway.providers.ollama import OllamaLLMService
+
+
+def build_task(transport_input, transport_output):
+    stt = WhisperSTTService(model="large-v3")
+    llm = OllamaLLMService(model="qwen2.5:3b")
+    tts = KokoroTTSService()
+
+    pipeline = Pipeline([transport_input, stt, llm, tts, transport_output])
+
+    return PipelineTask(
+        pipeline,
+        params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        observers=[voicegateway.Observer(project="local-dev")],
+    )
+```
+  </Tab>
+</Tabs>
 
 ## Docker Compose with Ollama
 
@@ -166,10 +165,6 @@ services:
     networks:
       - voicegw-net
 
-  # The dashboard runs inside the voicegateway service: the daemon
-  # mounts the React SPA at / and the dashboard API at /api/* on
-  # the same port as the public HTTP API. No second service needed.
-
 volumes:
   voicegw-data:
   ollama-models:
@@ -193,26 +188,26 @@ docker compose up -d
 docker exec voicegateway-ollama ollama pull qwen2.5:3b
 ```
 
-## Using Piper TTS as an Alternative
+## Using Piper TTS as an alternative
 
 If Kokoro is not available, Piper is another local TTS option:
+
+<CodeGroup>
+```bash uv
+uv add "voicegateway[piper]"
+```
+
+```bash pip
+pip install "voicegateway[piper]"
+```
+</CodeGroup>
 
 ```yaml
 providers:
   piper: {}
-
-models:
-  tts:
-    local/piper:
-      provider: piper
-      default_voice: en_US-lessac-medium
 ```
 
-```bash
-pip install voicegateway[piper]
-```
-
-## Performance Considerations
+## Performance considerations
 
 Local models have different performance characteristics than cloud APIs:
 
@@ -225,31 +220,25 @@ Local models have different performance characteristics than cloud APIs:
 
 Tips for optimizing local performance:
 
-- **GPU acceleration:** ensure CUDA/Metal is available for Whisper and Ollama
-- **Smaller models:** use `local/whisper-base` instead of `local/whisper-large-v3` for faster STT
-- **Quantized LLMs:** Ollama automatically uses quantized models (Q4_0, Q4_K_M)
-- **Keep models warm:** Ollama keeps the most recent model in memory; avoid switching frequently
+- **GPU acceleration:** ensure CUDA/Metal is available for Whisper and Ollama.
+- **Smaller models:** use `whisper-base` instead of `large-v3` for faster STT.
+- **Quantized LLMs:** Ollama automatically uses quantized models (Q4_0, Q4_K_M).
+- **Keep models warm:** Ollama keeps the most recent model in memory; avoid switching frequently.
 
-## Hybrid: Local Fallback for Cloud
+## Hybrid: local fallback for cloud
 
-A common pattern is to use cloud providers normally but fall back to local models when they are unavailable or the budget is exceeded:
+A common pattern is cloud providers as primaries, local as the final fallback:
 
-```yaml
-fallbacks:
-  stt:
-    - deepgram/nova-3
-    - local/whisper-large-v3
-  llm:
-    - openai/gpt-4.1-mini
-    - ollama/qwen2.5:3b
-  tts:
-    - cartesia/sonic-3
-    - local/kokoro
+```python
+from livekit.plugins import deepgram, openai
+from voicegateway import guard
+from voicegateway.providers.whisper import WhisperSTT
 
-projects:
-  prod:
-    daily_budget: 50.00
-    budget_action: throttle  # Falls back to local on exceed
+stt = guard(
+    deepgram.STT(model="nova-3"),
+    fallback=[WhisperSTT(model="large-v3")],
+    project="prod",
+)
 ```
 
-See [Fallback Chains](./fallback-chains) and [Budget Enforcement](./budget-enforcement) for more details.
+See [Fallback Chains](/examples/fallback-chains) and [Budget Enforcement](/examples/budget-enforcement) for more details.

--- a/docs/examples/multi-project.md
+++ b/docs/examples/multi-project.md
@@ -1,6 +1,13 @@
+---
+title: Multi-Project Setup
+description: Attribute costs across multiple projects by passing project= to attach() for per-project isolation.
+---
+
 # Multi-Project Setup
 
-Configure multiple projects with different model stacks, budgets, and tracking. This is useful when you have separate teams, environments, or products sharing a single VoiceGateway instance.
+Configure multiple projects with different model stacks, budgets, and tracking. Useful when separate teams, environments, or products share a single VoiceGateway instance.
+
+Pass `project=` to `attach()` (and optionally to `guard()`) to isolate cost tracking per session.
 
 ## Configuration
 
@@ -53,43 +60,97 @@ cost_tracking:
   enabled: true
 ```
 
-## Using Projects in Code
+## Using projects in code
 
+Pass `project=` directly to `attach()` so the active project is explicit on every session:
+
+<Tabs>
+  <Tab title="LiveKit">
 ```python
-from voicegateway import inference
+from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli
+from livekit.plugins import cartesia, deepgram, openai, silero
+from voicegateway import attach
 
-# Production: pass the project explicitly per call context.
-inference.set_project("prod")
-stt = inference.STT("deepgram/nova-3")
-llm = inference.LLM("openai/gpt-4.1-mini")
-tts = inference.TTS("cartesia/sonic-3")
+
+async def production_entrypoint(ctx: JobContext):
+    await ctx.connect()
+
+    session = AgentSession(
+        vad=silero.VAD.load(),
+        stt=deepgram.STT(model="nova-3"),
+        llm=openai.LLM(model="gpt-4o-mini"),
+        tts=cartesia.TTS(model="sonic-3"),
+    )
+
+    # project= is explicit; no global state, no leakage between concurrent tasks.
+    attach(session, project="prod")
+
+    await session.start(
+        agent=Agent(instructions="You are a helpful voice assistant."),
+        room=ctx.room,
+    )
+
+
+async def staging_entrypoint(ctx: JobContext):
+    await ctx.connect()
+
+    session = AgentSession(
+        vad=silero.VAD.load(),
+        stt=deepgram.STT(model="nova-3"),
+        llm=openai.LLM(model="gpt-4o-mini"),
+        tts=cartesia.TTS(model="sonic-3"),
+    )
+
+    attach(session, project="staging")
+
+    await session.start(
+        agent=Agent(instructions="You are a helpful voice assistant."),
+        room=ctx.room,
+    )
 ```
-
-The active project is scoped to the current async context, so different
-asyncio tasks within the same process can each pick a different
-project without interfering:
-
+  </Tab>
+  <Tab title="Pipecat">
 ```python
-async def production_handler(ctx):
-    inference.set_project("prod")
-    # all inference factories below charge prod
-    ...
+import os
 
-async def staging_handler(ctx):
-    inference.set_project("staging")
-    # sibling task: no leakage
-    ...
+import voicegateway
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.openai.llm import OpenAILLMService
 
-async def dev_handler(ctx):
-    inference.set_project("dev")
-    stt = inference.STT("local/whisper-large-v3")
-    llm = inference.LLM("ollama/qwen2.5:3b")
-    tts = inference.TTS("local/kokoro")
+
+def build_task(transport_input, transport_output, *, project: str):
+    stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
+    llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4o-mini")
+    tts = CartesiaTTSService(api_key=os.environ["CARTESIA_API_KEY"])
+
+    pipeline = Pipeline([transport_input, stt, llm, tts, transport_output])
+
+    # project= passed through; each pipeline task charges its own project.
+    return PipelineTask(
+        pipeline,
+        params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        observers=[voicegateway.Observer(project=project)],
+    )
+
+
+# Production pipeline
+prod_task = build_task(transport_in, transport_out, project="prod")
+
+# Staging pipeline
+staging_task = build_task(transport_in, transport_out, project="staging")
 ```
+  </Tab>
+</Tabs>
 
-For workers that always serve one project, set `default_project: prod` (or whichever) in `voicegw.yaml` and skip the `set_project` call entirely.
+<Note>
+There is no `VOICEGW_PROJECT` env var. Pass `project=` explicitly to `attach()`
+or `guard()` so the attribution is always unambiguous in code.
+</Note>
 
-## Querying Per-Project Costs
+## Querying per-project costs
 
 ### Via the CLI
 
@@ -103,42 +164,28 @@ voicegw projects   # shows budget + recent spend per project
 
 ```bash
 # Per-project cost breakdown
-curl http://localhost:8080/v1/costs?period=today&project=prod
+curl 'http://localhost:8080/v1/costs?period=today&project=prod'
 
 # All projects
 curl http://localhost:8080/v1/projects
 
 # Project-level request logs
-curl http://localhost:8080/v1/logs?project=prod&limit=50
+curl 'http://localhost:8080/v1/logs?project=prod&limit=50'
 ```
 
-## Project Accent Colors
+## Budget behavior by project
 
-The dashboard assigns accent colors based on the project's first tag:
-
-| Tag Contains | Color |
-|-------------|-------|
-| `prod` | Green |
-| `stag` | Yellow |
-| `dev` or `test` | Blue |
-| (anything else) | Pink |
-
-This makes it easy to visually distinguish environments at a glance.
-
-## Budget Behavior by Project
-
-| Project | Budget | Action | What Happens When Exceeded |
+| Project | Budget | Action | What happens when exceeded |
 |---------|--------|--------|---------------------------|
-| prod | $50/day | `throttle` | Raises `BudgetThrottleSignal` -- app falls back to local models |
+| prod | $50/day | `throttle` | `guard()` falls back to cheaper model |
 | staging | $10/day | `warn` | Logs a warning, request proceeds normally |
-| dev | $5/day | `block` | Raises `BudgetExceededError` -- request is rejected |
+| dev | $5/day | `block` | `guard()` raises `BudgetExceededError` |
 
-## Dynamic Project Management
+## Dynamic project management
 
 Projects can also be created and updated at runtime through the dashboard or MCP server, without editing `voicegw.yaml`:
 
 ```bash
-# Via the HTTP API
 curl -X POST http://localhost:8080/v1/projects \
   -H "Content-Type: application/json" \
   -d '{
@@ -152,7 +199,7 @@ curl -X POST http://localhost:8080/v1/projects \
 
 These dynamically created projects are stored in the `managed_projects` SQLite table and merged with YAML-defined projects at startup and after each write.
 
-## SQL Views for Reporting
+## SQL views for reporting
 
 The `project_daily_costs` view aggregates costs by project and day:
 

--- a/docs/examples/openrtc-multi-agent.md
+++ b/docs/examples/openrtc-multi-agent.md
@@ -1,4 +1,9 @@
-# OpenRTC: track every agent in one worker
+---
+title: OpenRTC Multi-Agent
+description: Track every agent in one OpenRTC worker with VoiceGateway's SessionObserver seam for per-call cost attribution.
+---
+
+# OpenRTC Multi-Agent
 
 [OpenRTC](https://github.com/mahimailabs/openrtc-runtime) runs N LiveKit voice
 agents in one worker. VoiceGateway plugs into its `SessionObserver` seam, so a
@@ -7,9 +12,15 @@ and per tenant.
 
 ## Install
 
-```bash
+<CodeGroup>
+```bash uv
 uv add "voicegateway[openrtc]"
 ```
+
+```bash pip
+pip install "voicegateway[openrtc]"
+```
+</CodeGroup>
 
 ## One line: hand the pool an observer
 
@@ -68,3 +79,8 @@ worker's life. It holds only configuration, so it is safe to use with OpenRTC
 `process` isolation (it pickles cleanly and rebuilds its sink in the worker).
 `attach()` flushes the shared sink when each session closes but never closes it,
 so one session ending never disrupts the others.
+
+## Related
+
+- [Multi-Project Setup](/examples/multi-project): explicit per-project attribution using `attach(..., project=...)`.
+- [Hosted quickstart](/hosted/quickstart): the hosted fleet collector you can push to from any worker.

--- a/docs/examples/pipecat-attach-guard.md
+++ b/docs/examples/pipecat-attach-guard.md
@@ -1,8 +1,13 @@
-# Pipecat: attach() + guard()
+---
+title: "Pipecat: attach + guard"
+description: Native Pipecat services metered by an Observer with a guarded LLM providing fallback and a daily spend cap.
+---
+
+# Pipecat: attach + guard
 
 A minimal Pipecat pipeline built from native `pipecat.services`, metered by an
 [`Observer`](/guide/attach) (the single passive meter) and controlled by one
-[`voicegateway.guard(...)`](/guide/guard) wrapper around the LLM (fallback and a
+[`guard()`](/guide/guard) wrapper around the LLM (fallback and a
 daily spend cap). The public surface is identical to the
 [LiveKit example](/examples/livekit-attach-guard); only the providers differ.
 
@@ -11,8 +16,17 @@ The full runnable file lives at
 
 ## Install
 
-```bash
+<CodeGroup>
+```bash uv
+uv add "voicegateway[pipecat]" "pipecat-ai[openai,deepgram,cartesia,silero]"
+```
+
+```bash pip
 pip install "voicegateway[pipecat]" "pipecat-ai[openai,deepgram,cartesia,silero]"
+```
+</CodeGroup>
+
+```bash
 export OPENAI_API_KEY=... DEEPGRAM_API_KEY=... CARTESIA_API_KEY=...
 ```
 
@@ -52,7 +66,7 @@ def build_task(transport_input, transport_output):
         # Pipecat emits the usage MetricsFrames the meter reads only when these
         # are on; without them there is nothing for attach() to record.
         params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
-        # attach the single meter via the exported Observer. Equivalent to
+        # Attach the single meter via the exported Observer. Equivalent to
         # voicegateway.attach(task, project=PROJECT) after construction.
         observers=[voicegateway.Observer(project=PROJECT)],
     )


### PR DESCRIPTION
## Summary

- Added frontmatter (`title` + `description`) to all 12 example pages (were all missing).
- Removed every `voicegateway.inference` usage (rule 5); replaced with `from voicegateway import attach, guard`.
- Rewrote `examples/index.md` as a `<CardGroup>` indexing all 11 child examples with icons and one-line descriptions.
- Fixed broken `/deployment` link in `docker-deployment.md` to `/deployment/index`.
- Added `<Tabs>` for LiveKit/Pipecat side-by-side in `basic-voice-agent`, `local-only`, and `multi-project`.
- Rewrote `fallback-chains` and `livekit-fallback-adapter` to use `guard(primary, fallback=[...])` throughout instead of the deprecated inference factory pattern.
- Added `<Steps>`, `<CodeGroup>` (uv/pip), `<Note>`, `<Tip>`, and `<Warning>` callouts where appropriate.
- All internal links use root-absolute paths resolving to nav pages.

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 12 scoped)
```