### PR TITLE
docs(cli): revoice the 6 plain CLI pages (B2)

### DIFF
--- a/docs/cli/costs.md
+++ b/docs/cli/costs.md
@@ -7,11 +7,11 @@ description: Display cost summaries from the gateway's request log, broken down 
 
 Display cost summaries from the gateway's request log.
 
-## Purpose
+## Synopsis
 
-The `costs` command queries the SQLite database to show how much you have spent on voice AI requests. It breaks costs down by provider and by model, and can be filtered by project and time period.
+`voicegw costs` queries the SQLite database to show how much you have spent on voice AI requests. It breaks costs down by provider and by model, and can be filtered by project and time period.
 
-## Syntax
+## Usage
 
 ```bash
 voicegw costs [OPTIONS]
@@ -26,7 +26,9 @@ voicegw costs [OPTIONS]
 | `--week` | | `boolean` | `false` | Show the weekly summary instead of today. |
 | `--month` | | `boolean` | `false` | Show the monthly summary instead of today. |
 
+<Note>
 When both `--week` and `--month` are omitted, the default period is `today`. If both are provided, `--month` takes precedence.
+</Note>
 
 ## Prerequisites
 
@@ -90,15 +92,13 @@ voicegw costs --month
 voicegw costs -c /etc/voicegateway/voicegw.yaml --week
 ```
 
-## Exit Codes
+## Exit codes
 
 | Code | Meaning |
 |---|---|
-| `0` | Success (including when cost tracking is disabled -- prints warning). |
+| `0` | Success (including when cost tracking is disabled; prints warning). |
 | `1` | Config failed to load. |
 
-## Related Commands
+## Related
 
-- [`voicegw status`](/cli/status) -- see which providers are configured
-- [`voicegw logs`](/cli/logs) -- view individual request records
-- [`voicegw projects`](/cli/projects) -- list projects with budget info
+[`voicegw status`](/cli/status) | [`voicegw logs`](/cli/logs) | [`voicegw projects`](/cli/projects)

--- a/docs/cli/export-costs.md
+++ b/docs/cli/export-costs.md
@@ -7,11 +7,11 @@ description: Export per-request cost line items for a date window in CSV or JSON
 
 Export per-request cost line items for a date window in CSV or JSON.
 
-## Purpose
+## Synopsis
 
-The `export-costs` command writes one row per recorded request, suitable for spreadsheet review or as the input to a downstream reconciliation step. Pair with [`voicegw reconcile`](/cli/reconcile) to compare the exported numbers against a provider's invoice. The full reconciliation workflow lives at [Cost Reconciliation](/guide/cost-reconciliation).
+`voicegw export-costs` writes one row per recorded request, suitable for spreadsheet review or as the input to a downstream reconciliation step. Pair with [`voicegw reconcile`](/cli/reconcile) to compare the exported numbers against a provider's invoice. The full reconciliation workflow lives at [Cost Reconciliation](/guide/cost-reconciliation).
 
