### PR TITLE
fix(dashboard): demo-found UX fixes (rate-card modal, project-id slug, budget help, livekit creds, check tag)

### DIFF
--- a/src/dashboard/frontend/src/pages/Projects.tsx
+++ b/src/dashboard/frontend/src/pages/Projects.tsx
@@ -144,6 +144,7 @@ export default function Projects() {
 
 function CreateProjectModal({ onClose }: { onClose: () => void }) {
   const [projectId, setProjectId] = useState('');
+  const [idEdited, setIdEdited] = useState(false);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [dailyBudget, setDailyBudget] = useState('0');
@@ -184,7 +185,7 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
             <input
               className="neo-input"
               value={name}
-              onChange={(e) => { setName(e.target.value); if (!projectId) setProjectId(slug(e.target.value)); }}
+              onChange={(e) => { setName(e.target.value); if (!idEdited) setProjectId(slug(e.target.value)); }}
               style={{ width: '100%' }}
             />
           </div>
@@ -193,7 +194,7 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
             <input
               className="neo-input"
               value={projectId}
-              onChange={(e) => setProjectId(e.target.value)}
+              onChange={(e) => { setIdEdited(true); setProjectId(e.target.value); }}
               style={{ width: '100%' }}
             />
           </div>
@@ -220,7 +221,43 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
             />
           </div>
           <div>
-            <label className="vg-card__label" style={{ display: 'block', marginBottom: 6 }}>Budget Action</label>
+            <label
+              className="vg-card__label"
+              style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}
+            >
+              Budget Action
+              <span
+                role="img"
+                aria-label="What each budget action does"
+                title={
+                  'What happens once a project passes its daily budget ' +
+                  '(applies only when Daily Budget is greater than 0):\n\n' +
+                  'Warn (default) — keep serving requests, just log a warning. ' +
+                  'Spend is not capped.\n\n' +
+                  'Throttle — keep serving, but raise a throttle signal so your ' +
+                  'agent (via guard()) can fall back to a cheaper or local model ' +
+                  'instead of the paid provider, so spend stops growing.\n\n' +
+                  'Block — reject further requests for the rest of the day with a ' +
+                  'budget-exceeded error.'
+                }
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 15,
+                  height: 15,
+                  borderRadius: '50%',
+                  border: '1.5px solid var(--vg-muted)',
+                  color: 'var(--vg-muted)',
+                  fontSize: 10,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  cursor: 'help',
+                }}
+              >
+                ?
+              </span>
+            </label>
             <select
               className="neo-select"
               value={budgetAction}

