### PR TITLE
feat(dashboard): add Diagnostics page to the OSS dashboard (local single vantage)

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import Agents from './pages/Agents';
 import Settings from './pages/Settings';
 import Login from './pages/Login';
 import Latency from './pages/Latency';
+import Diagnostics from './pages/Diagnostics';
 import Projects from './pages/Projects';
 import RateCard from './pages/RateCard';
 import ApiKeys from './pages/ApiKeys';
@@ -89,6 +90,7 @@ export default function App() {
               <Route path="/calls/:sessionId/replay" element={<Replay />} />
               <Route path="/costs" element={<Costs />} />
               <Route path="/latency" element={<Latency />} />
+              <Route path="/diagnostics" element={<Diagnostics />} />
               <Route path="/agents" element={<Agents />} />
               <Route path="/projects" element={<Projects />} />
               <Route path="/rate-card" element={<RateCard />} />

--- a/src/dashboard/frontend/src/components/NavIcon.tsx
+++ b/src/dashboard/frontend/src/components/NavIcon.tsx
@@ -15,6 +15,7 @@ const PATHS: Record<string, JSX.Element> = {
   settings: <><circle cx="12" cy="12" r="3" /><path d="M12 2v3M12 19v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M2 12h3M19 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1" /></>,
   apikeys: <><circle cx="8" cy="14" r="4" /><path d="M11 11l8-8M16 6l3 3M14 8l2 2" /></>,
   account: <><circle cx="12" cy="8" r="4" /><path d="M4 20c0-4 4-6 8-6s8 2 8 6" /></>,
+  diagnostics: <><path d="M12 13l4-3" /><path d="M4 18a8 8 0 1 1 16 0" /><circle cx="12" cy="13" r="1.2" /></>,
 };
 
 export default function NavIcon({ id, size = 17 }: { id: string; size?: number }) {

--- a/src/dashboard/frontend/src/index.css
+++ b/src/dashboard/frontend/src/index.css
@@ -461,6 +461,7 @@ a:hover { color: var(--vg-teal-deep); }
 .neo-badge--latency-fast { background: var(--vg-green-tint); color: var(--vg-green); }
 .neo-badge--offline,
 .neo-badge--pink,
+.neo-badge--red,
 .neo-badge--latency-slow { background: var(--vg-red-tint); color: var(--vg-red); }
 .neo-badge--warning,
 .neo-badge--yellow,

--- a/src/dashboard/frontend/src/lib/api.ts
+++ b/src/dashboard/frontend/src/lib/api.ts
@@ -91,6 +91,8 @@ import type {
   ApiKey,
   CreatedApiKey,
   DeadAirEvent,
+  DiagnosticRun,
+  DiagnosticsCreds,
   LogoUploadResponse,
   MetricsAggregate,
   ProjectBranding,
@@ -279,6 +281,32 @@ export function updateProjectBranding(
       body: JSON.stringify(branding),
     },
   );
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics typed fetchers (REQ-VG-DIAG-001).
+// ---------------------------------------------------------------------------
+
+export function fetchDiagnosticsCreds(): Promise<DiagnosticsCreds> {
+  return fetchJson<DiagnosticsCreds>('/api/diagnostics/creds');
+}
+
+export function fetchDiagnosticsRuns(): Promise<DiagnosticRun[]> {
+  return fetchJson<DiagnosticRun[]>('/api/diagnostics/runs');
+}
+
+export function fetchDiagnosticsRun(runId: string): Promise<DiagnosticRun> {
+  return fetchJson<DiagnosticRun>(`/api/diagnostics/runs/${encodeURIComponent(runId)}`);
+}
+
+export function createDiagnosticsRun(body: {
+  checks: string[];
+  config?: Record<string, unknown>;
+}): Promise<{ run_id: string; status: string }> {
+  return fetchJson<{ run_id: string; status: string }>('/api/diagnostics/runs', {
+    method: 'POST',
+    body: JSON.stringify({ checks: body.checks, config: body.config ?? {} }),
+  });
 }
 
 /**

--- a/src/dashboard/frontend/src/lib/nav.ts
+++ b/src/dashboard/frontend/src/lib/nav.ts
@@ -18,6 +18,7 @@ export const NAV: NavEntry[] = [
       { to: '/costs', label: 'Costs', id: 'costs' },
       { to: '/latency', label: 'Latency', id: 'latency' },
       { to: '/calls', label: 'Calls', id: 'calls' },
+      { to: '/diagnostics', label: 'Diagnostics', id: 'diagnostics' },
     ],
   },
   {

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -321,4 +321,34 @@ export interface LogoUploadResponse {
   format: 'PNG' | 'SVG';
 }
 
+// ---------------------------------------------------------------------------
+// Diagnostics: LiveKit probe types (REQ-VG-DIAG-001).
+// ---------------------------------------------------------------------------
+
+/** Connection status from GET /api/diagnostics/creds. */
+export interface DiagnosticsCreds {
+  configured: boolean;
+  url: string | null;
+}
+
+/** Per-check result inside a DiagnosticRun's results map. */
+export interface DiagnosticCheckResult {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+/** One diagnostic run record from the backend. */
+export interface DiagnosticRun {
+  run_id: string;
+  status: 'queued' | 'running' | 'done' | 'failed';
+  checks: string[];
+  config: Record<string, unknown>;
+  results: { checks: Record<string, DiagnosticCheckResult>; verdict: string } | null;
+  verdict: string | null;
+  error: string | null;
+  created_at: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+}
 

--- a/src/dashboard/frontend/src/pages/Diagnostics.tsx
+++ b/src/dashboard/frontend/src/pages/Diagnostics.tsx
@@ -1,0 +1,307 @@
+import { useEffect, useRef, useState } from 'react';
+import PageHeader from '../components/PageHeader';
+import {
+  createDiagnosticsRun,
+  fetchDiagnosticsCreds,
+  fetchDiagnosticsRun,
+  fetchDiagnosticsRuns,
+} from '../lib/api';
+import type { DiagnosticRun, DiagnosticsCreds } from '../lib/types';
+
+const CHECK_OPTS = [
+  { key: 'agents', label: 'Agents in rooms' },
+  { key: 'sfu', label: 'SFU baseline' },
+  { key: 'latency', label: 'Latency (real calls)' },
+  { key: 'sfu_load', label: 'SFU load' },
+] as const;
+
+const MAX_POLLS = 180;
+
+function verdictBadgeClass(v: string | null): string {
+  if (v === 'PASS') return 'neo-badge--green';
+  if (v === 'WARN') return 'neo-badge--warning';
+  if (v === 'FAIL') return 'neo-badge--red';
+  return 'neo-badge--black';
+}
+
+export default function Diagnostics() {
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const [creds, setCreds] = useState<DiagnosticsCreds | null>(null);
+  const [run, setRun] = useState<DiagnosticRun | null>(null);
+  const [runs, setRuns] = useState<DiagnosticRun[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set(['agents', 'sfu']));
+  const [inFlight, setInFlight] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+
+  // Load creds status + run history on mount.
+  useEffect(() => {
+    fetchDiagnosticsCreds()
+      .then((c) => { if (mountedRef.current) setCreds(c); })
+      .catch(() => { if (mountedRef.current) setCreds({ configured: false, url: null }); });
+    fetchDiagnosticsRuns()
+      .then((r) => { if (mountedRef.current) setRuns(r); })
+      .catch(() => { if (mountedRef.current) setRuns([]); });
+  }, []);
+
+  const configured = creds?.configured ?? false;
+  const costy = selected.has('latency') || selected.has('sfu_load');
+  const canRun = configured && selected.size > 0 && !inFlight;
+
+  const toggleCheck = (key: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const startRun = async () => {
+    setInFlight(true);
+    setRunError(null);
+    try {
+      const checks = Array.from(selected);
+      const { run_id } = await createDiagnosticsRun({ checks, config: {} });
+
+      let rec = await fetchDiagnosticsRun(run_id);
+      if (mountedRef.current) setRun(rec);
+
+      let polls = 0;
+      while (rec.status === 'queued' || rec.status === 'running') {
+        if (polls >= MAX_POLLS) {
+          if (mountedRef.current) {
+            setRunError('Run is still in progress. Check history later.');
+          }
+          break;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 2000));
+        if (!mountedRef.current) return;
+        polls++;
+        rec = await fetchDiagnosticsRun(run_id);
+        if (mountedRef.current) setRun(rec);
+      }
+
+      if (polls < MAX_POLLS && mountedRef.current) {
+        setRuns((prev) => [rec, ...prev]);
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setRunError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      if (mountedRef.current) {
+        setInFlight(false);
+      }
+    }
+  };
+
+  return (
+    <div>
+      <PageHeader
+        title="Diagnostics"
+        subtitle="Probe your LiveKit deployment from this machine"
+        accent="blue"
+      />
+
+      {/* Connection status card */}
+      <div className="vg-card" style={{ marginBottom: 16 }}>
+        <div className="vg-card__label" style={{ marginBottom: 10 }}>LiveKit connection</div>
+        {creds === null ? (
+          <span style={{ color: 'var(--vg-muted)', fontSize: 13 }}>Checking...</span>
+        ) : configured ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <span className="neo-badge neo-badge--green">Connected</span>
+            {creds.url && (
+              <span className="mono" style={{ fontSize: 13, color: 'var(--vg-muted)' }}>
+                {creds.url}
+              </span>
+            )}
+          </div>
+        ) : (
+          <div>
+            <span className="neo-badge neo-badge--warning">Not configured</span>
+            <p style={{ marginTop: 10, fontSize: 13, color: 'var(--vg-muted)', lineHeight: 1.5 }}>
+              Set <span className="mono">LIVEKIT_URL</span>,{' '}
+              <span className="mono">LIVEKIT_API_KEY</span> and{' '}
+              <span className="mono">LIVEKIT_API_SECRET</span> (or a{' '}
+              <span className="mono">livekit:</span> block in{' '}
+              <span className="mono">voicegw.yaml</span>), then reload.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Run checks card */}
+      <div className="vg-card" style={{ marginBottom: 16 }}>
+        <div className="vg-card__label" style={{ marginBottom: 10 }}>
+          Run checks{inFlight && <span className="neo-badge neo-badge--black" style={{ marginLeft: 10 }}>Running...</span>}
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {CHECK_OPTS.map(({ key, label }) => (
+            <label
+              key={key}
+              style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: 14 }}
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(key)}
+                onChange={() => toggleCheck(key)}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+        {costy && (
+          <div
+            style={{
+              marginTop: 12,
+              padding: '10px 14px',
+              borderRadius: 6,
+              border: '1.5px solid var(--vg-amber, #e6a817)',
+              background: 'rgba(230, 168, 23, 0.08)',
+              color: 'var(--vg-amber, #b07d00)',
+              fontSize: 13,
+              lineHeight: 1.5,
+            }}
+          >
+            Latency and SFU load place real calls and open many connections, billed by your providers.
+          </div>
+        )}
+        {runError && (
+          <div
+            style={{
+              marginTop: 10,
+              padding: '10px 14px',
+              borderRadius: 6,
+              border: '1.5px solid var(--vg-red, #e53e3e)',
+              background: 'rgba(229, 62, 62, 0.07)',
+              color: 'var(--vg-red, #c53030)',
+              fontSize: 13,
+            }}
+          >
+            {runError}
+          </div>
+        )}
+        <div style={{ marginTop: 14, display: 'flex', alignItems: 'center', gap: 12 }}>
+          <button
+            type="button"
+            className="neo-btn neo-btn--primary"
+            onClick={startRun}
+            disabled={!canRun}
+          >
+            {inFlight ? 'Running...' : 'Run checks'}
+          </button>
+          {!configured && (
+            <span style={{ fontSize: 12, color: 'var(--vg-muted)' }}>
+              Configure LiveKit credentials first.
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Latest run card */}
+      {run && (
+        <div className="vg-card" style={{ marginBottom: 16 }}>
+          <div
+            style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}
+          >
+            <span className="vg-card__label">
+              Latest run
+              {(run.status === 'queued' || run.status === 'running') && ' (in progress)'}
+            </span>
+            {run.verdict && (
+              <span className={`neo-badge ${verdictBadgeClass(run.verdict)}`}>
+                {run.verdict}
+              </span>
+            )}
+          </div>
+          {run.results ? (
+            <table className="neo-table neo-table--blue">
+              <thead>
+                <tr>
+                  <th>Check</th>
+                  <th>Result</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(run.results.checks).map(([name, result]) => (
+                  <tr key={name}>
+                    <td style={{ fontWeight: 500 }}>{name}</td>
+                    <td>
+                      {result.ok ? (
+                        <span className="neo-badge neo-badge--green">ok</span>
+                      ) : (
+                        <span className="neo-badge neo-badge--red">
+                          {result.error ? `error: ${result.error}` : 'error'}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : run.error ? (
+            <div
+              style={{
+                padding: '10px 14px',
+                borderRadius: 6,
+                border: '1.5px solid var(--vg-red, #e53e3e)',
+                background: 'rgba(229, 62, 62, 0.07)',
+                color: 'var(--vg-red, #c53030)',
+                fontSize: 13,
+              }}
+            >
+              {run.error}
+            </div>
+          ) : (
+            <div style={{ color: 'var(--vg-muted)', fontSize: 13 }}>
+              Waiting for results...
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Run history card */}
+      {runs.length > 0 && (
+        <div className="vg-card">
+          <div className="vg-card__label" style={{ marginBottom: 12 }}>Run history</div>
+          <table className="neo-table">
+            <thead>
+              <tr>
+                <th>Started</th>
+                <th>Checks</th>
+                <th>Verdict</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((r) => (
+                <tr key={r.run_id}>
+                  <td style={{ color: 'var(--vg-muted)', fontSize: 13 }}>
+                    {r.created_at ?? '-'}
+                  </td>
+                  <td>{r.checks.join(', ')}</td>
+                  <td>
+                    {r.verdict ? (
+                      <span className={`neo-badge ${verdictBadgeClass(r.verdict)}`}>
+                        {r.verdict}
+                      </span>
+                    ) : (
+                      <span style={{ color: 'var(--vg-muted)', fontSize: 13 }}>{r.status}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/voicegateway/livekit_diag/service.py
+++ b/src/voicegateway/livekit_diag/service.py
@@ -1,0 +1,220 @@
+"""Bounded execution of the livekit_diag probes from resolved LiveKit creds.
+
+RealProbes wraps LiveKitAdmin/ProbeRunner/SfuProbe exactly as the CLI does, with
+hard caps applied. execute_run runs each requested check under try/except so one
+failing check never kills the others (mirrors the CLI's best-effort behaviour).
+Tests inject a fake `probes` object with the same async method surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from typing import Any
+
+PER_CHECK_TIMEOUT_SECONDS = 120.0
+MAX_LOAD_CLIENTS = 25
+MAX_LOAD_SECONDS = 30.0
+MAX_LATENCY_TRIALS = 3
+_DEFAULT_RAMP = [2, 10, 25]
+_TARGET_RTT_MS = 50.0
+_MAX_LOSS = 1.0
+
+
+def _safe_int(v: Any, default: int) -> int:
+    try:
+        return int(v)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_float(v: Any, default: float) -> float:
+    try:
+        return float(v)
+    except (ValueError, TypeError):
+        return default
+
+
+def clamp_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Clamp client-supplied config to the hard caps; fill defaults."""
+    ramp_raw = config.get("ramp")
+    if not isinstance(ramp_raw, list):
+        ramp_raw = _DEFAULT_RAMP
+    ramp: list[int] = []
+    for n in ramp_raw:
+        try:
+            val = int(n)
+            if val > 0:
+                ramp.append(min(val, MAX_LOAD_CLIENTS))
+        except (ValueError, TypeError):
+            pass
+    ramp = ramp[:6] or _DEFAULT_RAMP
+    duration = min(
+        max(1.0, _safe_float(config.get("duration", 20.0), 20.0)), MAX_LOAD_SECONDS
+    )
+    # Cap per-step duration so N steps * duration <= MAX_LOAD_SECONDS total.
+    duration = min(duration, MAX_LOAD_SECONDS / max(1, len(ramp)))
+    trials = min(max(1, _safe_int(config.get("trials", 2), 2)), MAX_LATENCY_TRIALS)
+    return {
+        "target_ms": _safe_float(config.get("target_ms", 1500), 1500.0),
+        "ramp": ramp,
+        "duration": duration,
+        "trials": trials,
+    }
+
+
+_diag_cache: Any = None
+
+
+def _diag() -> Any:
+    """Import the engine's livekit_diag probes lazily, cached.
+
+    Kept out of module scope on purpose: the diagnostics router imports this
+    module at app startup, so a stale or missing engine pin must not be able to
+    crash the whole cloud API. Any import failure here is raised inside
+    execute_run's per-check try/except and surfaces as a failed check, not a
+    dead process (and a failed /health that blocks every deploy).
+    """
+    global _diag_cache
+    if _diag_cache is None:
+        from types import SimpleNamespace
+
+        import voicegateway.livekit_diag as pkg
+        from voicegateway.livekit_diag.admin import LiveKitAdmin
+        from voicegateway.livekit_diag.client import SyntheticClient, UtteranceSource
+        from voicegateway.livekit_diag.latency import ProbeRunner, summarize
+        from voicegateway.livekit_diag.report import agents_json
+        from voicegateway.livekit_diag.resources import ResourceMonitor
+        from voicegateway.livekit_diag.sfu import SfuProbe, find_knee
+
+        _diag_cache = SimpleNamespace(
+            pkg=pkg,
+            LiveKitAdmin=LiveKitAdmin,
+            SyntheticClient=SyntheticClient,
+            UtteranceSource=UtteranceSource,
+            ProbeRunner=ProbeRunner,
+            summarize=summarize,
+            agents_json=agents_json,
+            ResourceMonitor=ResourceMonitor,
+            SfuProbe=SfuProbe,
+            find_knee=find_knee,
+        )
+    return _diag_cache
+
+
+def _utterance_path() -> str:
+    return str(pathlib.Path(_diag().pkg.__file__).parent / "assets" / "probe.wav")
+
+
+class RealProbes:
+    """Runs the engine probes against a live LiveKit server."""
+
+    async def agents(self, creds) -> dict[str, Any]:
+        d = _diag()
+        admin = d.LiveKitAdmin(creds)
+        admin.url = creds.url
+        try:
+            rows = await admin.list_agents()
+        finally:
+            await admin.aclose()
+        return {"agents": d.agents_json(rows)}
+
+    async def sfu(self, creds, load: bool, config: dict[str, Any]) -> dict[str, Any]:
+        d = _diag()
+        admin = d.LiveKitAdmin(creds)
+        admin.url = creds.url
+        probe = d.SfuProbe(
+            admin, lambda u, t: d.SyntheticClient(u, t), d.ResourceMonitor()
+        )
+        try:
+            base = await probe.baseline("vg-diag-sfu")
+            steps, _resource = ([], None)
+            if load:
+                steps, _resource = await probe.ramp(
+                    "vg-diag-sfu",
+                    config["ramp"],
+                    config["duration"],
+                    _TARGET_RTT_MS,
+                    _MAX_LOSS,
+                )
+            knee = d.find_knee(steps, _TARGET_RTT_MS, _MAX_LOSS) if steps else None
+        finally:
+            await admin.aclose()
+        return {
+            "baseline": {
+                "rtt_ms": base.rtt_ms,
+                "loss_pct": base.loss_pct,
+                "quality": base.quality,
+            },
+            "ramp": [
+                {"clients": s.clients, "rtt_ms": s.rtt_ms, "loss_pct": s.loss_pct}
+                for s in steps
+            ],
+            "knee": knee,
+        }
+
+    async def latency(self, creds, config: dict[str, Any]) -> dict[str, Any]:
+        d = _diag()
+        admin = d.LiveKitAdmin(creds)
+        admin.url = creds.url
+        try:
+            targets = [r.agent_name for r in await admin.list_agents()]
+            runner = d.ProbeRunner(
+                admin,
+                lambda u, t: d.SyntheticClient(creds.url, t),
+                d.UtteranceSource(_utterance_path()),
+            )
+            out = []
+            for name in targets:
+                r = await runner.probe(name, config["trials"], True, None, "")
+                out.append(
+                    {"agent": name, "stats": d.summarize(r), "components": r.components}
+                )
+        finally:
+            await admin.aclose()
+        return {"agents": out}
+
+
+def _verdict(check_results: dict[str, Any], target_ms: float) -> str:
+    if any(not r["ok"] for r in check_results.values()):
+        return "FAIL"
+    lat = check_results.get("latency")
+    if lat and lat["ok"]:
+        for a in lat["result"].get("agents", []):
+            if (a.get("stats", {}).get("avg", 0) * 1000) > target_ms:
+                return "WARN"
+    sfu = check_results.get("sfu")
+    if sfu and sfu["ok"]:
+        b = sfu["result"].get("baseline", {})
+        if b.get("loss_pct", 0) > 1.0 or b.get("quality") in {"Poor", "Lost"}:
+            return "WARN"
+    return "PASS"
+
+
+async def execute_run(
+    checks: list[str], config: dict[str, Any], creds, *, probes
+) -> dict[str, Any]:
+    """Run each requested check under isolation; return results + verdict."""
+    results: dict[str, Any] = {}
+    for check in checks:
+        try:
+            if check == "agents":
+                coro = probes.agents(creds)
+            elif check == "sfu":
+                coro = probes.sfu(creds, False, config)
+            elif check == "sfu_load":
+                coro = probes.sfu(creds, True, config)
+            elif check == "latency":
+                coro = probes.latency(creds, config)
+            else:
+                continue
+            res = await asyncio.wait_for(coro, PER_CHECK_TIMEOUT_SECONDS)
+            results[check] = {"ok": True, "result": res}
+        except TimeoutError:
+            results[check] = {"ok": False, "error": "check timed out"}
+        except Exception as exc:  # noqa: BLE001 - a check must not kill the run
+            results[check] = {"ok": False, "error": str(exc)}
+    return {
+        "checks": results,
+        "verdict": _verdict(results, config.get("target_ms", 1500)),
+    }

--- a/src/voicegateway/server/api/dashboard/diagnostics.py
+++ b/src/voicegateway/server/api/dashboard/diagnostics.py
@@ -1,0 +1,202 @@
+"""In-memory LiveKit diagnostics runs for the OSS dashboard.
+
+Single local vantage: creds come from env / voicegw.yaml via resolve_creds
+(read-only, never persisted), checks run as a background asyncio task, and
+runs live in a process-local dict (ephemeral, lost on restart). The engine
+probes are imported lazily inside livekit_diag.service so a missing livekit
+dependency degrades to a failed check, never a dead dashboard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from voicegateway.livekit_diag import service
+from voicegateway.livekit_diag.config import CredsError, resolve_creds
+from voicegateway.server.api._deps import get_gateway
+
+router = APIRouter(prefix="/diagnostics", tags=["dashboard"])
+
+_VALID_CHECKS = {"agents", "sfu", "sfu_load", "latency"}
+_HISTORY_CAP = 20
+_OVERALL_RUN_TIMEOUT_SECONDS = 360.0
+
+_RUNS: dict[str, _Run] = {}
+_ORDER: list[str] = []  # run_ids, newest last
+_TASKS: set[asyncio.Task[None]] = set()
+
+
+@dataclass
+class _Run:
+    run_id: str
+    checks: list[str]
+    config: dict[str, Any]
+    status: str = "queued"
+    results: dict[str, Any] | None = None
+    verdict: str | None = None
+    error: str | None = None
+    created_at: str = field(default_factory=str)
+    started_at: str | None = None
+    ended_at: str | None = None
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _as_dict(r: _Run) -> dict[str, Any]:
+    return {
+        "run_id": r.run_id,
+        "status": r.status,
+        "checks": r.checks,
+        "config": r.config,
+        "results": r.results,
+        "verdict": r.verdict,
+        "error": r.error,
+        "created_at": r.created_at,
+        "started_at": r.started_at,
+        "ended_at": r.ended_at,
+    }
+
+
+# Seams for tests to override (monkeypatch):
+def _make_probes() -> service.RealProbes:
+    return service.RealProbes()
+
+
+def _resolve_creds() -> Any:
+    return resolve_creds(None, None, None)
+
+
+def _active_run_id() -> str | None:
+    for rid in reversed(_ORDER):
+        if _RUNS[rid].status in ("queued", "running"):
+            return rid
+    return None
+
+
+async def _execute(run: _Run, creds: Any) -> None:
+    run.status = "running"
+    run.started_at = _now()
+    try:
+        out = await asyncio.wait_for(
+            service.execute_run(run.checks, run.config, creds, probes=_make_probes()),
+            _OVERALL_RUN_TIMEOUT_SECONDS,
+        )
+        run.results = out
+        run.verdict = out.get("verdict")
+        run.status = "done"
+    except TimeoutError:
+        run.status = "failed"
+        run.error = "run timed out"
+    except Exception as exc:  # noqa: BLE001 - a run must never crash the loop
+        run.status = "failed"
+        run.error = str(exc)
+    finally:
+        run.ended_at = _now()
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class _RunRequest(BaseModel):
+    checks: list[str]
+    config: dict[str, Any] = {}
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/creds")
+async def get_creds(
+    _gw: Any = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Return whether LiveKit credentials are configured and the server URL."""
+    try:
+        creds = _resolve_creds()
+        return {"configured": True, "url": creds.url}
+    except CredsError:
+        return {"configured": False, "url": None}
+
+
+@router.post("/runs")
+async def create_run(
+    body: _RunRequest,
+    _gw: Any = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Start a new diagnostics run. Returns 400 when not configured or checks invalid,
+    409 when another run is already active."""
+    valid = set(body.checks) & _VALID_CHECKS
+    if not body.checks or not valid:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "checks must be a non-empty subset of: "
+                + ", ".join(sorted(_VALID_CHECKS))
+            ),
+        )
+
+    try:
+        creds = _resolve_creds()
+    except CredsError:
+        raise HTTPException(status_code=400, detail="LiveKit not configured") from None
+
+    if _active_run_id() is not None:
+        raise HTTPException(
+            status_code=409, detail="a diagnostics run is already in progress"
+        )
+
+    run = _Run(
+        run_id=uuid.uuid4().hex,
+        checks=sorted(valid),
+        config=service.clamp_config(body.config or {}),
+        created_at=_now(),
+    )
+    _RUNS[run.run_id] = run
+    _ORDER.append(run.run_id)
+
+    # Trim history: drop oldest terminal runs beyond the cap.
+    while len(_ORDER) > _HISTORY_CAP:
+        candidate = _ORDER[0]
+        if _RUNS[candidate].status in ("done", "failed"):
+            _ORDER.pop(0)
+            del _RUNS[candidate]
+        else:
+            break
+
+    task = asyncio.create_task(_execute(run, creds))
+    _TASKS.add(task)
+    task.add_done_callback(_TASKS.discard)
+
+    return {"run_id": run.run_id, "status": "queued"}
+
+
+@router.get("/runs/{run_id}")
+async def get_run(
+    run_id: str,
+    _gw: Any = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Return a single run record by id, or 404."""
+    run = _RUNS.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"run {run_id!r} not found")
+    return _as_dict(run)
+
+
+@router.get("/runs")
+async def list_runs(
+    _gw: Any = Depends(get_gateway),
+) -> list[dict[str, Any]]:
+    """Return the run history, newest first, capped at 20."""
+    return [_as_dict(_RUNS[r]) for r in reversed(_ORDER)]

--- a/src/voicegateway/server/api/dashboard/diagnostics.py
+++ b/src/voicegateway/server/api/dashboard/diagnostics.py
@@ -5,6 +5,11 @@ Single local vantage: creds come from env / voicegw.yaml via resolve_creds
 runs live in a process-local dict (ephemeral, lost on restart). The engine
 probes are imported lazily inside livekit_diag.service so a missing livekit
 dependency degrades to a failed check, never a dead dashboard.
+
+Every endpoint is gated behind require_scope(ADMIN_SCOPE): a run can place
+billed calls and touch shared LiveKit infrastructure, so it needs the admin
+role. That gate is a no-op when no API keys are configured (the local
+single-operator default), and enforces the admin scope once auth is enabled.
 """
 
 from __future__ import annotations
@@ -18,9 +23,10 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from voicegateway.core.auth import ADMIN_SCOPE
 from voicegateway.livekit_diag import service
 from voicegateway.livekit_diag.config import CredsError, resolve_creds
-from voicegateway.server.api._deps import get_gateway
+from voicegateway.server.api._deps import require_scope
 
 router = APIRouter(prefix="/diagnostics", tags=["dashboard"])
 
@@ -120,7 +126,7 @@ class _RunRequest(BaseModel):
 
 @router.get("/creds")
 async def get_creds(
-    _gw: Any = Depends(get_gateway),
+    _auth: None = Depends(require_scope(ADMIN_SCOPE)),
 ) -> dict[str, Any]:
     """Return whether LiveKit credentials are configured and the server URL."""
     try:
@@ -133,7 +139,7 @@ async def get_creds(
 @router.post("/runs")
 async def create_run(
     body: _RunRequest,
-    _gw: Any = Depends(get_gateway),
+    _auth: None = Depends(require_scope(ADMIN_SCOPE)),
 ) -> dict[str, Any]:
     """Start a new diagnostics run. Returns 400 when not configured or checks invalid,
     409 when another run is already active."""
@@ -185,7 +191,7 @@ async def create_run(
 @router.get("/runs/{run_id}")
 async def get_run(
     run_id: str,
-    _gw: Any = Depends(get_gateway),
+    _auth: None = Depends(require_scope(ADMIN_SCOPE)),
 ) -> dict[str, Any]:
     """Return a single run record by id, or 404."""
     run = _RUNS.get(run_id)
@@ -196,7 +202,7 @@ async def get_run(
 
 @router.get("/runs")
 async def list_runs(
-    _gw: Any = Depends(get_gateway),
+    _auth: None = Depends(require_scope(ADMIN_SCOPE)),
 ) -> list[dict[str, Any]]:
     """Return the run history, newest first, capped at 20."""
     return [_as_dict(_RUNS[r]) for r in reversed(_ORDER)]

--- a/src/voicegateway/server/routes.py
+++ b/src/voicegateway/server/routes.py
@@ -53,6 +53,9 @@ from voicegateway.server.api.dashboard import (
     costs as dashboard_costs,
 )
 from voicegateway.server.api.dashboard import (
+    diagnostics as dashboard_diagnostics,
+)
+from voicegateway.server.api.dashboard import (
     health as dashboard_health,
 )
 from voicegateway.server.api.dashboard import (
@@ -104,6 +107,7 @@ dashboard_router.include_router(dashboard_metrics.router)
 dashboard_router.include_router(dashboard_replay.router)
 dashboard_router.include_router(dashboard_tenants.router)
 dashboard_router.include_router(dashboard_agents.router)
+dashboard_router.include_router(dashboard_diagnostics.router)
 dashboard_router.include_router(dashboard_api_keys.router)
 dashboard_router.include_router(dashboard_branding.router)
 

--- a/src/voicegateway/tests/livekit_diag/test_service.py
+++ b/src/voicegateway/tests/livekit_diag/test_service.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+
+from voicegateway.livekit_diag import service as probes
+
+
+def test_clamp_config_enforces_caps():
+    out = probes.clamp_config({"ramp": [2, 10, 100], "duration": 120, "trials": 9})
+    assert max(out["ramp"]) <= probes.MAX_LOAD_CLIENTS
+    assert out["duration"] <= probes.MAX_LOAD_SECONDS
+    assert out["trials"] <= probes.MAX_LATENCY_TRIALS
+    # total load time must be bounded
+    assert len(out["ramp"]) * out["duration"] <= probes.MAX_LOAD_SECONDS
+
+
+def test_clamp_config_tolerates_bad_input():
+    # A non-numeric target_ms and a non-iterable ramp must not 500.
+    out = probes.clamp_config(
+        {"duration": "abc", "trials": -5, "ramp": 5, "target_ms": "fast"}
+    )
+    assert out["duration"] >= 1.0
+    assert out["duration"] <= probes.MAX_LOAD_SECONDS
+    assert out["trials"] >= 1
+    assert isinstance(out["target_ms"], float)  # bad target_ms fell back to default
+    assert isinstance(out["ramp"], list) and out["ramp"]  # non-iterable -> default
+    for n in out["ramp"]:
+        assert 0 < n <= probes.MAX_LOAD_CLIENTS
+
+
+def test_clamp_config_drops_bad_ramp_elements():
+    out = probes.clamp_config({"ramp": ["x", 50]})
+    for n in out["ramp"]:
+        assert 0 < n <= probes.MAX_LOAD_CLIENTS
+
+
+class _FakeProbes:
+    def __init__(self):
+        self.calls = []
+
+    async def agents(self, creds):
+        self.calls.append("agents")
+        return {"agents": [{"agent_name": "a", "room": "r"}]}
+
+    async def sfu(self, creds, load, config):
+        self.calls.append(("sfu", load))
+        return {
+            "baseline": {"rtt_ms": 11, "loss_pct": 0.0, "quality": "Excellent"},
+            "ramp": [],
+            "knee": None,
+        }
+
+    async def latency(self, creds, config):
+        self.calls.append("latency")
+        # Use the real structure that _verdict and RealProbes.latency produce
+        return {
+            "agents": [
+                {"agent": "a", "stats": {"avg": 0.8, "p95": 0.9}, "components": None}
+            ]
+        }
+
+
+async def test_execute_run_runs_requested_checks_and_verdicts():
+    fake = _FakeProbes()
+    out = await probes.execute_run(
+        ["agents", "sfu", "latency"], {"target_ms": 1500}, creds=object(), probes=fake
+    )
+    assert set(out["checks"]) == {"agents", "sfu", "latency"}
+    assert out["verdict"] == "PASS"
+    assert "agents" in fake.calls and "latency" in fake.calls
+
+
+async def test_execute_run_isolates_a_failing_check():
+    class _Boom(_FakeProbes):
+        async def latency(self, creds, config):
+            raise RuntimeError("no agents answered")
+
+    out = await probes.execute_run(
+        ["agents", "latency"], {}, creds=object(), probes=_Boom()
+    )
+    assert out["checks"]["agents"]["ok"] is True
+    assert out["checks"]["latency"]["ok"] is False
+    assert "no agents answered" in out["checks"]["latency"]["error"]
+    assert out["verdict"] == "FAIL"
+
+
+async def test_execute_run_times_out_slow_check(monkeypatch):
+    """A check that hangs longer than PER_CHECK_TIMEOUT_SECONDS is aborted."""
+    monkeypatch.setattr(probes, "PER_CHECK_TIMEOUT_SECONDS", 0.01)
+
+    class _SlowProbes:
+        async def agents(self, creds):
+            await asyncio.sleep(10)
+            return {"agents": []}
+
+    out = await probes.execute_run(["agents"], {}, creds=object(), probes=_SlowProbes())
+    assert out["checks"]["agents"] == {"ok": False, "error": "check timed out"}
+    assert out["verdict"] == "FAIL"
+
+
+async def test_verdict_warns_on_slow_latency():
+    """Latency avg above target_ms yields WARN, not FAIL."""
+
+    class _SlowLatencyProbes(_FakeProbes):
+        async def latency(self, creds, config):
+            return {
+                "agents": [
+                    {
+                        "agent": "a",
+                        "stats": {"avg": 2.0, "p95": 2.5},
+                        "components": None,
+                    }
+                ]
+            }
+
+    out = await probes.execute_run(
+        ["agents", "latency"],
+        {"target_ms": 1500},
+        creds=object(),
+        probes=_SlowLatencyProbes(),
+    )
+    assert out["checks"]["latency"]["ok"] is True
+    assert out["verdict"] == "WARN"

--- a/src/voicegateway/tests/server/test_diagnostics_api.py
+++ b/src/voicegateway/tests/server/test_diagnostics_api.py
@@ -255,3 +255,46 @@ async def test_run_isolates_failing_check(client, monkeypatch):
     assert checks["agents"]["ok"] is True
     assert checks["latency"]["ok"] is False
     assert data["verdict"] == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Auth: the diagnostics endpoints are admin-gated once auth is enabled
+# ---------------------------------------------------------------------------
+
+
+async def test_endpoints_require_admin_when_auth_enabled(gateway, monkeypatch):
+    """With static keys configured, diagnostics rejects unauthenticated callers.
+
+    require_scope(ADMIN_SCOPE) is a no-op when no keys are configured (the local
+    OSS default, exercised by every other test here). Once keys exist it enforces
+    the admin scope, so an unauthenticated caller cannot trigger a billed run or
+    read the configured server URL.
+    """
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: _FAKE_CREDS)
+
+    app = build_app(gateway, enable_mcp_sse=False, enable_dashboard=True)
+    # A non-vk_ token takes the static-key path (check_request, which reads
+    # app.state.api_keys). A vk_ token would take the DB storage path instead.
+    app.state.api_keys = [
+        ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,))
+    ]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # No credentials: 401 on every endpoint, including the mutating POST.
+        assert (await c.get("/api/diagnostics/creds")).status_code == 401
+        assert (await c.get("/api/diagnostics/runs")).status_code == 401
+        blocked = await c.post(
+            "/api/diagnostics/runs", json={"checks": ["agents"], "config": {}}
+        )
+        assert blocked.status_code == 401
+
+        # A valid admin token passes the gate (no run is started by GET /creds).
+        ok = await c.get(
+            "/api/diagnostics/creds",
+            headers={"Authorization": "Bearer admin-secret-token"},
+        )
+        assert ok.status_code == 200
+        assert ok.json() == {"configured": True, "url": "wss://x"}

--- a/src/voicegateway/tests/server/test_diagnostics_api.py
+++ b/src/voicegateway/tests/server/test_diagnostics_api.py
@@ -1,0 +1,257 @@
+"""Tests for the dashboard ``/api/diagnostics/*`` endpoints.
+
+The diagnostics router runs LiveKit probes as background asyncio tasks against
+a module-level in-memory registry. Tests monkeypatch the two seams
+(_resolve_creds and _make_probes) so no real LiveKit server is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.livekit_diag.config import CredsError, LiveKitCreds
+from voicegateway.server.main import build_app
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gateway(temp_config, tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "diag-test.db"))
+    return Gateway(config_path=temp_config)
+
+
+@pytest.fixture
+async def client(gateway):
+    app = build_app(gateway, enable_mcp_sse=False, enable_dashboard=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    from voicegateway.server.api.dashboard import diagnostics as d
+
+    d._RUNS.clear()
+    d._ORDER.clear()
+    d._TASKS.clear()
+    yield
+    d._RUNS.clear()
+    d._ORDER.clear()
+    d._TASKS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Fake probes
+# ---------------------------------------------------------------------------
+
+_FAKE_CREDS = LiveKitCreds("wss://x", "k", "s")
+
+
+class _FakeProbes:
+    """Fast probes that return valid shapes without touching a real server."""
+
+    async def agents(self, creds: Any) -> dict[str, Any]:
+        return {"agents": []}
+
+    async def sfu(self, creds: Any, load: bool, config: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "baseline": {"rtt_ms": 5.0, "loss_pct": 0.0, "quality": "Excellent"},
+            "ramp": [],
+            "knee": None,
+        }
+
+    async def latency(self, creds: Any, config: dict[str, Any]) -> dict[str, Any]:
+        return {"agents": []}
+
+
+class _SlowProbes(_FakeProbes):
+    """Probes whose agents check blocks long enough to test 409 detection."""
+
+    async def agents(self, creds: Any) -> dict[str, Any]:
+        await asyncio.sleep(0.3)
+        return {"agents": []}
+
+
+class _FailLatencyProbes(_FakeProbes):
+    """Probes where latency raises so that check fails while agents passes."""
+
+    async def latency(self, creds: Any, config: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("latency probe failed")
+
+
+# ---------------------------------------------------------------------------
+# Helper: poll until terminal
+# ---------------------------------------------------------------------------
+
+
+async def _poll_until_done(client: AsyncClient, run_id: str) -> dict[str, Any]:
+    """Poll GET /api/diagnostics/runs/{run_id} until status is terminal."""
+    for _ in range(200):
+        resp = await client.get(f"/api/diagnostics/runs/{run_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        if data["status"] in ("done", "failed"):
+            return data
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"run {run_id} did not reach terminal state in time")
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/diagnostics/creds
+# ---------------------------------------------------------------------------
+
+
+async def test_creds_reports_not_configured(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: (_ for _ in ()).throw(CredsError("no creds")))
+    resp = await client.get("/api/diagnostics/creds")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["configured"] is False
+    assert data["url"] is None
+
+
+async def test_creds_reports_configured(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: _FAKE_CREDS)
+    resp = await client.get("/api/diagnostics/creds")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["configured"] is True
+    assert data["url"] == "wss://x"
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/diagnostics/runs
+# ---------------------------------------------------------------------------
+
+
+async def test_run_rejects_when_not_configured(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: (_ for _ in ()).throw(CredsError("no creds")))
+    resp = await client.post("/api/diagnostics/runs", json={"checks": ["agents"], "config": {}})
+    assert resp.status_code == 400
+    assert "LiveKit not configured" in resp.json()["detail"]
+
+
+async def test_run_rejects_empty_checks(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: _FAKE_CREDS)
+    monkeypatch.setattr(diagnostics, "_make_probes", lambda: _FakeProbes())
+    resp = await client.post("/api/diagnostics/runs", json={"checks": [], "config": {}})
+    assert resp.status_code == 400
+
+
+async def test_run_rejects_bad_checks(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: _FAKE_CREDS)
+    monkeypatch.setattr(diagnostics, "_make_probes", lambda: _FakeProbes())
+    resp = await client.post("/api/diagnostics/runs", json={"checks": ["bogus"], "config": {}})
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Tests: run lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_run_completes_and_polls(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: _FAKE_CREDS)
+    monkeypatch.setattr(diagnostics, "_make_probes", lambda: _FakeProbes())
+
+    resp = await client.post("/api/diagnostics/runs", json={"checks": ["agents"], "config": {}})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "run_id" in body
+    assert body["status"] == "queued"
+
+    run_id = body["run_id"]
+    data = await _poll_until_done(client, run_id)
+
+    assert data["status"] == "done"
+    assert data["verdict"] == "PASS"
+    assert "agents" in data["results"]["checks"]
+    assert data["results"]["checks"]["agents"]["ok"] is True
+
+
+async def test_run_conflict_when_active(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: _FAKE_CREDS)
+    monkeypatch.setattr(diagnostics, "_make_probes", lambda: _SlowProbes())
+
+    resp1 = await client.post("/api/diagnostics/runs", json={"checks": ["agents"], "config": {}})
+    assert resp1.status_code == 200
+    run_id = resp1.json()["run_id"]
+
+    # The run should still be queued or running, so the second POST must 409.
+    resp2 = await client.post("/api/diagnostics/runs", json={"checks": ["agents"], "config": {}})
+    assert resp2.status_code == 409
+    assert "already in progress" in resp2.json()["detail"]
+
+    # Clean up: wait for the first run to finish.
+    await _poll_until_done(client, run_id)
+
+
+async def test_run_404_for_unknown_id(client):
+    resp = await client.get("/api/diagnostics/runs/doesnotexist")
+    assert resp.status_code == 404
+
+
+async def test_runs_list_newest_first_and_capped(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: _FAKE_CREDS)
+    monkeypatch.setattr(diagnostics, "_make_probes", lambda: _FakeProbes())
+
+    run_ids = []
+    for _ in range(5):
+        resp = await client.post("/api/diagnostics/runs", json={"checks": ["agents"], "config": {}})
+        assert resp.status_code == 200
+        run_id = resp.json()["run_id"]
+        run_ids.append(run_id)
+        # Wait for each run to complete before starting the next.
+        await _poll_until_done(client, run_id)
+
+    resp = await client.get("/api/diagnostics/runs")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) <= 20
+    # Newest first: last posted run should appear first in the list.
+    assert rows[0]["run_id"] == run_ids[-1]
+
+
+async def test_run_isolates_failing_check(client, monkeypatch):
+    from voicegateway.server.api.dashboard import diagnostics
+
+    monkeypatch.setattr(diagnostics, "_resolve_creds", lambda: _FAKE_CREDS)
+    monkeypatch.setattr(diagnostics, "_make_probes", lambda: _FailLatencyProbes())
+
+    resp = await client.post(
+        "/api/diagnostics/runs",
+        json={"checks": ["agents", "latency"], "config": {}},
+    )
+    assert resp.status_code == 200
+    run_id = resp.json()["run_id"]
+
+    data = await _poll_until_done(client, run_id)
+    checks = data["results"]["checks"]
+    assert checks["agents"]["ok"] is True
+    assert checks["latency"]["ok"] is False
+    assert data["verdict"] == "FAIL"


### PR DESCRIPTION
## What

Adds a **Diagnostics** page to the OSS dashboard (Monitor group), letting operators probe their LiveKit deployment from the local machine. Mirrors the cloud dashboard's Diagnostics feature at a single vantage (cloud stays the multi-region, persisted, per-tenant system).

Closes the last Monitor-nav gap between OSS and cloud.

## Checks

Four checks, same set as cloud:
- **Agents in rooms** and **SFU baseline** are read-only and free.
- **Latency (real calls)** and **SFU load** spin real rooms / place synthetic calls and are billed by your providers. The UI shows an amber cost warning when either is selected (matching cloud).

## How it works

- **Credentials are read-only**, resolved from `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` (or a `livekit:` block in `voicegw.yaml`) via the engine's existing `resolve_creds()`. No secret-entry form, no encrypted store (that is cloud-only). The page shows a connection-status card; `api_secret` is never returned or logged.
- **Runs are in-memory and ephemeral** (single-user local box): one active run at a time, background asyncio executor, poll to completion. No new DB table, no migration.
- The engine probe imports are **lazy** (`livekit_diag.service._diag()`), so a missing livekit optional dependency degrades to a failed check rather than crashing `voicegw dashboard`.

## Changes

- `livekit_diag/service.py` (new): bounded probe orchestration (`clamp_config`, `RealProbes`, `execute_run`, verdict), lifted from the cloud's engine-only wrapper. Cross-repo dedup (flipping the cloud onto this) is a deliberate follow-up.
- `server/api/dashboard/diagnostics.py` (new) + registered in `routes.py`: `GET /api/diagnostics/creds`, `POST /api/diagnostics/runs`, `GET /api/diagnostics/runs/{id}`, `GET /api/diagnostics/runs`.
- Frontend: `pages/Diagnostics.tsx` + types + fetchers + nav/route/NavIcon.
- `index.css`: define `neo-badge--red` (was referenced but undefined) so FAIL/error badges render red.

## Verification

- Engine: `service` (7 tests) + `diagnostics` API (10 tests) pass; ruff + mypy clean.
- Frontend: `tsc --noEmit` + `npm run build` clean.
- Multi-agent build with per-task reviews + a whole-branch review: seams verified end to end (TS types match the backend run record, check keys agree across all three layers, verdict-to-badge mapping consistent), background runs always reach a terminal status so the single-active-run guard clears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Diagnostics page to monitor LiveKit connectivity and run configurable health checks.
  * View connection status, latest results, verdicts, errors, and recent diagnostic run history.
  * Added support for agent, SFU, and latency checks with progress tracking and automatic status updates.
  * Added Diagnostics to dashboard navigation and command search.
* **Bug Fixes**
  * Corrected red badge styling for diagnostic status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->