### PR TITLE
feat(capture): turn-level STT time-to-first-partial

### DIFF
--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -298,7 +298,12 @@ class MetricCapture:
             on("metrics_collected", self._on_session_metric)
             # Turn-level time-to-first-partial-transcript. The interim arrives on
             # the session's user_input_transcribed stream (STTMetrics carries no
-            # first-partial), anchored to the user_started_speaking onset.
+            # first-partial), anchored to the speech onset. LiveKit 1.6 signals
+            # onset via user_state_changed -> "speaking" (its created_at is the
+            # VAD-backdated true onset); it emits no discrete user_started_speaking.
+            # Older LiveKit builds / other frameworks may emit the discrete event,
+            # so we hook both and whichever fires first wins the turn.
+            on("user_state_changed", self._on_user_state_changed)
             on("user_started_speaking", self._on_user_started_speaking)
             on("user_input_transcribed", self._on_user_transcribed)
 
@@ -371,8 +376,24 @@ class MetricCapture:
         self._stamp_context(record)
         self._schedule(self._sink.log_request(record))
 
+    def _on_user_state_changed(self, event: object, *_a: Any, **_k: Any) -> None:
+        """LiveKit 1.6 onset signal: the transition into the ``speaking`` state.
+
+        ``user_state_changed`` also fires for ``listening``/``away``; only the
+        ``speaking`` edge starts a turn. Its ``created_at`` is the VAD-backdated
+        true onset (earlier than the raw detection instant), which is exactly
+        the anchor a first-partial latency should measure from.
+        """
+        if getattr(event, "new_state", None) != "speaking":
+            return
+        self._begin_turn(event)
+
     def _on_user_started_speaking(self, event: object, *_a: Any, **_k: Any) -> None:
-        """Start a new turn: anchor the onset and clear the first-partial latch."""
+        """Discrete onset signal (older LiveKit / non-LiveKit frameworks)."""
+        self._begin_turn(event)
+
+    def _begin_turn(self, event: object) -> None:
+        """Anchor the onset and clear the first-partial latch for a new turn."""
         self._turn_started_at = _event_time(event)
         self._first_partial_ms = None
 

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -81,6 +81,16 @@ def _network_meta(metric: object) -> dict[str, Any]:
     return meta
 
 
+def _event_time(event: object) -> float:
+    """Wall-clock time for a session event, preferring its own ``created_at``.
+
+    LiveKit session events (e.g. ``UserInputTranscribedEvent``) stamp
+    ``created_at`` at emit; fall back to receive time when absent.
+    """
+    ts = getattr(event, "created_at", None)
+    return float(ts) if ts else time.time()
+
+
 def units_from_metric(
     metric: object, modality: str
 ) -> tuple[float, float, float, float | None]:
@@ -266,6 +276,13 @@ class MetricCapture:
         # Per-(provider, model_id) running tally of captured units, so the
         # close-time reconcile can diff against cumulative session.usage.
         self._recorded: dict[tuple[str, str], dict[str, float]] = {}
+        # Per-turn latch for time-to-first-partial-transcript (a turn-level STT
+        # responsiveness metric): the moment the user started speaking, and the
+        # first-interim delay relative to it. Stashed onto the EOU row and reset
+        # per turn. Both stay None until an interim actually lands, so streaming
+        # STT that emits no interims never fabricates a number.
+        self._turn_started_at: float | None = None
+        self._first_partial_ms: float | None = None
 
     def bind(self, session: object) -> None:
         """Subscribe to every component's metrics + the session error event."""
@@ -279,6 +296,11 @@ class MetricCapture:
         if callable(on):
             on("error", self._on_error)
             on("metrics_collected", self._on_session_metric)
+            # Turn-level time-to-first-partial-transcript. The interim arrives on
+            # the session's user_input_transcribed stream (STTMetrics carries no
+            # first-partial), anchored to the user_started_speaking onset.
+            on("user_started_speaking", self._on_user_started_speaking)
+            on("user_input_transcribed", self._on_user_transcribed)
 
     def _make_metric_handler(self, modality: str, provider: str, model_id: str) -> Any:
         def handler(metric: object, *_args: Any, **_kwargs: Any) -> None:
@@ -349,6 +371,25 @@ class MetricCapture:
         self._stamp_context(record)
         self._schedule(self._sink.log_request(record))
 
