### PR TITLE
feat(dashboard): final pages + logo fix + polish (D4)

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -181,16 +181,7 @@ function Sidebar({
                 display: 'grid', placeItems: 'center',
               }}
             />
-            <img
-              src="/static/branding/wordings.svg"
-              alt="VoiceGateway"
-              className="sidebar__wordmark sidebar__wordmark--light"
-            />
-            <img
-              src="/static/branding/wordings-dark.svg"
-              alt="VoiceGateway"
-              className="sidebar__wordmark sidebar__wordmark--dark"
-            />
+            <span className="sidebar__brandname">VoiceGateway</span>
           </div>
         )}
         <button

--- a/src/dashboard/frontend/src/index.css
+++ b/src/dashboard/frontend/src/index.css
@@ -944,6 +944,12 @@ a:hover { color: var(--vg-teal-deep); }
 .info-table td { padding: 9px 0; border-bottom: 1px solid var(--vg-hairline-2); }
 .info-table td:first-child { width: 180px; font-weight: 600; color: var(--vg-muted); }
 
+/* Filter bar (settings audit-log and similar filter rows) */
+.filter-bar {
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 16px; flex-wrap: wrap;
+}
+
 /* ============================================================
    Segmented time-range control (D1: cloud tokens)
    ============================================================ */

--- a/src/dashboard/frontend/src/pages/ApiKeys.tsx
+++ b/src/dashboard/frontend/src/pages/ApiKeys.tsx
@@ -134,11 +134,11 @@ export default function ApiKeys() {
                       {revoked ? (
                         <span className="neo-badge neo-badge--black">revoked</span>
                       ) : stale ? (
-                        <span className="neo-badge" style={{ background: '#FFD166' }}>
+                        <span className="neo-badge neo-badge--warning">
                           stale
                         </span>
                       ) : (
-                        <span className="neo-badge" style={{ background: 'var(--accent-green)' }}>
+                        <span className="neo-badge neo-badge--green">
                           active
                         </span>
                       )}
@@ -302,9 +302,9 @@ function ShowKeyOnceModal({
         </p>
         <div
           className="neo-card mt-md"
-          style={{ background: '#FFF9C2', padding: '1rem' }}
+          style={{ background: 'var(--vg-amber-tint)', padding: '1rem', border: '1px solid var(--vg-hairline)' }}
         >
-          <code style={{ wordBreak: 'break-all', fontSize: '0.95rem' }}>
+          <code style={{ wordBreak: 'break-all', fontSize: '0.95rem', fontFamily: 'var(--vg-font-mono)', color: 'var(--vg-ink)' }}>
             {response.plaintext}
           </code>
         </div>

--- a/src/dashboard/frontend/src/pages/Login.tsx
+++ b/src/dashboard/frontend/src/pages/Login.tsx
@@ -45,14 +45,48 @@ export default function Login({ onAuthed }: { onAuthed: () => void }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        background: 'linear-gradient(160deg, var(--vg-teal-tint-2) 0%, var(--vg-paper) 60%)',
+        padding: '24px',
       }}
     >
-      <div className="neo-card" style={{ maxWidth: 420, width: '100%' }}>
-        <h3>VoiceGateway</h3>
-        <p className="label mt-sm">
+      <div
+        className="neo-card"
+        style={{
+          maxWidth: 420,
+          width: '100%',
+          padding: '32px',
+          boxShadow: 'var(--vg-shadow-lg)',
+        }}
+      >
+        {/* Brand mark + wordmark */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 }}>
+          <span
+            aria-hidden="true"
+            style={{
+              width: 32, height: 32, borderRadius: 10, flexShrink: 0,
+              background: 'linear-gradient(135deg, var(--vg-teal-bright), var(--vg-teal-deep))',
+              boxShadow: '0 2px 8px -2px rgba(21,120,138,0.5), inset 0 1px 0 rgba(255,255,255,0.25)',
+              display: 'grid', placeItems: 'center',
+            }}
+          />
+          <span
+            style={{
+              fontWeight: 800,
+              fontSize: 18,
+              letterSpacing: '-0.4px',
+              color: 'var(--vg-ink)',
+            }}
+          >
+            VoiceGateway
+          </span>
+        </div>
+
+        <h3 style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}>Sign in</h3>
+        <p className="label mt-sm" style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, fontSize: 13, color: 'var(--vg-muted)' }}>
           This gateway requires an API token. Paste yours below to continue.
         </p>
