### PR TITLE
feat(fleet): per-worker memory headroom on the roster

### DIFF
--- a/alembic/versions/f3c8a1d5e9b2_worker_memory.py
+++ b/alembic/versions/f3c8a1d5e9b2_worker_memory.py
@@ -25,9 +25,11 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column("workers", sa.Column("memory_rss_bytes", sa.Integer(), nullable=True))
     op.add_column(
-        "workers", sa.Column("memory_total_bytes", sa.Integer(), nullable=True)
+        "workers", sa.Column("memory_rss_bytes", sa.BigInteger(), nullable=True)
+    )
+    op.add_column(
+        "workers", sa.Column("memory_total_bytes", sa.BigInteger(), nullable=True)
     )
 
 

--- a/alembic/versions/f3c8a1d5e9b2_worker_memory.py
+++ b/alembic/versions/f3c8a1d5e9b2_worker_memory.py
@@ -1,0 +1,36 @@
+"""add memory_rss_bytes + memory_total_bytes to workers
+
+Revision ID: f3c8a1d5e9b2
+Revises: e1a4c8b6f2d9
+Create Date: 2026-07-11 15:00:00.000000
+
+Fleet workers report their process RSS and the effective memory ceiling
+(cgroup limit when capped, else system total) on each heartbeat, so the
+roster can show per-worker memory headroom. Nullable: existing rows and
+heartbeats without a memory sample stay valid.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f3c8a1d5e9b2"
+down_revision: str | None = "e1a4c8b6f2d9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("workers", sa.Column("memory_rss_bytes", sa.Integer(), nullable=True))
+    op.add_column(
+        "workers", sa.Column("memory_total_bytes", sa.Integer(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "memory_total_bytes")
+    op.drop_column("workers", "memory_rss_bytes")

--- a/src/voicegateway/fleet/resource.py
+++ b/src/voicegateway/fleet/resource.py
@@ -1,0 +1,59 @@
+"""Best-effort worker memory sampling for the fleet heartbeat.
+
+Captures the worker process's RSS and the effective memory ceiling (the
+cgroup limit when the process is capped, otherwise total system memory), so
+the roster can show how full a worker is. All reads are best-effort: any
+failure yields ``None`` so a heartbeat is never broken by a memory read.
+"""
+
+from __future__ import annotations
+
+import psutil
+
+_CGROUP_V2_MAX = "/sys/fs/cgroup/memory.max"
+_CGROUP_V1_MAX = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+
+def _read_cgroup_limit(
+    v2_path: str = _CGROUP_V2_MAX,
+    v1_path: str = _CGROUP_V1_MAX,
+) -> int | None:
+    """Container memory limit in bytes, or ``None`` if unlimited/unavailable.
+
+    cgroup v2 ``memory.max`` holds an integer or the literal ``max``. cgroup
+    v1 ``memory.limit_in_bytes`` uses a huge sentinel for "unlimited". A limit
+    at or above total system memory is treated as no real cap.
+    """
+    for path in (v2_path, v1_path):
+        try:
+            with open(path) as f:
+                raw = f.read().strip()
+        except OSError:
+            continue
+        if not raw or raw == "max":
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            continue
+        if value <= 0 or value >= psutil.virtual_memory().total:
+            continue
+        return value
+    return None
+
+
+def sample_memory() -> tuple[int | None, int | None]:
+    """Return ``(rss_bytes, total_bytes)`` for this worker process.
+
+    ``total`` is the cgroup limit when capped, else total system memory.
+    Best-effort: any failure returns ``(None, None)``.
+    """
+    try:
+        rss = psutil.Process().memory_info().rss
+        total = _read_cgroup_limit() or psutil.virtual_memory().total
+        return int(rss), int(total)
+    except Exception:
+        return None, None
+
+
+__all__ = ["sample_memory"]

--- a/src/voicegateway/fleet/worker.py
+++ b/src/voicegateway/fleet/worker.py
@@ -48,6 +48,9 @@ class _Worker:
         return "busy" if self.active_sessions > 0 else "idle"
 
     def presence(self) -> dict[str, Any]:
+        from voicegateway.fleet.resource import sample_memory
+
+        rss, total = sample_memory()
         return {
             "agent_id": self.agent_id,
             "agent_name": self.agent_name,
@@ -59,6 +62,8 @@ class _Worker:
             "region": self.region,
             "host": self.host,
             "started_at": self.started_at,
+            "memory_rss_bytes": rss,
+            "memory_total_bytes": total,
             "ts": time.time(),
         }
 

--- a/src/voicegateway/models/worker_model.py
+++ b/src/voicegateway/models/worker_model.py
@@ -34,3 +34,5 @@ class Worker(SQLModel, table=True):
     status: str = "idle"
     started_at: float | None
     last_seen: float
+    memory_rss_bytes: int | None = None
+    memory_total_bytes: int | None = None

--- a/src/voicegateway/models/worker_model.py
+++ b/src/voicegateway/models/worker_model.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import BigInteger, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
@@ -34,5 +34,5 @@ class Worker(SQLModel, table=True):
     status: str = "idle"
     started_at: float | None
     last_seen: float
-    memory_rss_bytes: int | None = None
-    memory_total_bytes: int | None = None
+    memory_rss_bytes: int | None = Field(default=None, sa_type=BigInteger)
+    memory_total_bytes: int | None = Field(default=None, sa_type=BigInteger)

--- a/src/voicegateway/repository/workers_repository.py
+++ b/src/voicegateway/repository/workers_repository.py
@@ -42,6 +42,8 @@ class RosterRow:
     status: str
     started_at: float | None
     last_seen: float
+    memory_rss_bytes: int | None
+    memory_total_bytes: int | None
 
 
 def _fields_from_presence(presence: dict[str, Any]) -> dict[str, Any]:
@@ -56,6 +58,8 @@ def _fields_from_presence(presence: dict[str, Any]) -> dict[str, Any]:
         "host": presence.get("host"),
         "active_sessions": int(presence.get("active_sessions", 0)),
         "status": presence.get("status", "idle"),
+        "memory_rss_bytes": presence.get("memory_rss_bytes"),
+        "memory_total_bytes": presence.get("memory_total_bytes"),
         "started_at": presence.get("started_at"),
         "last_seen": float(presence["ts"]),
     }
@@ -125,6 +129,8 @@ async def read_roster(
                 status=status,
                 started_at=w.started_at,
                 last_seen=w.last_seen,
+                memory_rss_bytes=w.memory_rss_bytes,
+                memory_total_bytes=w.memory_total_bytes,
             )
         )
     return rows

--- a/src/voicegateway/server/api/agents.py
+++ b/src/voicegateway/server/api/agents.py
@@ -31,6 +31,13 @@ router = APIRouter(prefix="/agents", tags=["agents"])
 logger = logging.getLogger(__name__)
 
 
+def _memory_pct(rss: int | None, total: int | None) -> float | None:
+    """RSS as a percentage of the memory ceiling (None when unavailable)."""
+    if not rss or not total:
+        return None
+    return round(rss / total * 100, 1)
+
+
 @router.post(
     "/heartbeat",
     status_code=202,
@@ -139,6 +146,9 @@ async def list_agents(
                 "status": row.status,
                 "started_at": row.started_at,
                 "last_seen": row.last_seen,
+                "memory_rss_bytes": row.memory_rss_bytes,
+                "memory_total_bytes": row.memory_total_bytes,
+                "memory_pct": _memory_pct(row.memory_rss_bytes, row.memory_total_bytes),
             }
             for row in roster
         ]

--- a/src/voicegateway/tests/fleet/test_resource.py
+++ b/src/voicegateway/tests/fleet/test_resource.py
@@ -1,0 +1,49 @@
+"""Unit tests for the fleet memory sampler."""
+
+from __future__ import annotations
+
+from voicegateway.fleet import resource
+
+
+def test_sample_memory_returns_plausible_values() -> None:
+    rss, total = resource.sample_memory()
+    assert isinstance(rss, int) and rss > 0
+    assert isinstance(total, int) and total > 0
+    assert rss <= total  # a process cannot use more than the ceiling
+
+
+def test_cgroup_limit_reads_v2_integer(tmp_path) -> None:
+    p = tmp_path / "memory.max"
+    p.write_text("536870912\n")  # 512 MiB, below any real machine's total
+    assert (
+        resource._read_cgroup_limit(v2_path=str(p), v1_path=str(tmp_path / "nope"))
+        == 536870912
+    )
+
+
+def test_cgroup_limit_max_means_unlimited(tmp_path) -> None:
+    p = tmp_path / "memory.max"
+    p.write_text("max\n")
+    assert (
+        resource._read_cgroup_limit(v2_path=str(p), v1_path=str(tmp_path / "nope"))
+        is None
+    )
+
+
+def test_cgroup_limit_missing_files_returns_none(tmp_path) -> None:
+    assert (
+        resource._read_cgroup_limit(
+            v2_path=str(tmp_path / "a"), v1_path=str(tmp_path / "b")
+        )
+        is None
+    )
+
+
+def test_cgroup_limit_ignores_limit_at_or_above_total(tmp_path) -> None:
+    # A limit >= system total is "no real cap" (the v1 unlimited sentinel is huge).
+    p = tmp_path / "memory.max"
+    p.write_text("9223372036854771712\n")
+    assert (
+        resource._read_cgroup_limit(v2_path=str(p), v1_path=str(tmp_path / "nope"))
+        is None
+    )

--- a/src/voicegateway/tests/fleet/test_worker_presence_memory.py
+++ b/src/voicegateway/tests/fleet/test_worker_presence_memory.py
@@ -1,0 +1,24 @@
+"""presence() carries the worker's memory sample."""
+
+from __future__ import annotations
+
+from voicegateway.fleet import worker as worker_mod
+
+
+def test_presence_includes_memory_fields() -> None:
+    w = worker_mod._Worker(
+        agent_id="a1",
+        agent_name="bot",
+        version="0.0.0",
+        project="default",
+        tenant_id=None,
+        region=None,
+        host="h",
+        started_at=1000.0,
+    )
+    p = w.presence()
+    assert "memory_rss_bytes" in p
+    assert "memory_total_bytes" in p
+    # On a real host these sample to positive ints; the contract allows None.
+    assert p["memory_rss_bytes"] is None or p["memory_rss_bytes"] > 0
+    assert p["memory_total_bytes"] is None or p["memory_total_bytes"] > 0

