### PR TITLE
feat: complete the latency capture (ttft/ttfa terms, total latency, network hop)

### DIFF
--- a/src/dashboard/frontend/src/components/LatencyChart.tsx
+++ b/src/dashboard/frontend/src/components/LatencyChart.tsx
@@ -41,7 +41,7 @@ export default function LatencyChart({ data }: Props) {
             <XAxis dataKey="name" tick={{ fontSize: 11, fontWeight: 600, fill: 'var(--vg-muted-2)' }} axisLine={false} tickLine={false} />
             <YAxis tick={{ fontSize: 11, fontWeight: 600, fill: 'var(--vg-muted-2)' }} axisLine={false} tickLine={false} width={48} />
             <Tooltip content={<NeoTooltip />} cursor={{ fill: 'var(--vg-teal-tint)' }} />
-            <Bar dataKey="ttfb" name="TTFB" fill="var(--vg-teal)" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="ttfb" name="First response" fill="var(--vg-teal)" radius={[4, 4, 0, 0]} />
             <Bar dataKey="total" name="Total" fill="var(--vg-teal-bright)" radius={[4, 4, 0, 0]} />
           </BarChart>
         </ResponsiveContainer>

--- a/src/dashboard/frontend/src/pages/Latency.tsx
+++ b/src/dashboard/frontend/src/pages/Latency.tsx
@@ -53,16 +53,16 @@ export default function Latency() {
     <div>
       <PageHeader
         title="Latency"
-        subtitle="Worst-model TTFB percentiles across today's requests"
+        subtitle="Worst-model first-response percentiles across today's requests (time to first token for LLM, first audio for TTS)"
         accent="pink"
       />
 
       <FilterBar showTenant={false} />
 
       <div className="grid grid-cols-3 mb-lg">
-        <StatusCard label="P50 TTFB" value={fmtP(p50)} accent="pink" icon="50" />
-        <StatusCard label="P95 TTFB" value={fmtP(p95)} accent="pink" icon="95" />
-        <StatusCard label="P99 TTFB" value={fmtP(p99)} accent="pink" icon="99" />
+        <StatusCard label="P50 first response" value={fmtP(p50)} accent="pink" icon="50" />
+        <StatusCard label="P95 first response" value={fmtP(p95)} accent="pink" icon="95" />
+        <StatusCard label="P99 first response" value={fmtP(p99)} accent="pink" icon="99" />
       </div>
 
       <div className="mb-lg">
@@ -76,8 +76,8 @@ export default function Latency() {
             <thead>
               <tr>
                 <th>Model</th>
-                <th>Avg TTFB</th>
-                <th>P95 TTFB</th>
+                <th>Avg first response</th>
+                <th>P95 first response</th>
                 <th>P95 Total</th>
                 <th>Requests</th>
               </tr>

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -38,12 +38,47 @@ _RECONCILE_EPSILON = 1e-9
 
 
 def _ttfb_ms(metric: object) -> float | None:
-    """Return first-byte latency in ms from a metric's ttft/ttfb, if present."""
+    """First-response latency in ms from a metric's ttft/ttfb, if present.
+
+    This is the modality's time-to-first-*: ``ttft`` (time to first token) on an
+    LLM metric, ``ttfb`` (time to first audio byte) on a TTS metric. LiveKit STT
+    metrics expose neither (a transcript is not streamed token-by-token), so STT
+    records ``None`` here and carries its latency in ``total_latency_ms``.
+    """
     value = getattr(metric, "ttft", None)
     if value is None:
         value = getattr(metric, "ttfb", None)
     # ``is not None`` so a genuine 0.0 latency records as 0.0, not None.
     return float(value) * 1000.0 if value is not None else None
+
+
+def _duration_ms(metric: object) -> float | None:
+    """Total request latency in ms from a metric's ``duration`` (seconds).
+
+    Every LiveKit STT/LLM/TTS metric carries ``duration`` (the full processing
+    time for that call). It is the STT latency (STT has no first-byte) and the
+    total-latency complement to ttft/ttfb on LLM/TTS.
+    """
+    value = getattr(metric, "duration", None)
+    return float(value) * 1000.0 if value is not None else None
+
+
+def _network_meta(metric: object) -> dict[str, Any]:
+    """Connection-hop latency from ``acquire_time`` (seconds) + reuse flag.
+
+    LiveKit STT/TTS metrics expose ``acquire_time`` (time to acquire the
+    provider connection) and ``connection_reused`` — the network/setup hop,
+    distinct from processing latency. Neither has a RequestRecord column, so
+    they ride in ``metadata`` like ``room`` / ``channel``.
+    """
+    acquire = getattr(metric, "acquire_time", None)
+    if acquire is None:
+        return {}
+    meta: dict[str, Any] = {"acquire_ms": float(acquire) * 1000.0}
+    reused = getattr(metric, "connection_reused", None)
+    if reused is not None:
+        meta["connection_reused"] = bool(reused)
+    return meta
 
 
 def units_from_metric(
@@ -250,6 +285,7 @@ class MetricCapture:
             input_units, output_units, cached, ttfb_ms = units_from_metric(
                 metric, modality
             )
+            total_latency_ms = _duration_ms(metric)
             status = (
                 "cancelled" if bool(getattr(metric, "cancelled", False)) else "success"
             )
@@ -275,11 +311,15 @@ class MetricCapture:
                 output_units=output_units,
                 cached_input_units=cached,
                 ttfb_ms=ttfb_ms,
+                total_latency_ms=total_latency_ms,
                 status=status,
                 fallback_from=fallback_from,
                 session_id=self._session_id,
                 agent_id=self._agent_id,
             )
+            network = _network_meta(metric)
+            if network:
+                record.metadata = {**record.metadata, **network}
             self._stamp_context(record)
             tally = self._recorded.setdefault(
                 (provider, model_id), {"input": 0.0, "output": 0.0, "cached": 0.0}

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -14,16 +14,23 @@ class _LLMMetric:
     prompt_tokens = 1000
     completion_tokens = 500
     prompt_cached_tokens = 200
-    ttft = 0.25
+    ttft = 0.25  # time to first token (seconds) -> ttfb_ms 250
+    duration = 1.8  # total LLM latency (seconds) -> total_latency_ms 1800
 
 
 class _STTMetric:
-    audio_duration = 120.0  # seconds
+    audio_duration = 120.0  # seconds of audio
+    duration = 0.4  # total STT latency (seconds) -> total_latency_ms 400
+    acquire_time = 0.05  # connection-acquisition hop (seconds) -> acquire_ms 50
+    connection_reused = True
 
 
 class _TTSMetric:
     characters_count = 350
-    ttfb = 0.1
+    ttfb = 0.1  # time to first audio byte (seconds) -> ttfb_ms 100
+    duration = 0.9  # total TTS latency (seconds) -> total_latency_ms 900
+    acquire_time = 0.03  # connection-acquisition hop (seconds) -> acquire_ms 30
+    connection_reused = False
 
 
 class _FakeEmitter:
@@ -93,6 +100,25 @@ def test_units_from_tts_metric():
     assert ttfb_ms == 100.0
 
 
+def test_duration_and_network_helpers():
+    from voicegateway.inference.session.capture import _duration_ms, _network_meta
+
+    # duration (seconds) -> total latency ms; absent -> None.
+    assert _duration_ms(_LLMMetric()) == 1800.0
+    assert _duration_ms(object()) is None
+
+    # acquire_time -> acquire_ms + connection_reused; absent -> {}.
+    assert _network_meta(_STTMetric()) == {
+        "acquire_ms": 50.0,
+        "connection_reused": True,
+    }
+    assert _network_meta(_TTSMetric()) == {
+        "acquire_ms": 30.0,
+        "connection_reused": False,
+    }
+    assert _network_meta(_LLMMetric()) == {}  # LLM metrics carry no acquire_time
+
+
 # --- capture binding -----------------------------------------------------
 
 
@@ -127,6 +153,9 @@ async def test_metric_capture_writes_llm_row(tmp_path):
     assert row["cached_input_units"] == 200.0
     assert row["agent_id"] == "agent-3"
     assert row["session_id"] == "vg-test"
+    # ttfb_ms is the LLM time-to-first-token; total_latency_ms is the full call.
+    assert row["ttfb_ms"] == 250.0
+    assert row["total_latency_ms"] == 1800.0
 
 
 def _stamp_capture(channel):
@@ -198,6 +227,21 @@ async def test_metric_capture_handles_three_modalities(tmp_path):
     assert by_modality["stt"]["input_units"] == 2.0
     assert by_modality["tts"]["model_id"] == "cartesia/sonic-3"
     assert by_modality["tts"]["input_units"] == 350.0
+
+    # STT has no first-byte metric, but its latency lands in total_latency_ms
+    # (no more "n/a") and its connection hop rides in metadata.
+    stt_row = by_modality["stt"]
+    assert stt_row["ttfb_ms"] is None
+    assert stt_row["total_latency_ms"] == 400.0
+    assert stt_row["metadata"]["acquire_ms"] == 50.0
+    assert stt_row["metadata"]["connection_reused"] is True
+    # TTS: ttfb_ms is time-to-first-audio; total + network hop captured too.
+    tts_row = by_modality["tts"]
+    assert tts_row["ttfb_ms"] == 100.0
+    assert tts_row["total_latency_ms"] == 900.0
+    assert tts_row["metadata"]["acquire_ms"] == 30.0
+    # LLM has no connection-acquire hop -> no acquire_ms key.
+    assert "acquire_ms" not in (by_modality["llm"].get("metadata") or {})
 
 
 class _LLMErrorSource:


### PR DESCRIPTION
The LiveKit meter only recorded the first-response latency (and mislabeled it), dropping total latency and the connection hop that live in the same metric objects. Verified against the installed `livekit.agents` metric classes.

### What LiveKit actually exposes (and we were dropping)
- **STT** has no `ttft`/`ttfb` — a transcript isn't streamed token-by-token. It carries `duration` (total STT latency) + `acquire_time`/`connection_reused`. We read only ttft/ttfb, so STT showed **no latency at all**.
- **LLM** carries `ttft` (time to first token) + `duration` (total). We captured ttft (correct value) but stored it in a field labeled "ttfb".
- **TTS** carries `ttfb` (= time to first *audio* byte, i.e. TTFA) + `duration` + `acquire_time`. Same mislabel.

### Fix
- **capture.py:** populate `total_latency_ms` from `metric.duration` for every modality (so STT reports its latency and every call has an end-to-end number), and capture `acquire_time` + `connection_reused` as `metadata.acquire_ms` — the network/connection hop, distinct from processing latency (rides in metadata like `room`/`channel`, no migration). `ttfb_ms` is unchanged as the modality's time-to-first-response.
- **dashboard:** the aggregate Latency page/chart mixed modalities under one "TTFB" label — relabeled to "first response" (TTFT for LLM, TTFA for TTS) on the chart, cards, per-model table, and subtitle.

### Verification
- Pure helper tests + full capture tests (total latency + STT `ttfb=None`/total captured + network-hop metadata for STT/TTS + LLM has no acquire hop). Verified end-to-end with an in-memory sink: STT total=400ms + net=50ms, LLM ttft=250ms + total=1800ms, TTS ttfa=100ms + total=900ms + net=30ms.
- Full-src mypy clean (253 files); ruff clean; frontend `tsc` + build clean.
- The storage round-trip tests fail only on the pre-existing local `no such table: requests` env issue (CI's migration-backed `test-coverage` job covers them).

### Follow-up (not in this PR)
- Surfacing `metadata.acquire_ms` as a dashboard column/percentile needs the `/api/latency` + logs API to expose it; the capture side (the hard part) is done here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated latency dashboard terminology from “TTFB” to “First response” for clearer reporting.
  - Renamed latency summary cards and model table columns to consistently describe first-response metrics.
  - Enhanced latency tracking across voice interactions to include total processing time and connection-acquisition details where available.
- **Bug Fixes**
  - Improved latency metric capture and reporting across language, speech-to-text, and text-to-speech components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->