-## Syntax
+## Usage
 
 ```bash
 voicegw export-costs --start <YYYY-MM-DD> --end <YYYY-MM-DD> [OPTIONS]
@@ -28,9 +28,9 @@ voicegw export-costs --start <YYYY-MM-DD> --end <YYYY-MM-DD> [OPTIONS]
 | `--output` | `-o` | `string` | `-` | Output path; `-` writes to stdout. |
 | `--config` | `-c` | `string` | `null` | Path to `voicegw.yaml`. Auto-discovered if omitted. |
 
-## Prerequisites
-
+<Note>
 Cost tracking must be enabled in `voicegw.yaml`. If storage is not configured, the command prints a warning and exits with code 1.
+</Note>
 
 ## Output columns
 
@@ -53,10 +53,7 @@ Rows are ordered by timestamp ascending.
 
 ### JSON format (JSONL)
 
-`--format json` emits **JSONL**: one JSON object per line, no
-outer array, no indent. Streamable; downstream consumers iterate
-`for line in f: row = json.loads(line)`. The schema matches the
-CSV column set 1:1.
+`--format json` emits JSONL: one JSON object per line, no outer array, no indent. Streamable; downstream consumers iterate `for line in f: row = json.loads(line)`. The schema matches the CSV column set 1:1.
 
 ## Examples
 
@@ -92,13 +89,11 @@ voicegw export-costs \
 | `1` | Cost tracking is not enabled. |
 | `2` | Bad input: malformed date or unknown format. |
 
-## Related commands
+## Related
 
-- [`voicegw reconcile`](/cli/reconcile) -- diff the exported numbers against a provider's usage file.
-- [`voicegw costs`](/cli/costs) -- aggregated summary instead of per-request rows.
-- [`voicegw logs`](/cli/logs) -- recent rows for terminal display.
+[`voicegw reconcile`](/cli/reconcile) | [`voicegw costs`](/cli/costs) | [`voicegw logs`](/cli/logs)
 
 ## See also
 
-- [Cost Reconciliation](/guide/cost-reconciliation) -- the full reconciliation workflow.
-- [Reconcile File Formats](/reference/reconcile-formats) -- per-provider schemas the reconcile step expects.
+- [Cost Reconciliation](/guide/cost-reconciliation): the full reconciliation workflow.
+- [Reconcile File Formats](/reference/reconcile-formats): per-provider schemas the reconcile step expects.

--- a/docs/cli/livekit.md
+++ b/docs/cli/livekit.md
@@ -7,6 +7,8 @@ description: Diagnostics commands for inspecting agents, measuring end-to-end la
 
 Diagnostics for a running LiveKit deployment. Four subcommands cover agent listing, end-to-end latency measurement, SFU health, and an all-in-one check report.
 
+## Usage
+
 ```bash
 voicegw livekit <subcommand> [OPTIONS]
 ```
@@ -112,11 +114,11 @@ For each probe turn the command:
 
 When the probed agent is instrumented with `voicegateway.attach(session)`, the command also shows the latency split across turn detection, STT, LLM (time-to-first-token), and TTS. The correlation key is the probe room name: `attach` stamps it on every captured row, and the probe reads those rows back by room after the turns finish.
 
-This read-back is **co-located** in this version: the agent and the prober must share the same local VoiceGateway store (`~/.config/voicegateway/voicegw.db`, or `VOICEGW_DB_PATH`). In collector mode (`VOICEGW_COLLECTOR_URL` set) the rows go to the collector rather than this host, so the split is not shown from the CLI. When no split is available, the command prints a one-line note explaining what is needed.
+This read-back is co-located in this version: the agent and the prober must share the same local VoiceGateway store (`~/.config/voicegateway/voicegw.db`, or `VOICEGW_DB_PATH`). In collector mode (`VOICEGW_COLLECTOR_URL` set) the rows go to the collector rather than this host, so the split is not shown from the CLI. When no split is available, the command prints a one-line note explaining what is needed.
 
-### Cost warning
-
-**Each probe is a real agent turn.** The agent's STT, LLM, and TTS providers are invoked with live credentials and will incur real provider charges. Run with a low `--trials` value (`1` or `2`) unless you are deliberately benchmarking. Keep `--agent` scoped to avoid probing every agent.
+<Warning>
+Each probe is a real agent turn. The agent's STT, LLM, and TTS providers are invoked with live credentials and will incur real provider charges. Run with a low `--trials` value (`1` or `2`) unless you are deliberately benchmarking. Keep `--agent` scoped to avoid probing every agent.
+</Warning>
 
 ### Options
 
@@ -166,19 +168,23 @@ Load-ramp mode (`--load`):
 
 ### Distributed load (multi-vantage)
 
-A single host only shows what one machine can push. To load the SFU concurrently from several regions, run one **coordinator** and N **probers**:
+A single host only shows what one machine can push. To load the SFU concurrently from several regions, run one coordinator and N probers:
 
-```bash
-# on the coordinator host (needs the [server] extra: pip install 'voicegateway[server]')
+<CodeGroup>
+```bash Coordinator
+# Needs the [server] extra: uv pip install 'voicegateway[server]'
 voicegw livekit sfu --coordinator --expect 3 --ramp 10,25,50 --duration 20s
+```
 
