### PR TITLE
docs(cli): rewrite CLI reference, part 1 (P9a)

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -7,15 +7,11 @@ description: Open the VoiceGateway dashboard in your browser. The daemon already
 
 Open the VoiceGateway dashboard in your browser.
 
-## Purpose
+## Synopsis
 
-The daemon (started by `voicegw onboard` or `voicegw serve`) already
-serves the React dashboard at `/`, the dashboard API at `/api/*`, and
-the public HTTP API at `/v1/*` on the same port. `voicegw dashboard`
-does not start a second process; it resolves the daemon URL from
-your config and opens your browser at it.
+The daemon (started by `voicegw onboard` or `voicegw serve`) already serves the React dashboard at `/`, the dashboard API at `/api/*`, and the public HTTP API at `/v1/*` on the same port. `voicegw dashboard` does not start a second process. It resolves the daemon URL from your config and opens your browser at it.
 
-## Syntax
+## Usage
 
 ```bash
 voicegw dashboard [OPTIONS]
@@ -30,73 +26,50 @@ voicegw dashboard [OPTIONS]
 
 ## Behaviour
 
-1. Load the gateway configuration (the same path `voicegw status`
-   uses).
-2. Resolve the host/port from `serve.host` / `serve.port` in
-   `voicegw.yaml`, falling back to `0.0.0.0` and `8080`. The
-   resolved URL replaces `0.0.0.0` with `localhost` because browsers
-   do not handle bare `0.0.0.0` as a host.
+1. Load the gateway configuration.
+2. Resolve the host/port from `serve.host` and `serve.port` in `voicegw.yaml`, falling back to `0.0.0.0` and `8080`. The resolved URL replaces `0.0.0.0` with `localhost` because browsers do not handle bare `0.0.0.0` as a host.
 3. Print the URL to the terminal.
-4. Unless `--no-open` is set, call `webbrowser.open(url)`. If the
-   browser auto-launch fails (no display, sandboxed environment),
-   the command prints a warning and exits with status 0; the URL
-   already printed in step 3 is enough to copy and open manually.
+4. Unless `--no-open` is set, call `webbrowser.open(url)`. If the browser auto-launch fails (no display, sandboxed environment), the command prints a warning and exits with status 0. The URL printed in step 3 is enough to copy and open manually.
 
-The command exits as soon as the browser receives the URL. There is
-no foreground process to stop.
+The command exits as soon as the browser receives the URL. There is no foreground process to stop.
 
 ## Prerequisites
 
-The daemon must be running. Onboarding installs and starts it by
-default; verify with `voicegw status`. If you skipped daemon install,
-start it in another shell first:
+The daemon must be running. Onboarding installs and starts it by default; verify with `voicegw status`. If you skipped daemon install, start it in another shell first:
 
 ```bash
-voicegw serve            # foreground; Ctrl+C to stop
-voicegw start            # background (uses the OS service manager)
+# Foreground (Ctrl+C to stop)
+voicegw serve
+
+# Background via OS service manager
+voicegw start
 ```
 
-The `dashboard` extra must be installed at the package level so the
-React bundle ships with the wheel:
+The `dashboard` extra must be installed so the React bundle ships with the wheel:
 
 ```bash
 pipx install 'voicegateway[dashboard]'
+# or
+pip install 'voicegateway[dashboard]'
 ```
 
 ## Examples
 
-### Open the dashboard
-
 ```bash
+# Open the dashboard in your browser
 voicegw dashboard
 ```
 
-Prints the URL and launches your browser.
-
-### Print the URL only
-
 ```bash
+# Print the URL only (useful over SSH)
 voicegw dashboard --no-open
 ```
 
-Useful when you are SSH'd into the host running the daemon and want
-to copy the URL into a browser on your laptop (after setting up an
-SSH tunnel).
-
-### Use a non-default config
-
 ```bash
