### PR TITLE
feat(dashboard): analytics + activity restyle (D2)

### DIFF
--- a/src/dashboard/frontend/src/components/CostChart.tsx
+++ b/src/dashboard/frontend/src/components/CostChart.tsx
@@ -24,24 +24,24 @@ export default function CostChart({ title, data }: Props) {
 
   if (chartData.length === 0) {
     return (
-      <div className="neo-card neo-card--strip-green">
-        <div className="label">{title}</div>
-        <div className="empty-state">No data yet</div>
+      <div className="vg-card">
+        <div className="vg-card__label">{title}</div>
+        <div className="empty-state mt-md">No data yet</div>
       </div>
     );
   }
 
   return (
-    <div className="neo-card neo-card--strip-green">
-      <div className="label">{title}</div>
+    <div className="vg-card">
+      <div className="vg-card__label">{title}</div>
       <div style={{ width: '100%', height: 240, marginTop: 16 }}>
         <ResponsiveContainer>
           <BarChart data={chartData} margin={{ top: 8, right: 8, left: 0, bottom: 8 }}>
-            <CartesianGrid strokeDasharray="4 4" stroke="var(--border)" strokeOpacity={0.3} />
-            <XAxis dataKey="name" tick={{ fontSize: 11, fontWeight: 600 }} />
-            <YAxis tick={{ fontSize: 11, fontWeight: 600 }} />
-            <Tooltip content={<NeoTooltip />} cursor={{ fill: 'rgba(31, 150, 170, 0.12)' }} />
-            <Bar dataKey="cost" fill={ACCENT_COLORS.blue} radius={[4, 4, 0, 0]} />
+            <CartesianGrid strokeDasharray="0" stroke="var(--vg-hairline-2)" strokeOpacity={1} />
+            <XAxis dataKey="name" tick={{ fontSize: 11, fontWeight: 600, fill: 'var(--vg-muted-2)' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fontWeight: 600, fill: 'var(--vg-muted-2)' }} axisLine={false} tickLine={false} width={48} />
+            <Tooltip content={<NeoTooltip />} cursor={{ fill: 'var(--vg-teal-tint)' }} />
+            <Bar dataKey="cost" fill="var(--vg-teal)" radius={[4, 4, 0, 0]} />
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/src/dashboard/frontend/src/components/DeadAirList.tsx
+++ b/src/dashboard/frontend/src/components/DeadAirList.tsx
@@ -14,12 +14,12 @@ interface Props {
 
 export default function DeadAirList({ count, thresholdSeconds }: Props) {
   return (
-    <div className="neo-card neo-card--strip-red">
-      <div className="label">Dead-air events</div>
-      <div className="stat-value stat-value--xl mt-md">
+    <div className="vg-card">
+      <div className="vg-card__label">Dead-air events</div>
+      <div className="vg-stat mt-md">
         {count}
       </div>
-      <div className="label mt-sm" style={{ opacity: 0.7 }}>
+      <div className="vg-card__label mt-sm" style={{ opacity: 0.7 }}>
         Silences longer than {thresholdSeconds}s that the caller did not
         initiate. Drill into a session to see per-event timestamps.
       </div>

--- a/src/dashboard/frontend/src/components/LatencyChart.tsx
+++ b/src/dashboard/frontend/src/components/LatencyChart.tsx
@@ -24,25 +24,25 @@ export default function LatencyChart({ data }: Props) {
 
   if (chartData.length === 0) {
     return (
-      <div className="neo-card neo-card--strip-pink">
-        <div className="label">Latency by Model</div>
-        <div className="empty-state">No latency data yet</div>
+      <div className="vg-card">
+        <div className="vg-card__label">Latency by Model</div>
+        <div className="empty-state mt-md">No latency data yet</div>
       </div>
     );
   }
 
   return (
-    <div className="neo-card neo-card--strip-pink">
-      <div className="label">Latency by Model (ms)</div>
+    <div className="vg-card">
+      <div className="vg-card__label">Latency by Model (ms)</div>
       <div style={{ width: '100%', height: 280, marginTop: 16 }}>
         <ResponsiveContainer>
           <BarChart data={chartData} margin={{ top: 8, right: 8, left: 0, bottom: 8 }}>
-            <CartesianGrid strokeDasharray="4 4" stroke="var(--border)" strokeOpacity={0.3} />
-            <XAxis dataKey="name" tick={{ fontSize: 11, fontWeight: 600 }} />
-            <YAxis tick={{ fontSize: 11, fontWeight: 600 }} />
-            <Tooltip content={<NeoTooltip />} cursor={{ fill: 'rgba(31, 150, 170, 0.12)' }} />
-            <Bar dataKey="ttfb" name="TTFB" fill={ACCENT_COLORS.blue} radius={[4, 4, 0, 0]} />
-            <Bar dataKey="total" name="Total" fill={ACCENT_COLORS.yellow} radius={[4, 4, 0, 0]} />
+            <CartesianGrid strokeDasharray="0" stroke="var(--vg-hairline-2)" strokeOpacity={1} />
+            <XAxis dataKey="name" tick={{ fontSize: 11, fontWeight: 600, fill: 'var(--vg-muted-2)' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fontWeight: 600, fill: 'var(--vg-muted-2)' }} axisLine={false} tickLine={false} width={48} />
+            <Tooltip content={<NeoTooltip />} cursor={{ fill: 'var(--vg-teal-tint)' }} />
+            <Bar dataKey="ttfb" name="TTFB" fill="var(--vg-teal)" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="total" name="Total" fill="var(--vg-teal-bright)" radius={[4, 4, 0, 0]} />
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/src/dashboard/frontend/src/components/LogTable.tsx
+++ b/src/dashboard/frontend/src/components/LogTable.tsx
@@ -8,9 +8,7 @@ interface Props {
 export default function LogTable({ logs }: Props) {
   if (!logs || logs.length === 0) {
     return (
-      <div className="neo-card">
-        <div className="empty-state">No requests logged yet</div>
-      </div>
+      <div className="empty-state">No requests logged yet</div>
     );
   }
   return (
@@ -32,7 +30,7 @@ export default function LogTable({ logs }: Props) {
             <td className="mono">{new Date(log.timestamp * 1000).toLocaleTimeString()}</td>
             <td className="mono">{log.model_id}</td>
             <td>
-              <span className="neo-badge neo-badge--black">{(log.modality || '').toUpperCase()}</span>
+              <span className="neo-badge neo-badge--info">{(log.modality || '').toUpperCase()}</span>
             </td>
             <td className="mono">{formatCost(log.cost_usd, 6)}</td>
             <td className="mono">{log.pricing_source || ''}</td>

--- a/src/dashboard/frontend/src/components/PerMinuteCostCard.tsx
+++ b/src/dashboard/frontend/src/components/PerMinuteCostCard.tsx
@@ -14,16 +14,16 @@ interface Props {
 
 export default function PerMinuteCostCard({ value, measuredSessionCount }: Props) {
   return (
-    <div className="neo-card neo-card--strip-green">
-      <div className="label">Per-minute cost</div>
-      <div className="stat-value stat-value--xl mt-md">
+    <div className="vg-card">
+      <div className="vg-card__label">Per-minute cost</div>
+      <div className="vg-stat mt-md">
         {value !== null ? (
           `$${value.toFixed(4)}`
         ) : (
-          <span className="empty-state-inline">not measured</span>
+          <span style={{ fontSize: 14, color: 'var(--vg-muted)' }}>not measured</span>
         )}
       </div>
-      <div className="label mt-sm" style={{ opacity: 0.7 }}>
+      <div className="vg-card__label mt-sm" style={{ opacity: 0.7 }}>
         Avg across {measuredSessionCount} session
         {measuredSessionCount === 1 ? '' : 's'}
       </div>

--- a/src/dashboard/frontend/src/components/ResponseSpeedChart.tsx
+++ b/src/dashboard/frontend/src/components/ResponseSpeedChart.tsx
@@ -30,8 +30,8 @@ export default function ResponseSpeedChart({ p50, p95 }: Props) {
 
   if (allNull) {
     return (
-      <div className="neo-card neo-card--strip-blue">
-        <div className="label">Response speed</div>
+      <div className="vg-card">
+        <div className="vg-card__label">Response speed</div>
         <div className="empty-state mt-md">not measured</div>
       </div>
     );
@@ -43,9 +43,9 @@ export default function ResponseSpeedChart({ p50, p95 }: Props) {
   ];
 
   return (
-    <div className="neo-card neo-card--strip-blue">
-      <div className="label">Response speed</div>
-      <div className="stat-value mt-sm" style={{ fontSize: 14, opacity: 0.7 }}>
+    <div className="vg-card">
+      <div className="vg-card__label">Response speed</div>
+      <div className="vg-card__label mt-sm" style={{ opacity: 0.7, textTransform: 'none', letterSpacing: 0, fontSize: 12, fontWeight: 500 }}>
         Caller stops &rarr; agent first audible byte (ms)
       </div>
       <div style={{ width: '100%', height: 200, marginTop: 12 }}>
@@ -56,21 +56,23 @@ export default function ResponseSpeedChart({ p50, p95 }: Props) {
             margin={{ top: 8, right: 24, left: 8, bottom: 8 }}
           >
             <CartesianGrid
-              strokeDasharray="4 4"
-              stroke="var(--border)"
-              strokeOpacity={0.3}
+              strokeDasharray="0"
+              stroke="var(--vg-hairline-2)"
+              strokeOpacity={1}
             />
-            <XAxis type="number" tick={{ fontSize: 11, fontWeight: 600 }} />
+            <XAxis type="number" tick={{ fontSize: 11, fontWeight: 600, fill: 'var(--vg-muted-2)' }} axisLine={false} tickLine={false} />
             <YAxis
               dataKey="name"
               type="category"
-              tick={{ fontSize: 11, fontWeight: 700 }}
+              tick={{ fontSize: 11, fontWeight: 700, fill: 'var(--vg-muted-2)' }}
+              axisLine={false}
+              tickLine={false}
             />
             <Tooltip
               content={<NeoTooltip />}
-              cursor={{ fill: 'rgba(31, 150, 170, 0.12)' }}
+              cursor={{ fill: 'var(--vg-teal-tint)' }}
             />
-            <Bar dataKey="ms" fill={ACCENT_COLORS.blue} radius={[0, 4, 4, 0]} />
+            <Bar dataKey="ms" fill="var(--vg-teal)" radius={[0, 4, 4, 0]} />
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/src/dashboard/frontend/src/components/TalkOverChart.tsx
+++ b/src/dashboard/frontend/src/components/TalkOverChart.tsx
@@ -14,16 +14,16 @@ interface Props {
 
 export default function TalkOverChart({ rate, thresholdMs }: Props) {
   return (
-    <div className="neo-card neo-card--strip-orange">
-      <div className="label">Talk-over rate</div>
-      <div className="stat-value stat-value--xl mt-md">
+    <div className="vg-card">
+      <div className="vg-card__label">Talk-over rate</div>
+      <div className="vg-stat mt-md">
         {rate !== null ? (
           `${(rate * 100).toFixed(1)}%`
         ) : (
-          <span className="empty-state-inline">not measured</span>
+          <span style={{ fontSize: 14, color: 'var(--vg-muted)' }}>not measured</span>
         )}
       </div>
-      <div className="label mt-sm" style={{ opacity: 0.7 }}>
+      <div className="vg-card__label mt-sm" style={{ opacity: 0.7 }}>
         Counts a turn as overlap when caller speech starts within
         {' '}{thresholdMs}ms of the prior agent speech finishing.
         Lower is better.

--- a/src/dashboard/frontend/src/pages/Costs.tsx
+++ b/src/dashboard/frontend/src/pages/Costs.tsx
@@ -65,46 +65,49 @@ function LatencyContent() {
       </div>
 
       {entries.length > 0 && (
-        <table className="neo-table neo-table--pink">
-          <thead>
-            <tr>
-              <th>Model</th>
-              <th>Avg TTFB</th>
-              <th>P95 TTFB</th>
-              <th>P95 Total</th>
-              <th>Requests</th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.map(([model, stats]) => {
-              const ttfbP95 = stats.ttfb_percentiles?.p95;
-              const latP95 = stats.latency_percentiles?.p95;
-              return (
-                <tr key={model}>
-                  <td className="mono">{model}</td>
-                  <td>
-                    <span className={`neo-badge ${latencyBadgeClass(stats.avg_ttfb_ms)}`}>
-                      {formatMs(stats.avg_ttfb_ms)}
-                    </span>
-                  </td>
-                  <td>
-                    <span className={`neo-badge ${badgeFor(ttfbP95)}`}>
-                      {fmtP(ttfbP95)}
-                    </span>
-                  </td>
-                  <td>
-                    <span className={`neo-badge ${badgeFor(latP95)}`}>
-                      {fmtP(latP95)}
-                    </span>
-                  </td>
-                  <td>
-                    <span className="neo-badge neo-badge--black">{stats.request_count}</span>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="vg-card">
+          <div className="vg-card__label" style={{ marginBottom: 12 }}>Latency by model</div>
+          <table className="neo-table neo-table--pink">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Avg TTFB</th>
+                <th>P95 TTFB</th>
+                <th>P95 Total</th>
+                <th>Requests</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map(([model, stats]) => {
+                const ttfbP95 = stats.ttfb_percentiles?.p95;
+                const latP95 = stats.latency_percentiles?.p95;
+                return (
+                  <tr key={model}>
+                    <td className="mono">{model}</td>
+                    <td>
+                      <span className={`neo-badge ${latencyBadgeClass(stats.avg_ttfb_ms)}`}>
+                        {formatMs(stats.avg_ttfb_ms)}
+                      </span>
+                    </td>
+                    <td>
+                      <span className={`neo-badge ${badgeFor(ttfbP95)}`}>
+                        {fmtP(ttfbP95)}
+                      </span>
+                    </td>
+                    <td>
+                      <span className={`neo-badge ${badgeFor(latP95)}`}>
+                        {fmtP(latP95)}
+                      </span>
+                    </td>
+                    <td>
+                      <span className="neo-badge neo-badge--black">{stats.request_count}</span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );
@@ -157,9 +160,9 @@ function CostsContent() {
         <div className="empty-state">Loading costs...</div>
       ) : (
         <>
-          <div className="neo-card neo-card--strip-green mb-lg">
-            <div className="label">Total Spend</div>
-            <div className="stat-value-xl mt-sm">{formatCost(data.total)}</div>
+          <div className="vg-card mb-lg">
+            <div className="vg-card__label">Total Spend</div>
+            <div className="vg-stat" style={{ fontSize: 42, letterSpacing: '-0.025em', marginTop: 6 }}>{formatCost(data.total)}</div>
           </div>
 
       <div className="grid grid-cols-2">
@@ -168,7 +171,8 @@ function CostsContent() {
       </div>
 
       {models.length > 0 && (
-        <div className="mt-lg">
+        <div className="vg-card mt-lg">
+          <div className="vg-card__label" style={{ marginBottom: 12 }}>Cost by model</div>
           <table className="neo-table neo-table--green">
             <thead>
               <tr>
@@ -194,8 +198,8 @@ function CostsContent() {
             </tbody>
           </table>
           <div
-            className="label mt-md"
-            style={{ fontStyle: 'italic', opacity: 0.8 }}
+            className="vg-card__label mt-md"
+            style={{ fontStyle: 'italic', opacity: 0.8, textTransform: 'none', letterSpacing: 0, fontWeight: 500 }}
           >
             Costs are estimates from the pricing sources above. Run{' '}
             <span className="mono">

--- a/src/dashboard/frontend/src/pages/Latency.tsx
+++ b/src/dashboard/frontend/src/pages/Latency.tsx
@@ -70,46 +70,49 @@ export default function Latency() {
       </div>
 
       {entries.length > 0 && (
-        <table className="neo-table neo-table--pink">
-          <thead>
-            <tr>
-              <th>Model</th>
-              <th>Avg TTFB</th>
-              <th>P95 TTFB</th>
-              <th>P95 Total</th>
-              <th>Requests</th>
-            </tr>
-          </thead>
-          <tbody>
-            {entries.map(([model, stats]) => {
-              const ttfbP95 = stats.ttfb_percentiles?.p95;
-              const latP95 = stats.latency_percentiles?.p95;
-              return (
-                <tr key={model}>
-                  <td className="mono">{model}</td>
-                  <td>
-                    <span className={`neo-badge ${latencyBadgeClass(stats.avg_ttfb_ms)}`}>
-                      {formatMs(stats.avg_ttfb_ms)}
-                    </span>
-                  </td>
-                  <td>
-                    <span className={`neo-badge ${badgeFor(ttfbP95)}`}>
-                      {fmtP(ttfbP95)}
-                    </span>
-                  </td>
-                  <td>
-                    <span className={`neo-badge ${badgeFor(latP95)}`}>
-                      {fmtP(latP95)}
-                    </span>
-                  </td>
-                  <td>
-                    <span className="neo-badge neo-badge--black">{stats.request_count}</span>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="vg-card">
+          <div className="vg-card__label" style={{ marginBottom: 12 }}>Latency by model</div>
+          <table className="neo-table neo-table--pink">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Avg TTFB</th>
+                <th>P95 TTFB</th>
+                <th>P95 Total</th>
+                <th>Requests</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map(([model, stats]) => {
+                const ttfbP95 = stats.ttfb_percentiles?.p95;
+                const latP95 = stats.latency_percentiles?.p95;
+                return (
+                  <tr key={model}>
+                    <td className="mono">{model}</td>
+                    <td>
+                      <span className={`neo-badge ${latencyBadgeClass(stats.avg_ttfb_ms)}`}>
+                        {formatMs(stats.avg_ttfb_ms)}
+                      </span>
+                    </td>
+                    <td>
+                      <span className={`neo-badge ${badgeFor(ttfbP95)}`}>
+                        {fmtP(ttfbP95)}
+                      </span>
+                    </td>
+                    <td>
+                      <span className={`neo-badge ${badgeFor(latP95)}`}>
+                        {fmtP(latP95)}
+                      </span>
+                    </td>
+                    <td>
+                      <span className="neo-badge neo-badge--black">{stats.request_count}</span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/src/dashboard/frontend/src/pages/Logs.tsx
+++ b/src/dashboard/frontend/src/pages/Logs.tsx
@@ -25,25 +25,31 @@ export default function Logs() {
 
       <FilterBar showTenant={false} />
 
-      <div className="filter-bar">
-        <span className="label">Modality</span>
-        <select className="neo-select" value={filter} onChange={(e) => setFilter(e.target.value)}>
-          <option value="">All</option>
-          <option value="stt">STT</option>
-          <option value="llm">LLM</option>
-          <option value="tts">TTS</option>
-        </select>
-        <button className="neo-btn neo-btn--orange">Apply</button>
-        <button className="neo-btn" onClick={() => setFilter('')}>
-          Reset
-        </button>
+      <div className="vg-card mb-lg">
+        <div className="flex-row flex-wrap" style={{ gap: 12, alignItems: 'flex-end' }}>
+          <div>
+            <div className="vg-card__label" style={{ marginBottom: 6 }}>Modality</div>
+            <select className="neo-select" value={filter} onChange={(e) => setFilter(e.target.value)}>
+              <option value="">All</option>
+              <option value="stt">STT</option>
+              <option value="llm">LLM</option>
+              <option value="tts">TTS</option>
+            </select>
+          </div>
+          <button className="neo-btn neo-btn--primary" onClick={() => setFilter(filter)}>Apply</button>
+          <button className="neo-btn" onClick={() => setFilter('')}>
+            Reset
+          </button>
+        </div>
       </div>
 
-      <LogTable logs={logs} />
+      <div className="vg-card" style={{ padding: 0, overflow: 'hidden' }}>
+        <LogTable logs={logs} />
+      </div>
 
       <div className="flex-row mt-lg">
-        <button className="neo-btn">← Previous</button>
-        <button className="neo-btn neo-btn--orange">Next →</button>
+        <button className="neo-btn">Previous</button>
+        <button className="neo-btn neo-btn--primary">Next</button>
       </div>
     </div>
   );

--- a/src/dashboard/frontend/src/pages/Metrics.tsx
+++ b/src/dashboard/frontend/src/pages/Metrics.tsx
@@ -66,10 +66,10 @@ export default function Metrics() {
 
       <FilterBar />
 
-      <div className="neo-card mb-lg">
-        <div className="flex flex-row gap-md items-end">
+      <div className="vg-card mb-lg">
+        <div className="flex-row flex-wrap" style={{ gap: 20, alignItems: 'flex-end' }}>
           <div>
-            <div className="label">Project</div>
+            <div className="vg-card__label" style={{ marginBottom: 6 }}>Project</div>
             <input
               type="text"
               className="neo-input"
@@ -79,9 +79,9 @@ export default function Metrics() {
             />
           </div>
           <div>
-            <div className="label">Window</div>
+            <div className="vg-card__label" style={{ marginBottom: 6 }}>Window</div>
             <select
-              className="neo-input"
+              className="neo-select"
               value={days}
               onChange={(e) => setDays(Number(e.target.value))}
             >
@@ -93,11 +93,11 @@ export default function Metrics() {
             </select>
           </div>
           {data && (
-            <div className="ml-auto">
-              <div className="label">Sessions</div>
-              <div className="stat-value">
+            <div style={{ marginLeft: 'auto' }}>
+              <div className="vg-card__label" style={{ marginBottom: 4 }}>Sessions</div>
+              <div className="vg-stat" style={{ fontSize: 22, letterSpacing: '-0.5px' }}>
                 {data.measured_session_count} / {data.session_count}
-                <span className="label ml-sm">measured</span>
+                <span className="vg-card__label" style={{ marginLeft: 6 }}>measured</span>
               </div>
             </div>
           )}

--- a/src/dashboard/frontend/src/pages/Replay.tsx
+++ b/src/dashboard/frontend/src/pages/Replay.tsx
@@ -83,9 +83,9 @@ export default function Replay() {
       )}
 
       {error && (
-        <div className="neo-card neo-card--strip-red">
-          <div className="label">Replay unavailable</div>
-          <div className="stat-value mt-md">{error}</div>
+        <div className="vg-card" style={{ borderColor: 'var(--vg-red)', borderLeftWidth: 3 }}>
+          <div className="vg-card__label" style={{ color: 'var(--vg-red)' }}>Replay unavailable</div>
+          <div className="vg-stat mt-md" style={{ fontSize: 16, fontWeight: 600 }}>{error}</div>
         </div>
       )}
 

--- a/src/dashboard/frontend/src/pages/Sessions.tsx
+++ b/src/dashboard/frontend/src/pages/Sessions.tsx
@@ -56,10 +56,10 @@ function MetricsContent() {
 
   return (
     <div>
-      <div className="neo-card mb-lg">
-        <div className="flex flex-row gap-md items-end">
+      <div className="vg-card mb-lg">
+        <div className="flex-row flex-wrap" style={{ gap: 20, alignItems: 'flex-end' }}>
           <div>
-            <div className="label">Project</div>
+            <div className="vg-card__label" style={{ marginBottom: 6 }}>Project</div>
             <input
               type="text"
               className="neo-input"
@@ -69,9 +69,9 @@ function MetricsContent() {
             />
           </div>
           <div>
-            <div className="label">Window</div>
+            <div className="vg-card__label" style={{ marginBottom: 6 }}>Window</div>
             <select
-              className="neo-input"
+              className="neo-select"
               value={days}
               onChange={(e) => setDays(Number(e.target.value))}
             >
@@ -83,11 +83,11 @@ function MetricsContent() {
             </select>
           </div>
           {data && (
-            <div className="ml-auto">
-              <div className="label">Sessions</div>
-              <div className="stat-value">
+            <div style={{ marginLeft: 'auto' }}>
+              <div className="vg-card__label" style={{ marginBottom: 4 }}>Sessions</div>
+              <div className="vg-stat" style={{ fontSize: 22, letterSpacing: '-0.5px' }}>
                 {data.measured_session_count} / {data.session_count}
-                <span className="label ml-sm">measured</span>
+                <span className="vg-card__label" style={{ marginLeft: 6 }}>measured</span>
               </div>
             </div>
           )}
@@ -263,67 +263,69 @@ export default function Sessions() {
               show up here grouped by their <span className="mono">session_id</span>.
             </div>
           ) : (
-            <table className="neo-table neo-table--blue">
-              <thead>
-                <tr>
-                  <th>Started</th>
-                  <th>Duration</th>
-                  <th>Project</th>
-                  <th>Tenant</th>
-                  <th>Modalities</th>
-                  <th>Requests</th>
-                  <th style={{ textAlign: 'right' }}>Cost</th>
-                  <th style={{ width: 110 }}>Replay</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((row) => (
-                  <tr
-                    key={row.id}
-                    onClick={() => handleRowClick(row.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        handleRowClick(row.id);
-                      }
-                    }}
-                    tabIndex={0}
-                    role="button"
-                    aria-label={`Open session ${row.id}`}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    <td className="mono">{formatRelative(row.started_at)}</td>
-                    <td className="mono">
-                      {formatDuration(row.started_at, row.ended_at)}
-                    </td>
-                    <td>{row.project}</td>
-                    <td onClick={(e) => e.stopPropagation()}>
-                      <TenantPill tenantId={row.tenant_id ?? null} asLink />
-                    </td>
-                    <td>
-                      <ModalityBadges modalities={row.modalities} />
-                    </td>
-                    <td>
-                      <span className="neo-badge neo-badge--black">
-                        {row.request_count}
-                      </span>
-                    </td>
-                    <td className="mono" style={{ textAlign: 'right' }}>
-                      {formatCost(row.total_cost_usd, 6)}
-                    </td>
-                    <td onClick={(e) => e.stopPropagation()}>
-                      <Link
-                        to={`/sessions/${encodeURIComponent(row.id)}/replay`}
-                        className="neo-btn neo-btn--small"
-                        aria-label={`Open replay for session ${row.id}`}
-                      >
-                        Open replay
-                      </Link>
-                    </td>
+            <div className="vg-card" style={{ padding: 0, overflow: 'hidden' }}>
+              <table className="neo-table neo-table--blue">
+                <thead>
+                  <tr>
+                    <th>Started</th>
+                    <th>Duration</th>
+                    <th>Project</th>
+                    <th>Tenant</th>
+                    <th>Modalities</th>
+                    <th>Requests</th>
+                    <th style={{ textAlign: 'right' }}>Cost</th>
+                    <th style={{ width: 110 }}>Replay</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr
+                      key={row.id}
+                      onClick={() => handleRowClick(row.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          handleRowClick(row.id);
+                        }
+                      }}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={`Open session ${row.id}`}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <td className="mono">{formatRelative(row.started_at)}</td>
+                      <td className="mono">
+                        {formatDuration(row.started_at, row.ended_at)}
+                      </td>
+                      <td>{row.project}</td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <TenantPill tenantId={row.tenant_id ?? null} asLink />
+                      </td>
+                      <td>
+                        <ModalityBadges modalities={row.modalities} />
+                      </td>
+                      <td>
+                        <span className="neo-badge neo-badge--black">
+                          {row.request_count}
+                        </span>
+                      </td>
+                      <td className="mono" style={{ textAlign: 'right' }}>
+                        {formatCost(row.total_cost_usd, 6)}
+                      </td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <Link
+                          to={`/sessions/${encodeURIComponent(row.id)}/replay`}
+                          className="neo-btn neo-btn--small"
+                          aria-label={`Open replay for session ${row.id}`}
+                        >
+                          Open replay
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
 
           {detail && (
@@ -539,7 +541,7 @@ function RoutingStrip({ session }: { session: SessionDetail }) {
   const overrun = !!session.budget_overrun;
 
   return (
-    <div className="neo-card neo-card--strip-green mt-lg" style={{ padding: '0.75rem 1rem' }}>
+    <div className="vg-card mt-lg" style={{ padding: '0.75rem 1rem' }}>
       <div className="flex-row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
         <div>
           <div className="label">Routing</div>


### PR DESCRIPTION
## Summary

- **Costs**: Total Spend becomes a `vg-card` stat block; cost-by-model and latency-by-model tables wrapped in `vg-card`; CostChart restyled to teal bars + `--vg-hairline-2` grid
- **Latency**: Latency-by-model table wrapped in `vg-card`; LatencyChart restyled to `--vg-teal` / `--vg-teal-bright` dual bars
- **Metrics**: Filter box switches from `neo-card` to `vg-card`; all four metric sub-cards (PerMinuteCostCard, ResponseSpeedChart, TalkOverChart, DeadAirList) use `vg-card` + `vg-stat`
- **Sessions**: Filter box `vg-card`; sessions table wrapped in `vg-card` (flush padding); routing strip `vg-card`; MetricsContent filter box `vg-card`
- **Replay**: Error state uses `vg-card` with red left-border accent instead of `neo-card--strip-red`
- **Logs**: Modality filter box is a `vg-card`; log table wrapped in a `vg-card` container; LogTable empty state uses shared `.empty-state` div
- **Shared components updated**: CostChart, LatencyChart, ResponseSpeedChart, PerMinuteCostCard, TalkOverChart, DeadAirList, LogTable

All data fetching, filters, chart data, pagination, and links are preserved unchanged.

## Build result

`npm run build` (tsc -b && vite build): **green, 0 errors** (1.07s, chunk-size advisory only — pre-existing)

Files changed: 6 pages + 7 shared components (13 files, 249 ins / 234 del)