### PR TITLE
feat(billing): persist rate-card overrides in a DB store, editable via CLI

### DIFF
--- a/alembic/versions/e1a4c8b6f2d9_managed_rate_rules.py
+++ b/alembic/versions/e1a4c8b6f2d9_managed_rate_rules.py
@@ -1,0 +1,69 @@
+"""create managed_rate_rules table (DB rate-card overrides)
+
+Revision ID: e1a4c8b6f2d9
+Revises: c7d2a9f1e6b4
+Create Date: 2026-07-11 12:00:00.000000
+
+Persisted rate-card overrides layered on the YAML ``rate_card:`` seed. One row
+per scope: ``rule_id`` is a deterministic key from (tenant, plan, modality,
+provider, model), so setting the same scope again updates the row in place.
+The gateway merges these after the seed rules when building the effective
+RateCard.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401 - migrations may reference SQLModel types
+
+from alembic import op
+
+revision: str = "e1a4c8b6f2d9"
+down_revision: str | None = "c7d2a9f1e6b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "managed_rate_rules",
+        sa.Column("rule_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column(
+            "modality",
+            sqlmodel.sql.sqltypes.AutoString(),
+            server_default="*",
+            nullable=False,
+        ),
+        sa.Column(
+            "provider",
+            sqlmodel.sql.sqltypes.AutoString(),
+            server_default="*",
+            nullable=False,
+        ),
+        sa.Column(
+            "model",
+            sqlmodel.sql.sqltypes.AutoString(),
+            server_default="*",
+            nullable=False,
+        ),
+        sa.Column("tenant", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("plan", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column(
+            "kind",
+            sqlmodel.sql.sqltypes.AutoString(),
+            server_default="cost_plus",
+            nullable=False,
+        ),
+        sa.Column("markup", sa.Float(), nullable=True),
+        sa.Column("unit_price_usd", sa.Float(), nullable=True),
+        sa.Column("unit", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("created_at", sa.Float(), nullable=False),
+        sa.Column("updated_at", sa.Float(), nullable=False),
+        sa.PrimaryKeyConstraint("rule_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("managed_rate_rules")

--- a/docs/architecture/rating.md
+++ b/docs/architecture/rating.md
@@ -39,7 +39,7 @@ The `rate_rule` token is human-readable and self-documenting: `cost_plus:1.3` (r
 
 ## Where rating runs
 
-Rating runs server-side, in the gateway's cost-tracking middleware, when you run `voicegw serve`. The active card is loaded from `rate_card:` and applied as each request row is written. If rating ever fails, it falls back to a cost pass-through so the row is still recorded with a billable price.
+Rating runs server-side, in the gateway's cost-tracking middleware, when you run `voicegw serve`. The active card is the `rate_card:` seed plus any DB overrides, merged at startup and on every config refresh, and applied as each request row is written. If rating ever fails, it falls back to a cost pass-through so the row is still recorded with a billable price.
 
 The agent-side `attach()` path stays a cost pass-through by design. Margins are a server-side concern: an agent process records raw cost, and the server (or a hosted cloud that rates on ingest) applies the card. The rating logic lives in the pure `voicegateway.billing` module, so a hosted cloud can import it and rate on ingest without pulling in the rest of the gateway.
 
@@ -52,10 +52,10 @@ A self-hosted collector re-rates fleet rows on ingest. Rows pushed to `POST /v1/
 Once every row carries `rated_price_usd`, two surfaces read it:
 
 - **Billing API.** `GET /v1/billing/usage` rolls rated revenue, recorded cost, and margin up per tenant for a window; passing `tenant` adds per-(modality, model) line items for invoice detail. `GET /v1/billing/rate-card` returns the card in effect. See the [HTTP API reference](/api/http-api).
-- **`voicegw prices` commands.** `voicegw prices ls` prints the card, `voicegw prices reconcile` flags tenants with thin or negative margins over a window, and `voicegw prices sync` checks fixed rules against the current base cost. See [voicegw prices](/cli/prices).
+- **`voicegw prices` commands.** `voicegw prices ls` prints the effective card, `voicegw prices reconcile` flags tenants with thin or negative margins over a window, `voicegw prices sync` checks fixed rules against the current base cost, and `voicegw prices set` / `rm` edit the DB overrides. See [voicegw prices](/cli/prices).
 
 <Note>
-Rate-card editing at runtime (a PUT on `/v1/billing/rate-card`, and `voicegw prices set`) is a planned follow-up tied to a DB override store that has not shipped yet. Today the card is the YAML seed; edit `voicegw.yaml` and reload to change rates.
+The rate card is one store with two surfaces: the `rate_card:` seed in `voicegw.yaml` plus DB overrides. `voicegw prices set` / `rm` edit the DB overrides (one rule per scope, keyed by `tenant|plan|modality|provider|model`), and a DB override wins a specificity tie against the seed rule it shadows. A PUT on `/v1/billing/rate-card` and a dashboard editor over the same store are follow-ups.
 </Note>
 
 ## Where to find each piece

--- a/docs/cli/prices.md
+++ b/docs/cli/prices.md
@@ -9,7 +9,7 @@ Inspect and reconcile the billing rate card that turns recorded provider cost in
 
 ## Synopsis
 
-`voicegw prices` is the command group for VoiceGateway's rating layer. The rate card in `voicegw.yaml` maps recorded cost to a billable price and stamps that price immutably onto every request row (`rated_price_usd` + `rate_rule`). These subcommands read that card: `ls` prints it, `reconcile` rolls up rated revenue against recorded cost per tenant, and `sync` checks fixed-price rules against the current base cost. The full model (cost-plus vs fixed, tenant->plan->global resolution, write-time immutability) lives at [Rating](/architecture/rating).
+`voicegw prices` is the command group for VoiceGateway's rating layer. The rate card maps recorded cost to a billable price and stamps that price immutably onto every request row (`rated_price_usd` + `rate_rule`). The card has two layers: the `rate_card:` seed in `voicegw.yaml` plus DB overrides you set at runtime with `set` (one store, both surfaces). `ls` prints the effective card (seed + overrides), `reconcile` rolls up rated revenue against recorded cost per tenant, `sync` checks fixed-price rules against the current base cost, and `set` / `rm` edit the DB overrides. The full model (cost-plus vs fixed, tenant->plan->global resolution, write-time immutability) lives at [Rating](/architecture/rating).
 
 ## Usage
 
@@ -17,6 +17,8 @@ Inspect and reconcile the billing rate card that turns recorded provider cost in
 voicegw prices ls [-c PATH]
 voicegw prices reconcile [-c PATH] [--period today|week|month] [--start YYYY-MM-DD] [--end YYYY-MM-DD] [--threshold FLOAT]
 voicegw prices sync [-c PATH] [--threshold FLOAT]
+voicegw prices set [-c PATH] [--modality M] [--provider P] [--model M] [--tenant T] [--plan PL] (--markup FLOAT | --fixed FLOAT --unit U)
+voicegw prices rm  [-c PATH] [--modality M] [--provider P] [--model M] [--tenant T] [--plan PL]
 ```
 
 ## `voicegw prices ls`
@@ -92,6 +94,44 @@ voicegw prices sync
 voicegw prices sync --threshold 25
 ```
 
+## `voicegw prices set`
+
+Upsert a DB rate-card override for a scope. Overrides layer on top of the `rate_card:` seed in `voicegw.yaml`, and a DB override wins a tie against a seed rule at the same scope. One rule per scope: setting the same scope again updates it in place (the scope is `tenant|plan|modality|provider|model`). Requires cost tracking enabled. A rule is either cost-plus (`--markup`) or fixed (`--fixed` + `--unit`), never both.
+
+### Options
+
+| Flag | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--config` | `-c` | `string` | `null` | Path to `voicegw.yaml`. Auto-discovered if omitted. |
+| `--modality` | | `string` | `*` | Scope: `stt`, `llm`, `tts`, or `*`. |
+| `--provider` | | `string` | `*` | Provider scope, or `*`. |
+| `--model` | | `string` | `*` | Model scope (bare or `provider/model`), or `*`. |
+| `--tenant` | | `string` | `null` | Tenant scope. |
+| `--plan` | | `string` | `null` | Plan scope. |
+| `--markup` | | `float` | `null` | Cost-plus markup (e.g. `1.3`). Mutually exclusive with `--fixed`. |
+| `--fixed` | | `float` | `null` | Fixed price per unit. Requires `--unit`. |
+| `--unit` | | `string` | `null` | Unit for a fixed rule: `minute`, `second`, `char`, `1k_char`, `token`, `1k_token`, `1m_token`, or `request`. |
+
+### Example
+
+```bash
+# A thinner markup for one tenant
+voicegw prices set --tenant acme --provider deepgram --markup 1.1
+
+# An advertised fixed price for a specific model
+voicegw prices set --modality tts --provider cartesia --model sonic --fixed 0.00005 --unit char
+```
+
+## `voicegw prices rm`
+
+Remove the DB override for a scope, using the same scope flags as `set`. Exits non-zero if there is no override at that scope.
+
+### Example
+
+```bash
+voicegw prices rm --tenant acme --provider deepgram
+```
+
 ## Examples
 
 ### Print the card, then check margins for last month
@@ -113,9 +153,10 @@ voicegw prices sync --threshold 20
 |---|---|
 | `0` | Success. |
 | `1` | Config could not be loaded, or (for `reconcile`) cost tracking is not enabled. |
+| `2` | Bad input: an invalid rule (`set` with both `--markup` and `--fixed`, a fixed rule missing a valid `--unit`, or neither), or `rm` for a scope with no override. |
 
 <Note>
-Editing the rate card at runtime (`voicegw prices set`) is a planned follow-up, tracked with the DB override store. Today the card is the YAML seed in `voicegw.yaml`; edit the file and reload the gateway to change rates.
+The gateway rebuilds the effective card (seed plus DB overrides) on startup and on config refresh, so a running server picks up `set` / `rm` changes the next time its config refreshes. Editing the rate card from the dashboard is a follow-up on top of the same DB store.
 </Note>
 
 ## Related

--- a/src/voicegateway/billing/rate_card.py
+++ b/src/voicegateway/billing/rate_card.py
@@ -128,6 +128,25 @@ def _fmt(value: float | None) -> str:
     return f"{value:g}"
 
 
+def rate_rule_from_row(row: dict) -> RateRule:
+    """Build a :class:`RateRule` from a managed_rate_rules DB row dict.
+
+    The DB row's fields map 1:1 to :class:`RateRule`, so this is a direct lift
+    (used when merging DB overrides onto the YAML seed).
+    """
+    return RateRule(
+        modality=row.get("modality", WILDCARD),
+        provider=row.get("provider", WILDCARD),
+        model=row.get("model", WILDCARD),
+        tenant=row.get("tenant"),
+        plan=row.get("plan"),
+        kind=row.get("kind", "cost_plus"),
+        markup=row.get("markup"),
+        unit_price_usd=row.get("unit_price_usd"),
+        unit=row.get("unit"),
+    )
+
+
 @dataclass
 class RateCard:
     """An ordered list of rules plus a global default markup fallback."""
@@ -195,6 +214,17 @@ class RateCard:
             markup=markup,
         )
 
+    def with_overrides(self, rows: list[dict]) -> RateCard:
+        """Return a new card with DB override rules appended after the seed.
+
+        Overrides go last so a DB rule wins a specificity tie against a seed
+        rule at the same scope (matching :meth:`resolve`'s later-wins rule).
+        """
+        return RateCard(
+            rules=[*self.rules, *(rate_rule_from_row(r) for r in rows)],
+            default_markup=self.default_markup,
+        )
+
     def resolve(
         self,
         *,
@@ -227,4 +257,10 @@ class RateCard:
         return best
 
 
-__all__ = ["WILDCARD", "VALID_UNITS", "RateRule", "RateCard"]
+__all__ = [
+    "WILDCARD",
+    "VALID_UNITS",
+    "RateRule",
+    "RateCard",
+    "rate_rule_from_row",
+]

--- a/src/voicegateway/cli/prices_cli.py
+++ b/src/voicegateway/cli/prices_cli.py
@@ -19,6 +19,7 @@ from voicegateway.billing.reconcile import margin_reconcile, sync_fixed_rules
 from voicegateway.cli._app import app, console
 from voicegateway.cli.base_cli import BaseCli
 from voicegateway.inference.pricing import catalog
+from voicegateway.repository.managed_rate_rule_repository import scope_key
 from voicegateway.utils.cli._shared import _parse_iso_date_arg
 
 _cli = BaseCli()
@@ -32,8 +33,13 @@ app.add_typer(prices_app, name="prices")
 
 
 def _load_card(config: str | None) -> RateCard:
+    """The effective card: YAML seed rules plus DB overrides."""
     gw = _cli.require_gateway(config)
-    return RateCard.from_config(gw.config.rate_card)
+    seed = RateCard.from_config(gw.config.rate_card)
+    if gw.storage is not None:
+        rows = _cli.async_run(gw.storage.list_rate_rules())
+        return seed.with_overrides(rows)
+    return seed
 
 
 @prices_app.command("ls")
@@ -175,3 +181,74 @@ def sync_cmd(
             _mark(ln.flag),
         )
     console.print(table)
+
+
+@prices_app.command("set")
+def set_cmd(
+    config: str | None = typer.Option(
+        None, "--config", "-c", help="Path to voicegw.yaml."
+    ),
+    modality: str = typer.Option("*", "--modality", help="stt | llm | tts | * scope."),
+    provider: str = typer.Option("*", "--provider", help="Provider scope, or *."),
+    model: str = typer.Option(
+        "*", "--model", help="Model scope (bare or provider/model), or *."
+    ),
+    tenant: str | None = typer.Option(None, "--tenant", help="Tenant scope."),
+    plan: str | None = typer.Option(None, "--plan", help="Plan scope."),
+    markup: float | None = typer.Option(
+        None,
+        "--markup",
+        help="Cost-plus markup, e.g. 1.3 (mutually exclusive with --fixed).",
+    ),
+    fixed: float | None = typer.Option(
+        None, "--fixed", help="Fixed price per unit (requires --unit)."
+    ),
+    unit: str | None = typer.Option(
+        None,
+        "--unit",
+        help="Unit for a fixed rule: minute | second | char | 1k_char | token | 1k_token | 1m_token | request.",
+    ),
+) -> None:
+    """Upsert a DB rate-card override for a scope (one rule per scope)."""
+    gw = _cli.require_gateway(config)
+    storage = _cli.require_storage(gw)
+    try:
+        rid = _cli.async_run(
+            storage.upsert_rate_rule(
+                modality=modality,
+                provider=provider,
+                model=model,
+                tenant=tenant,
+                plan=plan,
+                markup=markup,
+                fixed=fixed,
+                unit=unit,
+            )
+        )
+    except ValueError as exc:
+        _cli.fail(str(exc), code=2)
+    console.print(f"[green]set[/green] rule [bold]{rid}[/bold]")
+
+
+@prices_app.command("rm")
+def rm_cmd(
+    config: str | None = typer.Option(
+        None, "--config", "-c", help="Path to voicegw.yaml."
+    ),
+    modality: str = typer.Option("*", "--modality", help="stt | llm | tts | * scope."),
+    provider: str = typer.Option("*", "--provider", help="Provider scope, or *."),
+    model: str = typer.Option("*", "--model", help="Model scope, or *."),
+    tenant: str | None = typer.Option(None, "--tenant", help="Tenant scope."),
+    plan: str | None = typer.Option(None, "--plan", help="Plan scope."),
+) -> None:
+    """Remove the DB rate-card override for a scope (same flags as ``set``)."""
+    gw = _cli.require_gateway(config)
+    storage = _cli.require_storage(gw)
+    rid = scope_key(
+        modality=modality, provider=provider, model=model, tenant=tenant, plan=plan
+    )
+    removed = _cli.async_run(storage.delete_rate_rule(rid))
+    if removed:
+        console.print(f"[green]removed[/green] rule [bold]{rid}[/bold]")
+    else:
+        _cli.fail(f"no DB override for scope {rid!r}", code=2)

--- a/src/voicegateway/core/gateway.py
+++ b/src/voicegateway/core/gateway.py
@@ -76,7 +76,12 @@ class Gateway:
             LocalSqliteSink(self._storage) if self._storage is not None else None
         )
         self._cost_tracker = CostTracker(cost_sink)
-        self._cost_tracker.set_rate_card(RateCard.from_config(self._config.rate_card))
+        db_rate_rules = (
+            _run_async(self._storage.list_rate_rules())
+            if self._storage is not None
+            else []
+        )
+        self._cost_tracker.set_rate_card(self._effective_rate_card(db_rate_rules))
         self._latency_monitor = LatencyMonitor(
             ttfb_warning_ms=self._config.latency.get("ttfb_warning_ms", 500.0)
         )
@@ -104,12 +109,23 @@ class Gateway:
         """Return the cost tracker."""
         return self._cost_tracker
 
+    def _effective_rate_card(self, db_rows: list[dict[str, Any]]) -> RateCard:
+        """Build the rate card in effect: YAML seed rules + DB overrides.
+
+        DB rows are appended after the seed rules so a DB override wins a
+        specificity tie against a seed rule at the same scope.
+        """
+        return RateCard.from_config(self._config.rate_card).with_overrides(db_rows)
+
     async def refresh_config(self) -> None:
         """Reload config from YAML + SQLite. Called after any managed_* write."""
         self._config = await self._config_manager.refresh()
         self._budget_enforcer = BudgetEnforcer(self._config, self._storage)
         self._cost_tracker.set_budget_enforcer(self._budget_enforcer)
-        self._cost_tracker.set_rate_card(RateCard.from_config(self._config.rate_card))
+        db_rate_rules = (
+            await self._storage.list_rate_rules() if self._storage is not None else []
+        )
+        self._cost_tracker.set_rate_card(self._effective_rate_card(db_rate_rules))
 
     def costs(self, period: str = "today", project: str | None = None) -> dict:
         """Return cost summary for the given period, optionally filtered by project."""

--- a/src/voicegateway/models/__init__.py
+++ b/src/voicegateway/models/__init__.py
@@ -16,6 +16,7 @@ from voicegateway.models.latency_observation_model import LatencyObservation
 from voicegateway.models.managed_model_model import ManagedModel
 from voicegateway.models.managed_project_model import ManagedProject
 from voicegateway.models.managed_provider_model import ManagedProvider
+from voicegateway.models.managed_rate_rule_model import ManagedRateRule
 from voicegateway.models.replay_event_model import (
     ReplayLlmToken,
     ReplayStateSnapshot,
@@ -38,6 +39,7 @@ __all__ = [
     "ManagedModel",
     "ManagedProject",
     "ManagedProvider",
+    "ManagedRateRule",
     "ReplayLlmToken",
     "ReplaySttEvent",
     "ReplayStateSnapshot",

--- a/src/voicegateway/models/managed_rate_rule_model.py
+++ b/src/voicegateway/models/managed_rate_rule_model.py
@@ -1,0 +1,38 @@
+"""ORM model for the ``managed_rate_rules`` table.
+
+DB-side rate-card overrides layered on top of the YAML ``rate_card:`` seed.
+One row per scope: the primary key ``rule_id`` is a deterministic key built
+from (tenant, plan, modality, provider, model), so ``prices set`` for the same
+scope updates the existing row rather than accumulating duplicates.
+
+The gateway merges these rows after the seed rules when building the effective
+:class:`voicegateway.billing.rate_card.RateCard`, so a DB override wins a
+specificity tie against a seed rule at the same scope.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sqlmodel import Field, SQLModel
+
+
+class ManagedRateRule(SQLModel, table=True):
+    """A persisted rate-card rule (DB override)."""
+
+    __tablename__: ClassVar[str] = "managed_rate_rules"
+
+    rule_id: str = Field(primary_key=True)
+    modality: str = Field(default="*", sa_column_kwargs={"server_default": "*"})
+    provider: str = Field(default="*", sa_column_kwargs={"server_default": "*"})
+    model: str = Field(default="*", sa_column_kwargs={"server_default": "*"})
+    tenant: str | None = None
+    plan: str | None = None
+    kind: str = Field(
+        default="cost_plus", sa_column_kwargs={"server_default": "cost_plus"}
+    )
+    markup: float | None = None
+    unit_price_usd: float | None = None
+    unit: str | None = None
+    created_at: float
+    updated_at: float

--- a/src/voicegateway/repository/managed_rate_rule_repository.py
+++ b/src/voicegateway/repository/managed_rate_rule_repository.py
@@ -1,0 +1,168 @@
+"""Async repo for the managed_rate_rules table (DB rate-card overrides).
+
+One row per scope. ``rule_id`` is a deterministic key from
+(tenant, plan, modality, provider, model), so an upsert for the same scope
+replaces the existing rule rather than accumulating duplicates. The UPSERT is
+a ``text()`` clause with ``ON CONFLICT(rule_id) DO UPDATE`` (portable across
+SQLite and Postgres).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import text
+from sqlmodel import delete, select
+
+from voicegateway.billing.rate_card import VALID_UNITS, WILDCARD
+from voicegateway.models.managed_rate_rule_model import ManagedRateRule
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def scope_key(
+    *,
+    modality: str,
+    provider: str,
+    model: str,
+    tenant: str | None,
+    plan: str | None,
+) -> str:
+    """Deterministic primary key for a rule's scope (one row per scope)."""
+    return "|".join(
+        [
+            tenant or WILDCARD,
+            plan or WILDCARD,
+            modality,
+            provider,
+            model,
+        ]
+    )
+
+
+def validate_rule(
+    *,
+    markup: float | None,
+    fixed: float | None,
+    unit: str | None,
+) -> str:
+    """Validate a rule's pricing fields and return its kind.
+
+    Exactly one of ``markup`` (cost_plus) or ``fixed`` (fixed $/unit) must be
+    set. A fixed rule needs a valid ``unit``. Raises ``ValueError`` otherwise.
+    """
+    if markup is not None and fixed is not None:
+        raise ValueError("a rate rule sets either markup or fixed, not both")
+    if fixed is not None:
+        if unit not in VALID_UNITS:
+            raise ValueError(
+                f"a fixed rule needs a valid unit (one of {sorted(VALID_UNITS)})"
+            )
+        return "fixed"
+    if markup is not None:
+        if markup <= 0:
+            raise ValueError("markup must be > 0")
+        return "cost_plus"
+    raise ValueError("a rate rule needs either markup or fixed")
+
+
+_RULE_UPSERT = text(
+    """
+    INSERT INTO managed_rate_rules (
+        rule_id, modality, provider, model, tenant, plan,
+        kind, markup, unit_price_usd, unit, created_at, updated_at
+    ) VALUES (
+        :rule_id, :modality, :provider, :model, :tenant, :plan,
+        :kind, :markup, :unit_price_usd, :unit, :now, :now
+    )
+    ON CONFLICT(rule_id) DO UPDATE SET
+        kind=excluded.kind,
+        markup=excluded.markup,
+        unit_price_usd=excluded.unit_price_usd,
+        unit=excluded.unit,
+        updated_at=excluded.updated_at
+    """
+)
+
+
+def _row_to_dict(r: ManagedRateRule) -> dict[str, Any]:
+    """Row shaped like a RateRule (fields map 1:1)."""
+    return {
+        "rule_id": r.rule_id,
+        "modality": r.modality,
+        "provider": r.provider,
+        "model": r.model,
+        "tenant": r.tenant,
+        "plan": r.plan,
+        "kind": r.kind,
+        "markup": r.markup,
+        "unit_price_usd": r.unit_price_usd,
+        "unit": r.unit,
+        "created_at": r.created_at,
+        "updated_at": r.updated_at,
+    }
+
+
+async def list_rules(session: AsyncSession) -> list[dict[str, Any]]:
+    """Return every managed_rate_rules row, oldest first."""
+    result = await session.execute(
+        select(ManagedRateRule).order_by(ManagedRateRule.created_at.asc())  # type: ignore[attr-defined]
+    )
+    return [_row_to_dict(r) for r in result.scalars().all()]
+
+
+async def upsert_rule(
+    session: AsyncSession,
+    *,
+    modality: str = WILDCARD,
+    provider: str = WILDCARD,
+    model: str = WILDCARD,
+    tenant: str | None = None,
+    plan: str | None = None,
+    markup: float | None = None,
+    fixed: float | None = None,
+    unit: str | None = None,
+) -> str:
+    """Insert or update one rule (keyed by scope). Returns the ``rule_id``."""
+    kind = validate_rule(markup=markup, fixed=fixed, unit=unit)
+    rid = scope_key(
+        modality=modality, provider=provider, model=model, tenant=tenant, plan=plan
+    )
+    await session.execute(
+        _RULE_UPSERT,
+        {
+            "rule_id": rid,
+            "modality": modality,
+            "provider": provider,
+            "model": model,
+            "tenant": tenant,
+            "plan": plan,
+            "kind": kind,
+            "markup": markup if kind == "cost_plus" else None,
+            "unit_price_usd": fixed if kind == "fixed" else None,
+            "unit": unit if kind == "fixed" else None,
+            "now": time.time(),
+        },
+    )
+    await session.commit()
+    return rid
+
+
+async def delete_rule(session: AsyncSession, rule_id: str) -> bool:
+    """Delete one rule by ``rule_id``. True when a row was removed."""
+    result = await session.execute(
+        delete(ManagedRateRule).where(ManagedRateRule.rule_id == rule_id)  # type: ignore[arg-type]
+    )
+    await session.commit()
+    return (result.rowcount or 0) > 0  # type: ignore[attr-defined]
+
+
+__all__ = [
+    "delete_rule",
+    "list_rules",
+    "scope_key",
+    "upsert_rule",
+    "validate_rule",
+]

--- a/src/voicegateway/services/managed_config_service.py
+++ b/src/voicegateway/services/managed_config_service.py
@@ -13,6 +13,9 @@ from voicegateway.repository import (
 from voicegateway.repository import (
     managed_provider_repository as provider_repo,
 )
+from voicegateway.repository import (
+    managed_rate_rule_repository as rate_rule_repo,
+)
 
 if TYPE_CHECKING:
     from voicegateway.core.database import Database
@@ -147,6 +150,41 @@ class ManagedConfigService:
     async def delete_project(self, project_id: str) -> bool:
         async with self._db.session() as s:
             return await project_repo.delete_project(s, project_id)
+
+    # --- rate rules (DB rate-card overrides) -------------------------
+
+    async def list_rate_rules(self) -> list[dict[str, Any]]:
+        async with self._db.session() as s:
+            return await rate_rule_repo.list_rules(s)
+
+    async def upsert_rate_rule(
+        self,
+        *,
+        modality: str = "*",
+        provider: str = "*",
+        model: str = "*",
+        tenant: str | None = None,
+        plan: str | None = None,
+        markup: float | None = None,
+        fixed: float | None = None,
+        unit: str | None = None,
+    ) -> str:
+        async with self._db.session() as s:
+            return await rate_rule_repo.upsert_rule(
+                s,
+                modality=modality,
+                provider=provider,
+                model=model,
+                tenant=tenant,
+                plan=plan,
+                markup=markup,
+                fixed=fixed,
+                unit=unit,
+            )
+
+    async def delete_rate_rule(self, rule_id: str) -> bool:
+        async with self._db.session() as s:
+            return await rate_rule_repo.delete_rule(s, rule_id)
 
 
 __all__ = ["ManagedConfigService"]

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -460,3 +460,39 @@ class StorageService:
         """Delegate to ManagedConfigService.delete_project."""
         await self._ensure_initialized()
         return await self._managed_config_service.delete_project(project_id)
+
+    # Rate rules (DB rate-card overrides)
+    async def list_rate_rules(self) -> list[dict[str, Any]]:
+        """Delegate to ManagedConfigService.list_rate_rules."""
+        await self._ensure_initialized()
+        return await self._managed_config_service.list_rate_rules()
+
+    async def upsert_rate_rule(
+        self,
+        *,
+        modality: str = "*",
+        provider: str = "*",
+        model: str = "*",
+        tenant: str | None = None,
+        plan: str | None = None,
+        markup: float | None = None,
+        fixed: float | None = None,
+        unit: str | None = None,
+    ) -> str:
+        """Delegate to ManagedConfigService.upsert_rate_rule."""
+        await self._ensure_initialized()
+        return await self._managed_config_service.upsert_rate_rule(
+            modality=modality,
+            provider=provider,
+            model=model,
+            tenant=tenant,
+            plan=plan,
+            markup=markup,
+            fixed=fixed,
+            unit=unit,
+        )
+
+    async def delete_rate_rule(self, rule_id: str) -> bool:
+        """Delegate to ManagedConfigService.delete_rate_rule."""
+        await self._ensure_initialized()
+        return await self._managed_config_service.delete_rate_rule(rule_id)

--- a/src/voicegateway/tests/billing/test_rate_card_overrides.py
+++ b/src/voicegateway/tests/billing/test_rate_card_overrides.py
@@ -1,0 +1,67 @@
+"""RateCard.with_overrides + rate_rule_from_row: merging DB overrides onto seed.
+
+DB override rows are appended after the seed rules, so a DB rule wins a
+specificity tie against a seed rule at the same scope (later-wins).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.billing.rate_card import RateCard, RateRule, rate_rule_from_row
+
+
+def test_rate_rule_from_row_maps_fields() -> None:
+    row = {
+        "modality": "stt",
+        "provider": "deepgram",
+        "model": "nova-3",
+        "tenant": "acme",
+        "plan": None,
+        "kind": "fixed",
+        "markup": None,
+        "unit_price_usd": 0.006,
+        "unit": "minute",
+    }
+    rule = rate_rule_from_row(row)
+    assert rule == RateRule(
+        modality="stt",
+        provider="deepgram",
+        model="nova-3",
+        tenant="acme",
+        kind="fixed",
+        unit_price_usd=0.006,
+        unit="minute",
+    )
+
+
+def test_with_overrides_appends_after_seed() -> None:
+    seed = RateCard(
+        rules=[RateRule(provider="deepgram", markup=1.5)], default_markup=1.3
+    )
+    merged = seed.with_overrides(
+        [{"provider": "deepgram", "kind": "cost_plus", "markup": 1.9}]
+    )
+    # Seed untouched; merged keeps default and has both rules.
+    assert len(seed.rules) == 1
+    assert merged.default_markup == 1.3
+    assert len(merged.rules) == 2
+
+
+def test_db_override_wins_specificity_tie() -> None:
+    seed = RateCard(rules=[RateRule(provider="deepgram", markup=1.5)])
+    merged = seed.with_overrides(
+        [{"provider": "deepgram", "kind": "cost_plus", "markup": 1.9}]
+    )
+    hit = merged.resolve(
+        modality="stt", provider="deepgram", model_id="deepgram/nova-3"
+    )
+    assert hit is not None
+    assert hit.markup == 1.9  # DB override (appended last) wins the tie
+
+
+def test_no_overrides_returns_equivalent_card() -> None:
+    seed = RateCard(rules=[RateRule(provider="openai", markup=1.4)], default_markup=1.2)
+    merged = seed.with_overrides([])
+    assert merged.rules == seed.rules
+    assert merged.default_markup == pytest.approx(1.2)

--- a/src/voicegateway/tests/cli/test_prices_cli.py
+++ b/src/voicegateway/tests/cli/test_prices_cli.py
@@ -68,3 +68,59 @@ def test_prices_ls_empty_card(tmp_path) -> None:
     result = runner.invoke(app, ["prices", "ls", "--config", str(p)])
     assert result.exit_code == 0, result.output
     assert "default markup" in result.output
+
+
+def test_prices_set_ls_rm_roundtrip(tmp_path, monkeypatch) -> None:
+    # chdir so alembic env.py + the CLI resolve the same tmp config (no stray).
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    cfg = {
+        "cost_tracking": {"enabled": True, "db_path": "prices.db"},
+        "models": {"stt": {}, "llm": {}, "tts": {}},
+        "fallbacks": {"stt": [], "llm": [], "tts": []},
+    }
+    (tmp_path / "voicegw.yaml").write_text(yaml.dump(cfg))
+
+    # set a DB override
+    r = runner.invoke(app, ["prices", "set", "--provider", "openai", "--markup", "1.5"])
+    assert r.exit_code == 0, r.output
+    assert "openai" in r.output  # the printed rule_id (*|*|*|openai|*)
+
+    # ls now runs against the effective card (exercises the DB read path)
+    r = runner.invoke(app, ["prices", "ls"])
+    assert r.exit_code == 0, r.output
+
+    # rm removes it
+    r = runner.invoke(app, ["prices", "rm", "--provider", "openai"])
+    assert r.exit_code == 0, r.output
+
+    # rm again: nothing to remove
+    r = runner.invoke(app, ["prices", "rm", "--provider", "openai"])
+    assert r.exit_code != 0
+
+
+def test_prices_set_rejects_markup_and_fixed(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    cfg = {
+        "cost_tracking": {"enabled": True, "db_path": "prices2.db"},
+        "models": {"stt": {}, "llm": {}, "tts": {}},
+        "fallbacks": {"stt": [], "llm": [], "tts": []},
+    }
+    (tmp_path / "voicegw.yaml").write_text(yaml.dump(cfg))
+    r = runner.invoke(
+        app,
+        [
+            "prices",
+            "set",
+            "--provider",
+            "openai",
+            "--markup",
+            "1.5",
+            "--fixed",
+            "0.006",
+            "--unit",
+            "minute",
+        ],
+    )
+    assert r.exit_code == 2

--- a/src/voicegateway/tests/core/test_config_rate_card.py
+++ b/src/voicegateway/tests/core/test_config_rate_card.py
@@ -133,3 +133,30 @@ def test_gateway_wires_rate_card_into_cost_tracker(tmp_path) -> None:
     assert record.cost_usd == pytest.approx(0.0048)
     assert record.rated_price_usd == pytest.approx(0.0072)
     assert record.rate_rule == "cost_plus:1.5"
+
+
+async def test_gateway_merges_db_override_over_seed(tmp_path, monkeypatch) -> None:
+    """A DB rate rule overrides the YAML seed at the same scope after refresh."""
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "gw-override.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    cfg_path = _write(
+        tmp_path,
+        {
+            "providers": {"deepgram": {"api_key": "k"}},
+            "cost_tracking": {"enabled": True},
+            "rate_card": {"rules": [{"provider": "deepgram", "markup": 1.5}]},
+        },
+    )
+    gw = Gateway(config_path=cfg_path)
+    # DB override for the same scope with a higher markup.
+    await gw.storage.upsert_rate_rule(provider="deepgram", markup=1.9)
+    await gw.refresh_config()
+
+    record = gw.cost_tracker.create_record(
+        model_id="deepgram/nova-3",
+        modality="stt",
+        provider="deepgram",
+        input_units=1.0,
+    )
+    assert record.rate_rule == "cost_plus:1.9"  # DB override wins over seed 1.5
+    assert record.rated_price_usd == pytest.approx(0.0048 * 1.9)

--- a/src/voicegateway/tests/repository/test_managed_rate_rule_repository.py
+++ b/src/voicegateway/tests/repository/test_managed_rate_rule_repository.py
@@ -1,0 +1,90 @@
+"""managed_rate_rules repository: scope-keyed upsert, list, delete, validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.core.config import GatewayConfig
+from voicegateway.core.database import Database
+from voicegateway.repository import managed_rate_rule_repository as repo
+
+
+async def _db(tmp_path) -> Database:
+    db = Database(GatewayConfig(cost_tracking={"db_path": str(tmp_path / "rules.db")}))
+    await db.run_migrations()
+    return db
+
+
+def test_scope_key_is_deterministic() -> None:
+    a = repo.scope_key(
+        modality="stt", provider="deepgram", model="nova-3", tenant="acme", plan=None
+    )
+    b = repo.scope_key(
+        modality="stt", provider="deepgram", model="nova-3", tenant="acme", plan=None
+    )
+    assert a == b == "acme|*|stt|deepgram|nova-3"
+
+
+def test_validate_rule_kinds() -> None:
+    assert repo.validate_rule(markup=1.3, fixed=None, unit=None) == "cost_plus"
+    assert repo.validate_rule(markup=None, fixed=0.006, unit="minute") == "fixed"
+    with pytest.raises(ValueError):
+        repo.validate_rule(markup=1.3, fixed=0.006, unit="minute")  # both
+    with pytest.raises(ValueError):
+        repo.validate_rule(markup=None, fixed=0.006, unit="furlong")  # bad unit
+    with pytest.raises(ValueError):
+        repo.validate_rule(markup=None, fixed=None, unit=None)  # neither
+
+
+async def test_upsert_list_delete(tmp_path) -> None:
+    db = await _db(tmp_path)
+    try:
+        async with db.session() as s:
+            rid = await repo.upsert_rule(s, provider="openai", markup=1.5)
+        async with db.session() as s:
+            rows = await repo.list_rules(s)
+        assert len(rows) == 1
+        assert rows[0]["rule_id"] == rid
+        assert rows[0]["provider"] == "openai"
+        assert rows[0]["kind"] == "cost_plus"
+        assert rows[0]["markup"] == pytest.approx(1.5)
+
+        # Upsert the same scope updates in place (no duplicate row).
+        async with db.session() as s:
+            rid2 = await repo.upsert_rule(s, provider="openai", markup=2.0)
+        assert rid2 == rid
+        async with db.session() as s:
+            rows = await repo.list_rules(s)
+        assert len(rows) == 1
+        assert rows[0]["markup"] == pytest.approx(2.0)
+
+        # Delete.
+        async with db.session() as s:
+            removed = await repo.delete_rule(s, rid)
+        assert removed is True
+        async with db.session() as s:
+            assert await repo.list_rules(s) == []
+    finally:
+        await db.dispose()
+
+
+async def test_upsert_fixed_rule_persists_unit(tmp_path) -> None:
+    db = await _db(tmp_path)
+    try:
+        async with db.session() as s:
+            await repo.upsert_rule(
+                s,
+                modality="stt",
+                provider="deepgram",
+                model="nova-3",
+                fixed=0.006,
+                unit="minute",
+            )
+        async with db.session() as s:
+            rows = await repo.list_rules(s)
+        assert rows[0]["kind"] == "fixed"
+        assert rows[0]["unit_price_usd"] == pytest.approx(0.006)
+        assert rows[0]["unit"] == "minute"
+        assert rows[0]["markup"] is None
+    finally:
+        await db.dispose()


### PR DESCRIPTION
## What

The last major piece of the metering vision: the rate card becomes **one store, two surfaces** — the `rate_card:` YAML seed plus DB overrides you edit at runtime with `voicegw prices set` / `rm`. (A dashboard editor and a `PUT /v1/billing/rate-card` ride on the same store as a follow-up.)

## Changes

- **`managed_rate_rules` table** (model + migration `e1a4c8b6f2d9`, down_revision `c7d2a9f1e6b4`): one row per scope, keyed by a deterministic `rule_id` (`tenant|plan|modality|provider|model`), so setting the same scope updates in place instead of accumulating duplicates. Repository does scope-keyed upsert / list / delete and validates the rule kind (markup **xor** fixed, fixed needs a valid unit).
- **Effective card = seed + DB.** The gateway builds `RateCard.from_config(seed).with_overrides(db_rows)` at construction and on every config refresh. DB rows are appended after the seed rules, so a DB override wins a specificity tie against the seed rule it shadows (the same later-wins rule the resolver already uses).
- **`voicegw prices set` / `rm`** edit the DB overrides by scope; `prices ls` / `sync` now show the effective (seed + overrides) card.
- Exposed through `ManagedConfigService` + `StorageService`, mirroring the `managed_projects` pattern.

## Tests

- Repository: scope-key determinism, kind validation, upsert/list/delete, upsert-same-scope-updates, fixed-rule persistence.
- `RateCard.with_overrides` / `rate_rule_from_row`: DB override wins the tie, seed untouched.
- Gateway: a DB override overrides the seed at the same scope after refresh.
- CLI: `set` -> `ls` -> `rm` roundtrip, and `set` rejects markup+fixed together.

Verified live: `prices set --tenant acme --provider deepgram --markup 1.1` then `prices ls` shows the seed rule and the two DB overrides merged; `prices rm` removes by scope and fails cleanly when absent.

## Deferred

`PUT /v1/billing/rate-card` (mutate rules over HTTP) + the dashboard "Rate card" editor — both on top of this same store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent rate-card overrides for specific providers, models, modalities, tenants, or plans.
  * Added cost-plus markup and fixed price-per-unit override options.
  * Added `voicegw prices set` and `voicegw prices rm` commands for managing overrides.
  * Effective pricing now combines YAML configuration with database overrides, with overrides taking precedence.
* **Documentation**
  * Updated architecture and CLI documentation with override behavior, usage examples, validation rules, and exit codes.
* **Tests**
  * Added coverage for override precedence, validation, persistence, CLI workflows, and configuration refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->