### PR TITLE
feat(dashboard): config + entity restyle (D3)

### DIFF
--- a/src/dashboard/frontend/src/pages/Agents.tsx
+++ b/src/dashboard/frontend/src/pages/Agents.tsx
@@ -77,67 +77,71 @@ export default function Agents() {
         accent="blue"
       />
 
-      <div className="filter-bar">
-        <span className="label">Search</span>
-        <input
-          className="neo-input"
-          placeholder="Filter by agent id…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          style={{ maxWidth: '20rem' }}
-        />
+      <div className="vg-card mb-md" style={{ padding: '14px 20px' }}>
+        <div className="flex-row gap-sm">
+          <span className="vg-card__label" style={{ alignSelf: 'center' }}>Search</span>
+          <input
+            className="neo-input"
+            placeholder="Filter by agent id..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{ maxWidth: '20rem' }}
+          />
+        </div>
       </div>
 
       {sorted.length === 0 ? (
-        <div className="empty-state mt-lg">
+        <div className="empty-state mt-md">
           No agents yet. Agents appear here once they push telemetry to the
           collector (via <span className="mono">voicegateway.attach()</span> or a
           remote sink).
         </div>
       ) : (
-        <table className="neo-table neo-table--blue mt-lg">
-          <thead>
-            <tr>
-              <th>Status</th>
-              {COLUMNS.map((c) => (
-                <th
-                  key={c.key}
-                  onClick={() => onSort(c.key)}
-                  style={{ cursor: 'pointer', userSelect: 'none' }}
-                >
-                  {c.label}
-                  {sortKey === c.key ? (sortAsc ? ' ▲' : ' ▼') : ''}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.map((a) => {
-              const status = agentStatus(a.last_seen);
-              return (
-                <tr key={a.agent_id}>
-                  <td>
-                    <span className={`neo-badge ${agentStatusBadgeClass(status)}`}>
-                      {status}
-                    </span>
-                  </td>
-                  <td className="mono">
-                    <Link to={`/costs?agent=${encodeURIComponent(a.agent_id)}`}>
-                      {a.agent_id}
-                    </Link>
-                  </td>
-                  <td>{formatRelativeTime(a.last_seen)}</td>
-                  <td className="mono">{formatCost(a.total_cost_usd, 4)}</td>
-                  <td>
-                    <span className="neo-badge neo-badge--black">{a.request_count}</span>
-                  </td>
-                  <td className="mono">{formatMs(a.p95_latency_ms)}</td>
-                  <td className="mono">{(a.error_rate * 100).toFixed(1)}%</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        <div className="vg-card" style={{ padding: 0, overflow: 'hidden' }}>
+          <table className="neo-table neo-table--blue">
+            <thead>
+              <tr>
+                <th>Status</th>
+                {COLUMNS.map((c) => (
+                  <th
+                    key={c.key}
+                    onClick={() => onSort(c.key)}
+                    style={{ cursor: 'pointer', userSelect: 'none' }}
+                  >
+                    {c.label}
+                    {sortKey === c.key ? (sortAsc ? ' ▲' : ' ▼') : ''}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((a) => {
+                const status = agentStatus(a.last_seen);
+                return (
+                  <tr key={a.agent_id}>
+                    <td>
+                      <span className={`neo-badge ${agentStatusBadgeClass(status)}`}>
+                        {status}
+                      </span>
+                    </td>
+                    <td className="mono">
+                      <Link to={`/costs?agent=${encodeURIComponent(a.agent_id)}`}>
+                        {a.agent_id}
+                      </Link>
+                    </td>
+                    <td>{formatRelativeTime(a.last_seen)}</td>
+                    <td className="mono">{formatCost(a.total_cost_usd, 4)}</td>
+                    <td>
+                      <span className="neo-badge neo-badge--black">{a.request_count}</span>
+                    </td>
+                    <td className="mono">{formatMs(a.p95_latency_ms)}</td>
+                    <td className="mono">{(a.error_rate * 100).toFixed(1)}%</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/src/dashboard/frontend/src/pages/Models.tsx
+++ b/src/dashboard/frontend/src/pages/Models.tsx
@@ -10,53 +10,70 @@ export default function Models() {
     fetchJson<StatusResponse>('/api/status').then(setData).catch(() => setData(null));
   }, []);
 
-  if (!data) return <div className="empty-state">Loading models...</div>;
+  if (!data) {
+    return (
+      <div>
+        <PageHeader title="Models" subtitle="Loading..." accent="blue" />
+        <div className="empty-state">Loading models...</div>
+      </div>
+    );
+  }
 
   const entries = Object.entries(data.models);
 
   return (
     <div>
-      <PageHeader title="Models" subtitle={`${entries.length} configured`} accent="blue" />
-      <table className="neo-table neo-table--blue">
-        <thead>
-          <tr>
-            <th>Model</th>
-            <th>Modality</th>
-            <th>Provider</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {entries.map(([id, cfg]) => {
-            const configured = data.providers[cfg.provider]?.configured;
-            return (
-              <tr key={id}>
-                <td className="mono">{id}</td>
-                <td>
-                  <span className="neo-badge neo-badge--black">
-                    {(cfg.modality || '').toUpperCase()}
-                  </span>
-                </td>
-                <td>
-                  <span className="neo-badge neo-badge--blue">{cfg.provider}</span>
-                </td>
-                <td>
-                  <span className={`neo-badge ${configured ? 'neo-badge--online' : 'neo-badge--offline'}`}>
-                    {configured ? 'Ready' : 'No API Key'}
-                  </span>
-                </td>
+      <PageHeader
+        title="Models"
+        subtitle={`${entries.length} configured`}
+        accent="blue"
+      />
+
+      <div className="vg-card" style={{ padding: 0, overflow: 'hidden' }}>
+        {entries.length === 0 ? (
+          <div className="empty-state" style={{ margin: 24 }}>
+            No models configured.
+          </div>
+        ) : (
+          <table className="neo-table neo-table--blue">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Modality</th>
+                <th>Provider</th>
+                <th>Status</th>
               </tr>
-            );
-          })}
-          {entries.length === 0 && (
-            <tr>
-              <td colSpan={4} className="empty-state">
-                No models configured.
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+            </thead>
+            <tbody>
+              {entries.map(([id, cfg]) => {
+                const configured = data.providers[cfg.provider]?.configured;
+                return (
+                  <tr key={id}>
+                    <td className="mono" style={{ fontWeight: 600 }}>{id}</td>
+                    <td>
+                      <span className="neo-badge">
+                        {(cfg.modality || '').toUpperCase()}
+                      </span>
+                    </td>
+                    <td>
+                      <span className="neo-badge neo-badge--blue">{cfg.provider}</span>
+                    </td>
+                    <td>
+                      <span
+                        className={`neo-badge ${
+                          configured ? 'neo-badge--online' : 'neo-badge--offline'
+                        }`}
+                      >
+                        {configured ? 'Ready' : 'No API Key'}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/dashboard/frontend/src/pages/Projects.tsx
+++ b/src/dashboard/frontend/src/pages/Projects.tsx
@@ -62,40 +62,60 @@ export default function Projects() {
           const spent = s?.cost_today ?? 0;
           const dailyBudget = p.daily_budget ?? 0;
           const pct = dailyBudget > 0 ? Math.min((spent / dailyBudget) * 100, 100) : 0;
-          const barColor = pct >= 100 ? 'var(--accent-pink)' : pct >= 80 ? '#FFD166' : 'var(--accent-green)';
+          const barColor =
+            pct >= 100
+              ? 'var(--vg-red)'
+              : pct >= 80
+              ? 'var(--vg-amber)'
+              : 'var(--vg-green)';
           const tags = p.tags ?? [];
 
           return (
-            <div key={p.id} className="neo-card neo-card--strip-orange">
-              <div className="flex-row" style={{ justifyContent: 'space-between' }}>
-                <strong>{p.name}</strong>
+            <div key={p.id} className="vg-card">
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0, left: 0, right: 0, height: 3,
+                  borderRadius: 'var(--vg-radius-sm) var(--vg-radius-sm) 0 0',
+                  background: 'linear-gradient(90deg, var(--vg-teal), var(--vg-teal-bright))',
+                }}
+              />
+              <div className="flex-row" style={{ justifyContent: 'space-between', paddingTop: 4 }}>
+                <strong style={{ color: 'var(--vg-ink)', fontWeight: 700 }}>{p.name}</strong>
                 <SourceBadge source={p.source ?? 'yaml'} />
               </div>
-              <div className="label mt-sm">{p.description || p.id}</div>
+              <div className="vg-card__label mt-sm" style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 500 }}>
+                {p.description || p.id}
+              </div>
 
               {tags.length > 0 && (
                 <div className="flex-row flex-wrap mt-sm">
                   {tags.map((t) => (
-                    <span key={t} className="neo-badge neo-badge--black">{t}</span>
+                    <span key={t} className="neo-badge">{t}</span>
                   ))}
                 </div>
               )}
 
               <div className="mt-md">
-                <div className="label">Budget: ${spent.toFixed(2)} / ${dailyBudget.toFixed(2)}</div>
+                <div className="vg-card__label">
+                  Budget: ${spent.toFixed(2)} / ${dailyBudget.toFixed(2)}
+                </div>
                 <div className="budget-bar mt-sm">
-                  <div className="budget-bar__fill" style={{ width: `${pct}%`, background: barColor }} />
+                  <div
+                    className="budget-bar__fill"
+                    style={{ width: `${pct}%`, background: barColor }}
+                  />
                 </div>
               </div>
 
               <div className="flex-row mt-md" style={{ justifyContent: 'space-between' }}>
-                <span className="label">{s?.requests_today ?? 0} requests today</span>
-                <span className="label">{p.budget_action}</span>
+                <span className="vg-card__label">{s?.requests_today ?? 0} requests today</span>
+                <span className="neo-badge neo-badge--info">{p.budget_action}</span>
               </div>
               <div className="mt-sm">
                 <button
                   type="button"
-                  className="neo-btn neo-btn--small"
+                  className="neo-btn neo-btn--sm"
                   onClick={() => setBrandingFor(p.id)}
                 >
                   Brand
@@ -105,7 +125,9 @@ export default function Projects() {
           );
         })}
         {projects.length === 0 && (
-          <div className="neo-card"><div className="empty-state">No projects configured.</div></div>
+          <div className="vg-card">
+            <div className="empty-state">No projects configured.</div>
+          </div>
         )}
       </div>
 
@@ -154,22 +176,65 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
   return (
     <div className="neo-modal-backdrop" onClick={onClose}>
       <div className="neo-modal" onClick={(e) => e.stopPropagation()}>
-        <h3>Create Project</h3>
-        <label className="label">Name</label>
-        <input className="neo-input" value={name} onChange={(e) => { setName(e.target.value); if (!projectId) setProjectId(slug(e.target.value)); }} />
-        <label className="label mt-md">Project ID</label>
-        <input className="neo-input" value={projectId} onChange={(e) => setProjectId(e.target.value)} />
-        <label className="label mt-md">Description</label>
-        <textarea className="neo-input" rows={2} value={description} onChange={(e) => setDescription(e.target.value)} />
-        <label className="label mt-md">Daily Budget (USD)</label>
-        <input className="neo-input" type="number" min="0" step="0.5" value={dailyBudget} onChange={(e) => setDailyBudget(e.target.value)} />
-        <label className="label mt-md">Budget Action</label>
-        <select className="neo-select" value={budgetAction} onChange={(e) => setBudgetAction(e.target.value)}>
-          <option value="warn">Warn</option>
-          <option value="throttle">Throttle</option>
-          <option value="block">Block</option>
-        </select>
-        <div className="flex-row mt-lg">
+        <h3 style={{ marginBottom: 20, color: 'var(--vg-ink)' }}>Create Project</h3>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Name</label>
+            <input
+              className="neo-input"
+              value={name}
+              onChange={(e) => { setName(e.target.value); if (!projectId) setProjectId(slug(e.target.value)); }}
+              style={{ width: '100%' }}
+            />
+          </div>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Project ID</label>
+            <input
+              className="neo-input"
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              style={{ width: '100%' }}
+            />
+          </div>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Description</label>
+            <textarea
+              className="neo-input"
+              rows={2}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              style={{ width: '100%', resize: 'vertical' }}
+            />
+          </div>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Daily Budget (USD)</label>
+            <input
+              className="neo-input"
+              type="number"
+              min="0"
+              step="0.5"
+              value={dailyBudget}
+              onChange={(e) => setDailyBudget(e.target.value)}
+              style={{ width: '100%' }}
+            />
+          </div>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Budget Action</label>
+            <select
+              className="neo-select"
+              value={budgetAction}
+              onChange={(e) => setBudgetAction(e.target.value)}
+              style={{ width: '100%' }}
+            >
+              <option value="warn">Warn</option>
+              <option value="throttle">Throttle</option>
+              <option value="block">Block</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="flex-row mt-lg" style={{ justifyContent: 'flex-end' }}>
           <button className="neo-btn" onClick={onClose}>Cancel</button>
           <button className="neo-btn neo-btn--primary" onClick={save} disabled={saving || !name}>
             {saving ? 'Creating...' : 'Create Project'}
@@ -264,69 +329,100 @@ function BrandingModal({
   return (
     <div className="neo-modal-backdrop" onClick={onClose}>
       <div className="neo-modal" onClick={(e) => e.stopPropagation()} style={{ maxWidth: '32rem' }}>
-        <h3>Branding · {projectId}</h3>
-        <p className="label mt-sm">
-          Per-project white-label. Logo, accent color, and product name
-          override the default VoiceGateway brand for users scoped to
-          this project (REQ-VG-ROUTE-004).
-        </p>
-
-        <label className="label mt-md">Product name</label>
-        <input
-          className="neo-input"
-          value={productName}
-          onChange={(e) => setProductName(e.target.value)}
-          placeholder="(default: VoiceGateway)"
-          maxLength={64}
-        />
-
-        <label className="label mt-md">Accent color</label>
-        <div className="flex-row" style={{ gap: '0.5rem', alignItems: 'center' }}>
-          <input
-            type="color"
-            value={accentColor}
-            onChange={(e) => setAccentColor(e.target.value)}
-            style={{ width: 48, height: 36, border: '2px solid black', cursor: 'pointer' }}
-          />
-          <input
-            className="neo-input"
-            value={accentColor}
-            onChange={(e) => setAccentColor(e.target.value)}
-            style={{ width: '8rem', fontFamily: 'monospace' }}
-          />
+        <h3 style={{ marginBottom: 6, color: 'var(--vg-ink)' }}>Branding</h3>
+        <div style={{ fontSize: 13, color: 'var(--vg-muted)', marginBottom: 20 }}>
+          <span className="mono" style={{ color: 'var(--vg-teal-deep)' }}>{projectId}</span>
+          {' '} - per-project white-label (logo, accent color, product name).
         </div>
 
-        <label className="label mt-md">Logo</label>
-        {(logoFile || logoUrl) && (
-          <div className="mt-sm" style={{ background: '#FFF9C2', padding: '0.5rem', border: '2px solid black' }}>
-            <img
-              src={logoFile ? URL.createObjectURL(logoFile) : logoUrl}
-              alt="Logo preview"
-              style={{ maxHeight: '48px', maxWidth: '200px', display: 'block' }}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Product name</label>
+            <input
+              className="neo-input"
+              value={productName}
+              onChange={(e) => setProductName(e.target.value)}
+              placeholder="(default: VoiceGateway)"
+              maxLength={64}
+              style={{ width: '100%' }}
             />
-            <code style={{ fontSize: '0.75rem', wordBreak: 'break-all' }}>
-              {logoFile ? logoFile.name : logoUrl}
-            </code>
           </div>
-        )}
-        <input
-          type="file"
-          accept="image/png,image/svg+xml"
-          className="neo-input mt-sm"
-          onChange={(e) => setLogoFile(e.target.files?.[0] ?? null)}
-        />
-        <div className="label" style={{ fontSize: '0.7rem', opacity: 0.7 }}>
-          PNG or SVG, max 256 KB, max 512x512 px.
+
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Accent color</label>
+            <div className="flex-row" style={{ gap: '0.5rem', alignItems: 'center' }}>
+              <input
+                type="color"
+                value={accentColor}
+                onChange={(e) => setAccentColor(e.target.value)}
+                style={{
+                  width: 40, height: 36, border: '1px solid var(--vg-hairline)',
+                  borderRadius: 'var(--vg-radius-xs)', cursor: 'pointer', padding: 2,
+                }}
+              />
+              <input
+                className="neo-input"
+                value={accentColor}
+                onChange={(e) => setAccentColor(e.target.value)}
+                style={{ width: '8rem', fontFamily: 'var(--vg-font-mono)' }}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Logo</label>
+            {(logoFile || logoUrl) && (
+              <div
+                className="mt-sm"
+                style={{
+                  background: 'var(--vg-teal-tint-2)',
+                  padding: '0.5rem',
+                  border: '1px solid var(--vg-hairline)',
+                  borderRadius: 'var(--vg-radius-xs)',
+                  marginBottom: 8,
+                }}
+              >
+                <img
+                  src={logoFile ? URL.createObjectURL(logoFile) : logoUrl}
+                  alt="Logo preview"
+                  style={{ maxHeight: '48px', maxWidth: '200px', display: 'block' }}
+                />
+                <code style={{ fontSize: '0.75rem', wordBreak: 'break-all', color: 'var(--vg-muted)' }}>
+                  {logoFile ? logoFile.name : logoUrl}
+                </code>
+              </div>
+            )}
+            <input
+              type="file"
+              accept="image/png,image/svg+xml"
+              className="neo-input"
+              onChange={(e) => setLogoFile(e.target.files?.[0] ?? null)}
+              style={{ width: '100%' }}
+            />
+            <div className="vg-card__label mt-xs" style={{ fontWeight: 400 }}>
+              PNG or SVG, max 256 KB, max 512x512 px.
+            </div>
+          </div>
         </div>
 
         {error && (
-          <div className="mt-md" style={{ color: 'var(--accent-pink, #FF3D71)' }}>
+          <div
+            className="mt-md"
+            style={{
+              background: 'var(--vg-red-tint)',
+              color: 'var(--vg-red)',
+              padding: '10px 14px',
+              borderRadius: 'var(--vg-radius-xs)',
+              fontSize: 13,
+              fontWeight: 500,
+            }}
+          >
             {error}
           </div>
         )}
 
         <div className="flex-row mt-lg" style={{ justifyContent: 'space-between' }}>
-          <button className="neo-btn" onClick={reset} disabled={saving}>
+          <button className="neo-btn neo-btn--danger" onClick={reset} disabled={saving}>
             Reset
           </button>
           <div className="flex-row">
@@ -342,4 +438,3 @@ function BrandingModal({
     </div>
   );
 }
-

--- a/src/dashboard/frontend/src/pages/Providers.tsx
+++ b/src/dashboard/frontend/src/pages/Providers.tsx
@@ -145,79 +145,95 @@ export default function Providers() {
         {projects.map((p) => {
           const rows = byProject[p.id] ?? [];
           return (
-            <div key={p.id} className="neo-card neo-card--strip-pink">
-              <div className="flex-row" style={{ justifyContent: 'space-between' }}>
-                <strong>{p.name}</strong>
-                <span className="label">{rows.length} provider{rows.length === 1 ? '' : 's'}</span>
+            <div key={p.id} className="vg-card">
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0, left: 0, right: 0, height: 3,
+                  borderRadius: 'var(--vg-radius-sm) var(--vg-radius-sm) 0 0',
+                  background: 'linear-gradient(90deg, var(--vg-teal), var(--vg-teal-bright))',
+                }}
+              />
+              <div className="flex-row" style={{ justifyContent: 'space-between', paddingTop: 4 }}>
+                <strong style={{ color: 'var(--vg-ink)', fontWeight: 700 }}>{p.name}</strong>
+                <span className="neo-badge neo-badge--info">
+                  {rows.length} provider{rows.length === 1 ? '' : 's'}
+                </span>
               </div>
-              <div className="label mt-sm">{p.description || p.id}</div>
+              <div className="vg-card__label mt-sm" style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 500 }}>
+                {p.description || p.id}
+              </div>
 
               {rows.length === 0 ? (
                 <div className="empty-state mt-md">
                   No per-project keys yet. Click <strong>+ Add Provider</strong> to scope a key to this project.
                 </div>
               ) : (
-                <table className="neo-table mt-md">
-                  <thead>
-                    <tr>
-                      <th>Provider</th>
-                      <th>Key</th>
-                      <th>Source</th>
-                      <th>Status</th>
-                      <th style={{ textAlign: 'right' }}>Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {rows.map((row) => {
-                      const test = testResults[row.provider_id] ?? { kind: 'unknown' };
-                      const isDb = row.source === 'db';
-                      return (
-                        <tr key={row.provider_id}>
-                          <td className="mono">{row.provider}</td>
-                          <td className="mono">{row.api_key_masked ?? '—'}</td>
-                          <td><SourceBadge source={row.source} /></td>
-                          <td><TestDot status={test} /></td>
-                          <td style={{ textAlign: 'right' }}>
-                            <button
-                              className="neo-btn neo-btn--small"
-                              type="button"
-                              onClick={() => handleTestRow(row)}
-                              disabled={test.kind === 'testing'}
-                            >
-                              {test.kind === 'testing' ? 'Testing…' : 'Test'}
-                            </button>
-                            {' '}
-                            <button
-                              className="neo-btn neo-btn--small"
-                              type="button"
-                              onClick={() => setRotateTarget(row)}
-                              disabled={!isDb}
-                              title={isDb ? 'Rotate the api key' : 'YAML-defined keys: edit voicegw.yaml'}
-                            >
-                              Rotate
-                            </button>
-                            {' '}
-                            <button
-                              className="neo-btn neo-btn--small neo-btn--danger"
-                              type="button"
-                              onClick={() => handleDeleteRow(row)}
-                              disabled={!isDb}
-                              title={isDb ? 'Delete this key' : 'YAML-defined keys: edit voicegw.yaml'}
-                            >
-                              Delete
-                            </button>
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                <div style={{ marginTop: 16, borderRadius: 'var(--vg-radius-xs)', overflow: 'hidden', border: '1px solid var(--vg-hairline)' }}>
+                  <table className="neo-table">
+                    <thead>
+                      <tr>
+                        <th>Provider</th>
+                        <th>Key</th>
+                        <th>Source</th>
+                        <th>Status</th>
+                        <th style={{ textAlign: 'right' }}>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((row) => {
+                        const test = testResults[row.provider_id] ?? { kind: 'unknown' };
+                        const isDb = row.source === 'db';
+                        return (
+                          <tr key={row.provider_id}>
+                            <td className="mono" style={{ fontWeight: 600 }}>{row.provider}</td>
+                            <td className="mono" style={{ color: 'var(--vg-muted)', fontSize: 12 }}>
+                              {row.api_key_masked ?? '—'}
+                            </td>
+                            <td><SourceBadge source={row.source} /></td>
+                            <td><TestDot status={test} /></td>
+                            <td style={{ textAlign: 'right' }}>
+                              <div className="flex-row" style={{ justifyContent: 'flex-end', gap: 6 }}>
+                                <button
+                                  className="neo-btn neo-btn--sm"
+                                  type="button"
+                                  onClick={() => handleTestRow(row)}
+                                  disabled={test.kind === 'testing'}
+                                >
+                                  {test.kind === 'testing' ? 'Testing...' : 'Test'}
+                                </button>
+                                <button
+                                  className="neo-btn neo-btn--sm"
+                                  type="button"
+                                  onClick={() => setRotateTarget(row)}
+                                  disabled={!isDb}
+                                  title={isDb ? 'Rotate the api key' : 'YAML-defined keys: edit voicegw.yaml'}
+                                >
+                                  Rotate
+                                </button>
+                                <button
+                                  className="neo-btn neo-btn--sm neo-btn--danger"
+                                  type="button"
+                                  onClick={() => handleDeleteRow(row)}
+                                  disabled={!isDb}
+                                  title={isDb ? 'Delete this key' : 'YAML-defined keys: edit voicegw.yaml'}
+                                >
+                                  Delete
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
               )}
             </div>
           );
         })}
         {projects.length === 0 && (
-          <div className="neo-card">
+          <div className="vg-card">
             <div className="empty-state">
               No projects configured. Add a project under the Projects page first; per-project provider keys live within projects.
             </div>
@@ -242,36 +258,27 @@ export default function Providers() {
 }
 
 function TestDot({ status }: { status: RowTestStatus }) {
-  let color = '#888';
+  let badgeClass = 'neo-badge';
   let label = 'untested';
   let title = 'Click Test to verify the key';
+
   if (status.kind === 'testing') {
-    color = '#FFD166';
+    badgeClass = 'neo-badge neo-badge--warning';
     label = 'testing';
     title = 'Health check in flight';
   } else if (status.kind === 'ok') {
-    color = '#8AC926';
+    badgeClass = 'neo-badge neo-badge--online';
     label = `ok ${status.latency_ms}ms`;
     title = `Last test ok in ${status.latency_ms}ms`;
   } else if (status.kind === 'failed') {
-    color = '#FF006E';
+    badgeClass = 'neo-badge neo-badge--offline';
     label = 'failed';
     title = status.message;
   }
+
   return (
-    <span title={title} style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-      <span
-        aria-hidden="true"
-        style={{
-          display: 'inline-block',
-          width: 10,
-          height: 10,
-          borderRadius: '50%',
-          background: color,
-          border: '1px solid var(--ink, #000)',
-        }}
-      />
-      <span className="label" style={{ fontSize: 11 }}>{label}</span>
+    <span title={title} className={badgeClass}>
+      {label}
     </span>
   );
 }
@@ -312,50 +319,67 @@ function RotateProviderModal({
   return (
     <div className="neo-modal-backdrop" onClick={onClose}>
       <div className="neo-modal" onClick={(e) => e.stopPropagation()}>
-        <h3>Rotate Provider Key</h3>
-        <p className="label">
-          {row.project} / <span className="mono">{row.provider}</span>
-        </p>
-
-        <label className="label mt-md">New API Key</label>
-        <div className="flex-row" style={{ gap: '8px' }}>
-          <input
-            className="neo-input"
-            type={revealKey ? 'text' : 'password'}
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="sk-..."
-            autoComplete="off"
-            spellCheck={false}
-            disabled={saving}
-            style={{ flex: 1 }}
-          />
-          <button
-            className="neo-btn"
-            type="button"
-            onClick={() => setRevealKey((r) => !r)}
-            disabled={saving}
-          >
-            {revealKey ? 'Hide' : 'Show'}
-          </button>
+        <h3 style={{ marginBottom: 6, color: 'var(--vg-ink)' }}>Rotate Provider Key</h3>
+        <div style={{ fontSize: 13, color: 'var(--vg-muted)', marginBottom: 20 }}>
+          {row.project} / <span className="mono" style={{ color: 'var(--vg-teal-deep)' }}>{row.provider}</span>
         </div>
 
-        <label className="label mt-md">Base URL (optional)</label>
-        <input
-          className="neo-input"
-          value={baseUrl}
-          onChange={(e) => setBaseUrl(e.target.value)}
-          placeholder="https://api.openai.com/v1"
-          disabled={saving}
-        />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>New API Key</label>
+            <div className="flex-row" style={{ gap: '8px' }}>
+              <input
+                className="neo-input"
+                type={revealKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="sk-..."
+                autoComplete="off"
+                spellCheck={false}
+                disabled={saving}
+                style={{ flex: 1 }}
+              />
+              <button
+                className="neo-btn"
+                type="button"
+                onClick={() => setRevealKey((r) => !r)}
+                disabled={saving}
+              >
+                {revealKey ? 'Hide' : 'Show'}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Base URL (optional)</label>
+            <input
+              className="neo-input"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://api.openai.com/v1"
+              disabled={saving}
+              style={{ width: '100%' }}
+            />
+          </div>
+        </div>
 
         {error && (
-          <div className="empty-state mt-md" style={{ color: 'var(--accent-pink)' }}>
+          <div
+            className="mt-md"
+            style={{
+              background: 'var(--vg-red-tint)',
+              color: 'var(--vg-red)',
+              padding: '10px 14px',
+              borderRadius: 'var(--vg-radius-xs)',
+              fontSize: 13,
+              fontWeight: 500,
+            }}
+          >
             {error}
           </div>
         )}
 
-        <div className="flex-row mt-lg">
+        <div className="flex-row mt-lg" style={{ justifyContent: 'flex-end' }}>
           <button className="neo-btn" onClick={onClose} disabled={saving}>Cancel</button>
           <button
             className="neo-btn neo-btn--primary"
@@ -473,68 +497,81 @@ function AddProviderModal({
   return (
     <div className="neo-modal-backdrop" onClick={onClose}>
       <div className="neo-modal" onClick={(e) => e.stopPropagation()}>
-        <h3>Add Provider Key</h3>
+        <h3 style={{ marginBottom: 20, color: 'var(--vg-ink)' }}>Add Provider Key</h3>
 
-        <label className="label">Project</label>
-        <select
-          className="neo-select"
-          value={project}
-          onChange={(e) => setProject(e.target.value)}
-          disabled={saving}
-        >
-          {projects.length === 0 ? (
-            <option value="">No projects configured</option>
-          ) : null}
-          {projects.map((p) => (
-            <option key={p.id} value={p.id}>{p.name} ({p.id})</option>
-          ))}
-        </select>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Project</label>
+            <select
+              className="neo-select"
+              value={project}
+              onChange={(e) => setProject(e.target.value)}
+              disabled={saving}
+              style={{ width: '100%' }}
+            >
+              {projects.length === 0 ? (
+                <option value="">No projects configured</option>
+              ) : null}
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>{p.name} ({p.id})</option>
+              ))}
+            </select>
+          </div>
 
-        <label className="label mt-md">Provider</label>
-        <select
-          className="neo-select"
-          value={provider}
-          onChange={(e) => setProvider(e.target.value)}
-          disabled={saving}
-        >
-          {SUPPORTED_PROVIDERS.map((p) => (
-            <option key={p} value={p}>{p}</option>
-          ))}
-        </select>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Provider</label>
+            <select
+              className="neo-select"
+              value={provider}
+              onChange={(e) => setProvider(e.target.value)}
+              disabled={saving}
+              style={{ width: '100%' }}
+            >
+              {SUPPORTED_PROVIDERS.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          </div>
 
-        <label className="label mt-md">API Key</label>
-        <div className="flex-row" style={{ gap: '8px' }}>
-          <input
-            className="neo-input"
-            type={revealKey ? 'text' : 'password'}
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="sk-..."
-            autoComplete="off"
-            spellCheck={false}
-            disabled={saving}
-            style={{ flex: 1 }}
-          />
-          <button
-            className="neo-btn"
-            type="button"
-            onClick={() => setRevealKey((r) => !r)}
-            disabled={saving}
-          >
-            {revealKey ? 'Hide' : 'Show'}
-          </button>
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>API Key</label>
+            <div className="flex-row" style={{ gap: '8px' }}>
+              <input
+                className="neo-input"
+                type={revealKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="sk-..."
+                autoComplete="off"
+                spellCheck={false}
+                disabled={saving}
+                style={{ flex: 1 }}
+              />
+              <button
+                className="neo-btn"
+                type="button"
+                onClick={() => setRevealKey((r) => !r)}
+                disabled={saving}
+              >
+                {revealKey ? 'Hide' : 'Show'}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Base URL (optional)</label>
+            <input
+              className="neo-input"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://api.openai.com/v1"
+              disabled={saving}
+              style={{ width: '100%' }}
+            />
+          </div>
         </div>
 
-        <label className="label mt-md">Base URL (optional)</label>
-        <input
-          className="neo-input"
-          value={baseUrl}
-          onChange={(e) => setBaseUrl(e.target.value)}
-          placeholder="https://api.openai.com/v1"
-          disabled={saving}
-        />
-
-        <div className="mt-md">
+        <div className="flex-row mt-md" style={{ alignItems: 'center', gap: 12 }}>
           <button
             className="neo-btn"
             type="button"
@@ -544,24 +581,34 @@ function AddProviderModal({
             {testState.kind === 'testing' ? 'Testing...' : 'Test connection'}
           </button>
           {testState.kind === 'ok' && (
-            <span className="neo-badge neo-badge--online" style={{ marginLeft: 12 }}>
+            <span className="neo-badge neo-badge--online">
               OK ({testState.latency_ms}ms)
             </span>
           )}
           {testState.kind === 'failed' && (
-            <span className="neo-badge neo-badge--offline" style={{ marginLeft: 12 }}>
+            <span className="neo-badge neo-badge--offline">
               {testState.message}
             </span>
           )}
         </div>
 
         {error && (
-          <div className="empty-state mt-md" style={{ color: 'var(--accent-pink)' }}>
+          <div
+            className="mt-md"
+            style={{
+              background: 'var(--vg-red-tint)',
+              color: 'var(--vg-red)',
+              padding: '10px 14px',
+              borderRadius: 'var(--vg-radius-xs)',
+              fontSize: 13,
+              fontWeight: 500,
+            }}
+          >
             {error}
           </div>
         )}
 
-        <div className="flex-row mt-lg">
+        <div className="flex-row mt-lg" style={{ justifyContent: 'flex-end' }}>
           <button className="neo-btn" onClick={onClose} disabled={saving}>Cancel</button>
           <button
             className="neo-btn neo-btn--primary"

--- a/src/dashboard/frontend/src/pages/Routing.tsx
+++ b/src/dashboard/frontend/src/pages/Routing.tsx
@@ -27,7 +27,7 @@ const MODALITY_ORDER: Record<string, number> = { stt: 0, llm: 1, tts: 2 };
 const MODALITY_BADGE: Record<string, string> = {
   stt: 'neo-badge--blue',
   llm: 'neo-badge--green',
-  tts: 'neo-badge--pink',
+  tts: 'neo-badge--warning',
 };
 
 const REFRESH_INTERVAL_MS = 60 * 60 * 1000; // OQ2 lock: at least hourly.
@@ -128,17 +128,25 @@ export default function Routing() {
 
       <FilterBar showTenant={false} showAgent={false} />
 
-      <div className="neo-card mt-md">
+      <div className="vg-card mt-md" style={{ padding: 0, overflow: 'hidden' }}>
         {refreshedAt && (
-          <div className="label" style={{ marginBottom: '0.5rem' }}>
-            Last refreshed {formatRelative(refreshedAt)}. Auto-refresh every hour.
+          <div
+            className="vg-card__label"
+            style={{ padding: '12px 16px', borderBottom: '1px solid var(--vg-hairline-2)', textTransform: 'none', letterSpacing: 0 }}
+          >
+            Last refreshed {formatRelative(refreshedAt)}.{' '}
+            <span style={{ color: 'var(--vg-muted-2)' }}>Auto-refresh every hour.</span>
           </div>
         )}
 
-        {loading && !data && <div className="empty-state">Loading observations...</div>}
+        {loading && !data && (
+          <div className="empty-state" style={{ margin: 24 }}>
+            Loading observations...
+          </div>
+        )}
 
         {!loading && rows.length === 0 && (
-          <div className="empty-state">
+          <div className="empty-state" style={{ margin: 24 }}>
             No latency observations yet. The roll-up worker refreshes every 15
             minutes; once a few sessions complete the table will populate.
           </div>
@@ -181,27 +189,33 @@ export default function Routing() {
                   <td>
                     <span
                       className={`neo-badge ${
-                        MODALITY_BADGE[row.modality] ?? 'neo-badge--black'
+                        MODALITY_BADGE[row.modality] ?? 'neo-badge--info'
                       }`}
                     >
                       {row.modality}
                     </span>
                   </td>
-                  <td className="mono">{row.provider}</td>
+                  <td className="mono" style={{ fontWeight: 600 }}>{row.provider}</td>
                   <td className="mono" style={{ textAlign: 'right' }}>
                     {row.p50_ms === null ? (
-                      <span className="label">no observations yet</span>
+                      <span className="vg-card__label">no data</span>
                     ) : (
                       row.p50_ms
                     )}
                   </td>
                   <td className="mono" style={{ textAlign: 'right' }}>
-                    {row.p95_ms === null ? '-' : row.p95_ms}
+                    {row.p95_ms === null ? (
+                      <span className="vg-card__label">-</span>
+                    ) : (
+                      row.p95_ms
+                    )}
                   </td>
                   <td className="mono" style={{ textAlign: 'right' }}>
                     {row.sample_count}
                   </td>
-                  <td>{row.project_id}</td>
+                  <td style={{ color: 'var(--vg-muted)', fontSize: 13 }}>
+                    {row.project_id}
+                  </td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Pages changed

- **Agents.tsx** - search bar moved into a `vg-card` toolbar; agent table wrapped in `vg-card` with `neo-table` shared styles; status/count badges use `neo-badge` token palette.
- **Models.tsx** - table wrapped in `vg-card` (padding 0, overflow hidden); modality badge switched from `neo-badge--black` to default teal badge; provider badge uses `neo-badge--blue`; status badge uses `neo-badge--online/offline`.
- **Projects.tsx** - project cards converted from `neo-card--strip-orange` to `vg-card` with inline teal gradient top strip using `--vg-teal` tokens; budget bar colours use `--vg-red/amber/green`; CreateProject + Branding modals use `neo-modal` with `vg-card__label` form labels, `neo-input`/`neo-select`, teal focus rings; error states use `--vg-red-tint` surface.
- **Providers.tsx** - project cards converted to `vg-card` with teal top strip; embedded per-project table wrapped in bordered container; `TestDot` component converted from inline colour dots to `neo-badge` tokens (untested/testing/ok/failed); AddProvider + RotateProvider modals use `neo-modal` with shared form classes; error states use `--vg-red-tint`.
- **Routing.tsx** - observations table wrapped in `vg-card` (padding 0); refresh-at header row uses `vg-card__label`; modality badges mapped to `neo-badge--blue/green/warning`; provider column bold; empty/loading states use `empty-state` within card.

## Build result

```
✓ tsc -b passed (no type errors)
✓ vite build succeeded in 2.07s
dist/assets/index-CI00yT_X.js  656 kB gzip 184 kB
```

## Functionality preserved

All CRUD operations, API calls, sorting, filtering, modals, form validation, and conditional rendering are unchanged. Only class names and inline styles were updated to use the shared `--vg-*` token system.