### PR TITLE
docs(mcp): rewrite MCP server reference (P10b)

### DIFF
--- a/docs/mcp/authentication.md
+++ b/docs/mcp/authentication.md
@@ -1,28 +1,31 @@
-# Authentication
+---
+title: Authentication
+description: Secure the VoiceGateway MCP HTTP/SSE transport with the VOICEGW_MCP_TOKEN bearer token environment variable.
+---
 
-The MCP server supports optional Bearer token authentication for the HTTP/SSE transport. The stdio transport never checks authentication since it is only accessible to the local process that launched it.
+The MCP server supports optional bearer token authentication for the HTTP/SSE transport. The stdio transport never checks authentication because it is only accessible to the local process that launched it.
 
-## Overview
+## How it works
 
-Authentication is controlled by the `VOICEGW_MCP_TOKEN` environment variable:
+Authentication is controlled by the `VOICEGW_MCP_TOKEN` environment variable.
 
-- **Set** -- all HTTP requests must include a matching `Authorization: Bearer <token>` header.
-- **Not set** -- authentication is disabled and all requests are accepted.
+| State | Behavior |
+|---|---|
+| `VOICEGW_MCP_TOKEN` is set | All HTTP requests must include a matching `Authorization: Bearer <token>` header. |
+| `VOICEGW_MCP_TOKEN` is not set | Authentication is disabled; all requests pass through. |
 
-## Setting Up Authentication
+The check runs on both the SSE connection endpoint (`GET /sse`) and the message endpoint (`POST /messages/`). It uses `hmac.compare_digest` for constant-time comparison to prevent timing attacks.
+
+## Setting up authentication
 
 ### 1. Generate a token
 
-Use any secure random generator:
-
 ```bash
-# Python
+# Python (recommended)
 python -c "import secrets; print(secrets.token_urlsafe(32))"
 
 # OpenSSL
 openssl rand -base64 32
-
-# Example output: dGhpcyBpcyBhIHNlY3JldCB0b2tlbg
 ```
 
 ### 2. Start the server with the token
@@ -34,7 +37,7 @@ voicegw mcp --transport http --port 8090
 
 ### 3. Configure agents to send the token
 
-In your agent's MCP configuration:
+In your agent's MCP config:
 
 ```json
 {
@@ -49,61 +52,37 @@ In your agent's MCP configuration:
 }
 ```
 
-## How It Works
+## HTTP response codes
 
-The authentication middleware checks the `Authorization` header on both the SSE connection (`GET /sse`) and the message endpoint (`POST /messages/`). The check uses `hmac.compare_digest` for constant-time comparison to prevent timing attacks.
+| Scenario | Response |
+|---|---|
+| Valid token present | Request proceeds normally. |
+| Token missing | `401 Unauthorized` with body `Missing bearer token`. |
+| Token incorrect | `401 Unauthorized` with body `Invalid token`. |
+| Wrong auth scheme (e.g. `Basic`) | `401 Unauthorized` with body `Missing bearer token`. |
 
-### Valid request
+Only the `Bearer` scheme is accepted.
 
-```
-GET /sse HTTP/1.1
-Authorization: Bearer dGhpcyBpcyBhIHNlY3JldCB0b2tlbg
-```
+## When to disable authentication
 
-### Missing token
+Leaving `VOICEGW_MCP_TOKEN` unset is appropriate when:
 
-```
-GET /sse HTTP/1.1
-```
-
-Returns `401 Unauthorized` with body: `Missing bearer token`.
-
-### Invalid token
-
-```
-GET /sse HTTP/1.1
-Authorization: Bearer wrong-token
-```
-
-Returns `401 Unauthorized` with body: `Invalid token`.
-
-### Malformed header
-
-```
-GET /sse HTTP/1.1
-Authorization: Basic dXNlcjpwYXNz
-```
-
-Returns `401 Unauthorized` with body: `Missing bearer token` (only `Bearer` scheme is accepted).
-
-## When Authentication is Disabled
-
-If `VOICEGW_MCP_TOKEN` is not set (or is an empty string), all requests pass through without any authentication check. This is the default and is appropriate for:
-
-- Local development.
-- Internal networks behind a VPN.
-- Environments where authentication is handled by a reverse proxy.
+- Running locally during development.
+- The server is on an internal network protected by a VPN.
+- Authentication is handled upstream by a reverse proxy.
 
 <Warning>
-When running the HTTP transport on a publicly accessible network, always set `VOICEGW_MCP_TOKEN` and use HTTPS (via a reverse proxy).
+When the HTTP transport is accessible from a public network, always set `VOICEGW_MCP_TOKEN` and terminate TLS at a reverse proxy. See the [Setup guide](/mcp/setup) for a sample Nginx config.
 </Warning>
 
-## stdio Transport
+## stdio transport
 
-The stdio transport bypasses authentication entirely. Since the agent launches the MCP server as a subprocess, there is no network boundary to protect. The `VOICEGW_MCP_TOKEN` variable is ignored for stdio connections.
+The stdio transport bypasses authentication entirely. The agent launches the MCP server as a subprocess, so there is no network boundary to protect. `VOICEGW_MCP_TOKEN` is ignored for stdio connections.
 
-## Environment Variable Reference
+## Environment variable reference
 
 | Variable | Required | Description |
 |---|---|---|
 | `VOICEGW_MCP_TOKEN` | No | Bearer token for HTTP/SSE authentication. If unset, auth is disabled. |
+
+See [Environment variables](/configuration/environment-variables) for the full list of VoiceGateway env vars.

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -1,77 +1,76 @@
-# MCP Server
+---
+title: MCP Server
+description: VoiceGateway's built-in Model Context Protocol server lets AI coding agents configure providers, manage projects, and query costs without leaving their workflow.
+---
 
