### PR TITLE
docs(architecture): rewrite Architecture part 2 + storage (P11b)

### DIFF
--- a/docs/architecture/config-layers.md
+++ b/docs/architecture/config-layers.md
@@ -1,8 +1,13 @@
-# Configuration Layers
+---
+title: Configuration layers
+description: How VoiceGateway merges voicegw.yaml, SQLite managed tables, and environment variables into a single resolved GatewayConfig, with clear priority rules and a live refresh cycle.
+---
 
-VoiceGateway merges configuration from three sources with a clear priority order. This allows base configuration in YAML, dynamic management via the dashboard/MCP, and environment-level overrides.
+# Configuration layers
 
-## Priority Order
+VoiceGateway merges configuration from three sources with a clear priority order. You can pin critical settings in YAML, manage everything else through the dashboard or MCP server, and override individual values at runtime with environment variables.
+
+## Priority order
 
 ```
 ENV variables (highest)  >  SQLite managed tables  >  YAML file (lowest)
@@ -10,9 +15,9 @@ ENV variables (highest)  >  SQLite managed tables  >  YAML file (lowest)
 
 ```mermaid
 graph TB
-    subgraph Sources["Configuration Sources"]
-        ENV["Environment Variables<br/>DEEPGRAM_API_KEY, VOICEGW_DB_PATH, etc."]
-        DB["SQLite Managed Tables<br/>managed_providers, managed_models, managed_projects"]
+    subgraph Sources["Configuration sources"]
+        ENV["Environment variables<br/>DEEPGRAM_API_KEY, VOICEGW_DB_PATH, etc."]
+        DB["SQLite managed tables<br/>managed_providers, managed_models, managed_projects"]
         YAML["voicegw.yaml<br/>Base configuration file"]
     end
 
@@ -42,7 +47,7 @@ graph TB
 
 **File:** `src/voicegateway/core/config_manager.py`
 
-The `ConfigManager` is responsible for merging YAML and SQLite sources into a single `GatewayConfig`.
+`ConfigManager` merges the YAML config and SQLite managed rows into a single `GatewayConfig`.
 
 ```python
 class ConfigManager:
@@ -62,9 +67,9 @@ class ConfigManager:
         return await self.load_merged()
 ```
 
-### Merge Rules
+### Merge rules
 
-The key rule is: **YAML always takes precedence**. If a provider, model, or project exists in both YAML and SQLite, the YAML version wins.
+YAML always takes precedence. If a provider, model, or project exists in both YAML and SQLite, the YAML version wins.
 
 ```python
 for row in await self._storage.list_managed_providers():
@@ -73,16 +78,16 @@ for row in await self._storage.list_managed_providers():
         continue  # YAML takes precedence -- don't overwrite
 ```
 
-This means you can "pin" critical configuration in YAML and use the dashboard/MCP for everything else, without worrying about managed resources overwriting your file-based config.
+This lets you pin critical configuration in `voicegw.yaml` and use the dashboard or MCP for everything else, without risk of managed resources overwriting file-based config.
 
-### The `source` Field
+### The `source` field
 
-Each `ProjectConfig` carries a `source` field indicating where it came from:
+Each `ProjectConfig` carries a `source` field indicating origin:
 
-| `source` Value | Meaning |
-|----------------|---------|
+| `source` value | Meaning |
+|---|---|
 | `"yaml"` | Defined in `voicegw.yaml` |
-| `"db"` | Created via dashboard or MCP, stored in `managed_projects` |
+| `"db"` | Created via the dashboard or MCP, stored in `managed_projects` |
 
 For providers and models, the `_source` key is injected into the config dict:
 
@@ -95,11 +100,11 @@ merged.providers[pid] = {
 }
 ```
 
-## YAML Configuration
+## YAML configuration
 
 **File:** `src/voicegateway/core/config.py`
 
-### Environment Variable Substitution
+### Environment variable substitution
 
 YAML values containing `${ENV_VAR}` are replaced with the corresponding environment variable at load time:
 
@@ -111,23 +116,22 @@ providers:
     api_key: ${DEEPGRAM_API_KEY}
 ```
 
-The substitution is recursive -- it works inside strings, dicts, and lists. Missing env vars resolve to empty strings.
+Substitution is recursive: it works inside strings, dicts, and lists. Missing env vars resolve to empty strings.
 
-### Config File Search
+### Config file search
 
-When no explicit path is provided:
+When no explicit path is provided, VoiceGateway searches in this order:
 
-1. Check `VOICEGW_CONFIG` env var.
-2. Search these paths in order:
-   - `./voicegw.yaml`
-   - `~/.config/voicegateway/voicegw.yaml`
-   - `/etc/voicegateway/voicegw.yaml`
+1. `VOICEGW_CONFIG` environment variable.
+2. `./voicegw.yaml` in the current directory.
+3. `~/.config/voicegateway/voicegw.yaml`.
+4. `/etc/voicegateway/voicegw.yaml`.
 
-### Pydantic Validation
+### Pydantic validation
 
 **File:** `src/voicegateway/core/schema.py`
 
-Before parsing, the raw YAML dict is validated against a Pydantic model (`VoiceGatewayConfig`). Validation errors are formatted with field paths and messages:
+The raw YAML dict is validated against `VoiceGatewayConfig` before use. Validation errors include field paths and messages:
 
 ```
 Configuration validation failed:
@@ -137,12 +141,12 @@ Configuration validation failed:
 Check your voicegw.yaml for typos or invalid values.
 ```
 
-### GatewayConfig Dataclass
+### GatewayConfig dataclass
 
-The parsed config is stored as a `GatewayConfig` dataclass with these fields:
+The parsed config is stored as a `GatewayConfig` dataclass:
 
 | Field | Type | Description |