--- a/src/voicegateway/tests/server/openorca/test_mapper.py
+++ b/src/voicegateway/tests/server/openorca/test_mapper.py
@@ -41,6 +41,8 @@ def _row(**overrides: Any) -> RosterRow:
         "status": "busy",
         "started_at": None,
         "last_seen": 1000.0,
+        "memory_rss_bytes": None,
+        "memory_total_bytes": None,
     }
     base.update(overrides)
     return RosterRow(**base)

--- a/src/voicegateway/tests/server/test_agents_memory.py
+++ b/src/voicegateway/tests/server/test_agents_memory.py
@@ -1,0 +1,49 @@
+"""GET /v1/agents returns per-worker memory + derived memory_pct."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.repository import workers_repository as repo
+from voicegateway.server import build_app
+
+_CFG = {
+    "providers": {},
+    "models": {"stt": {}, "llm": {}, "tts": {}},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+
+@pytest.fixture
+def gateway(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "agents-mem.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    p = tmp_path / "voicegw.yaml"
+    p.write_text(yaml.dump(_CFG))
+    return Gateway(config_path=str(p))
+
+
+async def test_roster_returns_memory_and_pct(gateway):
+    await gateway.storage._ensure_initialized()
+    presence = {
+        "agent_id": "a1", "agent_name": "bot", "project": "default",
+        "tenant_id": None, "region": None, "version": "0", "host": "h",
+        "active_sessions": 0, "status": "idle", "started_at": 1000.0,
+        "memory_rss_bytes": 268_435_456, "memory_total_bytes": 536_870_912,
+        "ts": 9_999_999_999.0,
+    }
+    async with gateway.storage._conn.session() as db:
+        await repo.upsert_heartbeat(db, presence)
+
+    client = AsyncClient(transport=ASGITransport(app=build_app(gateway)), base_url="http://t")
+    async with client as c:
+        resp = await c.get("/v1/agents")
+    assert resp.status_code == 200
+    row = resp.json()["workers"][0]
+    assert row["memory_rss_bytes"] == 268_435_456
+    assert row["memory_total_bytes"] == 536_870_912
+    assert row["memory_pct"] == 50.0

--- a/src/voicegateway/tests/storage/test_worker_memory.py
+++ b/src/voicegateway/tests/storage/test_worker_memory.py
@@ -1,0 +1,64 @@
+"""Memory columns on the workers row: migration + heartbeat round-trip."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine, text
+
+from voicegateway.core.config import GatewayConfig
+from voicegateway.core.database import Database
+from voicegateway.repository import workers_repository as repo
+
+
+def _column_exists(engine: sa.Engine, table: str, column: str) -> bool:
+    with engine.connect() as conn:
+        info = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    return any(row[1] == column for row in info)
+
+
+async def _db(tmp_path: Path) -> Database:
+    db = Database(GatewayConfig(cost_tracking={"db_path": str(tmp_path / "wm.db")}))
+    await db.run_migrations()
+    return db
+
+
+async def test_migration_adds_memory_columns(tmp_path) -> None:
+    db = await _db(tmp_path)
+    eng = create_engine(f"sqlite:///{db.db_file_path}")
+    try:
+        assert _column_exists(eng, "workers", "memory_rss_bytes")
+        assert _column_exists(eng, "workers", "memory_total_bytes")
+    finally:
+        eng.dispose()
+        await db.dispose()
+
+
+async def test_heartbeat_round_trips_memory(tmp_path) -> None:
+    db = await _db(tmp_path)
+    presence = {
+        "agent_id": "a1",
+        "agent_name": "bot",
+        "project": "default",
+        "tenant_id": None,
+        "region": None,
+        "version": "0.0.0",
+        "host": "h",
+        "active_sessions": 0,
+        "status": "idle",
+        "started_at": 1000.0,
+        "memory_rss_bytes": 268_435_456,
+        "memory_total_bytes": 536_870_912,
+        "ts": 1000.0,
+    }
+    try:
+        async with db.session() as s:
+            await repo.upsert_heartbeat(s, presence)
+        async with db.session() as s:
+            roster = await repo.read_roster(s, tenant_id=None, now=1000.0)
+        assert len(roster) == 1
+        assert roster[0].memory_rss_bytes == 268_435_456
+        assert roster[0].memory_total_bytes == 536_870_912
+    finally:
+        await db.dispose()