-# on each prober host / region (needs only the base install)
+```bash Probers
+# Each prober needs only the base install
 voicegw livekit sfu --report-to http://<coordinator-host>:8787 --vantage iad
 voicegw livekit sfu --report-to http://<coordinator-host>:8787 --vantage sjc
 voicegw livekit sfu --report-to http://<coordinator-host>:8787 --vantage lhr
 ```
+</CodeGroup>
 
-Each prober registers, waits at a shared barrier so every vantage starts its ramp at the same instant, ramps the **same** room, and reports its per-tier measurements back. The coordinator aggregates: at each tier the SFU sees the sum of all vantages' clients, while rtt / loss / quality report the worst any single vantage saw. It then prints the combined capacity and cleans up the shared rooms.
+Each prober registers, waits at a shared barrier so every vantage starts its ramp at the same instant, ramps the same room, and reports its per-tier measurements back. The coordinator aggregates: at each tier the SFU sees the sum of all vantages' clients, while rtt / loss / quality report the worst any single vantage saw.
 
 ```
 SFU  distributed: 3 vantages
@@ -338,9 +344,6 @@ The following limitations apply across all four subcommands:
 
 ---
 
-## Related commands
+## Related
 
-- [`voicegw smoke-test`](/cli/smoke-test): validate the inference pipeline without a LiveKit server.
-- [`voicegw status`](/cli/status): check provider configuration.
-- [`voicegw logs`](/cli/logs): view per-request cost and latency records.
-- [`voicegw costs`](/cli/costs): aggregated cost view by provider and project.
+[`voicegw smoke-test`](/cli/smoke-test) | [`voicegw status`](/cli/status) | [`voicegw logs`](/cli/logs) | [`voicegw costs`](/cli/costs)

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -7,11 +7,11 @@ description: Show recent request logs from the gateway's SQLite database.
 
 Show recent request logs from the gateway's SQLite database.
 
-## Purpose
+## Synopsis
 
-The `logs` command displays a table of recent gateway requests, including the timestamp, project, modality, model, cost, latency, and status. Use it to debug request flow, investigate errors, or monitor activity in real time.
+`voicegw logs` displays a table of recent gateway requests, including the timestamp, project, modality, model, cost, latency, and status. Use it to debug request flow, investigate errors, or monitor activity in real time.
 
-## Syntax
+## Usage
 
 ```bash
 voicegw logs [OPTIONS]
@@ -26,9 +26,9 @@ voicegw logs [OPTIONS]
 | `--tail` | `-n` | `integer` | `20` | Number of rows to display. |
 | `--modality` | `-m` | `string` | `null` | Filter by modality: `stt`, `llm`, or `tts`. |
 
-## Prerequisites
-
+<Note>
 Cost tracking must be enabled in `voicegw.yaml` for logs to be recorded. If disabled, the command prints a warning and exits.
+</Note>
 
 ## Output
 
@@ -83,15 +83,13 @@ voicegw logs -p tonys-pizza -m llm -n 10
 
 Shows the last 10 LLM requests for the `tonys-pizza` project.
 
-## Exit Codes
+## Exit codes
 
 | Code | Meaning |
 |---|---|
 | `0` | Success (including when no logs are found). |
 | `1` | Config failed to load. |
 
-## Related Commands
+## Related
 
-- [`voicegw costs`](/cli/costs) -- aggregated cost view instead of individual records
-- [`voicegw status`](/cli/status) -- check which providers are active
-- [`voicegw projects`](/cli/projects) -- find project IDs to filter on
+[`voicegw costs`](/cli/costs) | [`voicegw status`](/cli/status) | [`voicegw projects`](/cli/projects)

--- a/docs/cli/reconcile.md
+++ b/docs/cli/reconcile.md
@@ -7,13 +7,13 @@ description: Diff VoiceGateway's recorded costs against a provider's usage expor
 
 Diff VoiceGateway's recorded costs against a provider's usage export.
 