-|-------|------|-------------|
+|---|---|---|
 | `providers` | `dict[str, dict]` | Provider configs keyed by name |
 | `models` | `dict[str, dict[str, dict]]` | Models keyed by modality, then model ID |
 | `fallbacks` | `dict[str, list[str]]` | Fallback chains per modality |
@@ -154,9 +158,9 @@ The parsed config is stored as a `GatewayConfig` dataclass with these fields:
 | `stacks` | `dict[str, dict[str, str]]` | Named model bundles |
 | `observability` | `dict` | Feature flags for tracking |
 
-## Refresh Cycle
+## Refresh cycle
 
-When the dashboard or MCP server creates/updates/deletes a managed resource:
+When the dashboard or MCP server creates, updates, or deletes a managed resource, the config is refreshed without a server restart:
 
 ```mermaid
 sequenceDiagram
@@ -178,9 +182,11 @@ sequenceDiagram
     GW->>GW: Rebuild BudgetEnforcer + FallbackChains
 ```
 
-This ensures that newly added providers and models are immediately available for routing, without requiring a server restart.
+<Note>
+Newly added providers and models are immediately available for routing after the refresh. No restart needed.
+</Note>
 
-## Example Configuration
+## Example configuration
 
 ```yaml
 providers:
@@ -246,3 +252,20 @@ observability:
   cost_tracking: true
   request_logging: true
 ```
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="voicegw.yaml reference" href="/configuration/voicegw-yaml">
+    Full YAML schema with all fields and defaults.
+  </Card>
+  <Card title="Environment variables" href="/configuration/environment-variables">
+    All supported environment variables and their defaults.
+  </Card>
+  <Card title="Storage" href="/architecture/storage">
+    The SQLite tables that back managed configuration.
+  </Card>
+  <Card title="Security" href="/architecture/security">
+    How managed provider API keys are encrypted at rest.
+  </Card>
+</CardGroup>

--- a/docs/architecture/fleet-worker-heartbeat.md
+++ b/docs/architecture/fleet-worker-heartbeat.md
@@ -1,33 +1,29 @@
 ---
-title: Fleet worker heartbeat contract
-description: The single canonical contract every roster backend (the hosted cloud and the self-hosted engine console) must ingest identically, so the two worker stores cannot silently drift.
+title: Fleet worker heartbeat
+description: The canonical heartbeat contract that every agent process produces and every roster backend (hosted cloud and self-hosted engine) must ingest identically, so the two worker stores cannot silently drift.
 ---
 
-# Fleet worker heartbeat contract
+# Fleet worker heartbeat
 
-VoiceGateway has **one** producer of worker presence and **two** stores that
-consume it. This page is the canonical contract between them. Any change to how
-either store ingests a heartbeat must update this page and match it, or the two
-rosters silently diverge (a worker judged "online" in one and "offline" in the
-other, or attributed to different tenants).
+VoiceGateway has one producer of worker presence and two stores that consume it. This page is the canonical contract between them. Any change to how either store ingests a heartbeat must update this page and match it, or the two rosters silently diverge (a worker judged "online" in one and "offline" in the other, or attributed to different tenants).
 
 ## The one producer, the two stores
 
-- **Producer:** `voicegateway.register_worker(...)` in every agent process. It
-  posts a periodic presence payload (below) to
-  `${VOICEGW_COLLECTOR_URL}/v1/agents/heartbeat` with the tenant's `vk_` ingest
-  key as the bearer token.
-- **Store A (hosted):** `voicegateway-cloud`'s `cloud_workers` table +
-  `POST /v1/agents/heartbeat` / `GET /v1/agents`, surfaced on
-  `dash.voicegateway.dev`.
-- **Store B (self-hosted):** the engine's own `voicegw serve` `workers` table +
-  the same `/v1/agents/heartbeat` / `/v1/agents` routes, surfaced in the
-  OpenOrca console via `/openorca/snapshot` and `/openorca/events`.
+- **Producer:** `voicegateway.register_worker(...)` in every agent process. It posts a periodic presence payload to `${VOICEGW_COLLECTOR_URL}/v1/agents/heartbeat` with the tenant's `vk_` ingest key as the bearer token.
+- **Store A (hosted):** `voicegateway-cloud`'s `cloud_workers` table and `POST /v1/agents/heartbeat` / `GET /v1/agents`, surfaced on `dash.voicegateway.dev`.
+- **Store B (self-hosted):** the engine's own `voicegw serve` `workers` table and the same `/v1/agents/heartbeat` / `/v1/agents` routes, surfaced in the OpenOrca console via `/openorca/snapshot` and `/openorca/events`.
 
-Because both stores implement the **same** `/v1/agents/heartbeat` contract, the
-same `register_worker` heartbeat feeds either one: point `VOICEGW_COLLECTOR_URL`
-at the cloud for the SaaS dashboard, or at a self-hosted `voicegw serve` for the
-OpenOrca console. That symmetry only holds if both ingest identically.
+Because both stores implement the same `/v1/agents/heartbeat` contract, the same `register_worker` heartbeat feeds either one. Point `VOICEGW_COLLECTOR_URL` at the cloud for the SaaS dashboard, or at a self-hosted `voicegw serve` for the OpenOrca console. That symmetry only holds if both ingest identically.
+
+## Agent environment variables
+
+Each agent process needs three environment variables to participate in the fleet roster:
+
+| Variable | Purpose |
+|---|---|
+| `VOICEGW_COLLECTOR_URL` | Base URL of the heartbeat endpoint (e.g. `https://api.voicegateway.dev`) |
+| `VOICEGW_API_KEY` | The `vk_` ingest key that authenticates the agent and determines its tenant |
+| `VOICEGW_AGENT_ID` | Stable node identity for this worker process (e.g. `worker-host-1`) |
 
 ## The heartbeat payload (canonical)
 