+# Use a non-default config
 voicegw dashboard --config /etc/voicegateway/voicegw.yaml
 ```
 
-Resolves host/port from that file. The daemon must already be bound
-to the matching address; this command does not start the daemon.
+## Related
 
-## Related commands
-
-- [`voicegw serve`](/cli/serve) starts the daemon in the foreground.
-- `voicegw start` brings the OS-managed daemon up.
-- [`voicegw status`](/cli/status) shows daemon and provider state in
-  the terminal.
-- [`voicegw onboard`](/cli/onboard) writes the config, installs the
-  daemon, and prints the dashboard URL at the end.
+[`voicegw serve`](/cli/serve) | [`voicegw start`](/cli/serve) | [`voicegw status`](/cli/status) | [`voicegw onboard`](/cli/onboard) | [`voicegw tui`](/cli/tui)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -30,18 +30,18 @@ After installation, the `voicegw` command is available globally. See
 | [`onboard`](/cli/onboard) | Five-question wizard. Writes config, installs and starts the daemon. |
 | [`init`](/cli/init) | Scaffold a `voicegw.yaml` from the bundled template. |
 | [`serve`](/cli/serve) | Run the daemon in the foreground. |
-| [`start`](/cli/serve#start) | Start the OS-managed daemon. |
-| [`stop`](/cli/serve#stop) | Stop the OS-managed daemon. |
-| [`restart`](/cli/serve#restart) | Restart the OS-managed daemon. |
-| [`daemon-logs`](/cli/serve#daemon-logs) | Tail the OS-native daemon log stream. |
-| [`uninstall-daemon`](/cli/serve#uninstall) | Remove the daemon registration (config + db preserved). |
+| [`start`](/cli/serve#voicegw-start) | Start the OS-managed daemon. |
+| [`stop`](/cli/serve#voicegw-stop) | Stop the OS-managed daemon. |
+| [`restart`](/cli/serve#voicegw-restart) | Restart the OS-managed daemon. |
+| [`daemon-logs`](/cli/serve#voicegw-daemon-logs) | Tail the OS-native daemon log stream. |
+| [`uninstall-daemon`](/cli/serve#voicegw-uninstall-daemon) | Remove the daemon registration (config + db preserved). |
 
 ### Inspect and verify
 
 | Command | Description |
 |---|---|
 | [`status`](/cli/status) | Provider configuration status. |
-| [`doctor`](/cli/status#doctor) | Numbered punch list with fix steps. |
+| [`doctor`](/cli/status#voicegw-doctor) | Numbered punch list with fix steps. |
 | [`smoke-test`](/cli/smoke-test) | Verify the inference pipeline end-to-end without LiveKit. |
 | [`livekit`](/cli/livekit) | Diagnostics against a LiveKit server: agents, latency, SFU health, combined check. |
 | [`logs`](/cli/logs) | Recent request logs. |

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -7,18 +7,13 @@ description: Scaffold a voicegw.yaml configuration file from the bundled templat
 
 Create a `voicegw.yaml` configuration file from the bundled template.
 
-## Purpose
+## Synopsis
 
-`voicegw init` scaffolds a new configuration file with example
-provider, model, and project definitions. Use it when you want a
-hand-edited starting point. For a guided wizard that also installs
-the daemon, use [`voicegw onboard`](/cli/onboard) instead.
+Scaffold a new config file with example provider, model, and project definitions. Use it when you want a hand-edited starting point. For a guided wizard that also installs the daemon, use [`voicegw onboard`](/cli/onboard) instead.
 
-The starter template ships inside the wheel at
-`voicegateway/data/voicegw.example.yaml` and is copied verbatim to
-the output path.
+The starter template ships inside the wheel at `voicegateway/data/voicegw.example.yaml` and is copied verbatim to the output path.
 
-## Syntax
+## Usage
 
 ```bash
 voicegw init [OPTIONS]
@@ -32,55 +27,38 @@ voicegw init [OPTIONS]
 
 ## Behaviour
 
-1. If the target file already exists, the CLI prompts for
-   confirmation before overwriting.
-2. The starter template at `voicegateway/data/voicegw.example.yaml`
-   (inside the installed wheel, resolved via `importlib.resources`)
-   is written to the output path.
+1. If the target file already exists, the CLI prompts for confirmation before overwriting.
+2. The starter template at `voicegateway/data/voicegw.example.yaml` (inside the installed wheel, resolved via `importlib.resources`) is written to the output path.
 
 ## Examples
 
-### Create config in the current directory
-
 ```bash
+# Create config in the current directory
 voicegw init
 ```
 
-Creates `./voicegw.yaml` with the example template.
-
-### Create config at a custom path
-
 ```bash
+# Create config at a custom path
 voicegw init --output /etc/voicegateway/voicegw.yaml
 ```
 
-### Create config with the short flag
-
 ```bash
+# Create config with the short flag
 voicegw init -o ~/projects/my-agent/voicegw.yaml
 ```
 
-### Overwrite an existing config
-
 ```bash
+# Overwrite an existing config (prompts for confirmation)
 voicegw init --output ./voicegw.yaml
 # Prompts: "./voicegw.yaml already exists. Overwrite? [y/N]"
 ```
 
-## Next steps
-
-After running `init`:
+## After running init
 
 1. Open the generated file in your editor and add your API keys.
 2. Configure models under the `models:` section.
-3. Verify with `voicegw status`.
+3. Verify the config with `voicegw status`.
 
-## Related commands
+## Related
 
-- [`voicegw onboard`](/cli/onboard): the wizard alternative
-  (also installs the daemon).
-- [`voicegw status`](/cli/status): verify the config loads
-  correctly.
-- [`voicegw serve`](/cli/serve): run the daemon with the
-  config.
-- [`voicegw dashboard`](/cli/dashboard): open the dashboard.
+[`voicegw onboard`](/cli/onboard) | [`voicegw status`](/cli/status) | [`voicegw serve`](/cli/serve) | [Configuration reference](/configuration/voicegw-yaml)

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -1,17 +1,17 @@
 ---
 title: voicegw mcp
-description: Start the VoiceGateway MCP (Model Context Protocol) server so coding agents can inspect and manage the gateway.
+description: Start the VoiceGateway MCP server so coding agents can inspect and manage the gateway via stdio or HTTP/SSE.
 ---
 
 # voicegw mcp
 
 Start the VoiceGateway MCP (Model Context Protocol) server.
 