-VoiceGateway includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that lets AI coding agents inspect, configure, and manage your voice AI gateway without leaving their workflow.
+VoiceGateway ships a built-in [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server. Connect Claude Code, Cursor, Codex, or Cline to the gateway and manage it conversationally. No dashboard required.
 
-## What is MCP?
+## What the MCP server does
 
-MCP is an open protocol that allows AI agents to use tools provided by external servers. When you connect an agent like Claude Code or Cursor to VoiceGateway's MCP server, the agent gains access to 17 tools for querying gateway state and performing administrative operations.
+The server exposes 17 tools across four categories. Your AI editor can:
 
-## Tools Overview
+- Check gateway health and provider connectivity.
+- Register new providers and models.
+- Create projects with budgets and routing rules.
+- Query cost summaries and request logs.
 
-The MCP server exposes tools in four categories:
+All destructive tools (`delete_provider`, `delete_model`, `delete_project`) use a two-phase confirmation pattern. The agent always shows you the impact before applying the change.
 
-### Observability (read-only)
+## Tool categories
 
-| Tool | Description |
-|---|---|
-| `get_health` | Gateway health, uptime, version |
-| `get_provider_status` | Provider configuration status |
-| `get_costs` | Cost summary by period/project |
-| `get_latency_stats` | Latency percentiles and per-model stats |
-| `get_logs` | Recent request logs with filters |
+| Category | Tools | Purpose |
+|---|---|---|
+| Observability | `get_health`, `get_provider_status`, `get_costs`, `get_latency_stats`, `get_logs` | Read-only health, cost, and log queries |
+| Providers | `list_providers`, `get_provider`, `test_provider`, `add_provider`, `delete_provider` | Configure and test voice AI providers |
+| Models | `list_models`, `register_model`, `delete_model` | Manage model registrations |
+| Projects | `list_projects`, `get_project`, `create_project`, `delete_project` | Create and track projects with budgets |
 
-### Provider Management
+## Quick start
 
-| Tool | Description |
-|---|---|
-| `list_providers` | List all configured providers |
-| `get_provider` | Details for one provider |
-| `test_provider` | Live connectivity test |
-| `add_provider` | Register a new provider |
-| `delete_provider` | Remove a managed provider (destructive) |
-
-### Model Management
-
-| Tool | Description |
-|---|---|
-| `list_models` | List all registered models |
-| `register_model` | Register a new model |
-| `delete_model` | Remove a managed model (destructive) |
-
-### Project Management
-
-| Tool | Description |
-|---|---|
-| `list_projects` | List projects with today's stats |
-| `get_project` | Full project details and cost trends |
-| `create_project` | Create a new project |
-| `delete_project` | Remove a managed project (destructive) |
-
-## Safety Features
-
-Destructive tools (`delete_provider`, `delete_model`, `delete_project`) implement a two-phase confirmation pattern:
-
-1. **Preview phase**: Called without `confirm=True`, the tool returns a preview of the impact (affected models, projects, total spend, etc.).
-2. **Confirm phase**: Called with `confirm=True`, the deletion is performed.
-
-This ensures agents always show the user what will happen before making irreversible changes.
-
-## Quick Start
-
-```bash
-# Install MCP dependencies
+<CodeGroup>
+```bash pip
 pip install "voicegateway[mcp]"
-
-# Start with stdio (for local agents)
-voicegw mcp
-
-# Start with HTTP/SSE (for remote agents)
-VOICEGW_MCP_TOKEN=my-token voicegw mcp --transport http --port 8090
+voicegw mcp --transport stdio
 ```
 
-## Next Steps
+```bash uv
+uv add "voicegateway[mcp]"
+voicegw mcp --transport stdio
+```
+</CodeGroup>
 
-- [Setup guide](/mcp/setup) -- configure Claude Code, Cursor, or Codex
-- [Transports](/mcp/transports) -- stdio vs HTTP/SSE
-- [Authentication](/mcp/authentication) -- securing the HTTP transport
-- Tool references: [Observability](/mcp/tools/observability), [Providers](/mcp/tools/providers), [Models](/mcp/tools/models), [Projects](/mcp/tools/projects)
+For HTTP/SSE (team or remote setup):
+
+```bash
+export VOICEGW_MCP_TOKEN=$(python -c "import secrets; print(secrets.token_urlsafe(32))")
+voicegw mcp --transport http --host 0.0.0.0 --port 8090
+```
+
+## Explore further
+
+<CardGroup cols={2}>
+  <Card title="Setup" href="/mcp/setup">
+    Register the server in Claude Code, Cursor, or Codex.
+  </Card>
+  <Card title="Transports" href="/mcp/transports">
+    Choose between stdio (local) and HTTP/SSE (remote).
+  </Card>
+  <Card title="Authentication" href="/mcp/authentication">
+    Secure the HTTP transport with a bearer token.
+  </Card>
+  <Card title="Observability tools" href="/mcp/tools/observability">
+    Health, cost, latency, and log query tools.
+  </Card>
+  <Card title="Provider tools" href="/mcp/tools/providers">
+    Add, test, and remove provider configurations.
+  </Card>
+  <Card title="Model tools" href="/mcp/tools/models">
+    Register and delete model entries.
+  </Card>
+  <Card title="Project tools" href="/mcp/tools/projects">
+    Create projects with budgets and routing stacks.
+  </Card>
+  <Card title="Claude Code example" href="/examples/claude-code-integration">
+    Full walkthrough with Claude Code.
+  </Card>
+</CardGroup>

--- a/docs/mcp/setup.md
+++ b/docs/mcp/setup.md
@@ -1,26 +1,47 @@
-# Agent Setup
+---
+title: Agent Setup
+description: Connect Claude Code, Cursor, Codex, or any MCP-compatible agent to VoiceGateway's MCP server using stdio or HTTP/SSE.
+---
 
-This guide covers how to connect different AI coding agents to VoiceGateway's MCP server.
+This page shows how to register VoiceGateway's MCP server in popular AI coding agents.
 
 ## Prerequisites
 
-Install the MCP dependencies:
+Install the MCP extra:
 
-```bash
+<CodeGroup>
+```bash pip
 pip install "voicegateway[mcp]"
 ```
 
-For the HTTP transport, also install the dashboard extra:
+```bash uv
+uv add "voicegateway[mcp]"
+```
+</CodeGroup>
 
-```bash
+For the HTTP/SSE transport, also install the dashboard extra:
+
+<CodeGroup>
+```bash pip
 pip install "voicegateway[mcp,dashboard]"
 ```
 
+```bash uv
+uv add "voicegateway[mcp,dashboard]"
+```
+</CodeGroup>
+
 ## Claude Code
 
-Claude Code connects via stdio transport. Add VoiceGateway to your project's `.mcp.json` or global config.
+Claude Code reads MCP server definitions from `.mcp.json` in the project root (project-scoped) or from your global Claude config (user-scoped).
 
-### Project-level configuration
+### Via the CLI
+
+```bash
+claude mcp add voicegateway --command "voicegw mcp --transport stdio"
+```
+
+### Via .mcp.json
 
 Create or edit `.mcp.json` in your project root:
 
@@ -50,7 +71,7 @@ Create or edit `.mcp.json` in your project root:
 
 ### Using a virtual environment
 
-If VoiceGateway is installed in a virtual environment, use the full path:
+If VoiceGateway is installed in a virtual environment, use the full binary path:
 
 ```json
 {
@@ -63,15 +84,13 @@ If VoiceGateway is installed in a virtual environment, use the full path:
 }
 ```
 
-After adding the config, restart Claude Code. The agent will automatically discover the 17 VoiceGateway tools.
+Restart Claude Code after saving. It will discover all 17 VoiceGateway tools automatically.
 
 ## Cursor
 
-Cursor supports MCP servers via its settings. Add VoiceGateway to your Cursor MCP configuration:
+Add VoiceGateway to `.cursor/mcp.json` (project) or the global Cursor MCP settings.
 
 ### stdio transport
-
-In your Cursor MCP config (`.cursor/mcp.json` or global settings):
 
 ```json
 {
@@ -84,9 +103,9 @@ In your Cursor MCP config (`.cursor/mcp.json` or global settings):
 }
 ```
 
-### HTTP transport
+### HTTP/SSE transport
 
-If you are running the MCP server remotely:
+If the gateway runs on a remote host:
 
 ```json
 {
@@ -103,7 +122,7 @@ If you are running the MCP server remotely:
 
 ## Codex (OpenAI CLI)
 
-Codex supports MCP via stdio. Configure it in your project:
+Codex supports MCP via stdio. Add VoiceGateway to its MCP config:
 
 ```json
 {
@@ -116,11 +135,11 @@ Codex supports MCP via stdio. Configure it in your project:
 }
 ```
 
-## Remote / Team Setup
+## Remote / team setup
 
-For shared team gateways, run the MCP server over HTTP/SSE so multiple agents can connect:
+Run the MCP server over HTTP/SSE so multiple developers can share one gateway instance.
 
-### 1. Start the server
+### 1. Generate a token and start the server
 
 ```bash
 export VOICEGW_MCP_TOKEN=$(python -c "import secrets; print(secrets.token_urlsafe(32))")
@@ -129,9 +148,7 @@ echo "Token: $VOICEGW_MCP_TOKEN"
 voicegw mcp --transport http --host 0.0.0.0 --port 8090
 ```
 
-### 2. Connect agents
-
-Each team member configures their agent to connect to the shared URL:
+### 2. Point agents at the shared URL
 
 ```json
 {
@@ -146,9 +163,9 @@ Each team member configures their agent to connect to the shared URL:
 }
 ```
 
-### 3. Secure with HTTPS
+### 3. Add TLS in production
 
-In production, put the MCP server behind a reverse proxy with TLS:
+Put the MCP server behind a reverse proxy with TLS termination:
 
 ```nginx
 server {
@@ -166,15 +183,25 @@ server {
 }
 ```
 
-## Verifying the Connection
+<Warning>
+Never expose the HTTP transport on a public network without setting `VOICEGW_MCP_TOKEN` and enabling TLS. See [Authentication](/mcp/authentication) for details.
+</Warning>
 
-Once connected, ask the agent to check the gateway health:
+## Verify the connection
+
+Once connected, ask your agent to check the gateway:
 
 > "Check VoiceGateway health"
 
-The agent should call `get_health` and return something like:
+The agent calls `get_health` and returns something like:
 
 ```
 Gateway is running (uptime 1234.5s).
 3 providers configured, 2 projects, cost tracking enabled.
 ```
+
+## Next steps
+
+- [Transports](/mcp/transports): stdio vs HTTP/SSE comparison.
+- [Authentication](/mcp/authentication): securing the HTTP transport.
+- [CLI reference: mcp](/cli/mcp): all flags for `voicegw mcp`.

--- a/docs/mcp/tools/models.md
+++ b/docs/mcp/tools/models.md
@@ -1,45 +1,46 @@
-# Model Tools
+---
+title: Model Tools
+description: MCP tools for listing, registering, and deleting model entries on the VoiceGateway (list_models, register_model, delete_model).
+---
 
-These three tools manage model registrations on the gateway. Models represent specific AI models from a provider (e.g., `deepgram/nova-3`, `openai/gpt-4o-mini`) that the gateway can route requests to.
+These three tools manage model registrations on the gateway. A model represents a specific AI model from a provider (for example `deepgram/nova-3` or `openai/gpt-4o-mini`) that the gateway can route requests to.
 
 ## list_models
 
-List every registered model on the gateway, including YAML-defined and GUI-managed models.
+List every registered model on the gateway, including YAML-defined and database-managed models.
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `modality` | `string \| null` | No | `null` | Filter by `"stt"`, `"llm"`, or `"tts"`. |
-| `provider_id` | `string \| null` | No | `null` | Filter by provider (e.g., `"openai"`). |
-| `enabled_only` | `boolean` | No | `true` | If `true`, exclude disabled models. |
+| `modality` | `string` or `null` | No | `null` | Filter by `"stt"`, `"llm"`, or `"tts"`. |
+| `provider_id` | `string` or `null` | No | `null` | Filter by provider (e.g. `"openai"`). |
+| `enabled_only` | `boolean` | No | `true` | When `true`, excludes disabled models. |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `models` | `array` | List of model objects. |
-| `count` | `integer` | Total matching models. |
+| `models` | array | List of model objects. |
+| `count` | integer | Total matching models. |
 
 Each model object:
 
 | Field | Type | Description |
 |---|---|---|
-| `model_id` | `string` | Full model identifier (e.g., `"deepgram/nova-3"`). |
-| `modality` | `string` | `"stt"`, `"llm"`, or `"tts"`. |
-| `provider_id` | `string` | Provider this model belongs to. |
-| `model_name` | `string` | Provider-specific model name (e.g., `"nova-3"`). |
-| `default_voice` | `string \| null` | Default voice ID (TTS models only). |
-| `display_name` | `string \| null` | Human-readable name (managed models only). |
-| `default_language` | `string \| null` | Default language code (managed models only). |
-| `source` | `string` | `"yaml"` or `"db"`. |
-| `enabled` | `boolean` | Whether the model is active. |
+| `model_id` | string | Full model identifier (e.g. `"deepgram/nova-3"`). |
+| `modality` | string | `"stt"`, `"llm"`, or `"tts"`. |
+| `provider_id` | string | Provider this model belongs to. |
+| `model_name` | string | Provider-specific model name. |
+| `default_voice` | string or `null` | Default voice ID (TTS models only). |
+| `display_name` | string or `null` | Human-readable name (managed models only). |
+| `default_language` | string or `null` | Default language code (managed models only). |
+| `source` | string | `"yaml"` or `"db"`. |
+| `enabled` | boolean | Whether the model is active. |
 
-### Example: All models
-
-**Invocation:**
+### Example: all models
 
 ```json
 {
@@ -48,7 +49,7 @@ Each model object:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -85,9 +86,7 @@ Each model object:
 }
 ```
 
-### Example: Filter by modality and provider
-
-**Invocation:**
+### Example: filter by modality and provider
 
 ```json
 {
@@ -96,7 +95,7 @@ Each model object:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -123,33 +122,33 @@ Register a new model from an existing provider. The provider must already be con
 
 **Destructive:** No (creates a new resource)
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `modality` | `string` | Yes | | `"stt"`, `"llm"`, or `"tts"`. |
-| `provider_id` | `string` | Yes | | Must match an existing provider. |
-| `model_name` | `string` | Yes | | Provider-specific model name (e.g., `"nova-3"`, `"gpt-4o-mini"`). |
-| `display_name` | `string \| null` | No | `null` | Human-readable name for dashboards. |
-| `default_language` | `string \| null` | No | `null` | Default language code (STT models). |
-| `default_voice` | `string \| null` | No | `null` | Default voice ID (TTS models). |
-| `config` | `object \| null` | No | `null` | Extra provider-specific options. |
+| `modality` | string | Yes | | `"stt"`, `"llm"`, or `"tts"`. |
+| `provider_id` | string | Yes | | Must match an existing provider. |
+| `model_name` | string | Yes | | Provider-specific model name (e.g. `"nova-3"`). |
+| `display_name` | string or `null` | No | `null` | Human-readable name for dashboards. |
+| `default_language` | string or `null` | No | `null` | Default language code (STT models). |
+| `default_voice` | string or `null` | No | `null` | Default voice ID (TTS models). |
+| `config` | object or `null` | No | `null` | Extra provider-specific options. |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `model_id` | `string` | The generated model ID (e.g., `"deepgram/nova-3"`). |
-| `modality` | `string` | The model's modality. |
-| `provider_id` | `string` | The provider. |
-| `model_name` | `string` | The provider-specific name. |
-| `display_name` | `string \| null` | Human-readable name. |
-| `default_voice` | `string \| null` | Default voice. |
-| `default_language` | `string \| null` | Default language. |
-| `source` | `string` | Always `"db"`. |
-| `created` | `boolean` | Always `true`. |
+| `model_id` | string | The generated model ID. |
+| `modality` | string | The model's modality. |
+| `provider_id` | string | The provider. |
+| `model_name` | string | The provider-specific name. |
+| `display_name` | string or `null` | Human-readable name. |
+| `default_voice` | string or `null` | Default voice. |
+| `default_language` | string or `null` | Default language. |
+| `source` | string | Always `"db"`. |
+| `created` | boolean | Always `true`. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
@@ -158,8 +157,6 @@ Register a new model from an existing provider. The provider must already be con
 | `VALIDATION_ERROR` | Storage is not enabled. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -174,7 +171,7 @@ Register a new model from an existing provider. The provider must already be con
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -194,35 +191,35 @@ Register a new model from an existing provider. The provider must already be con
 
 ## delete_model
 
-Delete a GUI-registered model. This is a destructive operation that uses the two-phase confirmation pattern. Only models added via `register_model` (source `"db"`) can be deleted; YAML-defined models must be removed from the config file.
+Delete a database-registered model. This is a destructive operation that uses the two-phase confirmation pattern. Only models added via `register_model` (source `"db"`) can be deleted; YAML-defined models must be removed from the config file.
 
 **Destructive:** Yes
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `model_id` | `string` | Yes | | The model ID to delete (e.g., `"openai/gpt-4o-mini"`). |
-| `confirm` | `boolean` | No | `false` | Must be `true` to delete. Default returns a preview. |
+| `model_id` | string | Yes | | The model ID to delete (e.g. `"openai/gpt-4o-mini"`). |
+| `confirm` | boolean | No | `false` | Must be `true` to delete. Default returns a preview. |
 
-### Output (preview, confirm=false)
+### Output: preview (confirm=false)
 
 The tool raises a `CONFIRMATION_REQUIRED` error containing:
 
 | Field | Type | Description |
 |---|---|---|
-| `model_id` | `string` | The model to be deleted. |
-| `projects_affected` | `array` | Projects whose stacks reference this model. |
+| `model_id` | string | The model to be deleted. |
+| `projects_affected` | array | Projects whose stacks reference this model. |
 
-### Output (confirmed, confirm=true)
+### Output: confirmed (confirm=true)
 
 | Field | Type | Description |
 |---|---|---|
-| `action` | `string` | `"deleted"`. |
-| `model_id` | `string` | The deleted model ID. |
-| `projects_affected` | `array` | Projects that were affected. |
+| `action` | string | `"deleted"`. |
+| `model_id` | string | The deleted model ID. |
+| `projects_affected` | array | Projects that were affected. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
@@ -230,9 +227,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 | `READ_ONLY_RESOURCE` | The model is defined in YAML (cannot delete via MCP). |
 | `CONFIRMATION_REQUIRED` | Called without `confirm=true` (returns preview). |
 
-### Example: Preview
-
-**Invocation:**
+### Example: preview
 
 ```json
 {
@@ -241,7 +236,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-**Response (error envelope):**
+Response (error envelope):
 
 ```json
 {
@@ -256,9 +251,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-### Example: Confirm
-
-**Invocation:**
+### Example: confirm
 
 ```json
 {
@@ -267,7 +260,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -276,3 +269,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
   "projects_affected": ["tonys-pizza"]
 }
 ```
+
+<Note>
+YAML-defined models return `READ_ONLY_RESOURCE`. Remove them from `voicegw.yaml` instead. See [Models configuration](/configuration/models).
+</Note>

--- a/docs/mcp/tools/observability.md
+++ b/docs/mcp/tools/observability.md
@@ -1,14 +1,17 @@
-# Observability Tools
+---
+title: Observability Tools
+description: Read-only MCP tools for querying VoiceGateway health, provider status, cost summaries, latency stats, and request logs (get_health, get_provider_status, get_costs, get_latency_stats, get_logs).
+---
 
-These five read-only tools provide visibility into the gateway's health, provider status, costs, latency, and request logs. They never modify state and are safe to call at any time.
+These five tools provide read-only visibility into the gateway's health, provider status, costs, latency, and request logs. They never modify state and are safe to call at any time.
 
 ## get_health
 
-Return the overall health and identity of the VoiceGateway instance. Use this as a cheap first call to verify the gateway is running before using other tools.
+Return the overall health and identity of the VoiceGateway instance. Use this as a cheap first call to verify the gateway is running before invoking other tools.
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 No parameters required.
 
@@ -20,17 +23,15 @@ No parameters required.
 
 | Field | Type | Description |
 |---|---|---|
-| `version` | `string` | VoiceGateway version (e.g., `"0.1.0"`). |
-| `uptime_seconds` | `float` | Seconds since the MCP server started. |
-| `status` | `string` | Always `"ok"`. |
-| `db_configured` | `boolean` | Whether SQLite storage is enabled. |
-| `project_count` | `integer` | Number of configured projects. |
-| `provider_count` | `integer` | Number of configured providers. |
-| `observability` | `object` | Flags: `latency_tracking`, `cost_tracking`, `request_logging`. |
+| `version` | string | VoiceGateway version (e.g. `"0.1.0"`). |
+| `uptime_seconds` | float | Seconds since the MCP server started. |
+| `status` | string | Always `"ok"`. |
+| `db_configured` | boolean | Whether SQLite storage is enabled. |
+| `project_count` | integer | Number of configured projects. |
+| `provider_count` | integer | Number of configured providers. |
+| `observability` | object | Flags: `latency_tracking`, `cost_tracking`, `request_logging`. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -39,7 +40,7 @@ No parameters required.
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -61,31 +62,29 @@ No parameters required.
 
 ## get_provider_status
 
-Return the configuration status of providers. Reports whether each provider has credentials, its type (cloud/local), and model count. Does NOT make live network calls -- use `test_provider` for a connectivity check.
+Return the configuration status of providers. Reports whether each provider has credentials, its type (cloud/local), and model count. This does NOT make live network calls; use `test_provider` (in [Provider tools](/mcp/tools/providers)) for a connectivity check.
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `provider_id` | `string \| null` | No | `null` | If set, returns only that provider. Otherwise returns all. |
+| `provider_id` | string or `null` | No | `null` | If set, returns only that provider. Otherwise returns all. |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `providers` | `object` | Map of provider ID to status object. |
-| `providers[id].configured` | `boolean` | Whether the provider has credentials or is local. |
-| `providers[id].type` | `string` | `"cloud"` or `"local"`. |
-| `providers[id].model_count` | `integer` | Number of models registered for this provider. |
-| `providers[id].has_api_key` | `boolean` | Whether an API key is set. |
+| `providers` | object | Map of provider ID to status object. |
+| `providers[id].configured` | boolean | Whether the provider has credentials or is local. |
+| `providers[id].type` | string | `"cloud"` or `"local"`. |
+| `providers[id].model_count` | integer | Number of models registered for this provider. |
+| `providers[id].has_api_key` | boolean | Whether an API key is set. |
 
 If `provider_id` is specified and not found, `providers` is empty and `missing` contains the requested ID.
 
-### Example: All providers
-
-**Invocation:**
+### Example: all providers
 
 ```json
 {
@@ -94,7 +93,7 @@ If `provider_id` is specified and not found, `providers` is empty and `missing` 
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -115,9 +114,7 @@ If `provider_id` is specified and not found, `providers` is empty and `missing` 
 }
 ```
 
-### Example: Single provider
-
-**Invocation:**
+### Example: single provider
 
 ```json
 {
@@ -126,7 +123,7 @@ If `provider_id` is specified and not found, `providers` is empty and `missing` 
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -149,29 +146,29 @@ Return cost data for a period, optionally filtered by project. Reflects actual i
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `period` | `string` | No | `"today"` | One of: `"today"`, `"week"`, `"month"`, `"all"`. |
-| `project` | `string \| null` | No | `null` | Filter to a specific project. |
+| `period` | string | No | `"today"` | One of: `"today"`, `"week"`, `"month"`, `"all"`. |
+| `project` | string or `null` | No | `null` | Filter to a specific project. |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `period` | `string` | The requested period. |
-| `project` | `string \| null` | The project filter, if any. |
-| `total_usd` | `float` | Total cost in USD. |
-| `by_provider` | `object` | Cost and request count per provider. |
-| `by_model` | `object` | Cost and request count per model. |
-| `by_project` | `object` | Cost and request count per project (when unfiltered). |
+| `period` | string | The requested period. |
+| `project` | string or `null` | The project filter, if any. |
+| `total_usd` | float | Total cost in USD. |
+| `by_provider` | object | Cost and request count per provider. |
+| `by_model` | object | Cost and request count per model. |
+| `by_project` | object | Cost and request count per project (when unfiltered). |
 
+<Note>
 If the database is not enabled, all values are zero.
+</Note>
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -180,7 +177,7 @@ If the database is not enabled, all values are zero.
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -207,27 +204,25 @@ Return latency statistics computed from the request log. Provides overall percen
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `period` | `string` | No | `"today"` | One of: `"today"`, `"week"`, `"month"`. |
-| `project` | `string \| null` | No | `null` | Filter by project. |
-| `modality` | `string \| null` | No | `null` | Filter by `"stt"`, `"llm"`, or `"tts"`. |
+| `period` | string | No | `"today"` | One of: `"today"`, `"week"`, `"month"`. |
+| `project` | string or `null` | No | `null` | Filter by project. |
+| `modality` | string or `null` | No | `null` | Filter by `"stt"`, `"llm"`, or `"tts"`. |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `period` | `string` | The requested period. |
-| `project` | `string \| null` | The project filter. |
-| `modality` | `string \| null` | The modality filter. |
-| `overall` | `object` | `p50_ms`, `p95_ms`, `p99_ms`, `avg_ms`, `request_count`. |
-| `by_model` | `object` | Per-model stats: `avg_ttfb_ms`, `avg_latency_ms`, `request_count`. |
+| `period` | string | The requested period. |
+| `project` | string or `null` | The project filter. |
+| `modality` | string or `null` | The modality filter. |
+| `overall` | object | `p50_ms`, `p95_ms`, `p99_ms`, `avg_ms`, `request_count`. |
+| `by_model` | object | Per-model stats: `avg_ttfb_ms`, `avg_latency_ms`, `request_count`. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -236,7 +231,7 @@ Return latency statistics computed from the request log. Provides overall percen
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -273,37 +268,35 @@ Return recent request logs with optional filters. Each row is a record from the 
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `project` | `string \| null` | No | `null` | Filter by project ID. |
-| `modality` | `string \| null` | No | `null` | Filter by `"stt"`, `"llm"`, or `"tts"`. |
-| `model_id` | `string \| null` | No | `null` | Filter by exact model ID (e.g., `"openai/gpt-4o-mini"`). |
-| `status` | `string \| null` | No | `null` | Filter by `"success"`, `"error"`, or `"fallback"`. |
-| `limit` | `integer` | No | `50` | Max rows to return (1--1000). |
+| `project` | string or `null` | No | `null` | Filter by project ID. |
+| `modality` | string or `null` | No | `null` | Filter by `"stt"`, `"llm"`, or `"tts"`. |
+| `model_id` | string or `null` | No | `null` | Filter by exact model ID (e.g. `"openai/gpt-4o-mini"`). |
+| `status` | string or `null` | No | `null` | Filter by `"success"`, `"error"`, or `"fallback"`. |
+| `limit` | integer | No | `50` | Max rows to return (1 to 1000). |
 
 ### Output
 
-A list of log record dicts, each containing:
+A list of log record objects, each containing:
 
 | Field | Type | Description |
 |---|---|---|
-| `timestamp` | `float` | Unix timestamp. |
-| `project` | `string` | Project ID. |
-| `modality` | `string` | `"stt"`, `"llm"`, or `"tts"`. |
-| `model_id` | `string` | Full model identifier. |
-| `provider` | `string` | Provider name. |
-| `cost_usd` | `float` | Cost of this request. |
-| `pricing_source` | `string \| null` | Source that priced this row (e.g. `"voice-prices@0.0.8"` for cloud models or `"voicegateway-local"` for self-hosted). Empty string when the model is unknown (unpriced). Persisted on the `requests` table; see `src/voicegateway/storage/sqlite.py`. |
-| `ttfb_ms` | `float` | Time to first byte in milliseconds. |
-| `total_latency_ms` | `float` | Total latency in milliseconds. |
-| `status` | `string` | `"success"`, `"error"`, or `"fallback"`. |
-| `error_message` | `string \| null` | Error details if status is `"error"`. |
+| `timestamp` | float | Unix timestamp. |
+| `project` | string | Project ID. |
+| `modality` | string | `"stt"`, `"llm"`, or `"tts"`. |
+| `model_id` | string | Full model identifier. |
+| `provider` | string | Provider name. |
+| `cost_usd` | float | Cost of this request. |
+| `pricing_source` | string or `null` | Source that priced this row (e.g. `"voice-prices@0.0.8"` for cloud models or `"voicegateway-local"` for self-hosted). Empty when the model is unknown (unpriced). |
+| `ttfb_ms` | float | Time to first byte in milliseconds. |
+| `total_latency_ms` | float | Total latency in milliseconds. |
+| `status` | string | `"success"`, `"error"`, or `"fallback"`. |
+| `error_message` | string or `null` | Error details if status is `"error"`. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -317,7 +310,7 @@ A list of log record dicts, each containing:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 [
@@ -336,3 +329,7 @@ A list of log record dicts, each containing:
   }
 ]
 ```
+
+<Tip>
+For bulk log exports or scheduled reports, use `voicegw export-costs` from the CLI instead. See [CLI reference: export-costs](/cli/export-costs).
+</Tip>

--- a/docs/mcp/tools/projects.md
+++ b/docs/mcp/tools/projects.md
@@ -1,6 +1,9 @@
-# Project Tools
+---
+title: Project Tools
+description: MCP tools for listing, inspecting, creating, and deleting VoiceGateway projects with budgets and routing stacks (list_projects, get_project, create_project, delete_project).
+---
 
-These four tools manage projects on the gateway. Projects group requests for cost tracking, budget enforcement, and routing (via default stacks or explicit model assignments).
+These four tools manage projects on the gateway. Projects group requests for cost tracking, budget enforcement, and routing (via named stacks or explicit model assignments).
 
 ## list_projects
 
@@ -8,7 +11,7 @@ List every project on the gateway with today's stats, including spend, request c
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 No parameters required.
 
@@ -20,28 +23,26 @@ No parameters required.
 
 | Field | Type | Description |
 |---|---|---|
-| `projects` | `array` | List of project objects. |
-| `count` | `integer` | Total number of projects. |
+| `projects` | array | List of project objects. |
+| `count` | integer | Total number of projects. |
 
 Each project object:
 
 | Field | Type | Description |
 |---|---|---|
-| `id` | `string` | Project identifier. |
-| `name` | `string` | Human-readable name. |
-| `description` | `string` | Project description. |
-| `daily_budget` | `float` | Daily budget in USD (0 = unlimited). |
-| `budget_action` | `string` | `"warn"`, `"throttle"`, or `"block"`. |
-| `budget_status` | `string` | `"ok"`, `"warning"`, or `"exceeded"`. |
-| `today_spend` | `float` | Today's spend in USD. |
-| `today_requests` | `integer` | Today's request count. |
-| `tags` | `array` | List of tag strings. |
-| `default_stack` | `string \| null` | Named stack from config, if set. |
-| `source` | `string` | `"yaml"` or `"db"`. |
+| `id` | string | Project identifier. |
+| `name` | string | Human-readable name. |
+| `description` | string | Project description. |
+| `daily_budget` | float | Daily budget in USD (0 = unlimited). |
+| `budget_action` | string | `"warn"`, `"throttle"`, or `"block"`. |
+| `budget_status` | string | `"ok"`, `"warning"`, or `"exceeded"`. |
+| `today_spend` | float | Today's spend in USD. |
+| `today_requests` | integer | Today's request count. |
+| `tags` | array | List of tag strings. |
+| `default_stack` | string or `null` | Named stack from config, if set. |
+| `source` | string | `"yaml"` or `"db"`. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -50,7 +51,7 @@ Each project object:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -90,46 +91,44 @@ Each project object:
 
 ## get_project
 
-Return full details for one project including cost trends and model assignments.
+Return full details for one project including weekly cost trends and per-modality model assignments.
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `project_id` | `string` | Yes | The ID of the project to fetch. |
+| `project_id` | string | Yes | The ID of the project to fetch. |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `id` | `string` | Project identifier. |
-| `name` | `string` | Human-readable name. |
-| `description` | `string` | Project description. |
-| `daily_budget` | `float` | Daily budget in USD. |
-| `budget_action` | `string` | `"warn"`, `"throttle"`, or `"block"`. |
-| `budget_status` | `string` | `"ok"`, `"warning"`, or `"exceeded"`. |
-| `today_spend` | `float` | Today's spend in USD. |
-| `today_requests` | `integer` | Today's request count. |
-| `week_spend` | `float` | This week's total spend. |
-| `week_requests` | `integer` | This week's total requests. |
-| `tags` | `array` | List of tag strings. |
-| `default_stack` | `string \| null` | Named stack. |
-| `stt_model` | `string \| null` | Explicit STT model (managed projects). |
-| `llm_model` | `string \| null` | Explicit LLM model (managed projects). |
-| `tts_model` | `string \| null` | Explicit TTS model (managed projects). |
-| `source` | `string` | `"yaml"` or `"db"`. |
+| `id` | string | Project identifier. |
+| `name` | string | Human-readable name. |
+| `description` | string | Project description. |
+| `daily_budget` | float | Daily budget in USD. |
+| `budget_action` | string | `"warn"`, `"throttle"`, or `"block"`. |
+| `budget_status` | string | `"ok"`, `"warning"`, or `"exceeded"`. |
+| `today_spend` | float | Today's spend in USD. |
+| `today_requests` | integer | Today's request count. |
+| `week_spend` | float | This week's total spend. |
+| `week_requests` | integer | This week's total requests. |
+| `tags` | array | List of tag strings. |
+| `default_stack` | string or `null` | Named stack. |
+| `stt_model` | string or `null` | Explicit STT model (managed projects). |
+| `llm_model` | string or `null` | Explicit LLM model (managed projects). |
+| `tts_model` | string or `null` | Explicit TTS model (managed projects). |
+| `source` | string | `"yaml"` or `"db"`. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
 | `PROJECT_NOT_FOUND` | No project with the given ID exists. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -138,7 +137,7 @@ Return full details for one project including cost trends and model assignments.
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -165,54 +164,52 @@ Return full details for one project including cost trends and model assignments.
 
 ## create_project
 
-Create a new project for cost tracking and routing. You can either set `default_stack` (referencing a named stack from `voicegw.yaml`) or individual `stt_model`/`llm_model`/`tts_model` fields, but not both.
+Create a new project for cost tracking and routing. You can set `default_stack` (a named stack from `voicegw.yaml`) or individual `stt_model`/`llm_model`/`tts_model` fields, but not both at the same time.
 
 **Destructive:** No (creates a new resource)
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `project_id` | `string` | Yes | | Unique identifier (kebab-case recommended). |
-| `name` | `string` | Yes | | Human-readable name. |
-| `description` | `string` | No | `""` | Long description. |
-| `daily_budget` | `float` | No | `0.0` | USD limit per day (0 = unlimited). Must be >= 0. |
-| `budget_action` | `string` | No | `"warn"` | `"warn"` logs when exceeded, `"throttle"` falls back to local stack, `"block"` raises an error. |
-| `stt_model` | `string \| null` | No | `null` | Explicit STT model ID (must be registered). |
-| `llm_model` | `string \| null` | No | `null` | Explicit LLM model ID (must be registered). |
-| `tts_model` | `string \| null` | No | `null` | Explicit TTS model ID (must be registered). |
-| `default_stack` | `string \| null` | No | `null` | Named stack from `voicegw.yaml` (e.g., `"premium"`). |
-| `tags` | `array \| null` | No | `null` | Labels for grouping. |
+| `project_id` | string | Yes | | Unique identifier (kebab-case recommended). |
+| `name` | string | Yes | | Human-readable name. |
+| `description` | string | No | `""` | Long description. |
+| `daily_budget` | float | No | `0.0` | USD limit per day (0 = unlimited, must be >= 0). |
+| `budget_action` | string | No | `"warn"` | `"warn"` logs on excess; `"throttle"` falls back to local stack; `"block"` raises an error. |
+| `stt_model` | string or `null` | No | `null` | Explicit STT model ID (must be registered). |
+| `llm_model` | string or `null` | No | `null` | Explicit LLM model ID (must be registered). |
+| `tts_model` | string or `null` | No | `null` | Explicit TTS model ID (must be registered). |
+| `default_stack` | string or `null` | No | `null` | Named stack from `voicegw.yaml` (e.g. `"premium"`). |
+| `tags` | array or `null` | No | `null` | Labels for grouping in the dashboard. |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `project_id` | `string` | The created project ID. |
-| `name` | `string` | Project name. |
-| `description` | `string` | Project description. |
-| `daily_budget` | `float` | Daily budget. |
-| `budget_action` | `string` | Budget enforcement action. |
-| `default_stack` | `string \| null` | Stack name. |
-| `stt_model` | `string \| null` | STT model. |
-| `llm_model` | `string \| null` | LLM model. |
-| `tts_model` | `string \| null` | TTS model. |
-| `tags` | `array` | Tags. |
-| `source` | `string` | Always `"db"`. |
-| `created` | `boolean` | Always `true`. |
-| `created_at` | `float` | Unix timestamp of creation. |
+| `project_id` | string | The created project ID. |
+| `name` | string | Project name. |
+| `description` | string | Project description. |
+| `daily_budget` | float | Daily budget. |
+| `budget_action` | string | Budget enforcement action. |
+| `default_stack` | string or `null` | Stack name. |
+| `stt_model` | string or `null` | STT model. |
+| `llm_model` | string or `null` | LLM model. |
+| `tts_model` | string or `null` | TTS model. |
+| `tags` | array | Tags. |
+| `source` | string | Always `"db"`. |
+| `created` | boolean | Always `true`. |
+| `created_at` | float | Unix timestamp of creation. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
 | `PROJECT_ALREADY_EXISTS` | A project with the same ID already exists. |
-| `MODEL_NOT_FOUND` | A referenced `stt_model`, `llm_model`, or `tts_model` is not registered. |
-| `VALIDATION_ERROR` | Both `default_stack` and explicit models are set, or the stack name does not exist, or storage is disabled. |
+| `MODEL_NOT_FOUND` | A referenced model is not registered. |
+| `VALIDATION_ERROR` | Both `default_stack` and explicit models are set; the stack name does not exist; or storage is disabled. |
 
-### Example: With default stack
-
-**Invocation:**
+### Example: with a named stack
 
 ```json
 {
@@ -229,7 +226,7 @@ Create a new project for cost tracking and routing. You can either set `default_
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -249,9 +246,7 @@ Create a new project for cost tracking and routing. You can either set `default_
 }
 ```
 
-### Example: With explicit models
-
-**Invocation:**
+### Example: with explicit models
 
 ```json
 {
@@ -272,38 +267,38 @@ Create a new project for cost tracking and routing. You can either set `default_
 
 ## delete_project
 
-Delete a managed project. This is a destructive operation that uses the two-phase confirmation pattern. Only projects added via `create_project` (source `"db"`) can be deleted; YAML-defined projects must be removed from the config file. Request logs are NOT deleted -- only the project configuration is removed.
+Delete a managed project. This is a destructive operation that uses the two-phase confirmation pattern. Only projects added via `create_project` (source `"db"`) can be deleted; YAML-defined projects must be removed from the config file. Request logs are NOT deleted when a project is removed.
 
 **Destructive:** Yes
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `project_id` | `string` | Yes | | The ID of the project to delete. |
-| `confirm` | `boolean` | No | `false` | Must be `true` to delete. Default returns a preview. |
+| `project_id` | string | Yes | | The ID of the project to delete. |
+| `confirm` | boolean | No | `false` | Must be `true` to delete. Default returns a preview. |
 
-### Output (preview, confirm=false)
+### Output: preview (confirm=false)
 
 The tool raises a `CONFIRMATION_REQUIRED` error containing:
 
 | Field | Type | Description |
 |---|---|---|
-| `project_id` | `string` | The project to be deleted. |
-| `total_spend_usd` | `float` | All-time spend for this project. |
-| `total_requests` | `integer` | All-time request count. |
-| `last_activity` | `float \| null` | Unix timestamp of the most recent request. |
+| `project_id` | string | The project to be deleted. |
+| `total_spend_usd` | float | All-time spend for this project. |
+| `total_requests` | integer | All-time request count. |
+| `last_activity` | float or `null` | Unix timestamp of the most recent request. |
 
-### Output (confirmed, confirm=true)
+### Output: confirmed (confirm=true)
 
 | Field | Type | Description |
 |---|---|---|
-| `action` | `string` | `"deleted"`. |
-| `project_id` | `string` | The deleted project ID. |
-| `total_spend_usd` | `float` | All-time spend. |
-| `total_requests` | `integer` | All-time request count. |
+| `action` | string | `"deleted"`. |
+| `project_id` | string | The deleted project ID. |
+| `total_spend_usd` | float | All-time spend. |
+| `total_requests` | integer | All-time request count. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
@@ -311,9 +306,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 | `READ_ONLY_RESOURCE` | The project is defined in YAML, or storage is disabled. |
 | `CONFIRMATION_REQUIRED` | Called without `confirm=true` (returns preview). |
 
-### Example: Preview
-
-**Invocation:**
+### Example: preview
 
 ```json
 {
@@ -322,7 +315,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-**Response (error envelope):**
+Response (error envelope):
 
 ```json
 {
@@ -339,9 +332,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-### Example: Confirm
-
-**Invocation:**
+### Example: confirm
 
 ```json
 {
@@ -350,7 +341,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -360,3 +351,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
   "total_requests": 567
 }
 ```
+
+<Note>
+YAML-defined projects return `READ_ONLY_RESOURCE`. Remove them from `voicegw.yaml` instead. See [Projects configuration](/configuration/projects).
+</Note>

--- a/docs/mcp/tools/providers.md
+++ b/docs/mcp/tools/providers.md
@@ -1,6 +1,9 @@
-# Provider Tools
+---
+title: Provider Tools
+description: MCP tools for listing, inspecting, testing, adding, and deleting voice AI providers on the VoiceGateway (list_providers, get_provider, test_provider, add_provider, delete_provider).
+---
 
-These five tools manage voice AI providers on the gateway. They allow agents to list, inspect, test, add, and delete providers.
+These five tools manage voice AI providers on the gateway. Use them to list current providers, verify connectivity, add new ones, and remove managed (database) entries.
 
 ## list_providers
 
@@ -8,7 +11,7 @@ List every provider configured on the gateway, including both YAML-defined provi
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 No parameters required.
 
@@ -20,24 +23,22 @@ No parameters required.
 
 | Field | Type | Description |
 |---|---|---|
-| `providers` | `array` | List of provider objects. |
-| `count` | `integer` | Total number of providers. |
+| `providers` | array | List of provider objects. |
+| `count` | integer | Total number of providers. |
 
 Each provider object:
 
 | Field | Type | Description |
 |---|---|---|
-| `provider_id` | `string` | Unique identifier (e.g., `"deepgram"`). |
-| `provider_type` | `string` | The provider implementation type. |
-| `source` | `string` | `"yaml"` (config file) or `"db"` (added via API). |
-| `enabled` | `boolean` | Whether the provider has valid credentials. |
-| `api_key_masked` | `string \| null` | Masked API key (e.g., `"sk-a...1f2b"`). |
-| `base_url` | `string \| null` | Custom base URL, if configured. |
-| `type` | `string` | `"cloud"` or `"local"`. |
+| `provider_id` | string | Unique identifier (e.g. `"deepgram"`). |
+| `provider_type` | string | The provider implementation type. |
+| `source` | string | `"yaml"` (config file) or `"db"` (added via API). |
+| `enabled` | boolean | Whether the provider has valid credentials. |
+| `api_key_masked` | string or `null` | Masked API key (e.g. `"sk-a...1f2b"`). |
+| `base_url` | string or `null` | Custom base URL, if configured. |
+| `type` | string | `"cloud"` or `"local"`. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -46,7 +47,7 @@ Each provider object:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -78,15 +79,15 @@ Each provider object:
 
 ## get_provider
 
-Return full details for one provider, including how many models depend on it. The API key is always masked.
+Return full details for one provider, including the number of models that depend on it. The API key is always masked.
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `provider_id` | `string` | Yes | The ID of the provider to fetch. |
+| `provider_id` | string | Yes | The ID of the provider to fetch. |
 
 ### Output
 
@@ -94,17 +95,15 @@ Same fields as `list_providers` entries, plus:
 
 | Field | Type | Description |
 |---|---|---|
-| `model_count` | `integer` | Number of models registered for this provider. |
+| `model_count` | integer | Number of models registered for this provider. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
 | `PROVIDER_NOT_FOUND` | No provider with the given ID exists. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -113,7 +112,7 @@ Same fields as `list_providers` entries, plus:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -132,33 +131,31 @@ Same fields as `list_providers` entries, plus:
 
 ## test_provider
 
-Test connectivity to a provider by calling its `health_check()` method. This makes a real network request to the provider's API to verify credentials and reachability.
+Test connectivity to a provider by calling its health check method. This makes a real network request to the provider's API to verify credentials and reachability.
 
 **Destructive:** No
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `provider_id` | `string` | Yes | The ID of the provider to test. |
+| `provider_id` | string | Yes | The ID of the provider to test. |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `status` | `string` | `"ok"` or `"failed"`. |
-| `latency_ms` | `integer` | Round-trip time of the health check in milliseconds. |
-| `message` | `string` | `"reachable"` on success, or an error description. |
+| `status` | string | `"ok"` or `"failed"`. |
+| `latency_ms` | integer | Round-trip time of the health check in milliseconds. |
+| `message` | string | `"reachable"` on success, or an error description on failure. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
 | `PROVIDER_NOT_FOUND` | No provider with the given ID exists. |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -167,7 +164,7 @@ Test connectivity to a provider by calling its `health_check()` method. This mak
 }
 ```
 
-**Response (success):**
+Success response:
 
 ```json
 {
@@ -177,7 +174,7 @@ Test connectivity to a provider by calling its `health_check()` method. This mak
 }
 ```
 
-**Response (failure):**
+Failure response:
 
 ```json
 {
@@ -191,41 +188,39 @@ Test connectivity to a provider by calling its `health_check()` method. This mak
 
 ## add_provider
 
-Register a new voice AI provider. The gateway validates the credentials by running a health check before saving (for cloud providers). After adding, use `register_model` to add specific models from this provider.
+Register a new voice AI provider. For cloud providers, the gateway validates credentials by running a health check before saving. After adding, use `register_model` to add specific models from this provider.
 
 **Destructive:** No (creates a new resource)
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `provider_id` | `string` | Yes | | Unique identifier, typically the provider name in lowercase. |
-| `provider_type` | `string` | Yes | | One of: `deepgram`, `openai`, `anthropic`, `groq`, `cartesia`, `elevenlabs`, `assemblyai`, `ollama`, `whisper`, `kokoro`, `piper`. |
-| `api_key` | `string` | No | `""` | API key from the provider console. Empty for local providers. |
-| `base_url` | `string \| null` | No | `null` | Custom base URL (e.g., self-hosted Ollama). |
+| `provider_id` | string | Yes | | Unique identifier, typically the provider name in lowercase. |
+| `provider_type` | string | Yes | | One of: `deepgram`, `openai`, `anthropic`, `groq`, `cartesia`, `elevenlabs`, `assemblyai`, `ollama`, `whisper`, `kokoro`, `piper`. |
+| `api_key` | string | No | `""` | API key from the provider console. Leave empty for local providers. |
+| `base_url` | string or `null` | No | `null` | Custom base URL (e.g. a self-hosted Ollama instance). |
 
 ### Output
 
 | Field | Type | Description |
 |---|---|---|
-| `provider_id` | `string` | The created provider ID. |
-| `provider_type` | `string` | The provider type. |
-| `api_key_masked` | `string \| null` | Masked API key. |
-| `base_url` | `string \| null` | The base URL, if set. |
-| `source` | `string` | Always `"db"`. |
-| `created` | `boolean` | Always `true`. |
+| `provider_id` | string | The created provider ID. |
+| `provider_type` | string | The provider type. |
+| `api_key_masked` | string or `null` | Masked API key. |
+| `base_url` | string or `null` | The base URL, if set. |
+| `source` | string | Always `"db"`. |
+| `created` | boolean | Always `true`. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
 | `PROVIDER_ALREADY_EXISTS` | A YAML-defined provider has the same ID. |
 | `VALIDATION_ERROR` | Unknown `provider_type`, or storage is disabled. |
-| `PROVIDER_TEST_FAILED` | The health check failed (credentials invalid or unreachable). |
+| `PROVIDER_TEST_FAILED` | The health check failed (credentials invalid or provider unreachable). |
 
 ### Example
-
-**Invocation:**
 
 ```json
 {
@@ -238,7 +233,7 @@ Register a new voice AI provider. The gateway validates the credentials by runni
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -255,47 +250,45 @@ Register a new voice AI provider. The gateway validates the credentials by runni
 
 ## delete_provider
 
-Delete a managed (GUI/API-added) provider. This is a destructive operation that uses the two-phase confirmation pattern.
+Delete a managed (database-added) provider. This is a destructive operation that uses the two-phase confirmation pattern. YAML-defined providers must be removed from the config file.
 
 **Destructive:** Yes
 
-### Input Schema
+### Input schema
 
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `provider_id` | `string` | Yes | | The ID of the provider to delete. |
-| `confirm` | `boolean` | No | `false` | Must be `true` to actually delete. Default returns a preview. |
+| `provider_id` | string | Yes | | The ID of the provider to delete. |
+| `confirm` | boolean | No | `false` | Must be `true` to delete. Default returns a preview. |
 
-### Output (preview, confirm=false)
+### Output: preview (confirm=false)
 
 The tool raises a `CONFIRMATION_REQUIRED` error containing:
 
 | Field | Type | Description |
 |---|---|---|
-| `provider_id` | `string` | The provider to be deleted. |
-| `models_affected` | `array` | List of model IDs that reference this provider. |
-| `projects_affected` | `array` | List of project IDs that use this provider via stacks. |
+| `provider_id` | string | The provider to be deleted. |
+| `models_affected` | array | Model IDs that reference this provider. |
+| `projects_affected` | array | Project IDs that use this provider via stacks. |
 
-### Output (confirmed, confirm=true)
+### Output: confirmed (confirm=true)
 
 | Field | Type | Description |
 |---|---|---|
-| `action` | `string` | `"deleted"`. |
-| `provider_id` | `string` | The deleted provider ID. |
-| `models_affected` | `array` | Models that were affected. |
-| `projects_affected` | `array` | Projects that were affected. |
+| `action` | string | `"deleted"`. |
+| `provider_id` | string | The deleted provider ID. |
+| `models_affected` | array | Models that were affected. |
+| `projects_affected` | array | Projects that were affected. |
 
-### Errors
+### Error codes
 
 | Code | When |
 |---|---|
 | `PROVIDER_NOT_FOUND` | No managed provider with the given ID. |
-| `READ_ONLY_RESOURCE` | The provider is defined in YAML (cannot delete). |
+| `READ_ONLY_RESOURCE` | The provider is defined in YAML (cannot delete via MCP). |
 | `CONFIRMATION_REQUIRED` | Called without `confirm=true` (returns preview). |
 
-### Example: Preview
-
-**Invocation:**
+### Example: preview
 
 ```json
 {
@@ -304,7 +297,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-**Response (error envelope):**
+Response (error envelope):
 
 ```json
 {
@@ -320,9 +313,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-### Example: Confirm
-
-**Invocation:**
+### Example: confirm
 
 ```json
 {
@@ -331,7 +322,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
 }
 ```
 
-**Response:**
+Response:
 
 ```json
 {
@@ -341,3 +332,7 @@ The tool raises a `CONFIRMATION_REQUIRED` error containing:
   "projects_affected": []
 }
 ```
+
+<Note>
+YAML-defined providers return `READ_ONLY_RESOURCE`. Remove them from `voicegw.yaml` instead. See [Providers configuration](/configuration/providers).
+</Note>

--- a/docs/mcp/transports.md
+++ b/docs/mcp/transports.md
@@ -1,10 +1,13 @@
-# Transports
+---
+title: Transports
+description: VoiceGateway's MCP server supports stdio (local subprocess) and HTTP/SSE (network). Choose based on whether your agent runs locally or connects remotely.
+---
 
-VoiceGateway's MCP server supports two transport modes: **stdio** and **HTTP/SSE**. Choose based on whether the agent is running locally or connecting remotely.
+The MCP server supports two transport modes: stdio and HTTP/SSE. The right choice depends on where your agent runs and how many agents share the gateway.
 
 ## stdio
 
-The stdio transport communicates over the process's standard input and output streams. The agent launches the MCP server as a subprocess and exchanges MCP protocol messages directly.
+The stdio transport communicates over the process's standard input and output streams. The agent launches the MCP server as a subprocess and exchanges MCP protocol messages directly over stdin/stdout.
 
 ```bash
 voicegw mcp --transport stdio
@@ -12,12 +15,12 @@ voicegw mcp --transport stdio
 
 ### Characteristics
 
-- **No network involved** -- communication is over stdin/stdout pipes.
-- **No authentication** -- since the agent launches the process itself, there is no untrusted network boundary.
-- **Single agent** -- one process serves one agent.
-- **Automatic lifecycle** -- the agent starts and stops the server as needed.
+- No network involved. Communication is over stdin/stdout pipes.
+- No authentication. The agent owns the process, so there is no untrusted network boundary.
+- Single agent per process. One process serves one agent session.
+- Automatic lifecycle. The agent starts and stops the server as needed.
 
-### When to use
+### When to use stdio
 
 - Local development with Claude Code, Cursor, or Codex.
 - Single-developer workflows.
@@ -28,7 +31,7 @@ voicegw mcp --transport stdio
 1. The agent starts `voicegw mcp --transport stdio` as a subprocess.
 2. The agent writes MCP JSON-RPC messages to the process's stdin.
 3. The MCP server writes responses to stdout.
-4. When the agent disconnects, the process exits.
+4. When the agent session ends, the process exits.
 
 ## HTTP/SSE
 
@@ -42,24 +45,23 @@ voicegw mcp --transport http --host 0.0.0.0 --port 8090
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/sse` | `GET` | SSE connection point. The agent opens a long-lived connection here to receive messages. |
-| `/messages/` | `POST` | The agent sends tool calls and other MCP messages here. |
+| `/sse` | GET | SSE connection point. The agent opens a long-lived connection here to receive messages. |
+| `/messages/` | POST | The agent sends tool calls and other MCP messages here. |
 
 ### Characteristics
 
-- **Network-based** -- agents connect over HTTP.
-- **Authentication supported** -- controlled by the `VOICEGW_MCP_TOKEN` environment variable (Bearer token). See [Authentication](/mcp/authentication).
-- **Multiple agents** -- several agents can connect simultaneously.
-- **Persistent** -- the server runs until manually stopped.
+- Network-based. Agents connect over HTTP.
+- Optional bearer token authentication. Controlled by `VOICEGW_MCP_TOKEN`. See [Authentication](/mcp/authentication).
+- Multiple simultaneous agents. Several agents can connect at the same time.
+- Persistent. The server runs until you stop it manually.
 
-### When to use
+### When to use HTTP/SSE
 
-- Shared team gateways.
+- Shared team gateways where multiple developers need access.
 - Remote agents that cannot launch local processes.
 - Production environments behind a reverse proxy with TLS.
-- When multiple agents need to connect to the same gateway instance.
 
-## Comparison
+## Transport comparison
 
 | Feature | stdio | HTTP/SSE |
 |---|---|---|
@@ -70,7 +72,7 @@ voicegw mcp --transport http --host 0.0.0.0 --port 8090
 | Setup complexity | Minimal | Moderate |
 | Best for | Local dev | Team / production |
 
-## Configuration Examples
+## Configuration examples
 
 ### stdio with Claude Code
 
@@ -87,11 +89,14 @@ voicegw mcp --transport http --host 0.0.0.0 --port 8090
 
 ### HTTP/SSE with authentication
 
+Start the server:
+
 ```bash
-# Start server
 export VOICEGW_MCP_TOKEN=my-secret-token
 voicegw mcp --transport http --host 0.0.0.0 --port 8090
 ```
+
+Agent config:
 
 ```json
 {
@@ -105,3 +110,13 @@ voicegw mcp --transport http --host 0.0.0.0 --port 8090
   }
 }
 ```
+
+<Tip>
+The default transport when you run `voicegw mcp` with no flags is stdio. You only need to pass `--transport stdio` explicitly when the agent config requires the flag.
+</Tip>
+
+## Next steps
+
+- [Authentication](/mcp/authentication): secure the HTTP transport with a bearer token.
+- [Setup](/mcp/setup): full per-agent configuration examples.
+- [CLI reference: mcp](/cli/mcp): all flags for `voicegw mcp`.


### PR DESCRIPTION
## Summary

- Added `title:` and `description:` frontmatter to all 8 MCP pages (index, setup, authentication, transports, tools/models, tools/providers, tools/projects, tools/observability).
- Restructured `mcp/index` with a `<CardGroup>` hub linking to all sub-pages.
- Added `<CodeGroup>` pip/uv alternatives on install steps.
- Added `<Note>`, `<Tip>`, `<Warning>` callouts where appropriate.
- Replaced bare `/mcp` links with `/mcp/index` (validator rule 4).
- Removed any `{#anchor}` heading ids (validator rule 8).
- Kept all tool names, argument schemas, and example JSON exactly as authored.

## Acceptance

`python3 docs/_check_docs.py mcp/index mcp/setup mcp/authentication mcp/transports mcp/tools/models mcp/tools/providers mcp/tools/projects mcp/tools/observability`

Result: `docs validator: PASS (90 pages, 90 nav refs, content rules on 8 scoped)`