### PR TITLE
docs: AI-ready contextual menu (B3)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,6 +12,17 @@
     "dark": "/assets/logo.svg"
   },
   "favicon": "/assets/logo.svg",
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
+  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
## What this adds

Enables Mintlify's AI-consumption contextual menu by adding a top-level \`contextual\` block to \`docs/docs.json\`.

### Exact block added

\`\`\`json
"contextual": {
  "options": [
    "copy",
    "view",
    "chatgpt",
    "claude",
    "mcp",
    "cursor",
    "vscode"
  ]
}
\`\`\`

This surfaces a per-page contextual menu with:
- **copy** — Copy page as Markdown
- **view** — View as Markdown (opens \`<page>.md\`)
- **chatgpt** — Open page in ChatGPT
- **claude** — Open page in Claude
- **mcp** — Connect docs via MCP
- **cursor** — Add to Cursor
- **vscode** — Add to VS Code

## Schema source

Verified against: https://mintlify.com/docs/ai/contextual-menu

Valid option identifiers confirmed: \`copy\`, \`view\`, \`assistant\`, \`download-pdf\`, \`chatgpt\`, \`claude\`, \`perplexity\`, \`grok\`, \`aistudio\`, \`devin\`, \`devin-desktop\`, \`mcp\`, \`add-mcp\`, \`cursor\`, \`vscode\`, \`devin-mcp\`, \`download-spec\`.

## What was excluded and why

- **\`download-pdf\`** — Enterprise-only plan, would error the build for non-Enterprise accounts.
- **\`assistant\`** — Requires Mintlify's paid AI assistant feature (runs on credits, separate plan config under \`assistant:\`). Noted here rather than added.
- Other AI tool options (\`perplexity\`, \`grok\`, \`aistudio\`, \`devin\`, etc.) — not core to the ask; can be added incrementally.

## /llms.txt and per-page .md

Mintlify auto-generates \`/llms.txt\` and \`/llms-full.txt\` with zero config — confirmed returning HTTP 200 in dev. Individual pages are served as \`<slug>.md\` (e.g. \`/index.md\`) — also confirmed 200.

## Acceptance results

| Gate | Result |
|------|--------|
| \`python3 docs/_check_docs.py\` (full) | PASS (87 pages, 87 nav refs, content rules on all) |
| \`python3 -c "import json; json.load(open('docs/docs.json')); print('json-ok')"\` | json-ok |
| \`mint broken-links\` | success — no broken links found |
| \`curl http://localhost:3222/llms.txt\` (mint dev) | 200 |
| \`curl http://localhost:3222/index.md\` (mint dev) | 200 |