### PR TITLE
docs(billing): drop stale follow-up language now that editing shipped

### DIFF
--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -291,7 +291,7 @@ A rule that sets both `markup` and `fixed`, or a fixed rule with a missing/inval
 Delete a DB override by its `rule_id` (from `GET /rate-card/rules`). Requires the `write` scope. Returns `404` when no rule has that id.
 
 <Note>
-The rate card is one store with two surfaces: the `rate_card:` seed in `voicegw.yaml` plus these DB overrides, which `voicegw prices set` / `rm` edit from the CLI. A dashboard editor rides on the same endpoints. See [Rating](/architecture/rating).
+The rate card is one store, edited three ways: the `rate_card:` seed in `voicegw.yaml`, the CLI (`voicegw prices set` / `rm`), and these HTTP endpoints (which the dashboard Rate card page under Configure also uses). See [Rating](/architecture/rating).
 </Note>
 
 ---

--- a/docs/architecture/rating.md
+++ b/docs/architecture/rating.md
@@ -55,7 +55,7 @@ Once every row carries `rated_price_usd`, two surfaces read it:
 - **`voicegw prices` commands.** `voicegw prices ls` prints the effective card, `voicegw prices reconcile` flags tenants with thin or negative margins over a window, `voicegw prices sync` checks fixed rules against the current base cost, and `voicegw prices set` / `rm` edit the DB overrides. See [voicegw prices](/cli/prices).
 
 <Note>
-The rate card is one store with two surfaces: the `rate_card:` seed in `voicegw.yaml` plus DB overrides. `voicegw prices set` / `rm` edit the DB overrides (one rule per scope, keyed by `tenant|plan|modality|provider|model`), and a DB override wins a specificity tie against the seed rule it shadows. A PUT on `/v1/billing/rate-card` and a dashboard editor over the same store are follow-ups.
+The rate card is one store with three surfaces: the `rate_card:` seed in `voicegw.yaml` plus DB overrides edited from the CLI (`voicegw prices set` / `rm`), over HTTP (`POST` / `DELETE /v1/billing/rate-card/rules`), or from the dashboard (Configure -> Rate card). Each override is one rule per scope (keyed by `tenant|plan|modality|provider|model`), and a DB override wins a specificity tie against the seed rule it shadows.
 </Note>
 
 ## Where to find each piece

--- a/docs/cli/prices.md
+++ b/docs/cli/prices.md
@@ -156,7 +156,7 @@ voicegw prices sync --threshold 20
 | `2` | Bad input: an invalid rule (`set` with both `--markup` and `--fixed`, a fixed rule missing a valid `--unit`, or neither), or `rm` for a scope with no override. |
 
 <Note>
-The gateway rebuilds the effective card (seed plus DB overrides) on startup and on config refresh, so a running server picks up `set` / `rm` changes the next time its config refreshes. Editing the rate card from the dashboard is a follow-up on top of the same DB store.
+The gateway rebuilds the effective card (seed plus DB overrides) on startup and on config refresh, so a running server picks up `set` / `rm` changes the next time its config refreshes. The same DB overrides can also be edited over HTTP (`POST` / `DELETE /v1/billing/rate-card/rules`) or from the dashboard (Configure -> Rate card).
 </Note>
 
 ## Related


### PR DESCRIPTION
The rate-card editing surfaces (HTTP #118, dashboard #119) shipped, but a few docs still called them planned follow-ups. Updates cli/prices, architecture/rating, and api/http-api to describe the three editing surfaces (YAML seed, CLI, HTTP/dashboard) as shipped. Docs-only; validator PASS, no em dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the available rate-card editing methods across YAML configuration, CLI commands, HTTP endpoints, and the dashboard.
  * Documented that rate-card changes take effect after the next startup or configuration refresh.
  * Updated guidance on override precedence and rule scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->