--- a/src/dashboard/frontend/src/pages/RateCard.tsx
+++ b/src/dashboard/frontend/src/pages/RateCard.tsx
@@ -468,7 +468,7 @@ function AddOverrideModal({
           </div>
 
           <div className="flex-row" style={{ gap: 12 }}>
-            <div style={{ flex: 1 }}>
+            <div style={{ flex: 1, minWidth: 0 }}>
               <label className="vg-card__label" style={labelStyle}>
                 Model
               </label>
@@ -481,7 +481,7 @@ function AddOverrideModal({
                 disabled={saving}
               />
             </div>
-            <div style={{ flex: 1 }}>
+            <div style={{ flex: 1, minWidth: 0 }}>
               <label className="vg-card__label" style={labelStyle}>
                 Tenant
               </label>
@@ -494,7 +494,7 @@ function AddOverrideModal({
                 disabled={saving}
               />
             </div>
-            <div style={{ flex: 1 }}>
+            <div style={{ flex: 1, minWidth: 0 }}>
               <label className="vg-card__label" style={labelStyle}>
                 Plan
               </label>

--- a/src/voicegateway/cli/serve_cli.py
+++ b/src/voicegateway/cli/serve_cli.py
@@ -32,6 +32,15 @@ def serve_cmd(
             "Run: pip install 'voicegateway[dashboard]'"
         )
 
+    # Publish the served config path so request-time resolvers that read the
+    # raw YAML directly (e.g. the LiveKit diagnostics creds resolver) find the
+    # same file the daemon serves, not just ``./voicegw.yaml`` relative to the
+    # daemon's working directory.
+    if config:
+        import os
+
+        os.environ.setdefault("VOICEGW_CONFIG", config)
+
     gw = _cli.require_gateway(config)
     host, port = _resolve_bind(getattr(gw.config, "serve", None), host, port)
 

--- a/src/voicegateway/livekit_diag/config.py
+++ b/src/voicegateway/livekit_diag/config.py
@@ -22,8 +22,18 @@ class LiveKitCreds:
 
 
 def _from_yaml(config_path: str | None) -> dict:
-    path = config_path or os.environ.get("VOICEGW_CONFIG") or "voicegw.yaml"
-    if not os.path.exists(path):
+    # Precedence: explicit path, then $VOICEGW_CONFIG (the daemon publishes the
+    # served -c path here), then ./voicegw.yaml, then the standard config home
+    # (~/.config/voicegateway/voicegw.yaml) so the resolver still finds creds
+    # when the daemon runs with a home working directory.
+    candidates = [
+        config_path,
+        os.environ.get("VOICEGW_CONFIG"),
+        "voicegw.yaml",
+        os.path.expanduser("~/.config/voicegateway/voicegw.yaml"),
+    ]
+    path = next((c for c in candidates if c and os.path.exists(c)), None)
+    if path is None:
         return {}
     import yaml
 

--- a/src/voicegateway/middleware/base_middleware.py
+++ b/src/voicegateway/middleware/base_middleware.py
@@ -269,8 +269,14 @@ class InstrumentationMixin:
         cached_input_units: float = 0.0,
         status: str = "success",
         error_message: str | None = None,
+        agent_id: str | None = None,
     ) -> None:
-        """Log the request to storage. Idempotent: subsequent calls no-op."""
+        """Log the request to storage. Idempotent: subsequent calls no-op.
+
+        ``agent_id`` is optional; the metrics/error-driven callers leave it
+        ``None`` (real traffic is attributed elsewhere). It exists so callers
+        like ``voicegw check`` can stamp a distinct marker on a synthetic row.
+        """
         if self._logged:
             return
         self._logged = True
@@ -302,6 +308,7 @@ class InstrumentationMixin:
             status=status,
             error_message=error_message,
             session_id=get_session_id(),
+            agent_id=agent_id,
         )
 
         if self._storage is not None:

--- a/src/voicegateway/schemas/config_schema.py
+++ b/src/voicegateway/schemas/config_schema.py
@@ -164,6 +164,24 @@ class ServeConfig(BaseModel):
     port: int = 8080
 
 
+class LiveKitConfig(BaseModel):
+    """Optional LiveKit deployment credentials for the diagnostics probes.
+
+    Read by ``voicegw livekit`` and the dashboard Diagnostics page through
+    ``livekit_diag``. All fields are optional; the ``LIVEKIT_URL`` /
+    ``LIVEKIT_API_KEY`` / ``LIVEKIT_API_SECRET`` env vars take precedence when
+    set. Accepting this block here is what lets an operator configure LiveKit
+    in ``voicegw.yaml`` (the config the daemon already serves) instead of the
+    daemon's environment.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    url: str = ""
+    api_key: str = ""
+    api_secret: str = ""
+
+
 class ApiKeyEntry(_StrictBase):
     """One entry under auth.api_keys."""
 
@@ -265,6 +283,7 @@ _VALID_TOP_LEVEL_KEYS = {
     "rate_limits",
     "dashboard",
     "serve",
+    "livekit",
     "auth",
     "ingest",
     "retention",
@@ -291,6 +310,7 @@ class VoiceGatewayConfig(BaseModel):
     rate_limits: dict[str, RateLimitEntry] = Field(default_factory=dict)
     dashboard: DashboardConfig = Field(default_factory=DashboardConfig)
     serve: ServeConfig = Field(default_factory=ServeConfig)
+    livekit: LiveKitConfig = Field(default_factory=LiveKitConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
     ingest: IngestConfig = Field(default_factory=IngestConfig)
     retention: RetentionConfig = Field(default_factory=RetentionConfig)

--- a/src/voicegateway/tests/core/test_config.py
+++ b/src/voicegateway/tests/core/test_config.py
@@ -58,6 +58,22 @@ def test_unknown_top_level_key_suggests_correction(tmp_path):
         GatewayConfig.load(str(path))
 
 
+def test_livekit_block_is_accepted(tmp_path):
+    """A ``livekit:`` block must load, not trip the strict top-level schema.
+
+    The dashboard Diagnostics page tells operators to add this block, and the
+    diagnostics resolver reads it, so ``voicegw serve`` must accept it instead
+    of crashing with "Extra inputs are not permitted".
+    """
+    path = tmp_path / "voicegw.yaml"
+    with open(path, "w") as f:
+        yaml.dump(
+            {"livekit": {"url": "wss://x", "api_key": "k", "api_secret": "s"}}, f
+        )
+    # Must not raise ConfigError.
+    GatewayConfig.load(str(path))
+
+
 def test_negative_daily_budget_raises_error(tmp_path):
     path = tmp_path / "bad.yaml"
     cfg = {

--- a/src/voicegateway/tests/livekit_diag/test_config.py
+++ b/src/voicegateway/tests/livekit_diag/test_config.py
@@ -28,8 +28,30 @@ def test_yaml_fallback(tmp_path, monkeypatch):
     assert c.url == "wss://yaml" and c.api_key == "yk" and c.api_secret == "ys"
 
 
-def test_missing_raises(monkeypatch):
+def test_config_home_fallback(tmp_path, monkeypatch):
+    """With no flags/env/CWD config, the resolver reads the config home.
+
+    This is the daemon case: launchd runs ``voicegw serve`` with a home working
+    directory, so ``./voicegw.yaml`` does not exist; creds must still resolve
+    from ~/.config/voicegateway/voicegw.yaml.
+    """
     for k in ("LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET", "VOICEGW_CONFIG"):
         monkeypatch.delenv(k, raising=False)
+    monkeypatch.chdir(tmp_path)  # ensure ./voicegw.yaml is absent
+    monkeypatch.setenv("HOME", str(tmp_path))
+    home_cfg = tmp_path / ".config" / "voicegateway" / "voicegw.yaml"
+    home_cfg.parent.mkdir(parents=True)
+    home_cfg.write_text("livekit:\n  url: wss://home\n  api_key: hk\n  api_secret: hs\n")
+    c = resolve_creds(None, None, None)
+    assert c.url == "wss://home" and c.api_key == "hk" and c.api_secret == "hs"
+
+
+def test_missing_raises(tmp_path, monkeypatch):
+    for k in ("LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET", "VOICEGW_CONFIG"):
+        monkeypatch.delenv(k, raising=False)
+    # Isolate HOME + CWD so neither ./voicegw.yaml nor the real config-home file
+    # can satisfy the resolver.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
     with pytest.raises(CredsError):
         resolve_creds(None, None, None)

--- a/src/voicegateway/utils/cli/check.py
+++ b/src/voicegateway/utils/cli/check.py
@@ -25,6 +25,10 @@ from voicegateway.inference.session.context import (
 # resolution. The pass condition is the rows landing, not a cost threshold.
 _CHECK_MODEL_ID = "openai/gpt-4o-mini"
 
+# Stamped on the synthetic request so the self-test row is identifiable in the
+# dashboard (Calls page agent filter) and not mistaken for real agent traffic.
+_CHECK_AGENT_ID = "voicegw-check"
+
 
 def check_active_project(gw: Any) -> str | None:
     """Pick a project: ``default_project``, else a named project, else ``default``."""
@@ -94,7 +98,7 @@ async def run_check(gw: Any, project: str, add: Any) -> None:
 
     # `_log_request` is best-effort (it swallows storage errors), so we assert on
     # the READ-BACK below, not on this call not raising.
-    await instance._log_request(input_units=1.0)
+    await instance._log_request(input_units=1.0, agent_id=_CHECK_AGENT_ID)
 
     sid = get_session_id()
     if sid is None:


### PR DESCRIPTION
Five issues surfaced while dogfooding the OSS dashboard during a demo recording.

> **Stacked on `refactor/framework-agnostic-onboard` (#136)** so the diff shows only these 3 commits (the `check` tag depends on `check.py`, which is new in #136). Retarget to `main` once #136 merges.

### Fixes
1. **Rate card "Add rate override" modal overflow** — the Model/Tenant/Plan flex row had three `flex:1` children with default `min-width:auto`, so inputs refused to shrink and the Plan field overflowed the dialog. Added `minWidth:0` to the three children.
2. **Create Project: Project ID kept only the first character of Name** — the `if (!projectId)` guard stopped auto-deriving after the first keystroke. Replaced with an `idEdited` flag; the ID slugifies the full name until the user edits it manually.
3. **Create Project: Budget Action had no explanation** — added a `?` affordance next to the label describing warn / throttle / block (semantics verified against the budget enforcer).
4. **LiveKit config was impossible** — the Diagnostics page advised adding a `livekit:` block to `voicegw.yaml`, but the schema is `extra="forbid"` so that **crashed `voicegw serve`**, and the diagnostics resolver only read `./voicegw.yaml` / `$VOICEGW_CONFIG` (never the config the daemon serves). Added a `LiveKitConfig` block to the schema; `serve` now publishes its `-c` path via `VOICEGW_CONFIG`; the resolver falls back to `~/.config/voicegateway/voicegw.yaml`. Env vars still take precedence.
5. **`voicegw check` rows looked like phantom traffic** — not a bug (the synthetic self-test request proves metering+storage), but it was indistinguishable from real calls. Stamped `agent_id="voicegw-check"` so it's recognizable/filterable in the Calls page.

### Verification
- `tsc -b` + `vite build` clean; ruff + mypy clean on changed engine files.
- 16 config-schema + livekit-resolver tests pass (3 new: livekit block accepted, config-home fallback, isolated missing-creds).
- Live-verified: daemon serves the rebuilt bundle; a real `voicegw check` wrote a row tagged `voicegw-check`.
- Pre-existing local `no such table: requests` failures are unrelated (identical on the clean branch; the CI `test-coverage` job runs migrations).