### PR TITLE
fix: ruff import-sort lint on A1 test file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ src/voicegateway/_version.py
 .agents
 .codex
 .playwright-mcp
-docs/superpowers
 .DS_Store
 .superpowers
 
@@ -432,3 +431,4 @@ web/references/
 /voicegw.yaml
 /helicone/
 /.shots/
+

--- a/src/voicegateway/tests/inference/test_attach_project_env.py
+++ b/src/voicegateway/tests/inference/test_attach_project_env.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from typing import Any
 
-
 # ---------------------------------------------------------------------------
 # Minimal fakes (mirroring the pattern in test_attach_capture.py)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The A1 test file (test_attach_project_env.py) had an extra blank line in its import block that failed the ruff lint CI job (test / py3.13). One-line fix (uvx ruff check confirms clean). Also lands the .gitignore update from relocating the planning workspace to .superpowers/. No behavior change.