### PR TITLE
docs(api): rewrite Python & HTTP API reference (P10a)

### DIFF
--- a/docs/api/dashboard-api.md
+++ b/docs/api/dashboard-api.md
@@ -1,15 +1,19 @@
-# Dashboard API reference
+---
+title: Dashboard API Reference
+description: Read-only `/api/*` endpoints served by the daemon alongside the HTTP API and the React SPA. Consumed automatically by the built-in web dashboard.
+---
 
-The dashboard API is mounted by the daemon (`voicegw serve`) under
-the `/api/` prefix on the same port as the public HTTP API
-(`/v1/*`) and the React SPA (`/`). The default port is 8080; the
-`serve.port` key in `voicegw.yaml` overrides it.
+The dashboard API is mounted by the daemon (`voicegw serve`) under the `/api/` prefix on the same port as the public HTTP API (`/v1/*`) and the React SPA (`/`). The default port is 8080; the `serve.port` key in `voicegw.yaml` overrides it.
 
 Start the daemon (the dashboard API ships with it):
 
 ```bash
 voicegw serve
 ```
+
+<Note>
+These endpoints are optimized for the dashboard UI and aggregate data slightly differently from the HTTP API (`/v1/*`). For example, `/api/overview` combines multiple queries into one response. If you are building external tooling, prefer the [HTTP API](/api/http-api).
+</Note>
 
 ## GET /api/status
 
@@ -40,6 +44,35 @@ Returns the configuration status of all providers, registered models, and fallba
 
 ```bash
 curl http://localhost:8080/api/status
+```
+
+## GET /api/overview
+
+Return aggregated dashboard overview statistics. This endpoint combines multiple queries into a single response for the dashboard's summary cards.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `project` | `string` | `null` | Filter all stats by project ID. |
+
+**Response:**
+
+```json
+{
+  "total_requests": 12450,
+  "total_cost_today": 15.23,
+  "total_cost_all": 342.87,
+  "active_models": 8,
+  "providers_configured": 5
+}
+```
+
+**Example:**
+
+```bash
+curl http://localhost:8080/api/overview
+curl "http://localhost:8080/api/overview?project=tonys-pizza"
 ```
 
 ## GET /api/costs
