### PR TITLE
docs(architecture): rewrite Architecture part 1 (P11a)

### DIFF
--- a/docs/architecture/cost-tracking.md
+++ b/docs/architecture/cost-tracking.md
@@ -1,4 +1,7 @@
-# Cost Tracking
+---
+title: Cost Tracking
+description: How VoiceGateway computes per-request cost for LLM tokens, STT audio-minutes, and TTS characters using voice-prices, and how that data flows from RequestRecord into SQLite and the dashboard.
+---
 
 VoiceGateway records the cost of every request that flows through it: tokens for LLM, audio seconds for STT, characters for TTS. Cost data lands in SQLite alongside latency metrics and is the source of truth for the dashboard, the `voicegw reconcile` command, and per-project budget enforcement.
 
@@ -8,7 +11,7 @@ This page covers the cost-tracking subsystem end-to-end: the pricing layer, the 
 
 ```mermaid
 graph LR
-    subgraph Request["Per-Request Path"]
+    subgraph Request["Per-request path"]
         WRAP["InstrumentedSTT/LLM/TTS<br/>(transparent proxy)"]
         CT["CostTracker.create_record()"]
         STORE["SQLiteStorage.log_request()"]
@@ -16,7 +19,7 @@ graph LR
     end
 
     subgraph Pricing["Pricing layer (modality dispatch)"]
-        FACADE["voicegateway.pricing.catalog<br/>calculate_cost()"]
+        FACADE["pricing/catalog.py<br/>calculate_cost()"]
         LLM["llm.py<br/>(voice-prices wrapper)"]
         STT["stt.py<br/>(voice-prices wrapper)"]
         TTS["tts.py<br/>(voice-prices wrapper)"]
@@ -51,8 +54,8 @@ pricing_source(modality: str) -> str
 
 `calculate_cost` dispatches by modality:
 
-- **LLM** (`modality="llm"`): uses `input_tokens` and `output_tokens`. Routes to `pricing/llm.py`, which wraps `voice-prices`. Returns the voice-prices total. `pricing_source("llm")` is `voice-prices@<version>`.
-- **STT** (`modality="stt"`): uses `audio_seconds`. Routes to `pricing/stt.py`, which maps the duration onto a `voice-prices` lookup. `pricing_source("stt")` is `voice-prices@<version>`.
+- **LLM** (`modality="llm"`): uses `input_tokens` and `output_tokens`. Routes to `pricing/llm.py`, which wraps `voice-prices`. Returns the voice-prices total.
+- **STT** (`modality="stt"`): uses `audio_seconds`. Routes to `pricing/stt.py`, which maps the duration onto a `voice-prices` lookup.
 - **TTS** (`modality="tts"`): uses `character_count`. Routes to `pricing/tts.py`, same `voice-prices` pattern as STT.
 - **Self-hosted** (`local/*`, `ollama/*`): priced at `$0` by a facade guard, attributed as `voicegateway-local`.
 
@@ -72,54 +75,71 @@ Every wrapped request flows through `_InstrumentedBase._log_request`:
 
 Each `RequestRecord` carries the same `pricing_source` string the catalog returned, so `voicegw reconcile` can attribute the recorded number to a specific upstream catalog version.
 
+## RequestRecord fields
+
+| Field | Type | Source |
+|-------|------|--------|
+| `model_id` | `str` | Parsed from the `"provider/model"` string |
+| `modality` | `str` | `"llm"`, `"stt"`, or `"tts"` |
+| `project` | `str` | `ContextVar` set by `attach()` or `guard()` |
+| `tenant_id` | `str \| None` | `ContextVar` set by `attach(tenant_id=...)` |
+| `input_units` | `int \| float` | Tokens, audio seconds, or characters |
+| `output_units` | `int` | Output tokens (LLM only) |
+| `cost_usd` | `Decimal` | Result of `calculate_cost()` |
+| `pricing_source` | `str` | `voice-prices@<version>` or `voicegateway-local` |
+| `ttfb_ms` | `float` | Time to first byte in milliseconds |
+| `total_latency_ms` | `float` | End-to-end latency in milliseconds |
+| `timestamp` | `datetime` | UTC time of the request |
+
 ## How streaming cost accounting is validated
 
-Streaming is where the real-world cost-tracking bugs hide: tokens that double at chunk boundaries, audio-second accumulators that drift, character counts that miss SSML markup. VoiceGateway closes the validation gap without requiring real production traffic.
+Streaming is where real-world cost-tracking bugs hide: tokens that double at chunk boundaries, audio-second accumulators that drift, character counts that miss SSML markup. VoiceGateway closes the validation gap without requiring real production traffic.
 
 ### The substitute strategy
 
-Rather than dogfood the gateway in production and reconcile against provider invoices, VG records real provider streaming responses **once** via `src/voicegateway/tests/fixtures/streaming/record_streaming_fixtures.py` and replays them in CI forever. Each fixture is a JSON file with three load-bearing sections:
+Rather than relying on production traffic, VoiceGateway records real provider streaming responses once via `src/voicegateway/tests/fixtures/streaming/record_streaming_fixtures.py` and replays them in CI. Each fixture is a JSON file with three load-bearing sections:
 
-- `request`: the literal payload VG sent.
+- `request`: the literal payload VoiceGateway sent.
 - `response_stream`: the chunks the provider returned, with `received_at_ms` timestamps.
 - `provider_reported_usage`: the usage block the provider reported at end-of-stream (tokens for LLM, duration for STT, character count for TTS).
 
-The fixture also pins `expected_cost_usd`, computed at recording time by passing `provider_reported_usage` through `voicegateway.pricing.catalog.calculate_cost`. Quantized to 8 decimal places. **This locks the cost math at the recording's price**: if a catalog updates later, the fixture's `expected_cost_usd` stays at the price-at-recording. The fixture validates VG's *math*, not "today's price."
+The fixture also pins `expected_cost_usd`, computed at recording time by passing `provider_reported_usage` through `calculate_cost`. Quantized to 8 decimal places. This locks the cost math at the recording's price: if a catalog updates later, the fixture's `expected_cost_usd` stays at the price-at-recording. The fixture validates VoiceGateway's math, not "today's price."
 
-Filename convention is locked at `<provider>_<model>_<modality>_<mode>_<YYYY-MM-DD>.json`. The date drives the staleness check.
+Filename convention: `<provider>_<model>_<modality>_<mode>_<YYYY-MM-DD>.json`. The date drives the staleness check.
 
 ### What the replay tests assert
 
 `src/voicegateway/tests/test_streaming_cost_accounting.py` parameterizes over every committed fixture and asserts three things per fixture:
 
-1. **Unit-count consistency**: `provider_reported_usage` agrees with the actual contents of `response_stream`. For LLM, the normalized `input_tokens` / `output_tokens` / `total_tokens` must equal the values inside the trailing ChatCompletion usage chunk. For STT, `audio_seconds` must equal Deepgram's `metadata.duration`. For TTS, `character_count` must equal `len(request.transcript)`. Catches recorder field-name typos, provider schema drift, and off-by-one normalization.
-2. **Cost calculation**: `calculate_cost(provider_reported_usage)` quantized to 8 dp must equal `fixture.expected_cost_usd` quantized to 8 dp. Catches cost-layer regressions (modality-dispatch bugs, pricing-source attribution drift, Decimal precision losses).
-3. **TTFB hook behavior** (stream fixtures only): a wrapper that calls `_mark_first_byte` partway through must produce `ttfb_ms < total_latency_ms`. A wrapper that never calls it must produce `ttfb_ms == total_latency_ms` (the documented fallback). Catches modality refactors that forget to wire TTFB.
+1. **Unit-count consistency.** `provider_reported_usage` agrees with the actual contents of `response_stream`. For LLM, normalized `input_tokens` / `output_tokens` / `total_tokens` must equal the values inside the trailing ChatCompletion usage chunk. For STT, `audio_seconds` must equal Deepgram's `metadata.duration`. For TTS, `character_count` must equal `len(request.transcript)`. Catches recorder field-name typos, provider schema drift, and off-by-one normalization.
+2. **Cost calculation.** `calculate_cost(provider_reported_usage)` quantized to 8 dp must equal `fixture.expected_cost_usd` quantized to 8 dp. Catches cost-layer regressions (modality-dispatch bugs, pricing-source attribution drift, Decimal precision losses).
+3. **TTFB hook behavior** (stream fixtures only). A wrapper that calls `_mark_first_byte` partway through must produce `ttfb_ms < total_latency_ms`. A wrapper that never calls it must produce `ttfb_ms == total_latency_ms` (the documented fallback). Catches modality refactors that forget to wire TTFB.
 
-Plus a separate `src/voicegateway/tests/test_ttfb_hook_coverage.py` runs the TTFB-hook contract against synthetic streams for every modality, gated against `wrap_provider`'s dispatch table so a future modality cannot land without TTFB coverage.
+A separate `src/voicegateway/tests/test_ttfb_hook_coverage.py` runs the TTFB-hook contract against synthetic streams for every modality, gated against `wrap_provider`'s dispatch table so a future modality cannot land without TTFB coverage.
 
 ### Honest limits of the substitute strategy
 
-Fixture replay is not a complete substitute for production traffic. It does **not** catch:
+Fixture replay is not a complete substitute for production traffic. It does not catch:
 
-- **Real-time streaming behavior**: replay is sequential and synchronous. We do not simulate network jitter, partial chunks split across TCP packets, or out-of-order delivery.
-- **Provider-side correctness**: if Deepgram's reported usage is off by 0.1 seconds, the fixture accepts that as ground truth. The suite validates VG's accounting matches the provider's, not whether the provider is right.
-- **Stale fixtures**: recorded fixtures capture provider behavior at a point in time. If a provider changes its streaming format, the fixture's `response_stream` no longer matches what VG would see today. The filename's date convention surfaces staleness; a quarterly refresh task is on the maintenance backlog.
-- **End-to-end LiveKit session validation**: the wrappers are tested in isolation, not as part of a real `AgentSession`. Session-level integration testing is deferred (it sits in the OpenRTC-Python Phase 2 plan).
+- **Real-time streaming behavior.** Replay is sequential and synchronous. Network jitter, partial chunks split across TCP packets, and out-of-order delivery are not simulated.
+- **Provider-side correctness.** If Deepgram's reported usage is off by 0.1 seconds, the fixture accepts that as ground truth. The suite validates VoiceGateway's accounting matches the provider's, not whether the provider is right.
+- **Stale fixtures.** Recorded fixtures capture provider behavior at a point in time. If a provider changes its streaming format, the fixture's `response_stream` no longer matches what VoiceGateway would see today. The filename's date convention surfaces staleness; a quarterly refresh task is on the maintenance backlog.
+- **End-to-end LiveKit session validation.** The wrappers are tested in isolation, not as part of a real `AgentSession`. Session-level integration testing is deferred.
 
-The architecture is honest about this scope: cost tracking is validated against fixture-recorded provider responses, not against real production traffic. Without the fixture-replay phase, that distinction would be invisible; with it, the per-fixture date and provider attribution make the validation surface explicit.
+<Note>
+Cost tracking is validated against fixture-recorded provider responses, not against real production traffic. The per-fixture date and provider attribution make the validation surface explicit.
+</Note>
 
-### Where to find each piece
+## Where to find each piece
 
-- `src/voicegateway/pricing/catalog.py`, `llm.py`, `stt.py`, `tts.py`: the pricing layer.
-- `src/voicegateway/middleware/cost_tracker.py`: per-request record builder.
-- `src/voicegateway/middleware/instrumented_provider.py`: `_InstrumentedBase` + `wrap_provider` + the TTFB / log_request hooks.
-- `src/voicegateway/tests/fixtures/streaming/`: recorded fixtures, schema, loader.
-  - `_schema.py`: `StreamingFixture` Pydantic model.
-  - `_loader.py`: `discover_fixtures`, `load_fixture`, filename-decode helper.
-  - `README.md`: the fixture format and refresh policy.
-  - `PLACEHOLDER.md`: runbook for recording the six minimum fixtures.
-- `src/voicegateway/tests/fixtures/streaming/record_streaming_fixtures.py`: the dev-only recorder, gated behind `--record` and `--confirm`. Its module docstring documents cost expectations and operational warnings.
-- `src/voicegateway/tests/test_streaming_cost_accounting.py`: the three-assertion replay suite.
-- `src/voicegateway/tests/test_ttfb_hook_coverage.py`: per-modality TTFB hardening.
-
+| Component | Path |
+|-----------|------|
+| Pricing facade | `src/voicegateway/pricing/catalog.py` |
+| LLM pricing | `src/voicegateway/pricing/llm.py` |
+| STT pricing | `src/voicegateway/pricing/stt.py` |
+| TTS pricing | `src/voicegateway/pricing/tts.py` |
+| CostTracker | `src/voicegateway/middleware/cost_tracker.py` |
+| InstrumentedProvider | `src/voicegateway/middleware/instrumented_provider.py` |
+| Streaming fixtures | `src/voicegateway/tests/fixtures/streaming/` |
+| Replay test suite | `src/voicegateway/tests/test_streaming_cost_accounting.py` |
+| TTFB hook coverage | `src/voicegateway/tests/test_ttfb_hook_coverage.py` |

--- a/docs/architecture/gateway-core.md
+++ b/docs/architecture/gateway-core.md
@@ -1,23 +1,26 @@
-# Gateway Core
+---
+title: Gateway Core
+description: How the internal Gateway class wires configuration, storage, middleware, and the provider registry together as the single source of truth for all VoiceGateway operations.
+---
 
-The core layer wires configuration, storage, and middleware together so the `voicegateway.inference` factories and the operations endpoints (CLI, HTTP, MCP, dashboard) all share one source of truth.
+The core layer connects configuration, storage, and middleware so the public `attach()` and `guard()` helpers, the CLI, the HTTP server, and the MCP runtime all share one source of truth.
 
-## Gateway Class
+## Gateway class
 
 **File:** `src/voicegateway/core/gateway.py`
 
-`Gateway` is an internal container; it is not part of the public Python SDK. The inference module holds a process-wide singleton via `voicegateway.inference._factory.get_gateway()`. The CLI, HTTP server, and MCP runtime each instantiate it directly because they own their own process lifecycle.
+`Gateway` is an internal container. It is not part of the public Python SDK. The `attach()` and `guard()` helpers hold a process-wide singleton, obtained via an internal factory. The CLI, HTTP server, and MCP runtime each instantiate it directly because they own their own process lifecycle.
 
 ### Initialization
 
 ```python
-# Internal use only. Not on the public SDK surface.
+# Internal use only -- not on the public SDK surface.
 from voicegateway.core.gateway import Gateway
 
-# Auto-discovers voicegw.yaml from standard locations
+# Auto-discovers voicegw.yaml from standard locations.
 gw = Gateway()
 
-# Or specify a config path explicitly
+# Or specify a config path explicitly.
 gw = Gateway(config_path="/path/to/voicegw.yaml")
 ```
 
@@ -28,7 +31,7 @@ Config file search order (when no path is given):
 3. `~/.config/voicegateway/voicegw.yaml`
 4. `/etc/voicegateway/voicegw.yaml`
 
-### What happens at `Gateway.__init__`
+### Startup sequence
 
 ```mermaid
 graph TD
@@ -43,25 +46,22 @@ graph TD
     J --> K["Init BudgetEnforcer, wire into CostTracker"]
 ```
 
-The database path is resolved as: `VOICEGW_DB_PATH` env > `cost_tracking.db_path` in YAML > default `~/.config/voicegateway/voicegw.db`.
+The database path resolves as: `VOICEGW_DB_PATH` env > `cost_tracking.db_path` in YAML > default `~/.config/voicegateway/voicegw.db`.
 
-### What `Gateway` exposes
+### What Gateway exposes internally
 
 | Surface | Purpose |
 |---|---|
 | `gw.config` | The merged `GatewayConfig` object (read-only). |
 | `gw.storage` | `SQLiteStorage` or `None` when cost tracking is disabled. |
-| `gw.cost_tracker` | The `CostTracker` middleware used by the inference wrappers. |
+| `gw.cost_tracker` | The `CostTracker` middleware used by attach(). |
 | `gw.costs(period, project=...)` | Cost summary helper used by the CLI and HTTP API. |
-| `gw.list_projects()` | Project list for the CLI / dashboard / MCP. |
+| `gw.list_projects()` | Project list for the CLI, dashboard, and MCP. |
 | `await gw.refresh_config()` | Re-merges YAML and SQLite after a managed_* write. |
 
-The public inference surface is `voicegateway.inference.STT/LLM/TTS`,
-which constructs the Gateway singleton internally and reads the same
-merged config. There is no separate `Gateway.stt()` / `llm()` /
-`tts()` method on the Gateway object.
+The public surface is `from voicegateway import attach, guard`. Both functions call the internal singleton and read the same merged config.
 
-### Config Refresh
+### Config refresh
 
 After the dashboard or MCP server writes to managed tables, the Gateway reloads its merged config:
 
@@ -69,40 +69,39 @@ After the dashboard or MCP server writes to managed tables, the Gateway reloads 
 await gw.refresh_config()
 ```
 
-This re-runs `ConfigManager.load_merged()` and rebuilds the `BudgetEnforcer` so it sees newly-added projects.
+This re-runs `ConfigManager.load_merged()` and rebuilds `BudgetEnforcer` so it sees newly added projects.
 
 ## ConfigManager
 
 **File:** `src/voicegateway/core/config_manager.py`
 
-`ConfigManager.load_merged()` deep-copies the YAML config and layers in `managed_providers`, `managed_models`, and `managed_projects` rows from SQLite. Per-project provider rows (those with a non-null `project` column) merge into `merged.projects[<id>].providers[<provider_type>]` so the inference resolver finds them via `GatewayConfig.get_provider_config_for_project`. YAML always wins on conflict.
+`ConfigManager.load_merged()` deep-copies the YAML config and layers in `managed_providers`, `managed_models`, and `managed_projects` rows from SQLite. Per-project provider rows (those with a non-null `project` column) merge into `merged.projects[<id>].providers[<provider_type>]` so the resolver finds them via `GatewayConfig.get_provider_config_for_project`. YAML always wins on conflict.
 
-## inference resolution
+See [Config Layers](/architecture/config-layers) for the full merge rules.
 
-**File:** `src/voicegateway/inference/_resolution.py`
+## Model ID resolution
 
-The inference factories parse `"provider/model"` strings inline and validate the provider against the registry. The variant suffix (language for STT, voice for TTS) is parsed in the modality-specific factory file (`_stt.py`, `_tts.py`) before resolution; LLM strings keep their trailing colon segments verbatim so Ollama tags survive.
+**File:** `src/voicegateway/core/registry.py` (via an inline parser in the provider layer)
+
+The `attach()` and `guard()` helpers parse `"provider/model"` strings and validate the provider against the registry. The variant suffix (language for STT, voice for TTS) is parsed before resolution; LLM strings keep their trailing colon segments verbatim so Ollama tags survive.
 
 ```python
-from voicegateway.inference._resolution import resolve_model
-
-resolve_model("deepgram/nova-3")      # ("deepgram", "nova-3")
-resolve_model("ollama/qwen2.5:3b")    # ("ollama", "qwen2.5:3b")
+# Examples of model strings VoiceGateway accepts
+"deepgram/nova-3"           # STT
+"openai/gpt-4.1-mini"       # LLM
+"cartesia/sonic-3"          # TTS
+"ollama/qwen2.5:3b"         # local LLM with tag
 ```
-
-Errors:
 
 | Exception | When |
 |---|---|
 | `ModelResolutionError` | Empty string, missing slash, empty halves, or unknown provider name. |
 
-The factories then call `voicegateway.core.registry.create_provider(provider_name, config)` to instantiate the matching `livekit.plugins.<provider>` wrapper.
-
 ## Registry
 
 **File:** `src/voicegateway/core/registry.py`
 
-The Registry maps provider names to their implementation classes via lazy import. No provider module is imported until it is actually needed.
+The Registry maps provider names to their implementation classes via lazy import. No provider module is imported until it is needed.
 
 ```python
 _PROVIDER_REGISTRY = {
@@ -126,3 +125,7 @@ _PROVIDER_REGISTRY = {
 Could not import provider 'deepgram': No module named 'deepgram'.
 Install with: pip install voicegateway[deepgram]
 ```
+
+<Note>
+The Registry is an internal detail. You never call `create_provider` directly. Use `from voicegateway import attach, guard` and pass `"provider/model"` strings; the registry is invoked automatically.
+</Note>

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,203 +1,114 @@
-# Architecture Overview
+---
+title: Architecture Overview
+description: How VoiceGateway wires attach(), guard(), the framework-neutral core, and the storage layer together into a complete cost-tracking and budget-enforcement system.
+---
 
-VoiceGateway is cost tracking and reconciliation for LiveKit voice agents. It returns native LiveKit STT, LLM, and TTS plugin instances across cloud providers and local models, with modality-aware unit accounting (audio-minutes, tokens, characters), resolver-time fallback chains, rate limiting, budget enforcement, a `voicegw reconcile` command, and a web dashboard.
+VoiceGateway is a framework-neutral observability and control layer for LiveKit voice agents. You call `attach()` as a passive observer that records every inference unit, and `guard()` as an active gate that enforces budgets and rate limits before a call is placed. Both functions share a single `RequestRecord` pipeline that lands in SQLite (or a remote sink) and feeds the dashboard and `voicegw reconcile`.
 
-## System Architecture
+## Request flow
 
 ```mermaid
-graph TB
-    subgraph UserCode["User Code / LiveKit Agent"]
-        A["gateway.stt('deepgram/nova-3')"]
-        B["gateway.llm('openai/gpt-4.1-mini')"]
-        C["gateway.tts('cartesia/sonic-3')"]
+graph TD
+    subgraph UserCode["Your Agent Code"]
+        A["attach(session, tenant_id=...)"]
+        B["guard(model_id, project=...)"]
     end
 
-    subgraph Core["Core Layer"]
-        GW[Gateway]
-        R[Router]
-        REG[Registry]
-        MID[ModelId Parser]
+    subgraph Core["Framework-neutral core"]
+        CTX["ContextVars (tenant, project)"]
+        CT["CostTracker"]
+        REC["RequestRecord builder"]
+        VPR["voice-prices catalog"]
     end
 
-    subgraph Middleware["Middleware Pipeline"]
-        BE[BudgetEnforcer]
-        IP[InstrumentedProvider]
-        CT[CostTracker]
-        LM[LatencyMonitor]
-        RL[RateLimiter]
-        FB[FallbackChain]
-        LG[RequestLogger]
-    end
-
-    subgraph Providers["Provider Layer"]
-        BP[BaseProvider ABC]
-        OAI[OpenAI]
-        DG[Deepgram]
-        CA[Cartesia]
-        AN[Anthropic]
-        GR[Groq]
-        EL[ElevenLabs]
-        AA[AssemblyAI]
-        OL[Ollama]
-        WH[Whisper]
-        KO[Kokoro]
-        PI[Piper]
-    end
-
-    subgraph Storage["Storage Layer"]
+    subgraph Storage["Storage"]
         DB[(SQLite)]
-        CM[ConfigManager]
-        CR[Crypto / Fernet]
+        SINK["Remote sink (cloud ingest)"]
     end
 
-    subgraph Interfaces["External Interfaces"]
-        API[FastAPI HTTP Server]
-        DASH[Dashboard - React/Vite]
-        MCP[MCP Server]
-        CLI[CLI - voicegw]
+    subgraph Interfaces["External interfaces"]
+        DASH["Dashboard (React + FastAPI)"]
+        CLI["voicegw reconcile / costs / logs"]
+        API["HTTP /v1/costs  /v1/logs"]
     end
 
-    A --> GW
-    B --> GW
-    C --> GW
-    GW --> BE
-    BE --> R
-    R --> MID
-    R --> REG
-    REG --> BP
-    BP --> OAI & DG & CA & AN & GR & EL & AA & OL & WH & KO & PI
-    GW --> IP
-    IP --> CT
-    IP --> LM
-    GW --> FB
-    CT --> DB
-    API --> GW
-    DASH --> API
-    MCP --> GW
-    CLI --> GW
-    CM --> DB
-    CR --> DB
+    A --> CTX
+    B --> CTX
+    CTX --> CT
+    CT --> VPR
+    VPR --> REC
+    REC --> DB
+    REC --> SINK
+    DB --> DASH
+    DB --> CLI
+    DB --> API
 ```
 
-## Request Flow
+`attach()` hooks into the LiveKit `AgentSession` event stream. It reads the current `ContextVars` (tenant, project, call ID) on each event, computes cost via `voice-prices`, and writes a `RequestRecord`. `guard()` checks BudgetEnforcer and RateLimiter before the call starts and raises `BudgetExceededError` or `RateLimitExceeded` when a limit is hit.
 
-Every call to `gateway.stt()`, `gateway.llm()`, or `gateway.tts()` follows the same path:
-
-```mermaid
-sequenceDiagram
-    participant App as User Code
-    participant GW as Gateway
-    participant BE as BudgetEnforcer
-    participant R as Router
-    participant MID as ModelId
-    participant REG as Registry
-    participant P as Provider
-    participant IP as InstrumentedProvider
-    participant CT as CostTracker
-    participant DB as SQLite
-
-    App->>GW: gateway.stt("deepgram/nova-3", project="prod")
-    GW->>BE: check_budget("prod")
-    BE->>DB: get_cost_summary("today", project="prod")
-    DB-->>BE: $4.20 / $10.00 budget
-    BE-->>GW: OK (under budget)
-    GW->>R: resolve("deepgram/nova-3", "stt")
-    R->>MID: parse("deepgram/nova-3")
-    MID-->>R: ModelId(provider="deepgram", model="nova-3")
-    R->>REG: create_provider("deepgram", config)
-    REG-->>R: DeepgramProvider instance
-    R->>P: create_stt(model="nova-3")
-    P-->>R: STT instance
-    R-->>GW: STT instance
-    GW->>IP: wrap_provider(instance, "stt", ...)
-    IP-->>GW: InstrumentedSTT wrapper
-    GW-->>App: InstrumentedSTT (proxies all access)
-    Note over IP,DB: On first byte/completion, records TTFB + latency
-    IP->>CT: create_record(...)
-    CT->>DB: log_request(record)
-```
-
-## Directory Structure
-
-The Python package lives under `voicegateway/`. A separate `dashboard/`
-tree carries the FastAPI backend and the React + TypeScript + Vite +
-Recharts frontend for the local cost dashboard.
+## Directory layout
 
 ```
-voicegateway/
+src/voicegateway/
 ├── core/
-│   ├── gateway.py
-│   ├── config.py
-│   ├── config_manager.py
-│   ├── registry.py
-│   ├── schema.py
-│   └── crypto.py
-├── inference/
-│   ├── __init__.py
-│   ├── _factory.py
-│   ├── _project.py
-│   ├── _session_context.py
-│   ├── _resolution.py
-│   ├── _stt.py
-│   ├── _llm.py
-│   └── _tts.py
+│   ├── gateway.py          # Internal orchestrator (not public API)
+│   ├── config.py           # YAML parser with ${ENV_VAR} substitution
+│   ├── config_manager.py   # Three-source merge: env > SQLite > YAML
+│   ├── registry.py         # Lazy provider factory
+│   └── schema.py           # Pydantic config models
 ├── providers/
-│   ├── base.py
-│   ├── openai_provider.py
-│   ├── deepgram_provider.py
-│   ├── cartesia_provider.py
-│   ├── anthropic_provider.py
-│   ├── groq_provider.py
-│   ├── elevenlabs_provider.py
-│   ├── assemblyai_provider.py
-│   ├── ollama_provider.py
-│   ├── whisper_provider.py
-│   ├── kokoro_provider.py
-│   └── piper_provider.py
+│   ├── base.py             # BaseProvider ABC
+│   └── *.py                # 11 provider implementations
 ├── middleware/
-│   ├── cost_tracker.py
-│   ├── latency_monitor.py
-│   ├── rate_limiter.py
-│   ├── logger.py
-│   ├── budget_enforcer.py
-│   └── instrumented_provider.py
+│   ├── cost_tracker.py     # RequestRecord builder, voice-prices dispatch
+│   ├── latency_monitor.py  # TTFB + total-latency timers
+│   ├── rate_limiter.py     # Sliding-window RPM limiter
+│   ├── budget_enforcer.py  # Per-project daily-budget checks
+│   ├── logger.py           # Structured request logger
+│   └── instrumented_provider.py  # Transparent proxy wrappers
 ├── storage/
-│   ├── sqlite.py
-│   └── models.py
-├── server.py
-├── mcp/
-│   ├── server.py
-│   ├── auth.py
-│   ├── errors.py
-│   ├── schemas.py
-│   └── tools/
+│   ├── sqlite.py           # Async SQLite backend
+│   └── models.py           # RequestRecord dataclass
 └── pricing/
-    └── catalog.py
+    └── catalog.py          # voice-prices facade
 dashboard/
-├── api/
-└── frontend/
+├── api/                    # FastAPI backend
+└── frontend/               # React + TypeScript + Vite + Recharts
 ```
 
-## Design Principles
+## Design principles
 
-1. **Async throughout** -- all database, HTTP, and provider operations use async/await. The Gateway provides synchronous wrapper methods for convenience.
+**Async throughout.** All database, HTTP, and provider operations use `async`/`await`. The public `attach()` and `guard()` helpers are async-native.
 
-2. **Lazy loading** -- providers are only imported and instantiated on first use. `pip install voicegateway[openai]` installs only the OpenAI SDK.
+**Framework neutral.** VoiceGateway does not own the inference path. You keep your own LiveKit plugin instances or Pipecat services; `attach()` observes them, `guard()` gates them.
 
-3. **Transparent instrumentation** -- `InstrumentedSTT/LLM/TTS` wrappers proxy all attribute access via `__getattr__`, so user code sees the exact same API as the underlying provider instance.
+**Lazy provider loading.** No provider SDK is imported until first use. `pip install voicegateway[openai]` installs only the OpenAI SDK.
 
-4. **Config layering** -- three sources merged at startup: environment variables (highest priority), SQLite managed tables (dashboard/MCP writes), and YAML (base config). Each resource carries a `source` field (`"yaml"` or `"db"`).
+**Transparent instrumentation.** `InstrumentedSTT/LLM/TTS` wrappers proxy all attribute access via `__getattr__`, so existing call sites see the identical API as the underlying plugin instance.
 
-5. **Encryption at rest** -- all API keys stored in SQLite are encrypted with Fernet (AES-128-CBC + HMAC-SHA256). Keys in API responses are masked to `secr...2345` format.
+**Config layering.** Three sources merge at startup: environment variables (highest priority), SQLite managed tables (dashboard/MCP writes), and YAML (base config).
 
-## Key Components
+**Encryption at rest.** API keys stored in SQLite are encrypted with Fernet (AES-128-CBC + HMAC-SHA256). Keys in API responses are masked to the `secr...2345` format.
 
-| Component | File | Purpose |
-|-----------|------|---------|
-| [Gateway Core](./gateway-core) | `core/gateway.py` | Main orchestrator, entry point for all requests |
-| [Provider Abstraction](./provider-abstraction) | `providers/base.py` | ABC for all 11 provider implementations |
-| [Middleware](./middleware) | `middleware/` | Cost, latency, rate limiting, fallback, budget |
-| [Cost Tracking](./cost-tracking) | `pricing/`, `middleware/cost_tracker.py` | Per-request cost calculation, pricing layer, streaming validation |
-| [Storage](./storage) | `storage/sqlite.py` | SQLite schema, tables, views, indexes |
-| [Config Layers](./config-layers) | `core/config_manager.py` | YAML + SQLite + env merge strategy |
-| [Security](./security) | `core/crypto.py` | Fernet encryption, secret management, masking |
+## Architecture pages
+
+<CardGroup cols={2}>
+  <Card title="Gateway Core" href="/architecture/gateway-core">
+    Gateway orchestration, config, router, registry, and ModelId parser.
+  </Card>
+  <Card title="Provider Abstraction" href="/architecture/provider-abstraction">
+    BaseProvider ABC and all 11 cloud and local provider implementations.
+  </Card>
+  <Card title="Middleware" href="/architecture/middleware">
+    Cost tracking, latency, rate limiting, budget enforcement, and request logging.
+  </Card>
+  <Card title="Cost Tracking" href="/architecture/cost-tracking">
+    Per-modality cost calculation: tokens, audio-minutes, characters, and voice-prices.
+  </Card>
+  <Card title="Config Layers" href="/architecture/config-layers">
+    YAML + SQLite + env merge strategy and the ConfigManager.
+  </Card>
+  <Card title="Storage" href="/architecture/storage">
+    SQLite schema, tables, views, indexes, and the remote-sink interface.
+  </Card>
+</CardGroup>

--- a/docs/architecture/middleware.md
+++ b/docs/architecture/middleware.md
@@ -1,64 +1,58 @@
-# Middleware
+---
+title: Middleware Pipeline
+description: The middleware components that sit between attach()/guard() and the storage layer: CostTracker, LatencyMonitor, RateLimiter, BudgetEnforcer, RequestLogger, and InstrumentedProvider.
+---
 
-The middleware layer sits between the Gateway and provider instances, providing cross-cutting concerns: cost tracking, latency monitoring, rate limiting, fallback chains, budget enforcement, and request logging.
+The middleware layer provides cross-cutting concerns: cost tracking, latency monitoring, rate limiting, fallback chains, budget enforcement, and request logging. `attach()` feeds completed call events through this pipeline. `guard()` runs the budget and rate checks before a call starts.
 
-## Middleware Components
+## Pipeline overview
 
 ```mermaid
 graph TD
-    subgraph Request["Incoming Request"]
-        REQ["gateway.stt('deepgram/nova-3', project='prod')"]
+    subgraph ActivePath["guard() - active gate (pre-call)"]
+        BE["BudgetEnforcer.check_budget()"]
+        RL["RateLimiter.acquire()"]
     end
 
-    subgraph Middleware["Middleware Pipeline"]
-        BE["BudgetEnforcer<br/>check_budget()"]
-        RL["RateLimiter<br/>acquire()"]
-        FB["FallbackChain<br/>resolve()"]
-        LG["RequestLogger<br/>log_request()"]
-        IP["InstrumentedProvider<br/>wrap_provider()"]
-        CT["CostTracker<br/>calculate_cost()"]
-        LM["LatencyMonitor<br/>start() / finish()"]
+    subgraph PassivePath["attach() - passive observer (post-call)"]
+        IP["InstrumentedProvider.wrap_provider()"]
+        CT["CostTracker.create_record()"]
+        LM["LatencyMonitor"]
+        LG["RequestLogger"]
     end
 
-    subgraph Post["Post-Request"]
-        REC["RequestRecord → SQLite"]
+    subgraph Storage["Storage"]
+        REC["RequestRecord -> SQLite / remote sink"]
     end
 
-    REQ --> BE
     BE -->|under budget| RL
     BE -->|over budget + block| ERR["BudgetExceededError"]
     BE -->|over budget + throttle| THR["BudgetThrottleSignal"]
-    RL --> LG
-    LG --> FB
-    FB --> IP
+    RL -->|OK| PassivePath
     IP --> CT
     IP --> LM
-    CT --> REC
-    LM --> REC
+    CT --> LG
+    LG --> REC
 ```
 
-## Execution Order
+## Execution order
 
-When a request flows through the Gateway:
-
-| Step | Component | Action |
-|------|-----------|--------|
-| 1 | **BudgetEnforcer** | Checks project's daily spend against its budget |
-| 2 | **RateLimiter** | Ensures provider hasn't exceeded RPM limit |
-| 3 | **RequestLogger** | Logs the incoming request |
-| 4 | **FallbackChain** | Tries primary model, falls back on failure |
-| 5 | **Router** | Resolves model ID to provider instance |
-| 6 | **InstrumentedProvider** | Wraps the instance to record metrics |
-| 7 | **CostTracker** | Calculates cost when the request completes |
-| 8 | **LatencyMonitor** | Records TTFB and total latency |
+| Step | Component | Path | Action |
+|------|-----------|------|--------|
+| 1 | **BudgetEnforcer** | guard() | Checks project daily spend against budget |
+| 2 | **RateLimiter** | guard() | Ensures provider RPM limit is not exceeded |
+| 3 | **InstrumentedProvider** | attach() | Wraps the instance to record metrics |
+| 4 | **CostTracker** | attach() | Calculates cost when the call completes |
+| 5 | **LatencyMonitor** | attach() | Records TTFB and total latency |
+| 6 | **RequestLogger** | attach() | Writes structured log entry |
 
 ## BudgetEnforcer
 
 **File:** `src/voicegateway/middleware/budget_enforcer.py`
 
-Enforces per-project daily spending limits. Budget checks are cached in memory with a **30-second TTL** to avoid hitting the database on every request.
+Enforces per-project daily spending limits. Budget checks are cached in memory with a 30-second TTL to avoid hitting the database on every request.
 
-### Three Modes
+### Three modes
 
 | Mode | `budget_action` | Behavior |
 |------|-----------------|----------|
@@ -88,7 +82,7 @@ class BudgetEnforcer:
             raise BudgetExceededError(project, today_spend, pcfg.daily_budget)
 ```
 
-The `get_budget_status()` method returns a status string for API responses: `"ok"`, `"warning"` (>80% spent), or `"exceeded"`.
+`get_budget_status()` returns a status string for API responses: `"ok"`, `"warning"` (>80% spent), or `"exceeded"`.
 
 ## CostTracker
 
@@ -98,17 +92,15 @@ Calculates per-request costs based on the pricing catalog and writes request rec
 
 ### Pricing
 
-Costs are delegated to `voice-prices`. The cost tracker maps the recorded
-units onto a `voice_prices.Usage` per modality (STT: `audio_input_seconds`,
-LLM: `input_tokens` / `output_tokens` / `cache_read_tokens`, TTS:
-`characters`) and calls `voice_prices.calc_price`. Self-hosted `local/*` and
-`ollama/*` models price at `$0`. See `voicegateway.inference.pricing.catalog`.
+Costs are delegated to `voice-prices`. The cost tracker maps the recorded units onto a `voice_prices.Usage` per modality (STT: `audio_input_seconds`, LLM: `input_tokens` / `output_tokens` / `cache_read_tokens`, TTS: `characters`) and calls `voice_prices.calc_price`. Self-hosted `local/*` and `ollama/*` models price at `$0`.
 
-### Key Methods
+See [Cost Tracking](/architecture/cost-tracking) for the full per-modality flow.
 
-- **`CostTracker.calculate_cost(model_id, modality, input_units, output_units, cached_input_units)`** -- returns cost in USD (0.0 for unknown or self-hosted)
-- **`create_record(...)`** -- creates a `RequestRecord` with cost, latency, and metadata
-- **`log_request(record)`** -- persists the record to SQLite (async)
+### Key methods
+
+- `CostTracker.calculate_cost(model_id, modality, input_units, output_units, cached_input_units)` returns cost in USD (0.0 for unknown or self-hosted).
+- `create_record(...)` builds a `RequestRecord` with cost, latency, and metadata.
+- `log_request(record)` persists the record to SQLite (async).
 
 ## LatencyMonitor
 
@@ -116,8 +108,8 @@ LLM: `input_tokens` / `output_tokens` / `cache_read_tokens`, TTS:
 
 Tracks two timing metrics:
 
-- **TTFB (Time to First Byte):** measured from request start to the first result/token
-- **Total latency:** measured from request start to completion
+- **TTFB (Time to First Byte).** Measured from request start to the first result or token.
+- **Total latency.** Measured from request start to completion.
 
 ```python
 class LatencyMonitor:
@@ -128,7 +120,7 @@ class LatencyMonitor:
         return _LatencyTimer(self._ttfb_warning_ms)
 ```
 
-The `_LatencyTimer` logs a warning when TTFB exceeds the configured threshold (default 500ms). This threshold is configurable via `latency.ttfb_warning_ms` in `voicegw.yaml`.
+The `_LatencyTimer` logs a warning when TTFB exceeds the configured threshold (default 500 ms). Configure via `latency.ttfb_warning_ms` in `voicegw.yaml`.
 
 ## RateLimiter
 
@@ -155,12 +147,7 @@ The limiter maintains a list of timestamps for each provider. On each `acquire()
 
 ## Resolver-time fallback (manual walk)
 
-VoiceGateway does not run an automatic fallback middleware.
-Resolver-time fallback is a startup-walk pattern: enumerate the
-chain and call the matching `voicegateway.inference.STT/LLM/TTS`
-factory until one succeeds, then pass the resolved instance to
-`AgentSession`. The chain lives in `voicegw.yaml` under
-`fallbacks:` and is documentation-only at runtime.
+VoiceGateway does not run automatic fallback middleware. Resolver-time fallback is a startup-walk pattern: you enumerate the chain and call `attach()` or `guard()` with each model ID until one succeeds, then pass the resolved instance to `AgentSession`. The chain lives in `voicegw.yaml` under `fallbacks:`.
 
 ```yaml
 # voicegw.yaml
@@ -175,16 +162,18 @@ fallbacks:
 ```
 
 ```python
+from voicegateway import guard
+
 def first_resolvable_stt(chain):
     for model_id in chain:
         try:
-            return inference.STT(model_id)
+            return guard(model_id)
         except Exception:
             continue
     raise RuntimeError("every STT model in the chain failed to resolve")
 ```
 
-Once that resolved model is wired into `AgentSession`, the call uses it for its lifetime: VG does not swap providers mid-call. For runtime / mid-call failover, compose LiveKit's `FallbackAdapter` around VG `inference.*` instances directly; see the [LiveKit FallbackAdapter integration](/examples/livekit-fallback-adapter) guide.
+Once a resolved model is wired into `AgentSession`, the call uses it for its lifetime. VoiceGateway does not swap providers mid-call. For runtime or mid-call failover, compose LiveKit's `FallbackAdapter` around instances created via `guard()`. See the [livekit-fallback-adapter example](/examples/livekit-fallback-adapter).
 
 ## RequestLogger
 
@@ -192,7 +181,7 @@ Once that resolved model is wired into `AgentSession`, the call uses it for its 
 
 Structured logging for all gateway operations under the `gateway.requests` logger name.
 
-| Method | Log Level | Format |
+| Method | Log level | Format |
 |--------|-----------|--------|
 | `log_request(model_id, modality)` | INFO | `[STT] deepgram/nova-3` |
 | `log_response(model_id, modality, latency_ms, cost_usd)` | INFO | `[STT] deepgram/nova-3 -> success (142ms, $0.000430)` |
@@ -203,9 +192,9 @@ Structured logging for all gateway operations under the `gateway.requests` logge
 
 **File:** `src/voicegateway/middleware/instrumented_provider.py`
 
-Transparent proxy wrappers that record TTFB, total latency, and cost without changing the provider's API surface.
+Transparent proxy wrappers that record TTFB, total latency, and cost without changing the provider's API surface. `attach()` applies these wrappers automatically when it hooks a session.
 
-### How It Works
+### How it works
 
 ```mermaid
 graph LR
@@ -213,16 +202,20 @@ graph LR
     B --> C["getattr(wrapped_stt, 'transcribe')"]
     C --> D["Actual Deepgram STT.transcribe()"]
     D --> E["_mark_first_byte()"]
-    E --> F["_log_request() → CostTracker → SQLite"]
+    E --> F["_log_request() -> CostTracker -> SQLite"]
 ```
 
 The three wrapper classes (`InstrumentedSTT`, `InstrumentedLLM`, `InstrumentedTTS`) extend `_InstrumentedBase`, which:
 
-1. Uses `object.__setattr__` in `__init__` to store internal state without triggering the proxy
-2. Implements `__getattr__` to delegate all attribute access to the wrapped instance
-3. Implements `__setattr__` to delegate attribute writes to the wrapped instance
-4. Records `_start_time` at construction via `time.perf_counter()`
-5. Provides `_mark_first_byte()` to record TTFB
-6. Provides `_log_request()` to write a `RequestRecord` to storage (with a `_logged` guard to prevent duplicates)
+1. Uses `object.__setattr__` in `__init__` to store internal state without triggering the proxy.
+2. Implements `__getattr__` to delegate all attribute access to the wrapped instance.
+3. Implements `__setattr__` to delegate attribute writes to the wrapped instance.
+4. Records `_start_time` at construction via `time.perf_counter()`.
+5. Provides `_mark_first_byte()` to record TTFB.
+6. Provides `_log_request()` to write a `RequestRecord` to storage (with a `_logged` guard to prevent duplicates).
 
-The wrapping is applied by the Gateway's `_wrap()` method and can be disabled by setting `observability.latency_tracking: false` in config.
+The `guard()` helper also uses `wrap_provider` internally when it creates a new plugin instance on your behalf, so both the passive (`attach()`) and active (`guard()`) paths go through the same instrumentation. Disable it via `observability.latency_tracking: false` in config.
+
+<Tip>
+You can use `from voicegateway import attach, guard` together on the same session. `attach()` instruments the existing instances; `guard()` enforces budgets before new calls start. See [Core Concepts](/guide/core-concepts).
+</Tip>

--- a/docs/architecture/provider-abstraction.md
+++ b/docs/architecture/provider-abstraction.md
@@ -1,6 +1,9 @@
-# Provider Abstraction
+---
+title: Provider Abstraction
+description: How VoiceGateway's BaseProvider ABC unifies 11 cloud and local implementations behind a single interface, and how attach() and guard() sit above that layer as framework-neutral observers and gates.
+---
 
-All 11 providers in VoiceGateway implement the same abstract base class, giving the core layer a uniform interface regardless of whether the underlying service is a cloud API or a local model.
+VoiceGateway does not replace your LiveKit plugin instances or Pipecat services. You keep creating them directly. `attach()` observes them as a passive hook on the `AgentSession` event stream. `guard()` gates calls before they start. The provider layer underneath exists to support the CLI health-check, the resolver-time fallback walk, and modular installation, not to intercept inference traffic.
 
 ## BaseProvider ABC
 
@@ -11,22 +14,22 @@ class BaseProvider(ABC):
 
     @abstractmethod
     def create_stt(self, model: str, **kwargs: Any) -> Any:
-        """Create an STT instance."""
+        """Return a LiveKit-compatible STT instance."""
         ...
 
     @abstractmethod
     def create_llm(self, model: str, **kwargs: Any) -> Any:
-        """Create an LLM instance."""
+        """Return a LiveKit-compatible LLM instance."""
         ...
 
     @abstractmethod
     def create_tts(self, model: str, voice: str | None = None, **kwargs: Any) -> Any:
-        """Create a TTS instance."""
+        """Return a LiveKit-compatible TTS instance."""
         ...
 
     @abstractmethod
     async def health_check(self) -> bool:
-        """Check if the provider is reachable."""
+        """Return True if the provider is reachable."""
         ...
 
     def _unsupported(self, modality: str) -> None:
@@ -36,26 +39,49 @@ class BaseProvider(ABC):
         )
 ```
 
-### Method Contracts
+### Method contracts
 
-| Method | Returns | Unsupported Behavior |
+| Method | Returns | Unsupported behavior |
 |--------|---------|---------------------|
 | `create_stt(model, **kwargs)` | LiveKit-compatible STT instance | Call `self._unsupported("stt")` |
 | `create_llm(model, **kwargs)` | LiveKit-compatible LLM instance | Call `self._unsupported("llm")` |
 | `create_tts(model, voice, **kwargs)` | LiveKit-compatible TTS instance | Call `self._unsupported("tts")` |
 | `health_check()` | `True` if reachable, `False` otherwise | Must always be implemented |
 
-Pricing is no longer a provider-level concern. Rates for all three modalities (LLM, STT, and TTS) resolve via `voice-prices` (see the wrapper modules `src/voicegateway/inference/pricing/{llm,stt,tts}.py`, which call `voice_prices.calc_price`). Use `voicegateway.inference.pricing.catalog.calculate_cost(modality, model, ...)` from anywhere that needs a per-request cost.
+Pricing is not a provider-level concern. Rates for all three modalities resolve via `voice-prices` inside `src/voicegateway/pricing/catalog.py`. Providers return plain plugin instances; the cost layer wraps them separately.
 
-> **Argument order trap.** `voicegateway.pricing.catalog.calculate_cost(modality, model, ...)` takes `modality` first; the legacy `CostTracker.calculate_cost(model_id, modality, ...)` on `voicegateway.middleware.cost_tracker` takes `model_id` first. The two helpers serve different layers (catalog is the pricing facade; CostTracker bridges to the storage record), but the reversed positional order is easy to transpose. When in doubt, use keyword arguments or call the catalog directly.
+## How attach() and guard() relate to providers
 
-## Provider Registry
+```mermaid
+graph TD
+    subgraph YourCode["Your agent code"]
+        PI["livekit.plugins.deepgram.STT(...)"]
+        ATT["attach(session, tenant_id=...)"]
+        GRD["guard('deepgram/nova-3', project='prod')"]
+    end
 
-All 11 providers are registered in `src/voicegateway/core/registry.py` as `(module_path, class_name)` tuples. The Registry uses `importlib.import_module()` for lazy loading -- a provider's SDK is only imported when that provider is first used.
+    subgraph VG["VoiceGateway layer"]
+        BP["BaseProvider (registry lookup)"]
+        CT["CostTracker"]
+        BE["BudgetEnforcer"]
+    end
+
+    PI -->|your existing instance| ATT
+    ATT -->|hooks session events| CT
+    GRD -->|budget + rate check| BE
+    BE -->|OK| BP
+    BP -->|creates a new plugin instance| YourCode
+```
+
+`attach()` is the passive path: you hand it the session you already have; it records cost from the event stream without touching the plugin instance. `guard()` is the active path: it checks limits and optionally resolves a new plugin instance for you via the registry. See [attach](/guide/attach) and [guard](/guide/guard) for usage.
+
+## Provider registry
+
+All 11 providers are registered in `src/voicegateway/core/registry.py` as `(module_path, class_name)` tuples. The Registry uses `importlib.import_module()` for lazy loading: a provider's SDK is only imported when that provider is first used.
 
 ```mermaid
 graph LR
-    subgraph Cloud["Cloud Providers"]
+    subgraph Cloud["Cloud providers"]
         OAI[OpenAI<br/>STT + LLM + TTS]
         DG[Deepgram<br/>STT]
         CA[Cartesia<br/>TTS]
@@ -65,7 +91,7 @@ graph LR
         AA[AssemblyAI<br/>STT]
     end
 
-    subgraph Local["Local Providers"]
+    subgraph Local["Local providers"]
         OL[Ollama<br/>LLM]
         WH[Whisper<br/>STT]
         KO[Kokoro<br/>TTS]
@@ -75,9 +101,9 @@ graph LR
     BP[BaseProvider ABC] --> OAI & DG & CA & AN & GR & EL & AA & OL & WH & KO & PI
 ```
 
-## Modality Support Matrix
+## Modality support matrix
 
-| Provider | STT | LLM | TTS | Install Extra |
+| Provider | STT | LLM | TTS | Install extra |
 |----------|-----|-----|-----|--------------|
 | OpenAI | Yes | Yes | Yes | `openai` |
 | Deepgram | Yes | -- | -- | `deepgram` |
@@ -91,9 +117,9 @@ graph LR
 | Kokoro | -- | -- | Yes | `kokoro` |
 | Piper | -- | -- | Yes | `piper` |
 
-When a provider does not support a modality, its `create_*` method calls `self._unsupported()`, which raises `NotImplementedError`. This propagates cleanly through the Router and Gateway layers.
+When a provider does not support a modality, its `create_*` method calls `self._unsupported()`, which raises `NotImplementedError`. This propagates cleanly through the resolver and surfaces as a clear error before the call starts.
 
-## Implementation Pattern
+## Implementation pattern
 
 Every provider follows the same structure:
 
@@ -103,7 +129,6 @@ class DeepgramProvider(BaseProvider):
 
     def __init__(self, config: dict[str, Any]):
         self._api_key = config.get("api_key") or os.environ.get("DEEPGRAM_API_KEY", "")
-        # Provider-specific initialization
 
     def create_stt(self, model: str, **kwargs: Any) -> Any:
         from livekit.plugins.deepgram import STT
@@ -116,19 +141,18 @@ class DeepgramProvider(BaseProvider):
         self._unsupported("tts")
 
     async def health_check(self) -> bool:
-        # Lightweight API call to verify credentials
         ...
 ```
 
-### Key patterns:
+Key patterns:
 
-1. **API key resolution:** `config.get("api_key")` first (from YAML or managed providers), then fall back to the standard environment variable (`DEEPGRAM_API_KEY`, `OPENAI_API_KEY`, etc.).
+1. **API key resolution.** `config.get("api_key")` first (from YAML or managed providers), then the standard environment variable (`DEEPGRAM_API_KEY`, `OPENAI_API_KEY`, etc.).
 
-2. **LiveKit plugin wrapping:** each `create_*` method returns a LiveKit Agents plugin instance (`livekit.plugins.deepgram.STT`, `livekit.plugins.openai.LLM`, etc.), making VoiceGateway a drop-in replacement for direct LiveKit plugin usage.
+2. **LiveKit plugin wrapping.** Each `create_*` method returns a `livekit.plugins.<provider>` instance directly, making it a drop-in replacement for direct LiveKit plugin construction.
 
-3. **Lazy SDK import:** the `from livekit.plugins.deepgram import STT` happens inside the method, not at module level. This allows installing only the providers you need.
+3. **Lazy SDK import.** The `from livekit.plugins.deepgram import STT` import happens inside the method, not at module level, so you pay the import cost only when the provider is first used.
 
-## Modular Installation
+## Modular installation
 
 Each provider is an optional dependency:
 
@@ -150,13 +174,13 @@ Could not import provider 'deepgram': No module named 'deepgram'.
 Install with: pip install voicegateway[deepgram]
 ```
 
-## Adding a New Provider
+## Adding a new provider
 
-1. Create `src/voicegateway/providers/myprovider_provider.py` extending `BaseProvider`
-2. Implement the five abstract methods (use `_unsupported()` for unsupported modalities)
+1. Create `src/voicegateway/providers/myprovider_provider.py` extending `BaseProvider`.
+2. Implement the five abstract methods (use `_unsupported()` for unsupported modalities).
 3. Register it in `src/voicegateway/core/registry.py`:
    ```python
    "myprovider": ("voicegateway.providers.myprovider_provider", "MyProviderProvider"),
    ```
-4. Add pricing data to `src/voicegateway/pricing/catalog.py`
-5. Add the optional dependency to `pyproject.toml`
+4. Add pricing data to `src/voicegateway/pricing/catalog.py`.
+5. Add the optional dependency to `pyproject.toml`.


### PR DESCRIPTION
## Summary

- Rewrites five architecture pages as part of the P11a docs restructure phase.
- Adds `title:` and `description:` frontmatter to all five pages (fixes rule 7).
- Removes all `voicegateway.inference` references from `gateway-core`, `middleware`, and `provider-abstraction` (fixes rule 5).
- Reframes the architecture around `attach()` and `guard()` as the public surface, with the internal Gateway singleton, provider registry, and middleware pipeline as implementation detail.
- Adds a Mermaid request-flow diagram and `<CardGroup>` nav on the index page.
- Preserves all accurate module names, class names, and design details from the originals.

## Acceptance

`python3 docs/_check_docs.py architecture/index architecture/gateway-core architecture/provider-abstraction architecture/middleware architecture/cost-tracking`

Output: `docs validator: PASS (90 pages, 90 nav refs, content rules on 5 scoped)`