+    def _on_user_started_speaking(self, event: object, *_a: Any, **_k: Any) -> None:
+        """Start a new turn: anchor the onset and clear the first-partial latch."""
+        self._turn_started_at = _event_time(event)
+        self._first_partial_ms = None
+
+    def _on_user_transcribed(self, event: object, *_a: Any, **_k: Any) -> None:
+        """Latch the FIRST interim transcript's delay from the turn onset.
+
+        Interims fire many times per turn, so only the first ``is_final=False``
+        counts, and only once we've seen a turn onset. Later interims and the
+        final transcript are ignored.
+        """
+        if self._turn_started_at is None or self._first_partial_ms is not None:
+            return
+        if getattr(event, "is_final", True):
+            return  # final transcript, not an interim
+        delay_ms = (_event_time(event) - self._turn_started_at) * 1000.0
+        self._first_partial_ms = max(0.0, delay_ms)
+
     def _on_session_metric(self, metric: object, *_a: Any, **_k: Any) -> None:
         metric = getattr(metric, "metrics", metric)
         eou = getattr(metric, "end_of_utterance_delay", None)
@@ -365,14 +406,20 @@ class MetricCapture:
             session_id=self._session_id,
             agent_id=self._agent_id,
         )
-        record.metadata = {
-            "eou": {
-                "end_of_utterance_delay": float(eou),
-                "transcription_delay": float(
-                    getattr(metric, "transcription_delay", 0.0) or 0.0
-                ),
-            }
+        eou_meta: dict[str, Any] = {
+            "end_of_utterance_delay": float(eou),
+            "transcription_delay": float(
+                getattr(metric, "transcription_delay", 0.0) or 0.0
+            ),
         }
+        # Turn-level time-to-first-partial-transcript, if an interim landed this
+        # turn (absent for non-streaming / final-only STT). Reset the latch so
+        # the next turn starts clean.
+        if self._first_partial_ms is not None:
+            eou_meta["time_to_first_partial_ms"] = self._first_partial_ms
+        self._turn_started_at = None
+        self._first_partial_ms = None
+        record.metadata = {"eou": eou_meta}
         self._stamp_context(record)
         self._schedule(self._sink.log_request(record))
 

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from voicegateway.inference.session.capture import MetricCapture, units_from_metric
 from voicegateway.middleware.cost_tracker_middleware import CostTracker
 from voicegateway.services.sinks import LocalSqliteSink
@@ -796,3 +798,96 @@ async def test_attach_explicit_room_overrides_session():
     await session._vg_capture.drain()
 
     assert sink.rows[0].metadata.get("room") == "explicit-room"
+
+
+# --- turn-level time-to-first-partial-transcript --------------------------
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.records: list[Any] = []
+
+    async def log_request(self, record: Any) -> None:
+        self.records.append(record)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _SpeakingEvent:
+    def __init__(self, created_at: float) -> None:
+        self.created_at = created_at
+
+
+class _Transcript:
+    def __init__(self, is_final: bool, created_at: float) -> None:
+        self.is_final = is_final
+        self.created_at = created_at
+
+
+class _TurnEOU:
+    end_of_utterance_delay = 0.5
+    transcription_delay = 0.2
+
+
+def _ttfp_capture():
+    sink = _RecordingSink()
+    capture = MetricCapture(
+        cost_tracker=CostTracker(sink),  # unused for eou rows
+        sink=sink,
+        project="fleet",
+        agent_id="agent-3",
+        session_id="vg-ttfp",
+    )
+    return capture, sink
+
+
+async def test_time_to_first_partial_latched_onto_eou_row():
+    """First interim's delay from speech onset lands on the turn's EOU row."""
+    capture, sink = _ttfp_capture()
+    session = _FakeSession()
+    capture.bind(session)
+
+    session.emit("user_started_speaking", _SpeakingEvent(100.0))
+    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.3))
+    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.5))
+    session.emit("user_input_transcribed", _Transcript(is_final=True, created_at=100.9))
+    session.emit("metrics_collected", _TurnEOU())
+    await capture.drain()
+
+    eou = next(r for r in sink.records if r.modality == "eou")
+    assert eou.metadata["eou"]["time_to_first_partial_ms"] == pytest.approx(300.0)  # first interim only
+    assert eou.metadata["eou"]["end_of_utterance_delay"] == 0.5
+
+
+async def test_no_first_partial_when_stt_emits_no_interim():
+    """Final-only / non-streaming STT never fabricates a first-partal number."""
+    capture, sink = _ttfp_capture()
+    session = _FakeSession()
+    capture.bind(session)
+
+    session.emit("user_started_speaking", _SpeakingEvent(200.0))
+    session.emit("user_input_transcribed", _Transcript(is_final=True, created_at=200.4))
+    session.emit("metrics_collected", _TurnEOU())
+    await capture.drain()
+
+    eou = next(r for r in sink.records if r.modality == "eou")
+    assert "time_to_first_partial_ms" not in eou.metadata["eou"]
+
+
+async def test_first_partial_latch_resets_between_turns():
+    """A turn with an interim doesn't leak its value into the next turn."""
+    capture, sink = _ttfp_capture()
+    session = _FakeSession()
+    capture.bind(session)
+
+    session.emit("user_started_speaking", _SpeakingEvent(100.0))
+    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.3))
+    session.emit("metrics_collected", _TurnEOU())
+    session.emit("user_started_speaking", _SpeakingEvent(200.0))  # turn 2: no interim
+    session.emit("metrics_collected", _TurnEOU())
+    await capture.drain()
+
+    eous = [r for r in sink.records if r.modality == "eou"]
+    assert eous[0].metadata["eou"]["time_to_first_partial_ms"] == pytest.approx(300.0)
+    assert "time_to_first_partial_ms" not in eous[1].metadata["eou"]

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -891,3 +891,50 @@ async def test_first_partial_latch_resets_between_turns():
     eous = [r for r in sink.records if r.modality == "eou"]
     assert eous[0].metadata["eou"]["time_to_first_partial_ms"] == pytest.approx(300.0)
     assert "time_to_first_partial_ms" not in eous[1].metadata["eou"]