@@ -122,35 +155,6 @@ curl "http://localhost:8080/api/logs?limit=50&modality=stt"
 curl "http://localhost:8080/api/logs?project=tonys-pizza"
 ```
 
-## GET /api/overview
-
-Return aggregated dashboard overview statistics. This endpoint combines multiple queries into a single response for the dashboard's summary cards.
-
-**Query parameters:**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `project` | `string` | `null` | Filter all stats by project ID. |
-
-**Response:**
-
-```json
-{
-  "total_requests": 12450,
-  "total_cost_today": 15.23,
-  "total_cost_all": 342.87,
-  "active_models": 8,
-  "providers_configured": 5
-}
-```
-
-**Example:**
-
-```bash
-curl http://localhost:8080/api/overview
-curl "http://localhost:8080/api/overview?project=tonys-pizza"
-```
-
 ## GET /api/projects
 
 List all configured projects with today's stats.
@@ -187,7 +191,7 @@ curl http://localhost:8080/api/projects
 
 ## Static File Serving
 
-The dashboard also serves the React frontend's built assets. If the frontend has been built (`src/dashboard/frontend/dist/` exists), the dashboard serves:
+The dashboard also serves the React frontend's built assets. If the frontend has been built (`src/dashboard/frontend/dist/` exists), the daemon serves:
 
 - `GET /` -- the React app's `index.html`
 - `GET /assets/*` -- bundled JavaScript, CSS, and other static files

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -1,4 +1,7 @@
-# HTTP API Reference
+---
+title: HTTP API Reference
+description: REST endpoints served by `voicegw serve`. Covers health, status, models, costs, projects, providers, logs, metrics, and audit log.
+---
 
 The VoiceGateway HTTP API runs via `voicegw serve` (default port 8080). It provides read-only observability endpoints and full CRUD for managing providers, models, and projects.
 
@@ -148,9 +151,7 @@ Return latency statistics for the given period.
 | `period` | `string` | `"today"` | One of: `today`, `week`, `month`. |
 | `project` | `string` | `null` | Filter by project ID. |
 
-**Response:**
-
-Returns per-model latency statistics including average TTFB and total latency.
+**Response:** Per-model latency statistics including average TTFB and total latency.
 
 **Example:**
 
@@ -476,7 +477,7 @@ curl -X POST http://localhost:8080/v1/models \
 
 ### DELETE /v1/models/{model_id}
 
-Delete a managed model. Requires `?confirm=true`. The `model_id` is a path parameter (e.g., `deepgram/nova-3`).
+Delete a managed model. Requires `?confirm=true`. The `model_id` is a path parameter (for example, `deepgram/nova-3`).
 
 **Example:**
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,64 +1,48 @@
-# API Reference
+---
+title: API Reference
+description: VoiceGateway exposes three distinct API surfaces. Choose the one that fits your integration point.
+---
 
 VoiceGateway exposes three distinct API surfaces, each designed for a different integration point.
 
-## Python SDK
+<CardGroup cols={2}>
+  <Card title="Python SDK" icon="python" href="/api/python-sdk">
+    `attach`, `guard`, and `Observer`. The public Python surface for wiring cost tracking and fallback into your LiveKit or Pipecat agent.
+  </Card>
+  <Card title="HTTP API" icon="server" href="/api/http-api">
+    REST endpoints served by `voicegw serve` on port 8080. Observability, project CRUD, Prometheus metrics.
+  </Card>
+  <Card title="Dashboard API" icon="chart-bar" href="/api/dashboard-api">
+    Read-only `/api/*` endpoints served alongside the HTTP API, consumed by the built-in React dashboard.
+  </Card>
+  <Card title="MCP Server" icon="plug" href="/mcp/index">
+    Model Context Protocol tools for AI coding agents. Add, rotate, and inspect providers, models, and costs from Claude Code or any MCP-compatible host.
+  </Card>
+</CardGroup>
 
-The **`voicegateway.inference` module** is the public Python surface. It is a drop-in mirror of `livekit.agents.inference`: change the import line in an existing LiveKit Cloud Inference agent and the rest of the code keeps working. Cost tracking, latency monitoring, and session correlation happen transparently in the middleware.
-
-```python
-from livekit.agents import AgentSession
-
-from voicegateway.inference import STT, LLM, TTS
-
-session = AgentSession(
-    stt=STT("deepgram/nova-3"),
-    llm=LLM("openai/gpt-4.1-mini"),
-    tts=TTS("cartesia/sonic-3"),
-)
-```
-
-Best for: application code, scripts, custom integrations.
-
-[Full Python SDK reference](/api/python-sdk)
-
-## HTTP API
-
-The **REST API** runs on port 8080 (default) via `voicegw serve`. It provides CRUD operations for providers, models, and projects, plus read-only endpoints for costs, latency, logs, and Prometheus-format metrics. The dashboard frontend consumes this API, and external monitoring tools can scrape `/v1/metrics`.
-
-```bash
-curl http://localhost:8080/v1/status
-curl http://localhost:8080/v1/costs?period=week&project=my-app
-```
-
-Best for: dashboards, monitoring, CI/CD pipelines, multi-language teams.
-
-[Full HTTP API reference](/api/http-api)
-
-## Dashboard API
-
-The **dashboard API** is mounted by the daemon (`voicegw serve`)
-under the `/api/` prefix on the same port as the HTTP API and the
-React SPA. It exposes a smaller set of read-only `/api/*` endpoints
-optimised for the dashboard UI. These endpoints aggregate data
-slightly differently from the HTTP API (for example, `/api/overview`
-combines multiple queries into a single response).
-
-```bash
-curl http://localhost:8080/api/overview
-curl http://localhost:8080/api/costs?period=today
-```
-
-Best for: the built-in web dashboard (consumed automatically).
-
-[Full Dashboard API reference](/api/dashboard-api)
-
-## Choosing the Right API
+## Choosing the right surface
 
 | Use case | API surface |
 |---|---|
-| Route voice AI requests in Python | Python SDK |
-| Manage providers/models/projects remotely | HTTP API |
-| Build a custom dashboard or integrate with monitoring | HTTP API |
-| Use the built-in web UI | Dashboard API (automatic, served by the daemon) |
-| Integrate with AI coding agents | [MCP server](/mcp/) |
+| Wire cost tracking into a Python agent | [Python SDK](/api/python-sdk) |
+| Manage providers, models, and projects remotely | [HTTP API](/api/http-api) |
+| Build a custom dashboard or integrate with monitoring | [HTTP API](/api/http-api) |
+| Scrape Prometheus-format metrics | [HTTP API](/api/http-api) (`/v1/metrics`) |
+| Use the built-in web dashboard | [Dashboard API](/api/dashboard-api) (automatic, served by the daemon) |
+| Integrate with AI coding agents | [MCP server](/mcp/index) |
+| Understand the system internals | [Architecture](/architecture/index) |
+
+## Quick orientation
+
+The Python SDK wraps your agent at construction time via `attach` and `guard`. You do not call the HTTP API from agent code; the daemon's middleware pipeline writes to SQLite and the HTTP and Dashboard APIs read from it.
+
+```
+Agent code
+  -> attach(session, ...) / guard(provider, ...)
+  -> middleware pipeline (cost tracking, rate limiting, fallback)
+  -> SQLite
+  -> HTTP API (/v1/*) + Dashboard API (/api/*)
+  -> Dashboard UI + external monitoring
+```
+
+See [Architecture](/architecture/index) and [Core concepts](/guide/core-concepts) for a deeper walkthrough.

--- a/docs/api/python-sdk.md
+++ b/docs/api/python-sdk.md
@@ -1,410 +1,273 @@
-# Python SDK Reference
+---
+title: Python SDK Reference
+description: Public Python API for attaching VoiceGateway cost tracking and fallback to LiveKit and Pipecat agents.
+---
 
-VoiceGateway exposes one public Python surface: the
-`voicegateway.inference` module, a drop-in mirror of
-`livekit.agents.inference`. New agent code uses it; existing LiveKit
-Cloud Inference code switches over with one import-line change.
+The public Python surface is four names exported from the top-level `voicegateway` package: `attach`, `guard`, `Observer`, and `__version__`.
 
-Cost queries, project management, latency stats, and request logs live outside the Python SDK. Use the [CLI](/cli/), the [HTTP API](/api/http-api), the [dashboard](/), or the [MCP tools](/mcp/) for those.
+```python
+from voicegateway import attach, guard, Observer, __version__
+```
+
+Cost queries, project management, latency stats, and request logs live outside the Python SDK. Use the [CLI](/cli/index), the [HTTP API](/api/http-api), the [Dashboard API](/api/dashboard-api), or the [MCP tools](/mcp/index) for those.
+
+<Note>
+The inference factories (`STT`, `LLM`, `TTS`) from the deprecated `inference` submodule are being removed. If you are migrating from them, see [Migrating from inference factories](/guide/migration-attach-guard).
+</Note>
 
 ## Installation
 
-```bash
+<CodeGroup>
+
+```bash uv
+uv add voicegateway
+# With provider extras:
+uv add "voicegateway[openai,deepgram,cartesia]"
+```
+
+```bash pip
 pip install voicegateway
-# Or with specific provider extras:
+# With provider extras:
 pip install "voicegateway[openai,deepgram,cartesia]"
 ```
 
-## Import
+</CodeGroup>
+
+## `attach`
 
 ```python
-from voicegateway import inference
-```
-
-The `inference` submodule is the only documented public entry point. The internal `voicegateway.core.gateway.Gateway` class still exists for the CLI, HTTP server, and MCP runtime, but it is not part of the supported Python SDK and may change without notice.
-
-## `inference.STT`
-
-```python
-inference.STT(
-    model: NotGivenOr[STTModels | str] = NOT_GIVEN,
+attach(
+    target,
     *,
-    language: NotGivenOr[str] = NOT_GIVEN,
-    base_url: NotGivenOr[str] = NOT_GIVEN,
-    encoding: NotGivenOr[STTEncoding] = NOT_GIVEN,
-    sample_rate: NotGivenOr[int] = NOT_GIVEN,
-    api_key: NotGivenOr[str] = NOT_GIVEN,
-    api_secret: NotGivenOr[str] = NOT_GIVEN,
-    http_session: aiohttp.ClientSession | None = None,
-    extra_kwargs: NotGivenOr[dict | DeepgramOptions | ...] = NOT_GIVEN,
-    fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
-    conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
-)
-```
-
-```python
-from voicegateway import inference
-
-stt = inference.STT("deepgram/nova-3:en")
-# Trailing :en parses as the language (mirrors LK STT).
-```
-
-The `model` string parses as `provider/model[:language]`. Provider names are validated against the eleven supported types (`openai`, `deepgram`, `cartesia`, `anthropic`, `groq`, `elevenlabs`, `assemblyai`, `ollama`, `whisper`, `kokoro`, `piper`). The `api_key` kwarg, when given, overrides the project's resolved key for this one instance (useful for testing).
-
-`api_secret`, `fallback`, and `conn_options` are accepted for drop-in compatibility but emit a `UserWarning`.
-
-## `inference.LLM`
-
-```python
-inference.LLM(
-    model: LLMModels | str,
-    *,
-    provider: str | None = None,
-    base_url: str | None = None,
-    api_key: str | None = None,
-    api_secret: str | None = None,
-    inference_class: InferenceClass | None = None,
-    extra_kwargs: ChatCompletionOptions | dict | None = None,
-)
-```
-
-```python
-llm = inference.LLM("openai/gpt-4o-mini")
-
-# Ollama tags are preserved: LLM does NOT strip the trailing colon
-# segment (only STT and TTS do).
-llm = inference.LLM("ollama/qwen2.5:3b")
-
-# Explicit provider= overrides any leading "<provider>/" segment in
-# the model string. Useful when the model name itself has no slash.
-llm = inference.LLM("gpt-4o-mini", provider="openai")
-```
-
-LLM uses `None` defaults instead of `NotGivenOr` to match LK's LLM shape. There is no `fallback`, `conn_options`, or `http_session` parameter; those are STT/TTS-specific.
-
-## `inference.TTS`
-
-```python
-inference.TTS(
-    model: TTSModels | str,
-    *,
-    voice: NotGivenOr[str] = NOT_GIVEN,
-    language: NotGivenOr[str] = NOT_GIVEN,
-    encoding: NotGivenOr[TTSEncoding] = NOT_GIVEN,
-    sample_rate: NotGivenOr[int] = NOT_GIVEN,
-    base_url: NotGivenOr[str] = NOT_GIVEN,
-    api_key: NotGivenOr[str] = NOT_GIVEN,
-    api_secret: NotGivenOr[str] = NOT_GIVEN,
-    http_session: aiohttp.ClientSession | None = None,
-    extra_kwargs: NotGivenOr[dict | CartesiaOptions | ...] = NOT_GIVEN,
-    fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
-    conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
-)
-```
-
-```python
-tts = inference.TTS("cartesia/sonic-3:my-voice-id")
-# Trailing :my-voice-id parses as the voice (mirrors LK TTS).
-
-# Or explicit voice kwarg:
-tts = inference.TTS("cartesia/sonic-3", voice="my-voice-id")
-```
-
-Same shape as STT, plus a `voice` kwarg. The trailing colon-suffix in the model string parses as voice (NOT language). That is the semantic asymmetry between STT and TTS that LiveKit defines.
-
-## Project routing
-
-### `inference.set_project`
-
-```python
-inference.set_project(name: str) -> None
-```
-
-```python
-from voicegateway import inference
-
-inference.set_project("tony-pizza")
-stt = inference.STT("deepgram/nova-3")  # uses tony-pizza's key
-```
-
-Sets the active project for the current async context. The setting inherits across awaited coroutines but is isolated across separate `asyncio.Task` instances.
-
-Resolution order for the active project:
-
-1. `inference.set_project(name)` in the current context.
-2. `VOICEGW_ACTIVE_PROJECT` environment variable.
-3. `default_project` field in `voicegw.yaml`.
-4. The literal `"default"`. The gateway auto-creates a project of this id on first run, so the fallback is always backed by a real row.
-
-### `inference.get_active_project`
-
-```python
-inference.get_active_project() -> str
-```
-
-Returns the active project name following the resolution order above.
-
-```python
-from voicegateway import inference
-
-print(f"Resolving keys for project: {inference.get_active_project()}")
-```
-
-## Session correlation
-
-### `inference.start_session`
-
-```python
-inference.start_session() -> str
-```
-
-VoiceGateway tags every STT, LLM, and TTS call from the same async context with one shared `session_id` (`"vg-<uuid4>"`). Inside `AgentSession` this happens automatically: the first factory constructed in a context creates the id, the others inherit it. The id is written to `requests.session_id` and accumulates into the `sessions` table.
-
-The standard `livekit-agents` worker spawns a fresh task per call, so the ContextVar starts clean and `start_session` is unnecessary. Worker patterns that handle multiple conversations sequentially in a single asyncio task need to call `start_session()` at the top of each conversation handler; otherwise the second conversation reuses the first's id.
-
-```python
-from voicegateway import inference
-
-async def handle_conversation():
-    session_id = inference.start_session()  # rolls a fresh id
-    stt = inference.STT("deepgram/nova-3")
-    llm = inference.LLM("openai/gpt-4o-mini")
-    tts = inference.TTS("cartesia/sonic-3")
-    # ... session_id is shared across all three modalities ...
-```
-
-The known gap: factories constructed in separate `asyncio.Task` instances created **before** the session opens get their own ids. Construct factories at session entry, not at module import time.
-
-### `inference.attach_session` (opt-in)
-
-```python
-inference.attach_session(
-    agent_session,
-    *,
-    session_id: str | None = None,
+    project: str = "default",
+    agent_id: str | None = None,
     tenant_id: str | None = None,
-    turn_tracker: TurnTracker | None = None,
-    dead_air_detector: DeadAirDetector | None = None,
-    cost_tracker: CostTracker | None = None,
+    channel: str | None = None,
+    collector_url: str | None = None,
+    api_key: str | None = None,
+    sink=None,
+    room=None,
 ) -> str
 ```
 
-Opt-in escape hatch that wires a LiveKit `AgentSession` into the voice-conversation metrics pipeline: per-turn response speed, talk-over rate, and dead-air detection.
+`attach` wires a LiveKit `AgentSession` or Pipecat `PipelineTask` into the VoiceGateway middleware pipeline. It returns a session id string (`"vg-<uuid4>"`).
 
-In the standard `livekit-agents` worker pattern, the metric capture happens automatically through plugin-level hooks on `InstrumentedSTT`/`InstrumentedTTS`. `attach_session` exists for the cases where those hooks miss events: custom AgentSession subclasses, in-process agent harnesses, or test rigs. When in doubt, you don't need to call it.
+### Parameters
 
-Returns the bound `session_id` so the caller can echo it into its own logs.
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `target` | `AgentSession` or `PipelineTask` | required | The agent session or pipeline task to instrument. |
+| `project` | `str` | `"default"` | Project to bill this session against. |
+| `agent_id` | `str \| None` | `None` | Human-readable agent identifier. Appears in the dashboard and logs. |
+| `tenant_id` | `str \| None` | `None` | Per-call tenant identifier for multi-tenant cost slicing. 128-char UTF-8 cap. |
+| `channel` | `str \| None` | `None` | Logical channel label (for example, `"inbound"`, `"outbound"`). |
+| `collector_url` | `str \| None` | `None` | Override the collector endpoint for this session. Falls back to `VOICEGW_COLLECTOR_URL`. |
+| `api_key` | `str \| None` | `None` | Override the API key for this session. Falls back to `VOICEGW_API_KEY`. |
+| `sink` | sink instance or `None` | `None` | Custom telemetry sink. Defaults to the process-level sink. |
+| `room` | LiveKit `Room` or `None` | `None` | LiveKit room for metadata propagation (optional, used for tenant carry-on-wire). |
+
+### Usage
+
+<Tabs>
+  <Tab title="LiveKit">
+
+```python
+from livekit.agents import AgentSession, Agent, RoomInputOptions
+from voicegateway import attach
+
+class MyAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="You are a helpful assistant.")
+
+async def entrypoint(ctx):
+    session = AgentSession()
+    session_id = attach(
+        session,
+        project="my-app",
+        agent_id="support-bot",
+        tenant_id=ctx.room.name,  # optional per-call tenant
+    )
+    await session.start(
+        agent=MyAgent(),
+        room=ctx.room,
+        room_input_options=RoomInputOptions(),
+    )
+```
+
+  </Tab>
+  <Tab title="Pipecat">
+
+```python
+from pipecat.pipeline.task import PipelineTask
+from voicegateway import attach, Observer
+
+task = PipelineTask(
+    pipeline,
+    observers=[Observer(project="my-app", tenant_id="acme")],
+)
+# Or use attach directly on the task after construction:
+session_id = attach(task, project="my-app", tenant_id="acme")
+```
+
+  </Tab>
+</Tabs>
+
+### Return value
+
+`attach` returns the session id string (`"vg-<uuid4>"`). Use it to correlate external logs with VoiceGateway cost rows.
+
+```python
+session_id = attach(session, project="my-app")
+logger.info("session started", extra={"vg_session": session_id})
+```
+
+### Tenant attribution
+
+Set `tenant_id` to attribute this session to a specific customer. When `room` is also passed, VoiceGateway carries the tenant id in LiveKit room metadata so it survives SFU hops.
+
+```python
+attach(session, project="acme-platform", tenant_id=request.user_id, room=room)
+```
+
+Sessions with no tenant set are stored as `tenant_id = NULL` and shown as "unattributed" in the dashboard.
+
+See [Attach guide](/guide/attach) for a full walkthrough.
+
+## `guard`
+
+```python
+guard(
+    provider,
+    *,
+    fallback: tuple | list = (),
+    rate_limit: int | None = None,
+    budget: float | None = None,
+    project: str | None = None,
+) -> <same type as provider>
+```
+
+`guard` wraps a provider instance with fallback chains, rate limiting, and per-project budget enforcement. It returns the same type as the input `provider`, so it is a transparent drop-in.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `provider` | STT, LLM, or TTS plugin instance | required | The provider to wrap. |
+| `fallback` | `tuple` or `list` | `()` | Ordered sequence of fallback provider instances tried on error or timeout. |
+| `rate_limit` | `int \| None` | `None` | Maximum requests per minute. Excess requests block until capacity recovers. |
+| `budget` | `float \| None` | `None` | Hard per-session cost ceiling in USD. Raises `BudgetExceeded` when crossed. |
+| `project` | `str \| None` | `None` | Project scope for budget tracking. Defaults to the session's active project. |
+
+### Usage
+
+<Tabs>
+  <Tab title="LiveKit">
 
 ```python
 from livekit.agents import AgentSession
-from voicegateway import inference
+from livekit.plugins import deepgram, openai, cartesia
+from voicegateway import attach, guard
 
-async def handle_call():
-    agent_session = AgentSession(...)  # your usual construction
-
-    # Opt into explicit metric wiring.
-    sid = inference.attach_session(agent_session)
-
-    await agent_session.start(...)
-    # Per-turn captures flow into the TurnTracker; the AgentSession's
-    # `close` event flushes them, stops the dead-air watcher, and
-    # calls cost-tracker's session-finalization hook.
-```
-
-The helper subscribes to five `AgentSession` events: `user_started_speaking`, `user_stopped_speaking`, `agent_started_speaking`, `agent_stopped_speaking`, `close`. The first four feed the `TurnTracker`; `close` flushes the tracker, stops the `DeadAirDetector`, and calls `CostTracker.close_session(sid)` so the aggregate columns (`talk_time_seconds`, `per_minute_cost_usd`, `response_speed_p50/p95_ms`, `talk_over_rate`) land on the `sessions` row by the time the dashboard's `/api/metrics` endpoint reads it.
-
-Components default to the process-level registry the Gateway populates on startup; pass explicit kwargs to override (the unit-test path).
-
-## Tenant attribution
-
-VoiceGateway tags each session with an optional `tenant_id` so multi-tenant operators can slice costs, metrics, and replay by customer. The tenant flows through three independent surfaces; pick the one that matches your deployment.
-
-### 1. `attach_session(..., tenant_id="…")`
-
-The opt-in path. Pass `tenant_id` at the same time you wire the LiveKit `AgentSession`, and every cost row, metric row, and replay event from that session lands tagged.
-
-```python
-from voicegateway import inference
-
-async def handle_call(tenant_id: str):
-    agent_session = AgentSession(...)
-    inference.attach_session(agent_session, tenant_id=tenant_id)
-    await agent_session.start(...)
-```
-
-When `tenant_id` is omitted (default `None`) the ContextVar is left alone, so a virtual key resolved earlier in the request (see surface 3 below) or an explicit `set_tenant(...)` call still wins. Calling with `tenant_id=None` does not clear a previously-set scope.
-
-### 2. `inference.set_tenant(tenant_id)`
-
-The escape hatch for code that does not own the `AgentSession` construction. Sets the `tenant_id_ctx` ContextVar for the rest of the async context; the next `log_request` call picks it up and stamps the session row. 128-char UTF-8 cap.
-
-```python
-from voicegateway import inference
-
-inference.set_tenant("acme")
-stt = inference.STT("deepgram/nova-3")
-# ... subsequent factories inherit the tenant via the ContextVar.
-```
-
-`inference.current_tenant()` reads the current scope without modifying it. `inference.reset_tenant_id()` clears the ContextVar for a new session boundary inside the same task.
-
-### 3. Scoped API keys (no code change required)
-
-When a request authenticates with an API key whose `tenant_id` is set, the HTTP API's auth middleware (in `src/voicegateway/server/main.py::build_app`) auto-tags the session with the key's scope. Agent code does not need to know the tenant: the dashboard's API Keys page (`/api-keys`) issues a scoped key, the operator ships it as `Authorization: Bearer <key>`, and every request inherits the scope.
-
-Body-level `tenant_id` is rejected with `403` when it conflicts with a scoped virtual key. Unscoped virtual keys (issued without a tenant) allow the body to declare any tenant, matching the static-key behavior.
-
-### The "unattributed" bucket
-
-Sessions where none of the three surfaces set a tenant get `tenant_id = NULL` in storage. The dashboard renders these as a muted "unattributed" pill rather than a literal tenant string.
-
-The first tenant-bearing request "wins" for the session's lifetime. A later unattributed request on the same `session_id` does not clear the tenant_id (the `sessions` UPSERT uses `COALESCE(tenant_id, excluded.tenant_id)`).
-
-For the operator-facing workflow (issuing keys, viewing per-tenant costs, exporting), see the [multi-tenant quickstart](/guide/multi-tenant-quickstart).
-
-## Cross-modality routing
-
-Each project carries a latency budget and a per-modality provider roster. When a session starts, VoiceGateway picks the (STT, LLM, TTS) combination from the roster that minimises predicted total latency under the budget. The pick is recorded on the session row so the dashboard can show what ran and how close the call landed to the budget.
-
-```yaml
-projects:
-  acme:
-    name: Acme
-    routing:
-      budget_ms: 1500            # Typical conversational target.
-      fallback_to_fastest: true  # When no triple fits, pick the fastest and flag budget_overrun.
-      rosters:
-        stt: [deepgram, assemblyai]    # Ordered by operator preference.
-        llm: [groq, openai, anthropic]
-        tts: [cartesia, elevenlabs]
-```
-
-### How the router picks
-
-At session start, the router reads three inputs and produces a `RoutedTriple` plus a `budget_overrun` boolean.
-
-1. **Observed p50 per (provider, modality)**: rolled up by the 15-minute worker from the requests table, written to `latency_observations`. The router prefers observed data when present.
-2. **Curated published-median baselines** in `src/voicegateway/core/provider_baselines.json`. Used when no observation exists for a candidate. Operators can edit the JSON to update a published median or add a missing provider.
-3. **Caller overrides**: explicit `{modality: provider}` map passed from the agent code. The router respects overrides for the named modalities and only picks for the unset ones.
-
-Candidate triples are the cartesian product of the rosters minus the overridden modalities. The router computes a predicted total (sum of per-modality predictions), picks the lowest one whose total fits the budget. If nothing fits and `fallback_to_fastest=true`, it picks the fastest available and flags `budget_overrun=true`. If `fallback_to_fastest=false`, it raises `BudgetExceeded`.
-
-### Explicit overrides from agent code
-
-Pass the caller-override dict through whatever surface attaches the session. The reference path is `route_session(...)` returning a `RoutedTriple`, with the caller then handing the triple to `attach_session(routed_triple=...)`:
-
-```python
-from voicegateway import inference
-from voicegateway.middleware import router
-
-async def handle_call(project_id: str, caller_overrides: dict[str, str] | None = None):
-    db = await gateway.storage._ensure_initialized()
-    triple = await router.route_session(
-        db,
-        project_id=project_id,
-        project_config=gateway.config.projects[project_id],
-        caller_overrides=caller_overrides,
+async def entrypoint(ctx):
+    session = AgentSession(
+        stt=guard(
+            deepgram.STT(model="nova-3"),
+            fallback=[openai.STT()],
+            rate_limit=60,
+        ),
+        llm=guard(
+            openai.LLM(model="gpt-4o-mini"),
+            fallback=[openai.LLM(model="gpt-4.1-nano")],
+            budget=0.05,
+        ),
+        tts=guard(
+            cartesia.TTS(model="sonic-3"),
+            fallback=[openai.TTS()],
+        ),
     )
-    agent_session = AgentSession(...)
-    inference.attach_session(
-        agent_session,
-        routed_triple=(triple.stt, triple.llm, triple.tts, triple.predicted_ms, triple.budget_overrun),
-    )
-    await agent_session.start(...)
+    attach(session, project="my-app")
+    await session.start(agent=MyAgent(), room=ctx.room)
 ```
 
-The router runs once per session; the picked triple is immutable for the session's lifetime.
-
-### Inspecting what the router would pick
-
-For ops debugging, `voicegw route show <project>` prints the current observations and rosters, and `voicegw route simulate <project> [--stt X] [--llm Y]` dry-runs the picker without writing a session row. Both accept `--json` for scripting.
-
-For the agency-facing operator workflow (tuning budgets, uploading branding, exporting per-project data), see the [agency quickstart](/guide/agency-quickstart).
-
-## Voice-specific guardrails
-
-Guardrails are project-scoped and injected through the existing drop-in `voicegateway.inference.LLM(...)` path. No separate session-create service is required.
-
-```yaml
-projects:
-  support:
-    name: Support Bot
-    guardrails:
-      enabled: true
-      categories:
-        pii: redact
-        financial: block
-        medical: alert
-        prompt_injection: block
-        off_topic: off
-```
-
-On the first guarded LLM chat in a session, VoiceGateway freezes the active policy, appends a versioned guardrail system block after existing system/developer instructions, and registers the reserved LiveKit tool `report_guardrail_action(category, action, context_excerpt)`. User-defined tools with that name are rejected when guardrails are active.
-
-Bypass is explicit and audited:
+  </Tab>
+  <Tab title="Pipecat">
 
 ```python
-from voicegateway import inference
+from pipecat.services.deepgram import DeepgramSTTService
+from pipecat.services.openai import OpenAILLMService
+from voicegateway import guard
 
-inference.start_session(bypass_guardrails=True)
-
-# Or when binding a custom LiveKit AgentSession:
-inference.attach_session(agent_session, bypass_guardrails=True)
+stt = guard(
+    DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"]),
+    fallback=[DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY_BACKUP"])],
+    rate_limit=60,
+)
 ```
 
-Bypass skips prompt/tool injection for that session and writes a `bypassed` audit row when a policy would otherwise be active. See the [guardrails guide](/guide/guardrails) and [prompt reference](/reference/guardrail-prompts).
+  </Tab>
+</Tabs>
 
-## Conversation replay capture
+### Return value
 
-VoiceGateway captures a per-event timeline for every voice conversation: each STT chunk, each LLM token, each TTS frame, plus periodic conversation-state snapshots. The dashboard's [Replay page](/) then scrubs through any past call moment-by-moment with cost accruing live. This happens automatically; users do not call any function to opt in.
+`guard` returns the same type as `provider`. The returned object is a transparent proxy: all provider method calls pass through to the underlying implementation and then to the fallback chain on error.
 
-The capture path runs alongside the metrics pipeline. The same `attach_session` helper covered above wires replay events into the [`ReplayCapture`](https://github.com/mahimailabs/voicegateway/blob/main/voicegateway/middleware/replay_capture.py) buffer on the standard worker pattern. Custom AgentSession subclasses use the same opt-in escape hatch.
+See [Guard guide](/guide/guard) for fallback chain behavior, budget enforcement details, and error handling.
 
-### Defaults and per-project knobs
+## `Observer`
 
-Replay capture defaults live under each project's `replay:` block in `voicegw.yaml`:
+`Observer` is the Pipecat integration class. Pass it to `PipelineTask(observers=[...])` to wire VoiceGateway cost tracking and metrics capture into a Pipecat pipeline.
 
-```yaml
-projects:
-  acme:
-    name: Acme Corp
-    replay:
-      enabled: true             # capture for every session in this project
-      retention_days: 90        # age replay rows out after this window
-      buffer_size_events: 5000  # per-session in-memory cap before dropping oldest
-      flush_size_events: 500    # batched writes to storage every N events
+```python
+from voicegateway import Observer
+from pipecat.pipeline.task import PipelineTask
+
+task = PipelineTask(
+    pipeline,
+    observers=[
+        Observer(
+            project="my-app",
+            agent_id="support-bot",
+            tenant_id="acme",
+            collector_url="https://ingest.voicegateway.dev",
+            api_key="vk_...",
+        )
+    ],
+)
 ```
 
-All four fields are optional; omitting `replay:` accepts the defaults shown above. The `enabled` toggle disables capture for the project (cost and metrics aggregates continue as before); the other three tune the storage/memory trade-off documented in [docs/storage/replay-storage-costs.md](/storage/replay-storage-costs).
+### Constructor parameters
 
-### Disabling capture
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `project` | `str` | `"default"` | Project to bill this pipeline run against. |
+| `agent_id` | `str \| None` | `None` | Human-readable agent identifier. |
+| `tenant_id` | `str \| None` | `None` | Per-call tenant identifier. |
+| `collector_url` | `str \| None` | `None` | Collector endpoint. Falls back to `VOICEGW_COLLECTOR_URL`. |
+| `api_key` | `str \| None` | `None` | API key. Falls back to `VOICEGW_API_KEY`. |
 
-For projects that should not record replay (sensitive content, regulatory constraint, storage cost concerns), set `enabled: false`:
+`Observer` implements the Pipecat `BaseObserver` protocol. It captures per-frame STT, LLM, and TTS events and flushes them to the VoiceGateway collector on pipeline shutdown.
 
-```yaml
-projects:
-  high-pii-project:
-    name: Sensitive Workflow
-    replay:
-      enabled: false
+<Tip>
+For LiveKit agents, use `attach` instead of `Observer`. `Observer` is the Pipecat-specific integration path.
+</Tip>
+
+## `__version__`
+
+```python
+from voicegateway import __version__
+
+print(__version__)  # e.g. "0.3.1"
 ```
 
-No replay events are captured for sessions in that project; the dashboard's Replay page renders a "replay capture is disabled for this project" banner with a link out to the per-modality session detail. Cost tracking, latency, and the metrics view continue uninterrupted.
+The installed package version string. Useful for logging and support diagnostics.
 
-### Retention worker
-
-The [`RetentionWorker`](https://github.com/mahimailabs/voicegateway/blob/main/voicegateway/storage/retention_worker.py) runs once an hour as a background asyncio task; it reads each project's `retention_days` and deletes replay rows tied to sessions whose `ended_at` is older than the window. Single-process; multi-replica coordination is out of scope.
-
-The dashboard's `POST /api/projects/{id}/replay/retention` endpoint updates `retention_days` in memory for the current process. The change applies on the next worker tick. Persistence to `voicegw.yaml` on disk is a future follow-up; restarting the gateway reverts to the file-defined value.
-
-## Operations: where to go
+## Where to go next
 
 | You want to | Use this |
 |---|---|
-| List projects | `voicegw projects` (CLI), `GET /v1/projects` (HTTP), `list_projects` (MCP) |
-| See costs | `voicegw costs` (CLI), `GET /v1/costs` (HTTP), `get_costs` (MCP), the dashboard |
-| Tail recent requests | `voicegw logs` (CLI), `GET /v1/logs` (HTTP), `get_logs` (MCP) |
-| Add or rotate a provider key | `vg_add_provider` / `vg_set_provider_key` (MCP), the dashboard Providers page |
-| Reconcile against an invoice | `voicegw reconcile --provider <name> --provider-usage-file <path>` |
-
-The Python SDK does not include these helpers; they live in the surfaces above.
+| Full attach walkthrough | [Guide: attach](/guide/attach) |
+| Full guard walkthrough | [Guide: guard](/guide/guard) |
+| Migrate from inference factories | [Migration guide](/guide/migration-attach-guard) |
+| List projects via CLI | [CLI reference](/cli/index) |
+| Query costs via REST | [HTTP API](/api/http-api) |
+| Integrate with AI coding agents | [MCP server](/mcp/index) |


### PR DESCRIPTION
## Summary

- Rewrites `api/index.md` with a `<CardGroup>` landing linking Python SDK, HTTP API, Dashboard API, MCP server, and Architecture.
- Rewrites `api/python-sdk.md` to document the current public surface: `attach`, `guard`, `Observer`, and `__version__`. Removes all deprecated `voicegateway.inference` / `inference.STT/LLM/TTS` content. Adds LiveKit/Pipecat `<Tabs>` for agent wiring examples.
- Adds `title:` + `description:` frontmatter to all four pages (`api/index`, `api/python-sdk`, `api/http-api`, `api/dashboard-api`).
- Fixes broken internal links: `/mcp/` -> `/mcp/index`, `/cli/` -> `/cli/index`.
- Preserves accurate endpoint paths, params, and response shapes in `http-api.md` and `dashboard-api.md` from the existing content.

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 4 scoped)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the API reference into clearer Python SDK, HTTP API, Dashboard API, and MCP Server sections.
  * Added guidance for choosing the right API surface and understanding the request/data flow.
  * Documented the Python SDK’s `attach`, `guard`, `Observer`, and version interfaces with installation and usage examples.
  * Expanded Dashboard API documentation, including overview requests, parameters, responses, and frontend serving behavior.
  * Clarified HTTP API endpoint responses and parameter descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->