### PR TITLE
feat(dashboard): mirror cloud sidebar + worker memory in Agents

### DIFF
--- a/src/dashboard/frontend/src/lib/nav.ts
+++ b/src/dashboard/frontend/src/lib/nav.ts
@@ -11,20 +11,20 @@ export type NavEntry = NavLeaf | NavGroup;
 
 export const NAV: NavEntry[] = [
   { to: '/', label: 'Overview', id: 'overview' },
-  { to: '/sessions', label: 'Sessions', id: 'sessions' },
-  { to: '/logs', label: 'Logs', id: 'logs' },
   {
     group: 'Monitor',
     items: [
+      { to: '/agents', label: 'Agents', id: 'agents' },
       { to: '/costs', label: 'Costs', id: 'costs' },
       { to: '/latency', label: 'Latency', id: 'latency' },
+      { to: '/sessions', label: 'Sessions', id: 'sessions' },
+      { to: '/logs', label: 'Logs', id: 'logs' },
       { to: '/metrics', label: 'Metrics', id: 'metrics' },
     ],
   },
   {
     group: 'Configure',
     items: [
-      { to: '/agents', label: 'Agents', id: 'agents' },
       { to: '/providers', label: 'Providers', id: 'providers' },
       { to: '/models', label: 'Models', id: 'models' },
       { to: '/routing', label: 'Routing', id: 'routing' },

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -234,6 +234,9 @@ export interface AgentRow {
   error_rate: number;
   /** p95 total-latency ms, merged in by /api/agents; null when no samples. */
   p95_latency_ms?: number | null;
+  /** RSS as a percent of the worker's memory ceiling, merged from the live
+   * roster; null when the agent is not a heartbeating worker or sent no sample. */
+  memory_pct?: number | null;
 }
 
 /** Aggregates for the implicit `agent_id IS NULL` bucket. */

--- a/src/dashboard/frontend/src/pages/Agents.tsx
+++ b/src/dashboard/frontend/src/pages/Agents.tsx
@@ -17,7 +17,8 @@ type SortKey =
   | 'total_cost_usd'
   | 'request_count'
   | 'p95_latency_ms'
-  | 'error_rate';
+  | 'error_rate'
+  | 'memory_pct';
 
 const COLUMNS: { key: SortKey; label: string }[] = [
   { key: 'agent_id', label: 'Agent' },
@@ -26,7 +27,15 @@ const COLUMNS: { key: SortKey; label: string }[] = [
   { key: 'request_count', label: 'Requests (24h)' },
   { key: 'p95_latency_ms', label: 'p95 (24h)' },
   { key: 'error_rate', label: 'Error rate (24h)' },
+  { key: 'memory_pct', label: 'Memory' },
 ];
+
+/** Bar color for a memory-headroom reading: teal healthy, amber warm, red tight. */
+function memoryBarColor(pct: number): string {
+  if (pct >= 90) return '#dc2626';
+  if (pct >= 75) return '#f59e0b';
+  return 'var(--vg-teal, #1F96AA)';
+}
 
 export default function Agents() {
   const [agents, setAgents] = useState<AgentRow[]>([]);
@@ -136,6 +145,42 @@ export default function Agents() {
                     </td>
                     <td className="mono">{formatMs(a.p95_latency_ms)}</td>
                     <td className="mono">{(a.error_rate * 100).toFixed(1)}%</td>
+                    <td>
+                      {a.memory_pct == null ? (
+                        <span className="mono" style={{ color: 'var(--vg-muted)' }}>
+                          -
+                        </span>
+                      ) : (
+                        <div
+                          className="flex-row gap-sm"
+                          style={{ alignItems: 'center' }}
+                          title={`RSS is ${a.memory_pct}% of this worker's memory ceiling`}
+                        >
+                          <span
+                            style={{
+                              display: 'inline-block',
+                              width: 60,
+                              height: 6,
+                              borderRadius: 999,
+                              background: 'rgba(31,150,170,0.15)',
+                              overflow: 'hidden',
+                              flexShrink: 0,
+                            }}
+                          >
+                            <span
+                              style={{
+                                display: 'block',
+                                width: `${Math.min(100, a.memory_pct)}%`,
+                                height: '100%',
+                                borderRadius: 999,
+                                background: memoryBarColor(a.memory_pct),
+                              }}
+                            />
+                          </span>
+                          <span className="mono">{a.memory_pct}%</span>
+                        </div>
+                      )}
+                    </td>
                   </tr>
                 );
               })}

--- a/src/voicegateway/server/api/dashboard/agents.py
+++ b/src/voicegateway/server/api/dashboard/agents.py
@@ -9,12 +9,15 @@ stays O(1) queries.
 from __future__ import annotations
 
 import dataclasses
+import time
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from voicegateway.repository import agent_observations_repository as agent_obs
 from voicegateway.repository import agents_repository as agents
+from voicegateway.repository import workers_repository
+from voicegateway.repository.workers_repository import DEFAULT_TTL_SECONDS
 from voicegateway.server.api._deps import get_gateway
 
 if TYPE_CHECKING:
@@ -39,7 +42,16 @@ def _error_rate(error_count: int, request_count: int) -> float:
     return (error_count / request_count) if request_count else 0.0
 
 
-def _agent_entry(row: AgentObservationRow) -> dict[str, Any]:
+def _memory_pct(rss: int | None, total: int | None) -> float | None:
+    """RSS as a percentage of the memory ceiling (None when unavailable)."""
+    if not rss or not total:
+        return None
+    return round(rss / total * 100, 1)
+
+
+def _agent_entry(
+    row: AgentObservationRow, memory_pct: float | None
+) -> dict[str, Any]:
     return {
         "agent_id": row.agent_id,
         "request_count": row.request_count,
@@ -47,6 +59,7 @@ def _agent_entry(row: AgentObservationRow) -> dict[str, Any]:
         "last_seen": row.last_seen,
         "error_rate": _error_rate(row.error_count, row.request_count),
         "p95_latency_ms": row.p95_ms,
+        "memory_pct": memory_pct,
     }
 
 
@@ -80,8 +93,19 @@ async def list_agents_endpoint(
     async with gateway.storage._conn.session() as db:
         rows = await agent_obs.read_agents(db, limit=limit, query=q)
         unattributed = await agent_obs.read_unattributed(db)
+        # Live worker roster carries per-agent memory headroom. tenant_id=None
+        # returns the full fleet, which is what the self-hosted dashboard wants.
+        roster = await workers_repository.read_roster(
+            db, tenant_id=None, now=time.time(), ttl_seconds=DEFAULT_TTL_SECONDS
+        )
+    memory_by_agent = {
+        r.agent_id: _memory_pct(r.memory_rss_bytes, r.memory_total_bytes)
+        for r in roster
+    }
     return {
-        "agents": [_agent_entry(r) for r in rows],
+        "agents": [
+            _agent_entry(r, memory_by_agent.get(r.agent_id)) for r in rows
+        ],
         "unattributed": _unattributed_entry(unattributed),
     }
 

--- a/src/voicegateway/server/api/dashboard/agents.py
+++ b/src/voicegateway/server/api/dashboard/agents.py
@@ -104,7 +104,8 @@ async def list_agents_endpoint(
     }
     return {
         "agents": [
-            _agent_entry(r, memory_by_agent.get(r.agent_id)) for r in rows
+            _agent_entry(r, memory_by_agent.get(r.agent_id) if r.agent_id else None)
+            for r in rows
         ],
         "unattributed": _unattributed_entry(unattributed),
     }

--- a/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
+++ b/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
@@ -128,3 +128,61 @@ async def test_detail_is_all_time_from_requests(tmp_path, monkeypatch) -> None:
     async with _client(gw) as c:
         detail = (await c.get("/api/agents/agent-a")).json()
     assert detail["request_count"] == 2  # from requests, not the rollup's 99
+
+
+async def _insert_worker(gw: Gateway, **cols) -> None:
+    await gw.storage._ensure_initialized()
+    keys = ", ".join(cols)
+    vals = ", ".join(f":{k}" for k in cols)
+    async with gw.storage._conn.session() as db:
+        await db.execute(
+            text(f"INSERT INTO workers ({keys}) VALUES ({vals})"), cols
+        )
+        await db.commit()
+
+
+async def test_list_merges_worker_memory_pct(tmp_path, monkeypatch) -> None:
+    gw = _gateway(tmp_path, monkeypatch)
+    await _insert_obs(
+        gw,
+        agent_id="mem-agent",
+        request_count=1,
+        total_cost_usd=0.0,
+        error_count=0,
+        last_seen=1000.0,
+        window_start="ws",
+        window_end="we",
+    )
+    # A live worker row: RSS 1 GiB of a 4 GiB ceiling -> 25.0%.
+    await _insert_worker(
+        gw,
+        agent_id="mem-agent",
+        agent_name="mem-agent",
+        last_seen=1000.0,
+        memory_rss_bytes=1073741824,
+        memory_total_bytes=4294967296,
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "mem-agent")
+    assert entry["memory_pct"] == 25.0
+
+
+async def test_list_memory_pct_null_when_no_worker(tmp_path, monkeypatch) -> None:
+    gw = _gateway(tmp_path, monkeypatch)
+    # An agent seen in telemetry but with no heartbeating worker row: the field
+    # is present and null, never absent.
+    await _insert_obs(
+        gw,
+        agent_id="rollup-only",
+        request_count=1,
+        total_cost_usd=0.0,
+        error_count=0,
+        last_seen=1000.0,
+        window_start="ws",
+        window_end="we",
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "rollup-only")
+    assert entry["memory_pct"] is None


### PR DESCRIPTION
Two related OSS-dashboard changes, both grounded in a comparison with the cloud console.

## 1. Sidebar mirrors the cloud dashboard

The OSS sidebar had `Agents` under a *Configure* group and split shared items across a different structure than the cloud console. `nav.ts` now mirrors cloud: `Overview` at the top, then a **Monitor** group led by `Agents`, `Costs`, `Latency`, `Sessions` (cloud calls it "Calls"), plus OSS-only `Logs`/`Metrics`; then an OSS-only **Configure** group (`Providers`, `Models`, `Routing`, `Projects`, `Rate card`). No routes added or removed; only regrouped/reordered. The shell styling (grouped labels, teal active state) already matched from the earlier revamp.

## 2. Worker memory headroom in the Agents page

PR #123 shipped the backend for per-worker memory (sampler -> heartbeat -> `workers` table -> `memory_pct` on `GET /v1/agents`) but nothing surfaced it. This wires it into the dashboard:

- **Backend** (`server/api/dashboard/agents.py`): `GET /api/agents` now joins the live worker roster (`read_roster`, `tenant_id=None` for the full self-hosted fleet) and attaches a per-agent `memory_pct` (`round(rss/total*100, 1)`, null when the agent has no heartbeating worker or no sample). The 24h rollup is unchanged.
- **Frontend**: the Agents table gets a sortable **Memory** column: a small teal/amber/red bar + percent, or a muted `-` when null.

## Tests / checks

- Backend: 2 new tests (memory merged from the roster; null when no worker), full `test_agents_endpoint_rollup.py` green; `uvx ruff check` clean on changed files.
- Frontend: `tsc` + `vite build` pass.
- Reviewed (correctness pass): SHIP, no blocking findings.

## Deferred

A dedicated fleet-health/Diagnostics page was considered and set aside; memory lives in the Agents roster (per the data, and matching where cloud shows fleet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Memory column to the Agents dashboard.
  * Display memory usage as a sortable percentage with visual indicators and tooltips.
  * Expanded Monitor navigation to include Agents, Sessions, and Logs.

* **Bug Fixes**
  * Memory usage now appears when worker data is available and clearly indicates unavailable data when it is not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->