### PR TITLE
feat(attach): VOICEGW_PROJECT env fallback for project resolution

### DIFF
--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -299,7 +299,7 @@ def _on_close_task_done(task: Any) -> None:
 def attach(
     session: Any,
     *,
-    project: str = "default",
+    project: str | None = None,
     agent_id: str | None = None,
     tenant_id: str | None = None,
     channel: str | None = None,
@@ -326,7 +326,9 @@ def attach(
 
     Args:
         session: the ``AgentSession`` (LiveKit) or ``PipelineTask`` (Pipecat).
-        project: project id to tag rows with.
+        project: project id to tag rows with. Resolution order: explicit
+            ``project=`` argument, then the ``VOICEGW_PROJECT`` environment
+            variable, then ``"default"``.
         agent_id: fleet label; defaults to ``VOICEGW_AGENT_ID`` or hostname.
         tenant_id: optional tenant attribution.
         channel: ``"telephony"`` | ``"web"``; auto-detected from the transport
@@ -340,12 +342,14 @@ def attach(
     Returns:
         The correlation session id stamped on every captured row.
     """
+    resolved_project = project or os.environ.get("VOICEGW_PROJECT") or "default"
+
     from voicegateway._frameworks import detect_framework
 
     if detect_framework(session) == "pipecat":
         return _attach_pipecat(
             session,
-            project=project,
+            project=resolved_project,
             agent_id=agent_id,
             tenant_id=tenant_id,
             channel=channel,
@@ -355,7 +359,7 @@ def attach(
         )
     return _attach_livekit(
         session,
-        project=project,
+        project=resolved_project,
         agent_id=agent_id,
         tenant_id=tenant_id,
         collector_url=collector_url,

--- a/src/voicegateway/tests/inference/test_attach_project_env.py
+++ b/src/voicegateway/tests/inference/test_attach_project_env.py
@@ -1,0 +1,137 @@
+"""Tests for VOICEGW_PROJECT env-var fallback on voicegateway.attach().
+
+Precedence (high to low):
+  1. explicit ``project=`` argument
+  2. ``VOICEGW_PROJECT`` environment variable
+  3. ``"default"``
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes (mirroring the pattern in test_attach_capture.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeEmitter:
+    def __init__(self, *, model: str = "gpt-4o-mini", provider: str = "openai") -> None:
+        self.model = model
+        self.provider = provider
+        self._handlers: dict[str, list[Any]] = {}
+
+    def on(self, event: str, handler: Any) -> None:
+        self._handlers.setdefault(event, []).append(handler)
+
+    def emit(self, event: str, *args: Any) -> None:
+        for handler in list(self._handlers.get(event, [])):
+            handler(*args)
+
+
+class _FakeSession:
+    def __init__(self, *, llm: Any = None) -> None:
+        self.llm = llm
+        self.stt = None
+        self.tts = None
+        self._handlers: dict[str, list[Any]] = {}
+
+    def on(self, event: str, handler: Any) -> None:
+        self._handlers.setdefault(event, []).append(handler)
+
+    def emit(self, event: str, *args: Any) -> None:
+        for handler in list(self._handlers.get(event, [])):
+            handler(*args)
+
+
+class _LLMMetric:
+    prompt_tokens = 100
+    completion_tokens = 50
+    prompt_cached_tokens = 0
+    ttft = 0.1
+
+
+class _CaptureSink:
+    """Minimal sink that records rows for inspection."""
+
+    def __init__(self) -> None:
+        self.rows: list = []
+
+    async def log_request(self, record: Any) -> None:
+        self.rows.append(record)
+
+    async def flush(self) -> None:
+        pass
+
+    async def aclose(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 1. Explicit project= wins even when VOICEGW_PROJECT is set
+# ---------------------------------------------------------------------------
+
+
+async def test_attach_explicit_project_wins_over_env(monkeypatch):
+    """attach(project='explicit') uses 'explicit' even when VOICEGW_PROJECT is set."""
+    import voicegateway
+
+    monkeypatch.setenv("VOICEGW_PROJECT", "from-env")
+
+    sink = _CaptureSink()
+    llm = _FakeEmitter()
+    session = _FakeSession(llm=llm)
+
+    voicegateway.attach(session, project="explicit", sink=sink)
+    llm.emit("metrics_collected", _LLMMetric())
+    await session._vg_capture.drain()
+
+    assert len(sink.rows) == 1
+    assert sink.rows[0].project == "explicit"
+
+
+# ---------------------------------------------------------------------------
+# 2. VOICEGW_PROJECT is used when no explicit project= is given
+# ---------------------------------------------------------------------------
+
+
+async def test_attach_uses_voicegw_project_env_when_no_arg(monkeypatch):
+    """attach() without project= picks up VOICEGW_PROJECT from the environment."""
+    import voicegateway
+
+    monkeypatch.setenv("VOICEGW_PROJECT", "from-env")
+
+    sink = _CaptureSink()
+    llm = _FakeEmitter()
+    session = _FakeSession(llm=llm)
+
+    voicegateway.attach(session, sink=sink)
+    llm.emit("metrics_collected", _LLMMetric())
+    await session._vg_capture.drain()
+
+    assert len(sink.rows) == 1
+    assert sink.rows[0].project == "from-env"
+
+
+# ---------------------------------------------------------------------------
+# 3. Falls back to "default" when neither arg nor env is set
+# ---------------------------------------------------------------------------
+
+
+async def test_attach_falls_back_to_default_when_neither_set(monkeypatch):
+    """attach() with no project= and no VOICEGW_PROJECT uses 'default'."""
+    import voicegateway
+
+    monkeypatch.delenv("VOICEGW_PROJECT", raising=False)
+
+    sink = _CaptureSink()
+    llm = _FakeEmitter()
+    session = _FakeSession(llm=llm)
+
+    voicegateway.attach(session, sink=sink)
+    llm.emit("metrics_collected", _LLMMetric())
+    await session._vg_capture.drain()
+
+    assert len(sink.rows) == 1
+    assert sink.rows[0].project == "default"


### PR DESCRIPTION
## Summary

- `attach()` now resolves `project` with three-tier precedence: explicit `project=` argument, then `VOICEGW_PROJECT` env var, then `"default"`.
- Previously `project: str = "default"` ignored the env var entirely; the signature is now `project: str | None = None`.
- `_attach_livekit` and `_attach_pipecat` both receive the resolved value (no change to their own signatures).

## Precedence

```
attach(session, project="explicit")          # "explicit" wins
VOICEGW_PROJECT=from-env attach(session)     # "from-env" used
attach(session)                              # falls back to "default"
```

## Acceptance results

New tests (3): all pass
```
src/voicegateway/tests/inference/test_attach_project_env.py ...  3 passed in 0.84s
```

Broader inference+core surface (`-k project`): 31 passed, 1 pre-existing failure (`test_three_projects_get_distinct_routes` - `no such table: latency_observations`, confirmed on main before this change).

Import purity: `PURE` (no livekit/pipecat imported on `import voicegateway`).

Ruff: `All checks passed!`

## Files changed

- `src/voicegateway/inference/session/attach.py` - signature + resolution logic
- `src/voicegateway/tests/inference/test_attach_project_env.py` - 3 new TDD tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project selection can now be configured through the `VOICEGW_PROJECT` environment setting.
  * Explicit project values take precedence over the environment setting.
  * A default project is used when neither an explicit value nor the environment setting is provided.

* **Bug Fixes**
  * Ensured captured metrics consistently use the resolved project value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->