@@ -49,51 +45,53 @@ OpenOrca console. That symmetry only holds if both ingest identically.
 }
 ```
 
-## Ingestion rules (both stores MUST follow)
+## Ingestion rules (both stores must follow)
 
-1. **Tenant is derived server-side from the `vk_` key, never from the body.**
-   The `tenant_id` in the payload is advisory only. A worker can only ever be
-   written under the key's tenant, so it can never appear under another tenant.
-2. **Identity is `(tenant, agent_id)`.** `agent_id` is the node identity for
-   upsert, roster keys, and any UI node id. Do not key identity on
-   `agent_name` (it groups workers, it does not identify one).
-3. **`last_seen` is stamped SERVER-SIDE at ingest** (`now()` / `time.time()` on
-   the receiving server). The payload `ts` is informational metadata only and
-   MUST NOT drive liveness: a client clock that is skewed or forged would
-   otherwise read perpetually online or offline.
-4. **Upsert atomically** on `(tenant, agent_id)` via a native
-   `INSERT ... ON CONFLICT DO UPDATE`. A get-then-insert races two concurrent
-   first beats into duplicate rows (and a subsequent read that expects one row).
-5. **Offline TTL is 45 seconds** (three missed ~15s beats). A worker whose
-   server-stamped `last_seen` is older than the TTL reports `status: "offline"`
-   and `active_sessions: 0`, regardless of the last status it sent.
-6. **Status vocabulary is `idle | busy | offline`.** Constrain to this set on
-   ingest; do not store or serve arbitrary client-supplied status strings.
+1. **Tenant is derived server-side from the `vk_` key, never from the body.** The `tenant_id` in the payload is advisory only. A worker can only ever be written under the key's tenant, so it can never appear under another tenant.
+2. **Identity is `(tenant, agent_id)`.** `agent_id` is the node identity for upsert, roster keys, and any UI node id. Do not key identity on `agent_name` (it groups workers, it does not identify one).
+3. **`last_seen` is stamped server-side at ingest** (`now()` / `time.time()` on the receiving server). The payload `ts` is informational metadata only and must not drive liveness: a client clock that is skewed or forged would otherwise read perpetually online or offline.
+4. **Upsert atomically** on `(tenant, agent_id)` via a native `INSERT ... ON CONFLICT DO UPDATE`. A get-then-insert races two concurrent first beats into duplicate rows (and a subsequent read that expects one row).
+5. **Offline TTL is 45 seconds** (three missed ~15s beats). A worker whose server-stamped `last_seen` is older than the TTL reports `status: "offline"` and `active_sessions: 0`, regardless of the last status it sent.
+6. **Status vocabulary is `idle | busy | offline`.** Constrain to this set on ingest; do not store or serve arbitrary client-supplied status strings.
 
 ## Compatibility matrix
 
-Field / behavior, as of the two current implementations. `cloud_workers` is the
-reference; the engine `workers` table (introduced with the OpenOrca console)
-must align to it.
+Field or behavior as of the two current implementations. `cloud_workers` is the reference; the engine `workers` table (introduced with the OpenOrca console) must align to it.
 
-| Aspect | `cloud_workers` (cloud) | engine `workers` | Status |
+| Aspect | `cloud_workers` (cloud) | Engine `workers` | Status |
 |---|---|---|---|
-| Primary key | `(tenant_id, agent_id)` | surrogate `id` + `UniqueConstraint(tenant_id, agent_id)` | equivalent uniqueness (OK) |
-| `tenant_id` | NOT NULL (from key) | nullable (for the no-credential operator) | ⚠️ engine NULL path enables the duplicate-row race in rule 4 |
-| Tenant source | key only, body ignored | key, but falls back to body `tenant_id` when the key tenant is NULL | ⚠️ align to rule 1 |
-| `last_seen` | server-stamped `DateTime(tz)` | client `ts` stored as `float` | ⚠️ **primary drift** — align to rule 3 (server-stamp) |
-| Upsert | native `ON CONFLICT DO UPDATE` | get-then-insert with `IntegrityError` retry | ⚠️ align to rule 4 (matches only for non-null tenants) |
+| Primary key | `(tenant_id, agent_id)` | Surrogate `id` + `UniqueConstraint(tenant_id, agent_id)` | Equivalent uniqueness (OK) |
+| `tenant_id` | NOT NULL (from key) | Nullable (for the no-credential operator) | Engine NULL path enables the duplicate-row race in rule 4 |
+| Tenant source | Key only, body ignored | Key, but falls back to body `tenant_id` when the key tenant is NULL | Align to rule 1 |
+| `last_seen` | Server-stamped `DateTime(tz)` | Client `ts` stored as `float` | Primary drift: align to rule 3 (server-stamp) |
+| Upsert | Native `ON CONFLICT DO UPDATE` | Get-then-insert with `IntegrityError` retry | Align to rule 4 (matches only for non-null tenants) |
 | Offline TTL | 45s | 45s | OK |
-| Status vocab | idle / busy / offline | idle / busy / offline (but client status passed through unvalidated) | mostly OK, add rule 6 validation |
-| Node identity | `agent_id` | roster keys `agent_id`, but the OpenOrca mapper keys nodes on `agent_name` | ⚠️ align to rule 2 |
+| Status vocab | idle / busy / offline | idle / busy / offline (but client status passed through unvalidated) | Add rule 6 validation |
+| Node identity | `agent_id` | Roster keys `agent_id`, but the OpenOrca mapper keys nodes on `agent_name` | Align to rule 2 |
+
+<Warning>
+The most impactful drift today is `last_seen` source. The engine stores the client-supplied `ts` float instead of stamping server-side. A worker with a skewed clock appears permanently online or offline in the OpenOrca console even after the process exits.
+</Warning>
 
 ## Keeping them from drifting
 
-- This page is the single source of truth. A PR that changes ingestion in
-  either store must update this page in the same change and satisfy every rule
-  above.
-- Prefer sharing the semantics rather than re-deriving them: the offline TTL,
-  the status vocabulary, and the payload field names should have one definition
-  the engine owns (it is the producer), which the cloud consumes.
-- The engine-side alignment items (rules 1-4, 6) are tracked against the
-  OpenOrca console backend PR; the cloud side already satisfies the contract.
+- This page is the single source of truth. A PR that changes ingestion in either store must update this page in the same change and satisfy every rule above.
+- Prefer sharing semantics rather than re-deriving them: the offline TTL, the status vocabulary, and the payload field names should have one definition the engine owns (it is the producer), which the cloud consumes.
+- The engine-side alignment items (rules 1-4, 6) are tracked against the OpenOrca console backend PR; the cloud side already satisfies the contract.
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Security model" href="/architecture/security">
+    Tenant isolation via vk_ ingest keys and server-side stamping.
+  </Card>
+  <Card title="Hosted cloud quickstart" href="/hosted/quickstart">
+    Setting VOICEGW_COLLECTOR_URL, VOICEGW_API_KEY, and VOICEGW_AGENT_ID.
+  </Card>
+  <Card title="Guide: attach" href="/guide/attach">
+    Per-call attach for sub-tenant cost attribution.
+  </Card>
+  <Card title="Environment variables" href="/configuration/environment-variables">
+    Full reference for all fleet-related env vars.
+  </Card>
+</CardGroup>

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -1,46 +1,53 @@
-# Security
+---
+title: Security model
+description: How VoiceGateway protects provider API keys with Fernet encryption, masks secrets in API responses, enforces tenant isolation in multi-tenant deployments, and authenticates the MCP server.
+---
+
+# Security model
 
 VoiceGateway encrypts all API keys stored in its database, masks secrets in API responses, and maintains an audit log of configuration changes.
 
-## Fernet Encryption
+## Fernet encryption
 
 **File:** `src/voicegateway/core/crypto.py`
 
-All API keys stored in the `managed_providers` table are encrypted with **Fernet** (AES-128-CBC with HMAC-SHA256 authentication) from the `cryptography` library.
+All API keys stored in the `managed_providers` table are encrypted with Fernet (AES-128-CBC with HMAC-SHA256 authentication) from the `cryptography` library.
 
-### How It Works
+### How it works
 
 ```mermaid
 graph LR