### PR DESCRIPTION
## What

Fleet workers now report process RSS and their effective memory ceiling on each heartbeat, so the roster can show per-worker memory headroom.

- **Sampler** (`fleet/resource.py`): best-effort `sample_memory()` returns `(rss, total)`. The denominator is the cgroup limit when the process is capped (v2 `memory.max`, v1 `memory.limit_in_bytes`), else system total. Any failure returns `(None, None)` and never breaks the heartbeat.
- **Heartbeat** (`fleet/worker.py`): `presence()` stamps `memory_rss_bytes` / `memory_total_bytes` onto the payload.
- **Persistence** (`models/worker_model.py` + migration `f3c8a1d5e9b2`): two nullable `BigInteger` columns on `workers`. Nullable so existing rows and samples-less heartbeats stay valid.
- **Roster read** (`repository/workers_repository.py`): both fields flow through `RosterRow`.
- **API** (`server/api/agents.py`): `GET /v1/agents` exposes `memory_rss_bytes`, `memory_total_bytes`, and a derived `memory_pct`.

## Notes

- Columns are `BigInteger` (64-bit): a >2GiB host total overflows INT4 on the Postgres collector, which would 500 the heartbeat. `BigInteger` degrades to a normal INTEGER on SQLite, so existing SQLite behavior is unchanged.
- Sampling is best-effort throughout: a sampler failure yields `None` and the heartbeat still succeeds.
- Built TDD, task-by-task, with a per-task review and a final whole-branch review. The final review's one Critical (INT4 overflow) is fixed in this branch.

## Deferred

Dashboard memory gauge is a separate follow-up (Agents.tsx currently shows the observations rollup, not the live roster).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worker memory monitoring, including current usage and available memory limits.
  * Heartbeats now report memory metrics.
  * The agents roster now displays memory usage, capacity, and calculated utilization percentage.

* **Bug Fixes**
  * Memory sampling gracefully handles unavailable or unlimited system memory information without disrupting heartbeats.

* **Tests**
  * Added coverage for memory sampling, persistence, heartbeat reporting, and agent roster responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->