+
+
+class _UserStateChanged:
+    """Mirror of livekit.agents UserStateChangedEvent (the real 1.6 onset signal).
+
+    livekit-agents 1.6 emits no discrete ``user_started_speaking``; the onset is
+    the transition into the ``speaking`` state, carried on ``user_state_changed``.
+    """
+
+    def __init__(self, new_state: str, created_at: float) -> None:
+        self.new_state = new_state
+        self.created_at = created_at
+
+
+async def test_time_to_first_partial_via_user_state_changed():
+    """Real LiveKit 1.6 onset path: user_state_changed -> "speaking" anchors it.
+
+    This is the event that actually fires in production; the legacy
+    ``user_started_speaking`` tests above cover older / non-LiveKit frameworks.
+    """
+    capture, sink = _ttfp_capture()
+    session = _FakeSession()
+    capture.bind(session)
+
+    session.emit("user_state_changed", _UserStateChanged("speaking", 100.0))
+    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.28))
+    session.emit("user_input_transcribed", _Transcript(is_final=True, created_at=100.9))
+    session.emit("metrics_collected", _TurnEOU())
+    await capture.drain()
+
+    eou = next(r for r in sink.records if r.modality == "eou")
+    assert eou.metadata["eou"]["time_to_first_partial_ms"] == pytest.approx(280.0)
+
+
+async def test_non_speaking_user_state_change_does_not_anchor_onset():
+    """listening / away transitions must not start a turn or latch a partial."""
+    capture, sink = _ttfp_capture()
+    session = _FakeSession()
+    capture.bind(session)
+
+    session.emit("user_state_changed", _UserStateChanged("listening", 50.0))
+    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.28))
+    session.emit("metrics_collected", _TurnEOU())
+    await capture.drain()
+
+    eou = next(r for r in sink.records if r.modality == "eou")
+    assert "time_to_first_partial_ms" not in eou.metadata["eou"]


### PR DESCRIPTION
## What

Adds a genuine STT responsiveness metric: time to first partial transcript (TTFP), captured at the turn level.

This is the follow-on to #139. That PR fixed the per-call latency terms (ttft for LLM, ttfa for TTS, total latency, network hop) but left one honest gap: STT has no per-call first-response metric. LiveKit's `STTMetrics` carries only `duration` and `audio_duration`, so a per-call STT row correctly shows first=n/a. It is not invented here.

## Where the number actually comes from

The first-partial signal is not on the metric object. It is on the session event stream:

- `user_started_speaking` marks the onset (VG already hooks this at attach).
- The first `user_input_transcribed` event with `is_final=False` is the first interim transcript arriving from the provider.

TTFP = first-interim `created_at` minus onset. This is turn-level (there is no join key from an interim event back to a specific STT-call row), so it is latched onto the EOU/turn record metadata next to `transcription_delay`, not onto a per-call STT row.

## Details

- Turn onset latched on `user_started_speaking`; reset per turn.
- First `is_final=False` transcript wins; later interims and finals are ignored until the next turn.
- Provider-dependent: only streaming STT plugins with `interim_results=True` emit interims. When none arrive, no `time_to_first_partial_ms` key is written (no fabricated zero).
- Stored under the `eou` metadata block: `time_to_first_partial_ms` alongside `end_of_utterance_delay` and `transcription_delay`.

## Tests

3 new tests plus a helper-coverage test, all using in-memory recording sinks:
- latch onto the EOU row from a real event sequence
- no key emitted when STT emits no interim
- latch resets cleanly between turns

Ruff + full-src mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for the time from speech onset to the first partial transcript.
  * Included this latency in end-of-utterance records when an interim transcript is available.
  * Supports speech-start detection across supported user event types.

* **Bug Fixes**
  * Ensured latency tracking resets correctly between turns and is omitted when no interim transcript is produced.

* **Tests**
  * Added coverage for interim transcripts, turn resets, speech-state events, and non-speaking transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->