-## Purpose
+## Synopsis
 
-The `reconcile` command reads VG's per-request log records for a date window, parses an operator-supplied normalized provider usage file, and produces a per-model diff with absolute and percent differences. The full workflow (when to reconcile, how to interpret the diff, expected drift per modality) lives at [Cost Reconciliation](/guide/cost-reconciliation).
+`voicegw reconcile` reads VG's per-request log records for a date window, parses an operator-supplied normalized provider usage file, and produces a per-model diff with absolute and percent differences. The full workflow (when to reconcile, how to interpret the diff, expected drift per modality) lives at [Cost Reconciliation](/guide/cost-reconciliation).
 
 The provider-side input file format is documented per provider at [Reconcile File Formats](/reference/reconcile-formats).
 
-## Syntax
+## Usage
 
 ```bash
 voicegw reconcile --provider <name> --start <YYYY-MM-DD> --end <YYYY-MM-DD> \
@@ -41,7 +41,7 @@ voicegw reconcile --provider <name> --start <YYYY-MM-DD> --end <YYYY-MM-DD> \
 
 ### Text (default)
 
-An aligned table with one row per model. Columns: model, VG units, provider units, units Δ%, VG cost, provider cost, cost Δ$, cost Δ%. Rows whose absolute cost diff % exceeds `--threshold` are tagged with a trailing ` *` and rendered in ANSI yellow when stdout is a TTY (no color when piped or captured). Models present in only one side carry a `(no vg data)` or `(no provider data)` suffix instead.
+An aligned table with one row per model. Columns: model, VG units, provider units, units delta%, VG cost, provider cost, cost delta$, cost delta%. Rows whose absolute cost diff % exceeds `--threshold` are tagged with a trailing ` *` and rendered in ANSI yellow when stdout is a TTY (no color when piped or captured). Models present in only one side carry a `(no vg data)` or `(no provider data)` suffix instead.
 
 A Total row sums VG cost and provider cost across rows where both sides matched (missing-side rows are excluded so their `$0` placeholders do not skew the total). When any rows are flagged, a footer line `(N flagged row(s) marked with *)` follows.
 
@@ -64,14 +64,16 @@ A nested document matching design §2.2:
   "provider": "openai",
   "period": {"start": "2026-05-01", "end": "2026-05-31"},
   "rows": [
-    {"model": "gpt-4o-mini", "vg_cost": 0.94, "provider_cost": 1.0, "cost_diff_abs": 0.06, "cost_diff_pct": 6.0, "flagged": true, ...}
+    {"model": "gpt-4o-mini", "vg_cost": 0.94, "provider_cost": 1.0, "cost_diff_abs": 0.06, "cost_diff_pct": 6.0, "flagged": true}
   ],
   "total": {"vg_cost": 7.10, "provider_cost": 7.31, "diff_abs": 0.21, "diff_pct": 2.91},
   "flagged_count": 1
 }
 ```
 
+<Note>
 `total` sums only rows where both sides matched (missing-side rows excluded, mirroring the text format). `flagged_count` counts rows where `flagged=True`. Useful for piping into a monitoring or alerting tool.
+</Note>
 
 ## Examples
 
@@ -84,7 +86,7 @@ voicegw reconcile \
   --provider-usage-file openai-may-2026.csv
 ```
 
-### Same window as JSON for piping
+### JSON output for piping
 
 ```bash
 voicegw reconcile \
