### PR TITLE
feat(billing): edit rate-card DB overrides over HTTP

### DIFF
--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -236,7 +236,7 @@ curl "http://localhost:8080/v1/billing/usage?tenant=acme&start=2026-06-01&end=20
 
 ### GET /v1/billing/rate-card
 
-Return the rate card in effect: the global default markup plus every rule. The `rule` field on each rule is the audit token stamped onto matching requests (for example `cost_plus:1.3` or `fixed:0.006/minute`).
+Return the rate card **in effect**: the global default markup plus every rule, merging the `rate_card:` YAML seed with the DB overrides. The `rule` field on each rule is the audit token stamped onto matching requests (for example `cost_plus:1.3` or `fixed:0.006/minute`).
 
 **Response:**
 
@@ -266,8 +266,32 @@ Return the rate card in effect: the global default markup plus every rule. The `
 curl http://localhost:8080/v1/billing/rate-card
 ```
 
+### GET /v1/billing/rate-card/rules
+
+Return the editable DB override rules, each with its `rule_id`. Use this to drive an editor (the seed rules in `GET /rate-card` have no `rule_id`; only DB overrides are mutable).
+
+### POST /v1/billing/rate-card/rules
+
+Upsert a DB rate-card override for a scope (one rule per scope, keyed by `tenant|plan|modality|provider|model`). Requires the `write` scope. Takes effect on the next config refresh, which the call triggers.
+
+**Body:** a scope (`modality?`, `provider?`, `model?`, `tenant?`, `plan?`) plus either `markup` (cost-plus) or `fixed` + `unit`.
+
+```bash
+curl -X POST http://localhost:8080/v1/billing/rate-card/rules \
+  -H "Authorization: Bearer $VG_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"tenant": "acme", "provider": "deepgram", "markup": 1.1}'
+# -> {"rule_id": "acme|*|*|deepgram|*", "created": true}
+```
+
+A rule that sets both `markup` and `fixed`, or a fixed rule with a missing/invalid `unit`, returns `400`.
+
+### DELETE /v1/billing/rate-card/rules/{rule_id}
+
+Delete a DB override by its `rule_id` (from `GET /rate-card/rules`). Requires the `write` scope. Returns `404` when no rule has that id.
+
 <Note>
-Rate-card editing (a `PUT` on this endpoint) is a planned follow-up tied to a DB override store that has not shipped yet. Today the card is the YAML seed in `voicegw.yaml`; edit the file and reload the gateway to change rates. See [Rating](/architecture/rating).
+The rate card is one store with two surfaces: the `rate_card:` seed in `voicegw.yaml` plus these DB overrides, which `voicegw prices set` / `rm` edit from the CLI. A dashboard editor rides on the same endpoints. See [Rating](/architecture/rating).
 </Note>
 
 ---

--- a/src/voicegateway/server/api/billing.py
+++ b/src/voicegateway/server/api/billing.py
@@ -1,28 +1,28 @@
-"""Billing endpoints: GET /v1/billing/usage + GET /v1/billing/rate-card.
+"""Billing endpoints under /v1/billing.
 
-The rating layer's read surface. ShipVoice (or any biller) polls
-``/usage`` for rated revenue + margin per tenant over a window, and reads
-``/rate-card`` to see the price book in effect. Rate-card edits (PUT) land
-in a follow-up once the DB-override store ships; today the card is the
-YAML seed.
+The rating layer's HTTP surface. ShipVoice (or any biller) polls ``/usage``
+for rated revenue + margin per tenant over a window, reads ``/rate-card`` to
+see the price book in effect, and edits the DB overrides through
+``/rate-card/rules`` (the same store ``voicegw prices set`` writes to).
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from voicegateway.billing.rate_card import RateCard
 from voicegateway.clickhouse import read_repository as ch_read
 from voicegateway.repository.cost_repository import resolve_window
-from voicegateway.server.api._deps import get_gateway
+from voicegateway.server.api._deps import get_gateway, require_scope
 from voicegateway.server.api._helpers import parse_iso_date
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
 
 router = APIRouter(prefix="/billing", tags=["billing"])
+write_dep = Depends(require_scope("write"))
 
 
 def _totals(rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -114,13 +114,79 @@ def _serialize_rule(rule: Any) -> dict[str, Any]:
     }
 
 
+async def _effective_card(gateway: Gateway) -> RateCard:
+    """The card in effect: YAML seed rules plus DB overrides."""
+    seed = RateCard.from_config(gateway.config.rate_card)
+    if gateway.storage is None:
+        return seed
+    rows = await gateway.storage.list_rate_rules()
+    return seed.with_overrides(rows)
+
+
 @router.get("/rate-card")
 async def get_rate_card(
     gateway: Gateway = Depends(get_gateway),
 ) -> dict[str, Any]:
-    """Return the rate card in effect (default markup + rules)."""
-    card = RateCard.from_config(gateway.config.rate_card)
+    """Return the rate card in effect (default markup + seed + DB rules)."""
+    card = await _effective_card(gateway)
     return {
         "default_markup": card.default_markup,
         "rules": [_serialize_rule(r) for r in card.rules],
     }