-## Purpose
+## Synopsis
 
 The `mcp` command starts an MCP server that exposes 17 tools for AI coding agents to inspect and manage the gateway. Agents like Claude Code, Cursor, and Codex can use these tools to check provider status, view costs, register models, create projects, and more -- all without leaving their workflow.
 
-## Syntax
+## Usage
 
 ```bash
 voicegw mcp [OPTIONS]
@@ -32,6 +32,8 @@ The `mcp` extra must be installed:
 
 ```bash
 pip install "voicegateway[mcp]"
+# or with uv
+uv pip install "voicegateway[mcp]"
 ```
 
 For the HTTP transport, the `dashboard` extra is also needed (for `uvicorn` and `starlette`):
@@ -40,7 +42,7 @@ For the HTTP transport, the `dashboard` extra is also needed (for `uvicorn` and 
 pip install "voicegateway[mcp,dashboard]"
 ```
 
-## Transport Modes
+## Transport modes
 
 ### stdio (default)
 
@@ -60,37 +62,31 @@ Used for remote access or shared team gateways. The server exposes an SSE endpoi
 voicegw mcp --transport http --port 8090
 ```
 
-Authentication is enabled by setting the `VOICEGW_MCP_TOKEN` environment variable. See [MCP Authentication](/mcp/authentication) for details.
+Authentication is enabled by setting the `VOICEGW_MCP_TOKEN` environment variable. See [MCP transports](/mcp/transports) for details.
 
 ## Examples
 
-### Start with stdio for Claude Code
-
 ```bash
+# Start with stdio for Claude Code (default transport)
 voicegw mcp
 ```
 
-Claude Code would be configured to launch this command as its MCP server.
-
-### Start HTTP server for remote agents
-
 ```bash
+# Start HTTP server for remote agents
 VOICEGW_MCP_TOKEN=my-secret-token voicegw mcp --transport http --port 8090
 ```
 
-### Start on a custom host and port
-
 ```bash
+# Start on a custom host and port
 voicegw mcp -t http --host 0.0.0.0 --port 9000
 ```
 
-### Use a specific config file
-
 ```bash
+# Use a specific config file
 voicegw mcp --config /etc/voicegateway/voicegw.yaml
 ```
 
-## Available Tools
+## Available tools
 
 The MCP server exposes 17 tools across four categories:
 
@@ -103,8 +99,6 @@ The MCP server exposes 17 tools across four categories:
 
 See the [MCP tools reference](/mcp/tools/observability) for full documentation.
 
-## Related Commands
+## Related
 
-- [`voicegw serve`](/cli/serve) -- the HTTP API (MCP is a separate server)
-- [`voicegw dashboard`](/cli/dashboard) -- the web UI
-- [`voicegw status`](/cli/status) -- quick status check before starting MCP
+[`voicegw serve`](/cli/serve) | [`voicegw dashboard`](/cli/dashboard) | [`voicegw status`](/cli/status) | [MCP setup](/mcp/setup) | [MCP index](/mcp/index)

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -5,26 +5,13 @@ description: Five-question wizard that writes voicegw.yaml, registers the daemon
 
 # voicegw onboard
 
-Five-question wizard that gets VoiceGateway running from a fresh
-install.
+Five-question wizard that gets VoiceGateway running from a fresh install.
 
-## Purpose
+## Synopsis
 
-`voicegw onboard` is the recommended first-run command. It:
+`voicegw onboard` is the recommended first-run command. It collects your project name, provider, API key, port, and daemon preference, then writes the config, registers the daemon with your OS service manager, and starts it.
 
-- Collects project name, provider, API key, port, and a yes/no on
-  daemon installation.
-- Validates your API key against the provider (5-second timeout).
-- Writes `~/.config/voicegateway/voicegw.yaml` (or the path you
-  supply via `--config`).
-- Registers the daemon with the OS service manager (LaunchAgent on
-  macOS, `systemd --user` unit on Linux, Scheduled Task on Windows)
-  and starts it.
-- Optionally runs `voicegw smoke-test` and confirms the inference
-  pipeline.
-- Prints the dashboard URL and the next-step commands.
-
-## Syntax
+## Usage
 
 ```bash
 voicegw onboard [OPTIONS]
@@ -42,62 +29,40 @@ voicegw onboard [OPTIONS]
 | # | Question | Default | Notes |
 |---|---|---|---|
 | 1 | Project name | `default` | Becomes the key under `projects:` in the YAML. |
-| 2 | Provider | `openai` | One of the known providers: openai, deepgram, anthropic, groq, cartesia, elevenlabs, assemblyai. |
+| 2 | Provider | `openai` | One of: openai, deepgram, anthropic, groq, cartesia, elevenlabs, assemblyai. |
 | 3 | API key | (no default) | Pasted; hidden from terminal echo. Validated against the provider. |
 | 4 | Port for `voicegw serve` | `8080` | The daemon binds this port for `/v1/*`, `/api/*`, and the dashboard SPA at `/`. |