@@ -94,9 +96,9 @@ voicegw reconcile \
   --format json | jq '.rows[] | select(.cost_diff_pct > 5)'
 ```
 
-Note the `.rows[]` selector: the JSON output is a nested document
-keyed on `rows`, not a top-level array. See the [JSON section
-above](#json) for the full schema.
+<Tip>
+The JSON output is a nested document keyed on `rows`, not a top-level array. Use the `.rows[]` selector as shown above.
+</Tip>
 
 ### Cartesia with the JSON variant of the canonical file
 
@@ -115,12 +117,11 @@ voicegw reconcile \
 | `1` | Cost tracking is not enabled. |
 | `2` | Bad input: unsupported provider, malformed date, missing usage file, parse error, or unknown format. |
 
-## Related commands
+## Related
 
-- [`voicegw export-costs`](/cli/export-costs) -- inspect VG's per-request rows directly.
-- [`voicegw costs`](/cli/costs) -- aggregated summary by provider/model.
+[`voicegw export-costs`](/cli/export-costs) | [`voicegw costs`](/cli/costs)
 
 ## See also
 
-- [Cost Reconciliation](/guide/cost-reconciliation) -- when to reconcile, how to interpret the diff, per-modality drift tolerance.
-- [Reconcile File Formats](/reference/reconcile-formats) -- per-provider schemas this command expects.
+- [Cost Reconciliation](/guide/cost-reconciliation): when to reconcile, how to interpret the diff, per-modality drift tolerance.
+- [Reconcile File Formats](/reference/reconcile-formats): per-provider schemas this command expects.

--- a/docs/cli/replay.md
+++ b/docs/cli/replay.md
@@ -7,29 +7,44 @@ description: Print the dashboard Replay page URL for a recorded session.
 
 Print the dashboard Replay page URL for a recorded session.
 
-```bash
-voicegw replay <session-id>
-```
+## Synopsis
 
-The command is a signpost to the graphical dashboard timeline. It does not render replay events in the terminal.
+`voicegw replay` is a signpost to the graphical dashboard timeline. It outputs the URL for the given session and exits. It does not render replay events in the terminal.
+
+## Usage
+
+```bash
+voicegw replay <session-id> [OPTIONS]
+```
 
 ## Options
 
-| Option | Description |
-|---|---|
-| `--dashboard-url` | Base URL of the dashboard. Defaults to `http://127.0.0.1:8080` (the daemon's serve port). |
+| Flag | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--dashboard-url` | | `string` | `http://127.0.0.1:8080` | Base URL of the dashboard (the daemon's serve port). |
 
 ## Examples
 
+### Open a session in the dashboard
+
 ```bash
 voicegw replay vg-123
+```
+
+### Point at a remote dashboard
+
+```bash
 voicegw replay vg-123 --dashboard-url https://voicegateway.example.com
 ```
 
-The dashboard must already be running:
+<Note>
+The dashboard must already be running before following the printed URL. Start it with `voicegw dashboard` or confirm the daemon is up with `voicegw status`.
+</Note>
 
-```bash
-voicegw dashboard
-```
+## Related
 
-See [Replay storage costs](/storage/replay-storage-costs) for retention and storage trade-offs.
+[`voicegw dashboard`](/cli/dashboard) | [`voicegw status`](/cli/status) | [`voicegw logs`](/cli/logs)
+
+## See also
+
+- [Replay storage costs](/storage/replay-storage-costs): retention and storage trade-offs.


### PR DESCRIPTION
## Summary

- Applies the consistent per-command template to the 6 remaining plain CLI pages: `costs`, `export-costs`, `logs`, `reconcile`, `replay`, and `livekit`.
- Adds `## Synopsis` sections (replacing `## Purpose`), fenced `## Usage` blocks, and normalizes options tables to Flag/Short/Type/Default/Description columns.
- Introduces Mintlify components where they improve clarity: `<Note>` for prerequisite callouts, `<Tip>` for the JSON selector hint in `reconcile`, `<Warning>` for the real-provider-cost alert in `livekit latency`, and `<CodeGroup>` for the distributed SFU coordinator/prober example pair.
- Converts `## Related Commands` bullet lists to the pipe-separated inline style used across the rest of the CLI reference.
- All factual content (command names, flags, defaults, output examples) is unchanged.

## Acceptance

`python3 docs/_check_docs.py cli/costs cli/export-costs cli/logs cli/reconcile cli/replay cli/livekit` prints `docs validator: PASS (87 pages, 87 nav refs, content rules on 6 scoped)` and exits 0.