### PR TITLE
chore(dashboard): remove the dead /api/logs endpoint

### DIFF
--- a/src/dashboard/frontend/src/lib/api.ts
+++ b/src/dashboard/frontend/src/lib/api.ts
@@ -108,7 +108,7 @@ import type {
  * convention. ``null`` is "no filter" (param not set); ``""`` is the
  * unattributed bucket (param set to empty string); any other value is
  * that exact tenant. Matches the backend's ``tenant`` query parsing on
- * /api/costs, /api/latency, /api/logs, /api/sessions, and /api/metrics.
+ * /api/costs, /api/latency, /api/sessions, and /api/metrics.
  */
 export function appendTenantParam(
   params: URLSearchParams,

--- a/src/voicegateway/server/api/dashboard/costs.py
+++ b/src/voicegateway/server/api/dashboard/costs.py
@@ -1,6 +1,6 @@
-"""Dashboard endpoints: GET /api/costs, /api/latency, /api/logs.
+"""Dashboard endpoints: GET /api/costs, /api/latency.
 
-These three handlers share the read-only-aggregation shape (gateway +
+These handlers share the read-only-aggregation shape (gateway +
 storage required, period and project filters, tenant scoping) so they
 sit in one router file. Distinct from ``server/api/costs.py``, which
 serves the public ``/v1/costs`` endpoint with a different query schema
@@ -148,37 +148,3 @@ async def get_latency(
     )
 
 
-@router.get("/logs")
-async def get_logs(
-    request: Request,
-    limit: int = Query(100, ge=1, le=1000),
-    modality: str | None = Query(None, enum=["stt", "llm", "tts"]),
-    period: str = Query("all", enum=["today", "week", "month", "all"]),
-    project: str | None = Query(None),
-    tenant: str | None = Query(None),
-    agent: str | None = Query(None),
-    gateway: Gateway = Depends(get_gateway),
-    principal: Principal = Depends(require_principal),
-) -> list[dict]:
-    """Get recent request logs, scoped to the authenticated principal."""
-    resolved = resolve_read_tenant(principal, tenant)
-    if gateway.storage is None:
-        return []
-    ch_client = getattr(request.app.state, "ch_client", None)
-    if ch_client is not None:
-        if resolved is None:
-            raise HTTPException(status_code=400, detail=_NEEDS_TENANT)
-        # The ClickHouse read repo deduplicates and orders rows but does not
-        # filter by modality; the SQLite path below keeps the modality filter.
-        since, until = resolve_window(period)
-        return await ch_read.get_recent_requests(
-            ch_client,
-            tenant=resolved,
-            since=since,
-            until=until,
-            limit=limit,
-            project=project,
-        )
-    return await gateway.storage.get_recent_requests(
-        limit=limit, modality=modality, project=project, tenant=resolved, agent=agent
-    )

--- a/src/voicegateway/tests/server/test_agent_filter_api.py
+++ b/src/voicegateway/tests/server/test_agent_filter_api.py
@@ -99,13 +99,3 @@ async def test_api_agents_index(gateway):
     assert "unattributed" in body
 
 
-async def test_api_logs_filters_by_agent(gateway):
-    await gateway.storage.log_request(_rec("agent-x", 0.01))
-    await gateway.storage.log_request(_rec("agent-y", 0.05))
-    client = await _client(gateway)
-    async with client as c:
-        resp = await c.get("/api/logs?agent=agent-x")
-    assert resp.status_code == 200
-    rows = resp.json()
-    assert rows
-    assert all(r["agent_id"] == "agent-x" for r in rows)

--- a/src/voicegateway/tests/server/test_dashboard_api.py
+++ b/src/voicegateway/tests/server/test_dashboard_api.py
@@ -331,17 +331,6 @@ async def test_api_latency(client):
     assert resp.status_code == 200
 
 
-async def test_api_logs(client):
-    resp = await client.get("/api/logs")
-    assert resp.status_code == 200
-    assert resp.json() == []
-
-
-async def test_api_logs_with_modality(client):
-    resp = await client.get("/api/logs?modality=stt")
-    assert resp.status_code == 200
-
-
 async def test_api_overview(client):
     resp = await client.get("/api/overview")
     assert resp.status_code == 200

--- a/src/voicegateway/tests/server/test_dashboard_storage_none.py
+++ b/src/voicegateway/tests/server/test_dashboard_storage_none.py
@@ -55,12 +55,6 @@ def test_latency_returns_empty_dict_when_storage_disabled(storage_disabled_clien
     assert resp.json() == {}
 
 
-def test_logs_returns_empty_list_when_storage_disabled(storage_disabled_client):
-    resp = storage_disabled_client.get("/api/logs")
-    assert resp.status_code == 200
-    assert resp.json() == []
-
-
 def test_overview_returns_zero_counts_when_storage_disabled(storage_disabled_client):
     resp = storage_disabled_client.get("/api/overview")
     assert resp.status_code == 200

--- a/src/voicegateway/tests/server/test_read_tenant_isolation.py
+++ b/src/voicegateway/tests/server/test_read_tenant_isolation.py
@@ -35,7 +35,6 @@ _READ_PATHS = [
     "/api/sessions",
     "/api/costs",
     "/api/latency",
-    "/api/logs",
     "/api/metrics",
 ]
 
@@ -166,17 +165,6 @@ async def test_omitted_param_scopes_to_own_tenant_sessions(harness):
     ids = {r["id"] for r in resp.json()}
     assert ids == {"s-acme-1", "s-acme-2"}
     assert "s-beta-1" not in ids
-
-
-async def test_omitted_param_scopes_to_own_tenant_logs(harness):
-    """No tenant param -> acme key sees only acme request logs, never beta."""
-    token = await _make_key(harness.gateway, tenant_id="acme")
-    async with harness.client() as c:
-        resp = await c.get("/api/logs", headers={"Authorization": f"Bearer {token}"})
-    assert resp.status_code == 200, resp.text
-    sessions = {r["session_id"] for r in resp.json()}
-    assert sessions == {"s-acme-1", "s-acme-2"}
-    assert "s-beta-1" not in sessions
 
 
 async def test_no_credential_operator_sees_all(harness):


### PR DESCRIPTION
## What

Removes the now-dead `GET /api/logs` dashboard handler. PR #126 dropped the Logs page from the OSS dashboard frontend; this cleans up the backend handler it was the only caller of.

## Changes

- Remove the `get_logs` handler from `server/api/dashboard/costs.py` and drop `/api/logs` from the module docstring.
- Drop the stale `/api/logs` reference from a `lib/api.ts` comment.
- Remove the five `/api/logs`-specific tests across four test files (`test_dashboard_api.py`, `test_agent_filter_api.py`, `test_dashboard_storage_none.py`, `test_read_tenant_isolation.py`).

## Not touched

- `/v1/logs` stays: it is still used by the TUI and CLI.
- `/api/costs`, `/api/latency`, `/api/sessions` handlers and their tests are unchanged.

## Verification

- `mypy` clean (272 source files).
- Server test suite passes (316 tests).
- `grep -rn "api/logs"` across `server/` and `tests/` returns nothing.