### PR TITLE
docs(readme): reframe around the voice-agent profiler hook, drop removed inference API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,32 @@
 
 ```python
 from livekit.agents import AgentSession
-from voicegateway import inference          # the only line that changed
+from livekit.plugins import deepgram, openai, cartesia
+import voicegateway
 
 session = AgentSession(
-    stt=inference.STT("deepgram/nova-3"),
-    llm=inference.LLM("openai/gpt-4o-mini"),
-    tts=inference.TTS("cartesia/sonic-3"),
+    stt=deepgram.STT(model="nova-3"),
+    llm=openai.LLM(model="gpt-4o-mini"),
+    tts=cartesia.TTS(model="sonic-3"),
 )
-# every call logged: provider, model, tokens, $cost, latency, session_id
+voicegateway.attach(session)   # one line. profile every call.
+# logged per call: provider, model, tokens, $cost, latency, session_id
 ```
 
-A drop-in cost and quality observability layer for [LiveKit Agents](https://docs.livekit.io/agents). Use `voicegateway.inference` for VoiceGateway-managed plugins, or `voicegateway.attach(session)` to observe any existing LiveKit STT/LLM/TTS plugin in place. Modality-aware unit accounting (audio-minutes, tokens, characters) with LLM, STT, and TTS prices from [voice-prices](https://github.com/mahimailabs/voice-prices), reconciled against your real provider invoices with one command. Self-hosted. Your keys. No data leaves your infra.
+**The open-source profiler for voice agents.** Add one line and every STT, LLM, and TTS call is priced and timed: cost to the cent, latency p50/p95, and conversation quality. `attach()` takes a [LiveKit](https://docs.livekit.io/agents) `AgentSession` or a [Pipecat](https://github.com/pipecat-ai/pipecat) `PipelineTask`; `import voicegateway` pulls neither framework until you use it. Prices come from [voice-prices](https://github.com/mahimailabs/voice-prices) and reconcile against your real provider invoices with one command. Self-hosted. Your keys. No data leaves your infra.
+
+<details>
+<summary><b>Using Pipecat?</b> Same one line.</summary>
+
+```python
+from pipecat.pipeline.task import PipelineTask
+import voicegateway
+
+task = PipelineTask(pipeline)
+voicegateway.attach(task)   # profile every call, Pipecat
+```
+
+</details>
 
 ## Why VoiceGateway
 
@@ -34,22 +49,36 @@ Voice AI vendors hide three numbers. VoiceGateway exposes them, per call.
 
 - **Is it working?** Latency p50/p95 across the STT → LLM → TTS loop, interruption rate, dead air, talk-over: the metrics text stacks never have to think about.
 - **What does it cost?** STT bills by audio seconds, LLM by tokens, TTS by characters. Every call is broken down by modality and totaled to the cent. `voicegw reconcile` checks recorded numbers against your actual provider invoices.
-- **How do I make it cheaper?** Route by combined STT + LLM + TTS latency budget across providers, switch models per call type, attribute cost per tenant so agency clients see only their own usage.
+- **How do I make it cheaper?** See cost per provider and model so you know what to change. Cap daily spend and fall back on errors with `guard()`. Attribute cost per tenant so agency clients see only their own usage.
 
 Building a text-only LLM app with no voice component? [LiteLLM](https://docs.litellm.ai/) is the better fit. See the [decision tree](https://docs.voicegateway.dev/guide/decision-tree).
+
+## One more line: `guard()`
+
+`attach()` watches. `guard()` acts. Wrap one provider to cap spend, fall back on errors, and rate-limit. It returns a drop-in of the same type, so it slots into your session unchanged.
+
+```python
+llm = voicegateway.guard(
+    openai.LLM(model="gpt-4o-mini"),
+    fallback=[openai.LLM(model="gpt-4o")],   # on a primary error
+    budget="$5.00/day",                       # hard stop past the cap
+    rate_limit="60/min",
+)
+```
+
+`guard()` writes no metrics and `attach()` never double-counts, so use both together.
 
 ## Features
 
 | Capability                     | What it gives you                                                                         |
 | :----------------------------- | :---------------------------------------------------------------------------------------- |
-| **LiveKit Cloud parity**       | Drop-in for `livekit.agents.inference`. Your keys, your config                            |
-| **Voice-conversation metrics** | Per-minute cost, latency p50/p95, interruptions, dead air, talk-over                      |
+| **Framework-neutral**          | One `attach()` for LiveKit or Pipecat. Your keys, your plugins, no lock-in                 |
+| **Voice-conversation metrics** | Per-minute cost, latency p50/p95, interruptions, dead air, talk-over                       |
 | **Conversation replay**        | Scrub any past call: STT chunks, LLM tokens, TTS frames with timing and cost              |
+| **Spend control**              | `guard()`: daily budget cap, fallback on error, rate limit, per project                   |
+| **Reconciliation**             | `voicegw reconcile` checks recorded cost against your real provider invoices              |
 | **Terminal UI**                | `voicegw tui` opens a vim-key Textual UI for SSH-in inspection                            |
-| **Multi-tenant attribution**   | Per-tenant cost, scoped API keys per team, agency-ready                                   |
-| **Cross-modality routing**     | Route by combined latency budget, per-project rosters, white-label branding               |
-| **Voice-specific guardrails**  | Real-time PII detection in STT, prompt-injection detection, compliance hooks              |
-| **Daemon-first onboarding**    | Curl-bash install, OS daemon, five-question wizard, `voicegw doctor`                      |
+| **Multi-tenant attribution**   | Per-tenant cost, scoped API keys per team, agency-ready                                    |
 | **Fleet collector**            | One-line installer. N agents push to one collector. Slice costs by agent, project, tenant |
 
 Full release history: [CHANGELOG.md](CHANGELOG.md).
@@ -58,11 +87,11 @@ Full release history: [CHANGELOG.md](CHANGELOG.md).
 
 ```bash
 # Single node: local SQLite + the dashboard at http://localhost:8080
-pip install "voicegateway[cloud,dashboard]"
+pip install "voicegateway[dashboard]"
 voicegw init && voicegw serve
 ```
 
-Add the three `inference` lines from the snippet above to your agent and every call is tracked. Provider plugins install modularly (`pip install "voicegateway[deepgram,openai,cartesia]"`). The full extras matrix, the zero-install [uvx](https://uvx.sh) path, and the OS daemon installer (LaunchAgent / systemd / Scheduled Task) are in the [get-started docs](https://docs.voicegateway.dev/get-started). Python 3.11+.
+Add the one `voicegateway.attach(session)` line from the snippet above to your agent and every call is tracked. Provider plugins install with your framework (`pip install "voicegateway[livekit,deepgram,openai,cartesia]"` or `"voicegateway[pipecat]"`). The full extras matrix, the zero-install [uvx](https://uvx.sh) path, and the OS daemon installer (LaunchAgent / systemd / Scheduled Task) are in the [get-started docs](https://docs.voicegateway.dev/get-started). Python 3.11+.
 
 ## The dashboard
 
@@ -71,10 +100,10 @@ A self-hosted web UI at `http://localhost:8080`. Bundled. No SaaS account. No da
 <div align="center">
   <img src="https://raw.githubusercontent.com/mahimailabs/voicegateway/main/docs/assets/dashboard-tour.gif" alt="VoiceGateway dashboard tour" width="100%" />
   <br/>
-  <sub>A 7-day spend / requests trend, per-provider cost breakdowns, a live request log, and one-key light/dark.</sub>
+  <sub>A 7-day spend / requests trend, per-provider cost breakdowns, conversation replay, and one-key light/dark.</sub>
 </div>
 
-Overview with a 7-day spend and requests trend, Costs (per provider / model / project / tenant, plus latency p50/p95), Sessions (replay, routing decisions, budget overruns), Logs, Agents, and Settings. One-key light/dark theme. White-label it per project: upload a logo, set an accent color and product name, and the whole UI re-skins.
+Overview with a 7-day spend and requests trend, Agents (per-agent cost, model stack, worker memory), Costs (per provider / model / project / tenant, plus latency p50/p95), Calls (replay any conversation), Latency, and Diagnostics (probe your LiveKit deployment). Configure projects and a rate card for billing reconciliation. One-key light/dark theme. White-label it per project: upload a logo, set an accent color and product name, and the whole UI re-skins.
 
 ## Fleet collector
 
@@ -84,58 +113,48 @@ Run one shared collector on your VPS. Every agent on your fleet pushes telemetry
 curl -fsSL https://voicegateway.dev/collector.sh | bash
 ```
 
-The script installs Docker if needed, generates and persists secrets, pins the image version, and health-checks the container before returning. Point your agents at it:
+The script installs Docker if needed, generates and persists secrets, pins the image version, and health-checks the container before returning. Point your agents at it with three environment variables:
 
-```python
-from voicegateway.services.sinks import RemoteCollectorSink
-
-sink = RemoteCollectorSink(
-    collector_url="https://collector.example.com",
-    api_key="<your-ingest-key>",
-)
+```bash
+export VOICEGW_COLLECTOR_URL="https://collector.example.com/v1/ingest"
+export VOICEGW_API_KEY="<your-ingest-key>"
+export VOICEGW_PROJECT="my-agent"
 ```
 
-SQLite and Postgres backends, plus HTTPS via Caddy: [fleet collector docs →](https://docs.voicegateway.dev/deployment/vps)
+`attach()` reads them and batches every call to the collector instead of local SQLite. SQLite and Postgres backends, plus HTTPS via Caddy: [fleet collector docs →](https://docs.voicegateway.dev/deployment/vps)
 
 ## Manage from your coding agent (MCP)
 
-VoiceGateway ships a first-class [Model Context Protocol](https://modelcontextprotocol.io) server. Claude Code, Cursor, Codex, and Cline configure providers, create projects, check costs, and tail logs through natural language.
+VoiceGateway ships a first-class [Model Context Protocol](https://modelcontextprotocol.io) server. Claude Code, Cursor, Codex, and Cline create projects, check costs, and inspect calls through natural language.
 
 ```bash
 pipx inject voicegateway "voicegateway[mcp]"
 claude mcp add voicegateway --command "voicegw mcp --transport stdio"
 ```
 
-22 tools across observability, providers, models, and projects. Destructive ops (`delete_*`) require explicit `confirm=True` after a preview. Remote HTTP/SSE transport with bearer auth and the full tool list: [MCP reference →](https://docs.voicegateway.dev/mcp/)
+Tools across observability, projects, and costs. Destructive ops (`delete_*`) require explicit `confirm=True` after a preview. Remote HTTP/SSE transport with bearer auth and the full tool list: [MCP reference →](https://docs.voicegateway.dev/mcp/)
 
-## Supported providers
+## Priced providers
 
-11 providers across cloud and local. Mix and match per call.
+VoiceGateway prices calls from any provider [voice-prices](https://github.com/mahimailabs/voice-prices) covers. You bring your own native plugins; VoiceGateway meters and prices them. The common ones:
 
-| Modality             | Cloud                                         | Local                   |
-| :------------------- | :-------------------------------------------- | :---------------------- |
-| **STT**              | Deepgram, OpenAI Whisper, AssemblyAI, Groq    | `faster-whisper`        |
-| **LLM**              | OpenAI, Anthropic, Groq                       | Ollama (any compatible) |
-| **TTS**              | Cartesia, ElevenLabs, Deepgram Aura-2, OpenAI | Kokoro, Piper           |
-| **VAD** \*           | Silero                                        | Silero                  |
-| **Turn detector** \* | LiveKit MultilingualModel                     | None                    |
+| Modality | Cloud                                         | Local                   |
+| :------- | :-------------------------------------------- | :---------------------- |
+| **STT**  | Deepgram, OpenAI Whisper, AssemblyAI, Groq    | `faster-whisper`        |
+| **LLM**  | OpenAI, Anthropic, Groq                       | Ollama (any compatible) |
+| **TTS**  | Cartesia, ElevenLabs, Deepgram Aura-2, OpenAI | Kokoro, Piper           |
 
-\* Configured directly on the LiveKit `AgentSession`, not wrapped by VoiceGateway. The 11-provider count covers STT, LLM, and TTS.
-
-Per-model IDs: [configuration/providers](https://docs.voicegateway.dev/configuration/providers). Adding a provider takes about 10 steps: [contributing/adding-a-provider](https://docs.voicegateway.dev/contributing/adding-a-provider).
+A price it does not recognize records at zero and flags for a rate-card entry, so nothing is silently dropped. Per-model IDs: [configuration/providers](https://docs.voicegateway.dev/configuration/providers).
 
 ## Architecture
 
 ```mermaid
 flowchart TB
-    A[LiveKit Agent] --> B[voicegateway.inference]
-    B --> C[Router]
-    C --> D[Cloud Providers]
-    C --> E[Local Providers]
+    A[Voice Agent · LiveKit or Pipecat] --> B["voicegateway.attach()"]
     B --> F[Middleware Pipeline]
     F --> F1[Cost Tracker]
     F --> F2[Latency Monitor]
-    F --> F3[Guardrails]
+    F --> F3[Rate Limiter]
     F --> F4[Multi-tenant Attribution]
     F --> G[(SQLite · encrypted)]
     G --> H[Dashboard UI]
@@ -143,7 +162,7 @@ flowchart TB
     I --> J[Claude Code · Cursor · Codex]
 ```
 
-Async throughout. Modular provider installs pull only what you use. YAML config with `${ENV_VAR}` substitution. SQLite at the bottom for portability, encrypted with Fernet at rest. [Architecture deep dive →](https://docs.voicegateway.dev/architecture/)
+Async throughout. `import voicegateway` stays framework-neutral: the LiveKit and Pipecat integrations import their framework only on first use. YAML config with `${ENV_VAR}` substitution. SQLite at the bottom for portability, encrypted with Fernet at rest. [Architecture deep dive →](https://docs.voicegateway.dev/architecture/)
 
 ## Deploy
 
@@ -163,7 +182,7 @@ services:
     restart: unless-stopped
 
   collector:
-    image: mahimairaja/voicegateway:0.9.2
+    image: mahimairaja/voicegateway:latest
     ports:
       - "8080:8080"
     environment:
@@ -208,4 +227,4 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT
 
 [MIT](LICENSE). Fork it, ship it.
 
-Built by [Mahimai Raja](https://mahimai.dev), founder of [Mahimai AI](https://mahimai.ca), a voice AI company, in public. Standing on [LiveKit Agents](https://github.com/livekit/agents), [FastAPI](https://fastapi.tiangolo.com/), [Pydantic](https://docs.pydantic.dev/), and [voice-prices](https://github.com/mahimailabs/voice-prices).
+Built by [Mahimai Raja](https://mahimai.dev), founder of [Mahimai AI](https://mahimai.ca), a voice AI company, in public. Standing on [LiveKit Agents](https://github.com/livekit/agents), [Pipecat](https://github.com/pipecat-ai/pipecat), [FastAPI](https://fastapi.tiangolo.com/), [Pydantic](https://docs.pydantic.dev/), and [voice-prices](https://github.com/mahimailabs/voice-prices).


### PR DESCRIPTION
Reframes the README for the indie voice-agent developer, aligned with the launch video.

## Positioning
- Hook: **the open-source profiler for voice agents** (framework-neutral, not LiveKit-only).
- Hero is the real one line: native `AgentSession` + `voicegateway.attach(session)`. A `<details>` shows the Pipecat `attach(task)`.

## Correctness (the important part)
The README taught `voicegateway.inference.STT/LLM/TTS`, a **removed API** (`inference/__init__.py` has no such factories). Anyone copying the old hero got an `AttributeError`. Fixed everywhere it appeared: hero code block, subhead, a features row, quick start, and the architecture mermaid node.

## Also
- Dropped two features removed with the inference era: **cross-modality routing** and **voice-specific guardrails** (verified: only `rate_limiter` middleware remains).
- Added a short **`guard()`** section (budget cap, fallback, rate limit).
- Reframed "Supported providers" to **Priced providers** (VoiceGateway prices native plugins; it no longer provides them).
- Aligned the dashboard description with the refocused nav.
- Added Pipecat to the footer credits.

No em dashes; verified no `inference.`/routing/guardrail references remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the quick-start guide with a framework-neutral setup using LiveKit AgentSession and direct provider integrations.
  * Added guidance for spend controls, fallback behavior, rate limiting, and metric handling.
  * Refreshed feature descriptions, dashboard details, architecture diagrams, provider pricing, and fleet collector setup.
  * Updated Docker deployment instructions to use the latest VoiceGateway image.
  * Clarified multi-tenant attribution, reconciliation, terminal UI, and supported voice pipeline components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->