-| 5 | Install daemon? | `yes` | Skipped when `--install-daemon` / `--no-install-daemon` is passed. |
+| 5 | Install daemon? | `yes` | Skipped when `--install-daemon` or `--no-install-daemon` is passed. |
 
 ## Behaviour
 
 1. Resolves the config path (`--config`, else the default).
-2. Reads the existing config if one is present so the wizard can
-   merge new providers without clobbering the rest.
-3. Prompts five questions (or four if `--install-daemon` was
-   already passed).
-4. Validates the provider API key. On 5-second timeout the wizard
-   continues with a warning instead of failing.
+2. Reads the existing config if one is present so the wizard can merge new providers without clobbering the rest.
+3. Prompts five questions (or four if `--install-daemon` was already passed).
+4. Validates the provider API key. On 5-second timeout the wizard continues with a warning instead of failing.
 5. Writes the merged config to disk.
-6. If `install_daemon` is yes: renders the OS-specific service
-   definition (plist / unit / scheduled task), registers it,
-   and starts the daemon.
-7. Prints a summary table (project, provider, port, daemon status,
-   dashboard URL) and the next-step commands
-   (`voicegw status`, `voicegw doctor`, `voicegw stop`).
-8. Prompts whether to run `voicegw smoke-test` against the new
-   config.
+6. If `install_daemon` is yes: renders the OS-specific service definition (plist / unit / scheduled task), registers it, and starts the daemon.
+7. Prints a summary table (project, provider, port, daemon status, dashboard URL) and the next-step commands (`voicegw status`, `voicegw doctor`, `voicegw stop`).
+8. Prompts whether to run `voicegw smoke-test` against the new config.
 
-Pressing Ctrl+C at any point restores the prior `voicegw.yaml` (or
-deletes it if there was none) and exits with code 130.
+Pressing Ctrl+C at any point restores the prior `voicegw.yaml` (or deletes it if there was none) and exits with code 130.
 
 ## Examples
 
-### Default flow
-
 ```bash
+# Default flow: all five questions, installs and starts the daemon
 voicegw onboard
 ```
 
-Walks through all five questions and installs + starts the daemon
-when prompted.
-
-### Skip the daemon prompt
-
 ```bash
+# Skip the daemon prompt: writes the config but does not register the daemon
 voicegw onboard --no-install-daemon
 ```
 
-Writes the config but does not register the daemon. You can install
-it later with `voicegw onboard --install-daemon` or by re-running
-the wizard.
-
-### Write to a custom config path
-
 ```bash
+# Write to a custom config path
 voicegw onboard --config /etc/voicegateway/voicegw.yaml
 ```
-
-Useful when the gateway runs as a system service reading
-`/etc/voicegateway/voicegw.yaml`.
 
 ## Exit codes
 
@@ -107,13 +72,6 @@ Useful when the gateway runs as a system service reading
 | `1` | Validation or write failure. |
 | `130` | Ctrl+C cancellation. The prior config is restored. |
 
-## Related commands
+## Related
 
-- [`voicegw status`](/cli/status): verify the wizard wrote a
-  working config.
-- [`voicegw doctor`](/cli/status): numbered punch list when
-  something is off.
-- [`voicegw start`](/cli/serve): start the daemon manually if
-  you skipped the install step.
-- [`voicegw dashboard`](/cli/dashboard): open the dashboard URL
-  in your browser.
+[`voicegw status`](/cli/status) | [`voicegw doctor`](/cli/status) | [`voicegw serve`](/cli/serve) | [`voicegw dashboard`](/cli/dashboard) | [`voicegw smoke-test`](/cli/smoke-test)

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -5,16 +5,13 @@ description: Run the VoiceGateway daemon. serve runs in the foreground; start, s
 
 # voicegw serve / start / stop / restart
 
-The daemon is the single long-lived process behind VoiceGateway. It
-serves the HTTP API (`/v1/*`), the dashboard API (`/api/*`), and the
-React SPA (`/`) on a single port. Five lifecycle commands manage it.
+The daemon is the single long-lived process behind VoiceGateway. It serves the HTTP API (`/v1/*`), the dashboard API (`/api/*`), and the React SPA (`/`) on a single port. Five lifecycle commands manage it.
 
 ## `voicegw serve`
 
-Run the daemon in the foreground. Useful for development, smoke
-testing, and Docker entrypoints.
+Run the daemon in the foreground. Useful for development, smoke testing, and Docker entrypoints.
 