-    subgraph Write["Storing a Key"]
+    subgraph Write["Storing a key"]
         A["Plaintext API key"] --> B["encrypt()"]
         B --> C["Fernet.encrypt()"]
         C --> D["Ciphertext in SQLite"]
     end
 
-    subgraph Read["Reading a Key"]
+    subgraph Read["Reading a key"]
         E["Ciphertext from SQLite"] --> F["decrypt()"]
         F --> G["Fernet.decrypt()"]
         G --> H["Plaintext API key"]
     end
 
-    subgraph Key["Fernet Key Source"]
+    subgraph Key["Fernet key source"]
         K1["VOICEGW_SECRET env var"]
         K2["~/.config/voicegateway/.secret file"]
         K3["Auto-generated on first run"]
-        K1 -->|priority 1| FK["Fernet Key"]
+        K1 -->|priority 1| FK["Fernet key"]
         K2 -->|priority 2| FK
         K3 -->|fallback| FK
     end
 ```
 
-### Secret Key Resolution
+### Secret key resolution
 
 The Fernet key is resolved in this order:
 
-1. **`VOICEGW_SECRET` environment variable** -- highest priority, useful for containerized deployments
-2. **`~/.config/voicegateway/.secret` file** -- persisted on disk with `chmod 600` permissions
-3. **Auto-generated** -- on first run, a new Fernet key is generated and saved to the secret file
+1. `VOICEGW_SECRET` environment variable. Highest priority, recommended for containerized deployments.
+2. `~/.config/voicegateway/.secret` file. Persisted on disk with `chmod 600` permissions.
+3. Auto-generated on first run. A new Fernet key is generated and saved to the secret file.
+
+A `VOICEGW_SECRET_FALLBACK` variable is also supported for zero-downtime key rotation: the gateway attempts decryption with the primary key first, then falls back to the secondary key.
 
 ```python
 def get_secret() -> bytes:
@@ -61,7 +68,7 @@ def get_secret() -> bytes:
     return key
 ```
 
-The auto-generation uses atomic file operations (`os.replace`) to prevent partial writes. The file is created with `0600` permissions (owner read/write only) from the start -- it never exists in a world-readable state.
+The auto-generation uses `os.replace()` for atomic file creation. The file is created with `0600` permissions from the start and never exists in a world-readable state.
 
 ### Encryption API
 
@@ -87,9 +94,9 @@ mask("sk-abc123456789")
 
 Empty strings pass through `encrypt()` and `decrypt()` unchanged.
 
-### Key Rotation
+### Key rotation
 
-If `VOICEGW_SECRET` changes (or the `.secret` file is deleted), existing encrypted values will fail to decrypt. The `decrypt()` function raises a clear `ValueError`:
+If `VOICEGW_SECRET` changes or the `.secret` file is deleted, existing encrypted values fail to decrypt. The `decrypt()` function raises a clear `ValueError`:
 
 ```
 Failed to decrypt managed credential. This typically means VOICEGW_SECRET