+
+
+@router.get("/rate-card/rules")
+async def list_rate_card_rules(
+    gateway: Gateway = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Return the editable DB override rules (each with its ``rule_id``)."""
+    if gateway.storage is None:
+        return {"rules": []}
+    return {"rules": await gateway.storage.list_rate_rules()}
+
+
+@router.post("/rate-card/rules", dependencies=[write_dep])
+async def upsert_rate_card_rule(
+    body: dict[str, Any],
+    gateway: Gateway = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Upsert a DB rate-card override for a scope (one rule per scope).
+
+    Body: ``{modality?, provider?, model?, tenant?, plan?}`` scope plus either
+    ``markup`` (cost-plus) or ``fixed`` + ``unit``. Takes effect on the next
+    config refresh, which this triggers.
+    """
+    if gateway.storage is None:
+        raise HTTPException(400, "Storage not enabled")
+    try:
+        rule_id = await gateway.storage.upsert_rate_rule(
+            modality=body.get("modality", "*"),
+            provider=body.get("provider", "*"),
+            model=body.get("model", "*"),
+            tenant=body.get("tenant"),
+            plan=body.get("plan"),
+            markup=body.get("markup"),
+            fixed=body.get("fixed"),
+            unit=body.get("unit"),
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    await gateway.storage.log_audit_event("rate_rule", rule_id, "set", body, "api")
+    await gateway.refresh_config()
+    return {"rule_id": rule_id, "created": True}
+
+
+@router.delete("/rate-card/rules/{rule_id}", dependencies=[write_dep])
+async def delete_rate_card_rule(
+    rule_id: str,
+    gateway: Gateway = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Delete a DB override by ``rule_id`` (from ``GET /rate-card/rules``)."""
+    if gateway.storage is None:
+        raise HTTPException(400, "Storage not enabled")
+    removed = await gateway.storage.delete_rate_rule(rule_id)
+    if not removed:
+        raise HTTPException(404, f"no rate rule with id {rule_id!r}")
+    await gateway.storage.log_audit_event("rate_rule", rule_id, "delete", None, "api")
+    await gateway.refresh_config()
+    return {"rule_id": rule_id, "deleted": True}

--- a/src/voicegateway/tests/server/test_billing_api.py
+++ b/src/voicegateway/tests/server/test_billing_api.py
@@ -96,3 +96,54 @@ async def test_rate_card_endpoint_returns_effective_card(gateway):
     assert rule["kind"] == "cost_plus"
     assert rule["markup"] == 1.5
     assert rule["rule"] == "cost_plus:1.5"
+
+
+async def test_upsert_list_and_delete_rule(gateway):
+    client = await _client(gateway)
+    async with client as c:
+        # upsert a DB override
+        r = await c.post(
+            "/v1/billing/rate-card/rules",
+            json={"provider": "openai", "markup": 1.4},
+        )
+        assert r.status_code == 200, r.text
+        rule_id = r.json()["rule_id"]
+        assert rule_id == "*|*|*|openai|*"
+
+        # it appears in the editable DB rules list
+        r = await c.get("/v1/billing/rate-card/rules")
+        assert rule_id in [x["rule_id"] for x in r.json()["rules"]]
+
+        # and in the effective card alongside the seed rule
+        r = await c.get("/v1/billing/rate-card")
+        rules = r.json()["rules"]
+        assert any(x["provider"] == "openai" and x["markup"] == 1.4 for x in rules)
+        assert any(x["provider"] == "deepgram" for x in rules)  # seed still there
+
+        # delete by rule_id
+        r = await c.delete(f"/v1/billing/rate-card/rules/{rule_id}")
+        assert r.status_code == 200
+        r = await c.get("/v1/billing/rate-card/rules")
+        assert r.json()["rules"] == []
+
+
+async def test_upsert_rule_rejects_markup_and_fixed(gateway):
+    client = await _client(gateway)
+    async with client as c:
+        r = await c.post(
+            "/v1/billing/rate-card/rules",
+            json={
+                "provider": "openai",
+                "markup": 1.4,
+                "fixed": 0.006,
+                "unit": "minute",
+            },
+        )
+    assert r.status_code == 400
+
+
+async def test_delete_missing_rule_returns_404(gateway):
+    client = await _client(gateway)
+    async with client as c:
+        r = await c.delete("/v1/billing/rate-card/rules/does-not-exist")
+    assert r.status_code == 404


### PR DESCRIPTION
## What

The programmatic write surface for the rate-card store (#117 shipped the store + CLI). A dashboard editor rides on these endpoints.

## Changes

- **`POST /v1/billing/rate-card/rules`** — upsert a DB override by scope (one rule per scope). `write` scope; validates markup xor fixed; writes an audit-log entry; calls `refresh_config()` so the change takes effect on the running gateway. Returns `{rule_id, created}`. `400` on an invalid rule.
- **`DELETE /v1/billing/rate-card/rules/{rule_id}`** — remove one override by id. `write` scope; `404` when absent.
- **`GET /v1/billing/rate-card/rules`** — list the editable DB overrides with their `rule_id` (to drive an editor).
- **`GET /v1/billing/rate-card`** now returns the **effective** card (seed + DB overrides), matching `voicegw prices ls`. It previously showed only the seed — a latent gap, now fixed.

Mutations are gated on `require_scope("write")`, consistent with the projects/providers managed-config endpoints (open in keyless mode, key-scoped in production).

## Tests

`test_billing_api.py`: upsert -> list -> effective-card-reflects-it -> delete roundtrip (incl. the pipe/asterisk `rule_id` in the DELETE path), `markup`+`fixed` -> 400, delete-missing -> 404.

## Metering vision: complete

✅ #113 rating layer · ✅ #114 re-rate on ingest · ✅ #115 store rated cols in CH · ✅ #116 read from CH · ✅ #117 DB override store + CLI · this PR: HTTP editing. Only the dashboard "Rate card" **UI** remains (frontend, on top of these endpoints).