-### Syntax
+### Usage
 
 ```bash
 voicegw serve [OPTIONS]
@@ -31,15 +28,10 @@ voicegw serve [OPTIONS]
 ### Behaviour
 
 1. Load the gateway configuration.
-2. Build the FastAPI app (`build_app(gateway)`): registers all
-   `/v1/*` routers, all `/api/*` dashboard routers, mounts the
-   React SPA at `/`, mounts the branding directory at
-   `/static/branding/*`, and wires the MCP SSE transport.
+2. Build the FastAPI app: registers all `/v1/*` routers, all `/api/*` dashboard routers, mounts the React SPA at `/`, mounts the branding directory at `/static/branding/*`, and wires the MCP SSE transport.
 3. Start uvicorn on the resolved host and port.
 
-The server runs in the foreground; stop with `Ctrl+C`. For
-background operation use `voicegw start` (after `voicegw onboard`
-has installed the daemon) or run inside a process supervisor.
+The server runs in the foreground; stop with Ctrl+C. For background operation use `voicegw start` (after `voicegw onboard` has installed the daemon) or run inside a process supervisor.
 
 ### Examples
 
@@ -54,22 +46,19 @@ voicegw serve --port 8090
 voicegw serve --host 127.0.0.1
 ```
 
-## `voicegw start` {#start}
+## `voicegw start`
 
-Bring the OS-installed daemon up. The daemon must be installed
-first (via `voicegw onboard` or `voicegw onboard --install-daemon`).
+Bring the OS-installed daemon up. The daemon must be installed first (via `voicegw onboard` or `voicegw onboard --install-daemon`).
 
 ```bash
 voicegw start
 ```
 
-On macOS this calls `launchctl bootstrap`; on Linux,
-`systemctl --user start`; on Windows, `schtasks /Run`.
+On macOS this calls `launchctl bootstrap`; on Linux, `systemctl --user start`; on Windows, `schtasks /Run`.
 
-Exits 0 on success. Exits 1 if the OS service manager refuses
-(usually because the service is not installed).
+Exits 0 on success. Exits 1 if the OS service manager refuses (usually because the service is not installed).
 
-## `voicegw stop` {#stop}
+## `voicegw stop`
 
 Bring the OS-installed daemon down.
 
@@ -77,17 +66,15 @@ Bring the OS-installed daemon down.
 voicegw stop
 ```
 
-## `voicegw restart` {#restart}
+## `voicegw restart`
 
-Stop, then start. Equivalent to `voicegw stop && voicegw start`
-but does both inside one call to the service manager (so race
-conditions cannot leave the daemon in a half-down state).
+Stop, then start. Equivalent to `voicegw stop && voicegw start` but does both inside one call to the service manager so race conditions cannot leave the daemon in a half-down state.
 
 ```bash
 voicegw restart
 ```
 
-## `voicegw daemon-logs` {#daemon-logs}
+## `voicegw daemon-logs`
 
 Tail the OS-native daemon log stream.
 
@@ -99,34 +86,29 @@ voicegw daemon-logs [--tail N]
 |---|---|---|---|---|
 | `--tail` | `-n` | `integer` | `100` | Number of recent log lines to print. |
 
-On macOS this reads `~/Library/Logs/voicegateway/*.log`. On Linux,
-`journalctl --user -u voicegateway`. On Windows, the Task Scheduler
-event log.
+On macOS this reads `~/Library/Logs/voicegateway/*.log`. On Linux, `journalctl --user -u voicegateway`. On Windows, the Task Scheduler event log.
 
-## `voicegw uninstall-daemon` {#uninstall}
+## `voicegw uninstall-daemon`
 
-Remove the daemon registration. The config file at
-`~/.config/voicegateway/voicegw.yaml` and the SQLite database
-(`~/.config/voicegateway/voicegw.db` by default) are preserved.
+Remove the daemon registration. The config file at `~/.config/voicegateway/voicegw.yaml` and the SQLite database (`~/.config/voicegateway/voicegw.db` by default) are preserved.
 
 ```bash
 voicegw uninstall-daemon
 ```
 
-The command prints what was removed and what was preserved, plus
-the manual `rm -rf` command if you want to wipe state too.
+The command prints what was removed and what was preserved, plus the manual `rm -rf` command if you want to wipe state too.
 
 ## Prerequisites
 
-The `dashboard` extra must be installed so `uvicorn` is on the
-import path:
+The `dashboard` extra must be installed so `uvicorn` is on the import path:
 
 ```bash
 pipx install 'voicegateway[cloud,dashboard]'
+# or
+pip install 'voicegateway[cloud,dashboard]'
 ```
 
-If `uvicorn` is missing, `voicegw serve` exits with an error
-message pointing at this install command.
+If `uvicorn` is missing, `voicegw serve` exits with an error message pointing at this install command.
 
 ## Docker
 
@@ -136,16 +118,8 @@ The `serve` command is the default entrypoint in the Docker image:
 docker compose up -d
 ```
 
-The container binds port 8080 by default (override via
-`VOICEGW_PORT`).
+The container binds port 8080 by default (override via `VOICEGW_PORT`).
 
-## Related commands
+## Related
 
-- [`voicegw onboard`](/cli/onboard): writes the config and
-  installs the daemon in one go.
-- [`voicegw dashboard`](/cli/dashboard): open the dashboard in
-  your browser once the daemon is up.
-- [`voicegw status`](/cli/status): verify the daemon is
-  serving the expected providers.
-- [`voicegw mcp`](/cli/mcp): start the MCP server for coding
-  agents.
+[`voicegw onboard`](/cli/onboard) | [`voicegw dashboard`](/cli/dashboard) | [`voicegw status`](/cli/status) | [`voicegw mcp`](/cli/mcp)

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -7,14 +7,11 @@ description: Show provider configuration status. Useful for verifying setup afte
 
 Show the configuration status of all providers.
 
-## Purpose
+## Synopsis
 
-`voicegw status` displays a table of every provider defined in the
-config, whether it has credentials configured, and how many models
-are registered against it. This is the quickest way to verify your
-setup after editing `voicegw.yaml` or adding providers via the API.
+`voicegw status` displays a table of every provider defined in the config, whether it has credentials configured, and how many models are registered against it. This is the quickest way to verify your setup after editing `voicegw.yaml` or adding providers via the API.
 
-## Syntax
+## Usage
 
 ```bash
 voicegw status [OPTIONS]
@@ -39,9 +36,8 @@ A Rich-formatted table with three columns:
 
 ## Examples
 
-### Show all provider status
-
 ```bash
+# Show all provider status
 voicegw status
 ```
 
@@ -58,29 +54,15 @@ voicegw status
 └───────────┴────────────┴────────┘
 ```
 
-### Filter by project
-
 ```bash
+# Filter by project
 voicegw status --project tonys-pizza
 ```
 
-Displays the same table but with the project name in the header.
-Returns an error if the project id does not exist.
-
-### Use a specific config file
-
 ```bash
+# Use a specific config file
 voicegw status --config /etc/voicegateway/voicegw.yaml
 ```
-
-### Check for missing API keys
-
-```bash
-voicegw status
-```
-
-Look for providers showing `No API key`. Those need credentials
-before they can serve requests.
 
 ## Exit codes
 
@@ -89,26 +71,14 @@ before they can serve requests.
 | `0` | Success. |
 | `1` | Config failed to load, or the specified project was not found. |
 
-## `voicegw doctor` {#doctor}
+## `voicegw doctor`
 
-For a deeper check, run `voicegw doctor`. It runs a numbered punch
-list of checks (config loads, providers configured, daemon up,
-dashboard reachable, smoke test passes, secret-key set if managed
-providers exist, etc.) and prints a fix step for each failure. No
-stack traces. No bare "see docs" pointers.
+For a deeper check, run `voicegw doctor`. It runs a numbered punch list of checks (config loads, providers configured, daemon up, dashboard reachable, smoke test passes, secret-key set if managed providers exist, etc.) and prints a fix step for each failure. No stack traces. No bare "see docs" pointers.
 
 ```bash
 voicegw doctor
 ```
 
-## Related commands
+## Related
 
-- [`voicegw init`](/cli/init): create a config file if you do
-  not have one.
-- [`voicegw onboard`](/cli/onboard): five-question wizard.
-- [`voicegw costs`](/cli/costs): see what the providers are
-  costing you.
-- [`voicegw projects`](/cli/projects): list all configured
-  projects.
-- [`voicegw smoke-test`](/cli/smoke-test): exercise the
-  inference pipeline end-to-end without LiveKit.
+[`voicegw init`](/cli/init) | [`voicegw onboard`](/cli/onboard) | [`voicegw costs`](/cli/costs) | [`voicegw projects`](/cli/projects) | [`voicegw smoke-test`](/cli/smoke-test)

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -7,7 +7,7 @@ description: Launch the four-tab terminal UI for live monitoring of sessions, co
 
 Launch the four-tab terminal UI for live monitoring of sessions, costs, logs, and providers.
 
-## Purpose
+## Synopsis
 
 The `tui` command opens a Textual-based terminal interface that mirrors the web dashboard's read paths in a vim-friendly layout. Use it during local development for at-a-glance feedback on conversations and costs, during incident response when the daemon is partially degraded, or for postmortem inspection of the SQLite call DB after the daemon has been stopped.
 
@@ -16,7 +16,7 @@ Two modes are supported:
 - **Gateway mode** (default): polls the running daemon at 1 s cadence. Read paths and the Providers `t` test shortcut are available.
 - **Local mode** (`--local`): reads SQLite directly at 5 s cadence. Read paths only; write attempts raise `LocalModeUnsupportedError` and surface as a visible warning. A persistent `[Local mode]` chip is rendered in the header.
 
-## Syntax
+## Usage
 
 ```bash
 voicegw tui [OPTIONS]
@@ -24,15 +24,15 @@ voicegw tui [OPTIONS]
 
 ## Options
 
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `--local` | flag | off | Read SQLite directly; bypass the daemon regardless of its state. |
-| `--url` | `string` | from `voicegw.yaml` | Daemon URL. `0.0.0.0` from `serve.host` is rewritten to `127.0.0.1`. |
-| `--token` | `string` | `null` | Bearer token for daemon write paths. Required for the Providers `t` shortcut. |
-| `--history-limit` | `integer` | `100` | Initial row count for the Sessions and Logs tabs. |
-| `--theme` | `string` | `brand` | Color theme. `brand` is the default. |
-| `--poll` | `float` | mode-dependent | Polling cadence in seconds. Defaults: `1.0` (Gateway), `5.0` (Local). |
-| `--config` / `-c` | `string` | `null` | Path to `voicegw.yaml`. Auto-discovered if omitted. |
+| Flag | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--local` | | `flag` | off | Read SQLite directly; bypass the daemon regardless of its state. |
+| `--url` | | `string` | from `voicegw.yaml` | Daemon URL. `0.0.0.0` from `serve.host` is rewritten to `127.0.0.1`. |
+| `--token` | | `string` | `null` | Bearer token for daemon write paths. Required for the Providers `t` shortcut. |
+| `--history-limit` | | `integer` | `100` | Initial row count for the Sessions and Logs tabs. |
+| `--theme` | | `string` | `brand` | Color theme. |
+| `--poll` | | `float` | mode-dependent | Polling cadence in seconds. Defaults: `1.0` (Gateway), `5.0` (Local). |
+| `--config` | `-c` | `string` | `null` | Path to `voicegw.yaml`. Auto-discovered if omitted. |
 
 ## Prerequisites
 
@@ -40,6 +40,8 @@ The `tui` extra must be installed:
 
 ```bash
 pip install "voicegateway[tui]"
+# or with uv
+uv pip install "voicegateway[tui]"
 ```
 
 `pipx` users on a system install can inject it without reinstalling:
@@ -48,7 +50,7 @@ pip install "voicegateway[tui]"
 pipx inject voicegateway "voicegateway[tui]"
 ```
 
-For Gateway mode, the daemon must be reachable at the resolved URL. A 2 s preflight probe hits `GET /health` before Textual takes over the terminal; an unreachable daemon prints a one-line pointer and exits with code 1.
+For Gateway mode, the daemon must be reachable at the resolved URL. A 2 s preflight probe hits `GET /health` before Textual takes over the terminal. An unreachable daemon prints a one-line pointer and exits with code 1.
 
 ## Tabs
 
@@ -60,11 +62,11 @@ Recent voice conversations sorted by start time or total cost. Each row shows st
 
 ### Costs (`2`)
 
-Today's total as a single dollar number, with a per-modality breakdown (STT, LLM, TTS) beneath. Press `r` to cycle the active range between today, this week, and this month. Pricing is sourced from `voice-prices`, which version-stamps each source (`voice-prices@<version>`).
+Today's total as a single dollar number, with a per-modality breakdown (STT, LLM, TTS) beneath. Press `r` to cycle the active range between today, this week, and this month. Pricing is sourced from `voice-prices`, which version-stamps each source.
 
 ### Logs (`3`)
 
-Recent request logs in a `RichLog`-based tail viewer. New lines appear at the bottom in real time (polling-based; SSE is a future enhancement). Press `/` to filter to a substring; press `Escape` to clear the filter. Scrolling up disables auto-scroll until you return to the bottom.
+Recent request logs in a `RichLog`-based tail viewer. New lines appear at the bottom in real time (polling-based). Press `/` to filter to a substring; press `Escape` to clear the filter. Scrolling up disables auto-scroll until you return to the bottom.
 
 ### Providers (`4`)
 
@@ -72,7 +74,7 @@ Configured providers with a one-character indicator: `[ok]`, `[fail]`, or `[?]`.
 
 In Local mode, `t` raises `LocalModeUnsupportedError(feature='test_provider')`; the row's status stays unchanged and a warning notification (title: `Action requires the daemon`) surfaces so the failure is visible, not silent.
 
-## Vim Keybindings
+## Keybindings
 
 Vim navigation is consistent across all four tabs.
 
@@ -90,14 +92,14 @@ Vim navigation is consistent across all four tabs.
 | Key | Action |
 |---|---|
 | `j` / `k` | Focus next / previous row |
-| `h` / `l` | Alias for `k` / `j` (hidden in the footer hint) |
+| `h` / `l` | Alias for `k` / `j` |
 | `g` / `G` | Focus first / last row |
 
 ### Sessions extras
 
 | Key | Action |
 |---|---|
-| `s` | Toggle sort column (cost ↔ start time) |
+| `s` | Toggle sort column (cost vs start time) |
 | `Enter` | Open per-turn detail modal |
 | `Escape` / `q` | Close detail modal |
 
@@ -105,7 +107,7 @@ Vim navigation is consistent across all four tabs.
 
 | Key | Action |
 |---|---|
-| `r` | Cycle range (today → this week → this month) |
+| `r` | Cycle range (today / this week / this month) |
 
 ### Logs extras
 
@@ -122,7 +124,7 @@ Vim navigation is consistent across all four tabs.
 |---|---|
 | `t` | Run `test_provider` against the focused row |
 
-## Mode Comparison
+## Mode comparison
 
 | Aspect | Gateway mode | Local mode (`--local`) |
 |---|---|---|
@@ -132,74 +134,49 @@ Vim navigation is consistent across all four tabs.
 | Footer staleness suffix | live, no suffix | `(as of X ago)` from SQLite mtime |
 | Write actions (`t` shortcut) | live test against upstream | surfaces `LocalModeUnsupportedError` as warning notification |
 | Daemon required | yes (preflight enforced) | no (works when the daemon is down) |
-| Typical use | daily monitoring during development | postmortem after a daemon crash, audit on a stranger's machine |
+| Typical use | daily monitoring during development | postmortem after a daemon crash |
 
 ## Examples
 
-### Launch against the running daemon
-
 ```bash
+# Launch against the running daemon
 voicegw tui
 ```
 
-Resolves the daemon URL from `voicegw.yaml`, runs a 2 s health preflight, and opens the Sessions tab.
-
-### Launch in Local mode
-
 ```bash
+# Launch in Local mode (no daemon needed)
 voicegw tui --local
 ```
 
-Bypasses the daemon and reads the SQLite call DB directly. The `[Local mode]` chip stays visible in the header for the entire session.
-
-### Connect to a remote daemon
-
 ```bash
+# Connect to a remote daemon with authentication
 voicegw tui --url https://gateway.internal:8080 --token "$VG_TOKEN"
 ```
 
-Bearer token is sent on the health preflight and on every API call, including the Providers `t` shortcut.
-
-### Slower polling for shared environments
-
 ```bash
+# Slower polling for shared environments
 voicegw tui --poll 5.0
 ```
 
-Useful when running against a daemon that is also serving production traffic and you do not want the TUI's polling to register as a noticeable load.
-
 ## Troubleshooting
 
-### Terminal too small
+**Terminal too small:** The TUI assumes at least 80 cols x 24 rows. On smaller terminals, row content truncates and the help overlay may not render fully. Resize the terminal or open it in a fresh window.
 
-The TUI assumes at least 80 cols × 24 rows. On smaller terminals, row content truncates and the help overlay may not render fully. Resize the terminal or open it in a fresh window.
+**Colors look wrong:** Textual's `Color.downgrade()` auto-maps the brand-orange `#D85A30` to xterm color 166 on 256-color terminals. If colors look off, verify `TERM` is `xterm-256color` (or similar).
 
-### Colors look wrong on 256-color terminals
+**Local mode write attempts:** The `t` shortcut on Providers raises `LocalModeUnsupportedError` in Local mode. This is by design. To run a real test, start the daemon (`voicegw start`) and relaunch the TUI without `--local`.
 
-Textual's `Color.downgrade()` auto-maps the brand-orange `#D85A30` to xterm color 166 on 256-color terminals and to color 3 (yellow) or 1 (red) on 16-color terminals. If colors look off, verify `TERM` is `xterm-256color` (or similar). No code change is needed.
+**Daemon unreachable:** If `voicegw tui` exits with `Daemon at <url> is not reachable`, the 2 s health preflight failed. Verify the daemon is running (`voicegw status`) and that the `--url` is correct. For read-only inspection without the daemon, use `voicegw tui --local`.
 
-### Local mode write attempts
+**Reconnection:** If the daemon stops responding mid-session, the footer flips to `Reconnecting to daemon...`. The next successful poll cycle restores it.
 
-The `t` shortcut on Providers raises `LocalModeUnsupportedError` in Local mode. This is by design: the daemon is the only path that holds the upstream provider sessions and rate-limit budget. The warning notification names the unsupported feature (`test_provider`). To run a real test, start the daemon (`voicegw start`) and relaunch the TUI without `--local`.
-
-### Daemon unreachable
-
-If `voicegw tui` exits with `Daemon at <url> is not reachable`, the 2 s health preflight failed. Verify the daemon is running (`voicegw status`) and that the `--url` is correct. For read-only inspection of the SQLite call DB without the daemon, use `voicegw tui --local`.
-
-### Reconnection
-
-If the daemon stops responding mid-session, the footer flips to `Reconnecting to daemon...`. The next successful poll cycle replaces it with the live counter. The polling cadence (1 s default in Gateway mode) is the retry interval; exponential backoff is deferred to a future milestone.
-
-## Exit Codes
+## Exit codes
 
 | Code | Meaning |
 |---|---|
-| `0` | Clean exit (user pressed `q` or `Ctrl+C`). |
+| `0` | Clean exit (user pressed `q` or Ctrl+C). |
 | `1` | Daemon unreachable in Gateway mode, or any launch-time failure (corrupt SQLite in Local mode, missing `[tui]` extra, etc.). |
 
-## Related Commands
+## Related
 
-- [`voicegw status`](/cli/status) -- quick non-interactive provider status
-- [`voicegw dashboard`](/cli/dashboard) -- the web counterpart to the TUI
-- [`voicegw costs`](/cli/costs) -- non-interactive cost summary
-- [`voicegw logs`](/cli/logs) -- non-interactive log tail
+[`voicegw status`](/cli/status) | [`voicegw dashboard`](/cli/dashboard) | [`voicegw costs`](/cli/costs) | [`voicegw logs`](/cli/logs)


### PR DESCRIPTION
Part 1 of the CLI reference rewrite (init, onboard, serve, dashboard, tui, status, mcp, index). Removes the MDX-breaking {#anchor} heading ids on serve/status and repoints cli/index links to the auto-generated slugs. Consistent per-command template. Acceptance: python3 docs/_check_docs.py on the 8 pages passes. Pairs with #89 (part 2).