@@ -97,9 +104,13 @@ changed since the value was stored. Re-add the affected providers via the
 dashboard or MCP.
 ```
 
-## API Key Masking
+<Warning>
+Losing the Fernet key means losing all managed provider credentials stored in SQLite. Back up `VOICEGW_SECRET` or the `.secret` file the same way you back up any other secret.
+</Warning>
 
-All API responses that include provider information mask the API key using the `mask()` function:
+## API key masking
+
+All API responses that include provider information mask the API key using `mask()`:
 
 ```python
 def mask(value: str) -> str:
@@ -113,11 +124,11 @@ Examples:
 - `"short"` becomes `"*****"`
 - `""` becomes `""`
 
-This masking is applied in the HTTP API and MCP server responses -- plaintext keys never appear in API output.
+Masking is applied in the HTTP API and MCP server responses. Plaintext keys never appear in API output.
 
-## Plaintext Key Migration
+## Plaintext key migration
 
-When VoiceGateway opens a database that was created before encryption was added, it automatically detects and migrates plaintext API keys:
+When VoiceGateway opens a database created before encryption was added, it automatically detects and migrates plaintext API keys:
 
 ```python
 async def _migrate_plaintext_keys(self, db):
@@ -135,14 +146,31 @@ async def _migrate_plaintext_keys(self, db):
 
 This runs on first connection and logs a warning for each migrated key.
 
-## Audit Log
+## MCP token authentication
+
+The MCP server authenticates callers with a bearer token. Set `VOICEGW_MCP_TOKEN` to a strong random string. Any request without a matching `Authorization: Bearer <token>` header is rejected with 401.
+
+If `VOICEGW_MCP_TOKEN` is not set, the MCP server starts without authentication. This is acceptable for local development but should not be used in shared or networked environments.
+
+## Tenant isolation
+
+In multi-tenant cloud deployments, tenant identity is derived server-side from the ingest API key (`vk_` prefix). The key is presented as a bearer token on `POST /v1/ingest` and `POST /v1/agents/heartbeat`. The tenant ID from the key is stamped on every record at ingest time.
+
+Key rules:
+- A worker or record can only be written under the key's tenant. The `tenant_id` field in request bodies is advisory only and cannot override the key-derived tenant.
+- `VOICEGW_API_KEY` is the agent-side variable that holds the `vk_` key. Set it in the agent process environment.
+- The cloud verifies the key and resolves the tenant before any write.
+
+See [fleet worker heartbeat](/architecture/fleet-worker-heartbeat) for the full ingestion contract.
+
+## Audit log
 
 **Table:** `config_audit_log`
 
-Every create, update, or delete operation on managed resources is recorded in the audit log.
+Every create, update, or delete on managed resources is recorded.
 
 | Field | Description |
-|-------|-------------|
+|---|---|
 | `timestamp` | When the change was made |
 | `entity_type` | `"provider"`, `"model"`, or `"project"` |
 | `entity_id` | ID of the affected resource |
@@ -150,7 +178,7 @@ Every create, update, or delete operation on managed resources is recorded in th
 | `changes_json` | JSON describing what changed |
 | `source` | `"api"`, `"mcp"`, or `"dashboard"` |
 
-### Querying the Audit Log
+### Querying the audit log
 
 ```python
 # Get recent entries