-        <label className="label mt-md">API token</label>
+
+        <label className="label mt-md" style={{ display: 'block', marginBottom: 6 }}>API token</label>
         <input
           className="neo-input"
           type="password"
@@ -69,8 +103,8 @@ export default function Login({ onAuthed }: { onAuthed: () => void }) {
         />
         {error && (
           <div
-            className="label mt-sm"
-            style={{ color: 'var(--accent-pink, #e11)' }}
+            className="mt-sm"
+            style={{ color: 'var(--vg-red)', fontSize: 13, fontWeight: 500 }}
           >
             {error}
           </div>
@@ -81,14 +115,15 @@ export default function Login({ onAuthed }: { onAuthed: () => void }) {
         >
           <button
             className="neo-btn neo-btn--primary"
+            style={{ width: '100%', justifyContent: 'center', padding: '11px 16px' }}
             onClick={save}
             disabled={busy || !token.trim()}
           >
             {busy ? 'Checking…' : 'Sign in'}
           </button>
         </div>
-        <p className="label mt-md" style={{ opacity: 0.7 }}>
-          The token is stored in your browser (localStorage). It's never sent
+        <p className="label mt-md" style={{ textTransform: 'none', letterSpacing: 0, fontWeight: 400, fontSize: 12, color: 'var(--vg-muted-2)', opacity: 0.85 }}>
+          The token is stored in your browser (localStorage) and is never sent
           to third parties.
         </p>
       </div>

--- a/src/dashboard/frontend/src/pages/Settings.tsx
+++ b/src/dashboard/frontend/src/pages/Settings.tsx
@@ -126,7 +126,7 @@ function GeneralTab() {
 
   return (
     <div className="mt-lg">
-      <div className="neo-card neo-card--strip-pink">
+      <div className="neo-card">
         <div className="label">Gateway Info</div>
         <table className="info-table mt-md">
           <tbody>


### PR DESCRIPTION
## Pages changed

- **Login.tsx**: Centered card on teal-tint gradient background. Added brand-mark + wordmark header inside the card. Full-width sign-in button. Error text now uses `var(--vg-red)` token instead of `var(--accent-pink, #e11)`.
- **ApiKeys.tsx**: Stale badge switched to `neo-badge--warning` (amber tokens), active badge to `neo-badge--green`. Key-reveal card background changed from hardcoded `#FFF9C2` to `var(--vg-amber-tint)` with mono font from system token.
- **Settings.tsx**: Removed `neo-card--strip-pink` from GeneralTab (old pre-D1 class). Audit-log filter row now uses CSS `.filter-bar` class.

## Logo fix (App.tsx)

The default (non-white-label) sidebar branch was rendering two `<img>` tags pointing at `/static/branding/wordings.svg` and `/static/branding/wordings-dark.svg` — files that do not exist, producing broken-image icons. Fixed by replacing both `<img>` tags with `<span className="sidebar__brandname">VoiceGateway</span>`. The teal brand-mark square is retained. The `logo_url` `<img>` in the white-label branch is unaffected and remains guarded by `branding?.logo_url &&`.

## index.css

Added `.filter-bar` utility class (flex row, gap, wrap) used by the Settings audit-log filter bar.

## Build result

```
tsc -b && vite build
✓ 880 modules transformed.
✓ built in 1.08s
```

TypeScript compiled clean (no errors). No functionality removed.