@@ -166,16 +194,35 @@ entries = await storage.get_audit_log(entity_type="model", entity_id="openai/gpt
 entries = await storage.get_audit_log(action="delete")
 ```
 
-The audit log write is best-effort -- it never raises exceptions, to avoid blocking the actual operation if logging fails.
+The audit log write is best-effort: it never raises exceptions, to avoid blocking the actual operation if logging fails.
 
-## Security Checklist
+## Security checklist
 
 | Concern | Mitigation |
-|---------|------------|
+|---|---|
 | API keys at rest | Fernet encryption (AES-128-CBC + HMAC-SHA256) |
-| Secret key storage | `chmod 600` file or env var |
+| Secret key storage | `chmod 600` file or `VOICEGW_SECRET` env var |
 | API key exposure in responses | `mask()` applied to all API/MCP output |
 | Configuration changes | Audit log with timestamp, actor, and changes |
 | Plaintext key migration | Auto-detected and encrypted on startup |
 | Atomic secret file creation | `os.replace()` prevents partial writes |
 | Secret key change detection | Clear error message with recovery instructions |
+| MCP access control | Bearer token via `VOICEGW_MCP_TOKEN` |
+| Tenant isolation | Key-derived tenant stamped server-side on ingest |
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Storage" href="/architecture/storage">
+    The SQLite tables where encrypted keys are stored.
+  </Card>
+  <Card title="Fleet worker heartbeat" href="/architecture/fleet-worker-heartbeat">
+    Tenant isolation rules for the heartbeat ingest contract.
+  </Card>
+  <Card title="Configuration layers" href="/architecture/config-layers">
+    How managed provider credentials flow into the resolved config.
+  </Card>
+  <Card title="Environment variables" href="/configuration/environment-variables">
+    All VOICEGW_SECRET, VOICEGW_MCP_TOKEN, and related env vars.
+  </Card>
+</CardGroup>

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,20 +1,26 @@
+---
+title: Storage
+description: The SQLite backend that persists every inference request, managed configuration row, and audit event. Covers the RequestRecord schema, SQL views for daily and per-project cost aggregation, indexes, and the remote ClickHouse sink for cloud deployments.
+---
+
 # Storage
 
 VoiceGateway uses SQLite via `aiosqlite` for all persistent data: request logs, cost tracking, managed configuration, and audit trails.
 
 **File:** `src/voicegateway/storage/sqlite.py`
 
-## Database Location
+## Database location
 
 The database path is resolved in this priority order:
 
-1. `VOICEGW_DB_PATH` environment variable
-2. `cost_tracking.db_path` in `voicegw.yaml`
-3. Default: `~/.config/voicegateway/voicegw.db`
+1. `VOICEGW_DB_PATH` environment variable.
+2. `VOICEGW_DB_URL` environment variable (alternative form).
+3. `cost_tracking.db_path` in `voicegw.yaml`.
+4. Default: `~/.config/voicegateway/voicegw.db`.
 
 The parent directory is created automatically on first access.
 
-## Schema Overview
+## Schema overview
 
 ```mermaid
 erDiagram
@@ -95,7 +101,7 @@ erDiagram
 The primary table for all inference request logs. Every call through the Gateway that completes (or fails) is recorded here.
 
 | Column | Type | Description |
-|--------|------|-------------|
+|---|---|---|
 | `id` | TEXT PK | UUID v4 |
 | `timestamp` | REAL | Unix epoch (seconds) |
 | `project` | TEXT | Project ID (default: `"default"`) |
@@ -114,14 +120,14 @@ The primary table for all inference request logs. Every call through the Gateway
 
 ### `managed_providers`
 
-Providers added via the dashboard or MCP server (as opposed to YAML). API keys are encrypted with Fernet.
+Providers added via the dashboard or MCP server, as opposed to YAML. API keys are encrypted with Fernet (see [Security](/architecture/security)).
 
 | Column | Type | Description |
-|--------|------|-------------|
+|---|---|---|
 | `provider_id` | TEXT PK | Unique identifier (e.g. `"my-openai"`) |
 | `provider_type` | TEXT | Provider type from registry (e.g. `"openai"`) |
 | `api_key_encrypted` | TEXT | Fernet-encrypted API key |
-| `base_url` | TEXT | Custom base URL (for proxies or self-hosted) |
+| `base_url` | TEXT | Custom base URL (for proxies or self-hosted endpoints) |
 | `extra_config` | TEXT | JSON blob for additional config |
 | `created_at` | REAL | Unix epoch |
 | `updated_at` | REAL | Unix epoch |
@@ -131,7 +137,7 @@ Providers added via the dashboard or MCP server (as opposed to YAML). API keys a
 Models registered via the dashboard or MCP server.
 
 | Column | Type | Description |
-|--------|------|-------------|
+|---|---|---|
 | `model_id` | TEXT PK | Full model ID (e.g. `"openai/gpt-4.1-mini"`) |
 | `modality` | TEXT | `"stt"`, `"llm"`, or `"tts"` |
 | `provider_id` | TEXT | References `managed_providers.provider_id` |
@@ -149,7 +155,7 @@ Models registered via the dashboard or MCP server.
 Projects created via the dashboard or MCP server.
 
 | Column | Type | Description |
-|--------|------|-------------|
+|---|---|---|
 | `project_id` | TEXT PK | Unique identifier |
 | `name` | TEXT | Display name |
 | `description` | TEXT | Project description |
@@ -168,7 +174,7 @@ Projects created via the dashboard or MCP server.
 Records all changes to managed resources for compliance and debugging.
 
 | Column | Type | Description |
-|--------|------|-------------|
+|---|---|---|
 | `id` | INTEGER PK | Auto-increment |
 | `timestamp` | REAL | Unix epoch |
 | `entity_type` | TEXT | `"provider"`, `"model"`, or `"project"` |
@@ -181,7 +187,7 @@ Records all changes to managed resources for compliance and debugging.
 
 ### `daily_costs`
 
-Aggregates request data by day, modality, model, and provider.
+Aggregates request data by day, modality, model, and provider. Used by the dashboard trend charts and `voicegw costs`.
 
 ```sql
 CREATE VIEW daily_costs AS
@@ -200,7 +206,7 @@ GROUP BY day, modality, model_id, provider;
 
 ### `project_daily_costs`
 
-Aggregates request data by project, day, modality, and model.
+Aggregates request data by project, day, modality, and model. Powers per-project budget enforcement and the project breakdown panel.
 
 ```sql
 CREATE VIEW project_daily_costs AS
@@ -219,7 +225,7 @@ GROUP BY project, day, modality, model_id;
 ## Indexes
 
 | Index | Table | Column(s) | Purpose |
-|-------|-------|-----------|---------|
+|---|---|---|---|
 | `idx_requests_timestamp` | requests | `timestamp` | Time-range queries |
 | `idx_requests_model` | requests | `model_id` | Per-model aggregation |
 | `idx_requests_modality` | requests | `modality` | Filter by STT/LLM/TTS |
@@ -231,15 +237,40 @@ GROUP BY project, day, modality, model_id;
 | `idx_managed_models_modality` | managed_models | `modality` | Filter by modality |
 | `idx_managed_models_provider` | managed_models | `provider_id` | Models per provider |
 
-## Connection Management
+## Connection management
 
-`SQLiteStorage` opens a fresh `aiosqlite` connection per call and closes it in a `finally` block. There is no connection pooling -- this keeps things simple and avoids connection state issues with async code.
+`SQLiteStorage` opens a fresh `aiosqlite` connection per call and closes it in a `finally` block. There is no connection pooling. This keeps things simple and avoids connection state issues with async code.
 
 On first connection, the schema DDL is executed via `executescript()`, and a migration check adds the `project` column to older databases. The `_initialized` flag prevents re-running the schema on subsequent connections.
 
-## Auto-Migration
+## Auto-migration
 
-When VoiceGateway opens a database created by an older version:
+When VoiceGateway opens a database created by an older version, it applies these migrations automatically:
 
-1. **Missing `project` column:** automatically added with `ALTER TABLE` and `DEFAULT 'default'`
-2. **Plaintext API keys:** detected via `is_fernet_token()` and re-encrypted in place with a warning log
+1. **Missing `project` column:** added with `ALTER TABLE` and `DEFAULT 'default'`.
+2. **Plaintext API keys:** detected via `is_fernet_token()` and re-encrypted in place with a warning log. See [Security](/architecture/security) for the encryption details.
+
+## Cloud: ClickHouse sink
+
+In the hosted cloud deployment, the engine writes request records both to its local SQLite and forwards them to a remote ClickHouse sink. The sink URL is configured via `VOICEGW_COLLECTOR_URL`. The API key used to authenticate the push is `VOICEGW_API_KEY`.
+
+<Tip>
+For multi-tenant cloud deployments, each `RequestRecord` carries a `tenant_id` that is stamped server-side from the ingest key. The agent's local `VOICEGW_API_KEY` determines which tenant the records land under.
+</Tip>
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Configuration layers" href="/architecture/config-layers">
+    How SQLite managed tables fit into the config merge order.
+  </Card>
+  <Card title="Security" href="/architecture/security">
+    Fernet encryption for API keys stored in managed_providers.
+  </Card>
+  <Card title="Cost tracking" href="/architecture/cost-tracking">
+    How costs are computed before writing to the requests table.
+  </Card>
+  <Card title="Replay storage costs" href="/storage/replay-storage-costs">
+    On-disk footprint of the conversation replay tables.
+  </Card>
+</CardGroup>

--- a/docs/storage/replay-storage-costs.md
+++ b/docs/storage/replay-storage-costs.md
@@ -1,19 +1,24 @@
+---
+title: Replay storage costs
+description: On-disk footprint of VoiceGateway's conversation replay tables. Understand the per-minute byte budget across STT, LLM, TTS, and state snapshot events before setting per-project retention.
+---
+
 # Replay storage costs
 
 VoiceGateway's conversation replay captures every STT chunk, LLM token, TTS frame, and conversation-state snapshot for every session. This page surfaces the on-disk storage cost so the trade-off between fidelity and footprint is visible before you set per-project retention.
 
 ## What gets stored
 
-Four tables per the [migration 0004 schema](https://github.com/mahimailabs/voicegateway/blob/main/voicegateway/storage/migrations/0004_replay_tables.py):
+Four tables per the migration 0004 schema:
 
 | Table | Row payload | Typical row size |
 |---|---|---|
-| `replay_stt_events` | JSON: `text`, `is_final`, `alternatives` | 100 - 400 bytes |
-| `replay_llm_tokens` | JSON: `token_text`, `role`, `is_tool_invoke`, `tool_args_partial` | 80 - 200 bytes |
-| `replay_tts_frames` | JSON: `frame_duration_ms`, `underrun`, `voice_id` | 80 - 120 bytes |
-| `replay_state_snapshots` | JSON: `system_prompt`, `message_history`, `tool_call_in_flight`, `structured_output_collected` | 500 - 5000 bytes (depends on prompt + history size) |
+| `replay_stt_events` | JSON: `text`, `is_final`, `alternatives` | 100-400 bytes |
+| `replay_llm_tokens` | JSON: `token_text`, `role`, `is_tool_invoke`, `tool_args_partial` | 80-200 bytes |
+| `replay_tts_frames` | JSON: `frame_duration_ms`, `underrun`, `voice_id` | 80-120 bytes |
+| `replay_state_snapshots` | JSON: `system_prompt`, `message_history`, `tool_call_in_flight`, `structured_output_collected` | 500-5000 bytes (depends on prompt and history size) |
 
-Every row also carries the boilerplate: `id`, `session_id`, `t_ms`, `provider`, `cost_usd`, `created_at`. Add roughly 80-120 bytes of column overhead per row. Indexes on `(session_id, t_ms)` add another 30-50% of payload size.
+Every row also carries boilerplate columns: `id`, `session_id`, `t_ms`, `provider`, `cost_usd`, `created_at`. Add roughly 80-120 bytes of column overhead per row. Indexes on `(session_id, t_ms)` add another 30-50% of payload size.
 
 ## Per-minute estimate
 
@@ -21,12 +26,12 @@ For a typical voice conversation (caller speaks for half the time, agent for hal
 
 | Modality | Events per minute | Bytes per minute |
 |---|---|---|
-| STT (partials + finals) | 30 - 60 | 8 KB - 24 KB |
-| LLM tokens | 200 - 500 | 30 KB - 80 KB |
-| TTS frames (20-50ms each) | 600 - 1500 | 60 KB - 180 KB |
-| State snapshots (1/sec cap) | 60 | 30 KB - 300 KB |
+| STT (partials + finals) | 30-60 | 8 KB-24 KB |
+| LLM tokens | 200-500 | 30 KB-80 KB |
+| TTS frames (20-50ms each) | 600-1500 | 60 KB-180 KB |
+| State snapshots (1/sec cap) | 60 | 30 KB-300 KB |
 
-**Total: roughly 130 KB - 580 KB per minute of conversation**, with the floor for short crisp exchanges and the ceiling for chatty agents with long conversation histories. The design target of 30-100 KB/min is achievable on the floor; realistic agents will land closer to the ceiling.
+**Total: roughly 130 KB-580 KB per minute of conversation.** The floor applies to short, crisp exchanges; the ceiling applies to chatty agents with long conversation histories. The design target of 30-100 KB/min is achievable at the floor; realistic agents will land closer to the ceiling.
 
 If you find yourself trending above 500 KB/min consistently, the per-project `replay.enabled: false` toggle is the fastest mitigation.
 
@@ -35,22 +40,22 @@ If you find yourself trending above 500 KB/min consistently, the per-project `re
 A solo developer running 100 voice calls per day, averaging 5 minutes each:
 
 ```
-100 calls/day × 5 min/call × 200 KB/min = 100,000 KB/day ≈ 100 MB/day
+100 calls/day x 5 min/call x 200 KB/min = 100,000 KB/day ~ 100 MB/day
 ```
 
 At the default 90-day retention:
 
 ```
-100 MB/day × 90 days ≈ 9 GB total replay storage
+100 MB/day x 90 days ~ 9 GB total replay storage
 ```
 
 At AWS S3 standard storage prices (~$0.023/GB-month):
 
 ```
-9 GB × $0.023 ≈ $0.21/month
+9 GB x $0.023 ~ $0.21/month
 ```
 
-On the local SQLite database (no cloud markup), the cost is the disk byte cost: ~$0.01/GB-month on a developer SSD ≈ ~$0.09/month for the same 9 GB.
+On the local SQLite database (no cloud markup), the cost is the disk byte cost: ~$0.01/GB-month on a developer SSD, so ~$0.09/month for the same 9 GB.
 
 A team agency running 10,000 conversations per day at 3 minutes average scales linearly: ~3 TB at 90-day retention, ~$70/month on S3 standard or ~$30/month on local disk. At that point the `retention_days` knob matters: dropping to 30 days cuts storage to one-third.
 
@@ -60,16 +65,16 @@ Three per-project knobs in `voicegw.yaml`'s `replay:` block influence storage:
 
 | Knob | Default | Effect |
 |---|---|---|
-| `enabled` | `true` | Capture for every session. Set `false` to skip capture entirely. |
+| `enabled` | `true` | Set `false` to skip capture entirely for this project. |
 | `retention_days` | `90` | Age replay rows out after this window. Lower to reduce footprint linearly. |
-| `flush_size_events` | `500` | Batched writes; smaller writes more often, larger holds more memory. No storage effect. |
-| `buffer_size_events` | `5000` | In-memory cap. Above this, oldest events are dropped with a counter. The dashboard surfaces dropped events as "events dropped here" rather than silently misleading the developer. |
+| `flush_size_events` | `500` | Batched writes. Smaller flushes more often; larger holds more memory. No effect on long-term storage volume. |
+| `buffer_size_events` | `5000` | In-memory cap. Above this limit, the oldest events are dropped and the dashboard surfaces a "events dropped here" marker rather than silently misleading you. |
 
 The `enabled` toggle is the binary on/off. The `retention_days` knob is the gradient lever. The `buffer_size_events` and `flush_size_events` knobs trade off memory pressure and write batching but do not change long-term storage volume.
 
 ## Dashboard storage view
 
-`GET /api/replay/storage` returns per-project replay byte totals. The dashboard surfaces this as a breakdown so the developer sees the cost in real time:
+`GET /api/replay/storage` returns per-project replay byte totals. The dashboard surfaces this as a breakdown so you see the cost in real time:
 
 ```json
 {
@@ -81,10 +86,19 @@ The `enabled` toggle is the binary on/off. The `retention_days` knob is the grad
 }
 ```
 
-A future follow-up will surface this in a sidebar panel on the dashboard with cost-per-month estimates inline.
+## Related pages
 
-## Related
-
-- [Python SDK reference > Conversation replay capture](/api/python-sdk#conversation-replay-capture)
-- [Migration 0004 schema](https://github.com/mahimailabs/voicegateway/blob/main/voicegateway/storage/migrations/0004_replay_tables.py)
-- [`voicegw replay <session-id>` CLI signpost](/cli/replay)
+<CardGroup cols={2}>
+  <Card title="Storage" href="/architecture/storage">
+    The full SQLite schema including the replay tables.
+  </Card>
+  <Card title="CLI: replay" href="/cli/replay">
+    Inspect a specific session with voicegw replay.
+  </Card>
+  <Card title="Cost reconciliation" href="/guide/cost-reconciliation">
+    Verify recorded costs against provider invoices.
+  </Card>
+  <Card title="Architecture index" href="/architecture/index">
+    Overview of all architecture pages.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Adds Mintlify `title:` + `description:` frontmatter to all five pages (validator rule 7).
- Rewrites five docs pages for consistency: second person, present tense, short sentences, no em dashes.
- **architecture/config-layers**: ConfigManager merge order diagram, YAML substitution, GatewayConfig field table, live refresh cycle sequence diagram, CardGroup nav links.
- **architecture/storage**: Full schema (tables + views `daily_costs` and `project_daily_costs`), index table, connection management, auto-migration, ClickHouse cloud sink note.
- **architecture/security**: Fernet encryption details, `VOICEGW_SECRET` / `VOICEGW_SECRET_FALLBACK` resolution order, `VOICEGW_MCP_TOKEN` auth, tenant isolation rules, security checklist table.
- **architecture/fleet-worker-heartbeat**: Agent env var table (`VOICEGW_COLLECTOR_URL`, `VOICEGW_API_KEY`, `VOICEGW_AGENT_ID`), six ingestion rules, compatibility matrix, Warning callout on `last_seen` drift.
- **storage/replay-storage-costs**: Per-minute byte estimates, worked examples (solo dev + agency), four tuning knobs, dashboard storage API response, CardGroup nav links.

## Acceptance

```
docs validator: PASS (90 pages, 90 nav refs, content rules on 5 scoped)
```

Command: `python3 docs/_check_docs.py architecture/config-layers architecture/storage architecture/security architecture/fleet-worker-heartbeat storage/replay-storage-costs`