### PR TITLE
feat(diag): probe STT latency = time-to-first-partial, not transcription_delay

### DIFF
--- a/src/voicegateway/livekit_diag/latency.py
+++ b/src/voicegateway/livekit_diag/latency.py
@@ -24,15 +24,22 @@ def aggregate_components(rows: list[dict]) -> dict | None:
 
     ``rows`` are ``metadata.room``-tagged request records the instrumented agent
     wrote during the probe. Turn detection comes from the ``eou`` row's
-    ``end_of_utterance_delay``; STT from the per-component ttfb (falling back to
-    the eou row's ``transcription_delay``); LLM/TTS from their ttfb. Values are
-    seconds, averaged across every row for the room (so a fixed ``--room-name``
-    reused across turns averages them; the default per-trial rooms each hold one
-    turn). Returns None when nothing usable is present (an uninstrumented agent,
-    or rows without latencies).
+    ``end_of_utterance_delay``. STT responsiveness is the turn's
+    time-to-first-partial (the ``eou`` row's ``time_to_first_partial_ms``: speech
+    onset -> first interim, the head / first-byte metric). It is preferred, as
+    the STT headline, over the ``transcription_delay`` tail (end-of-speech ->
+    final, which folds in the provider's endpointing) and over a per-call STT
+    ``ttfb`` if a provider ever emits one. LLM/TTS come from their ttfb. Values
+    are seconds, averaged across every row for the room (so a fixed
+    ``--room-name`` reused across turns averages them; the default per-trial
+    rooms each hold one turn). ``stt`` is the headline number; ``stt_ttfp`` (head)
+    and ``stt_transcription_delay`` (tail) are also surfaced when present so a
+    caller can show both ends of the utterance. Returns None when nothing usable
+    is present (an uninstrumented agent, or rows without latencies).
     """
     eou: list[float] = []
     transcription: list[float] = []
+    first_partial: list[float] = []
     stt: list[float] = []
     llm: list[float] = []
     tts: list[float] = []
@@ -48,6 +55,9 @@ def aggregate_components(rows: list[dict]) -> dict | None:
             td = eou_meta.get("transcription_delay")
             if td is not None:
                 transcription.append(float(td))
+            ttfp_ms = eou_meta.get("time_to_first_partial_ms")
+            if ttfp_ms is not None:
+                first_partial.append(float(ttfp_ms) / 1000.0)
         elif modality == "stt" and ttfb_ms is not None:
             stt.append(float(ttfb_ms) / 1000.0)
         elif modality == "llm" and ttfb_ms is not None:
@@ -58,10 +68,19 @@ def aggregate_components(rows: list[dict]) -> dict | None:
     out: dict[str, float] = {}
     if eou:
         out["eou"] = mean(eou)
+    # STT headline: prefer a real first-response (a per-call ttfb, else the
+    # turn-level time-to-first-partial) over the endpointing-laden
+    # transcription_delay tail. Expose the head and tail separately too.
     if stt:
         out["stt"] = mean(stt)
+    elif first_partial:
+        out["stt"] = mean(first_partial)
     elif transcription:
         out["stt"] = mean(transcription)
+    if first_partial:
+        out["stt_ttfp"] = mean(first_partial)
+    if transcription:
+        out["stt_transcription_delay"] = mean(transcription)
     if llm:
         out["llm_ttft"] = mean(llm)
     if tts:

--- a/src/voicegateway/livekit_diag/report.py
+++ b/src/voicegateway/livekit_diag/report.py
@@ -78,6 +78,7 @@ def render_latency(results: list, target_ms: float, summarize) -> str:
             labels = [
                 ("eou", "turn-detect"),
                 ("stt", "STT"),
+                ("stt_ttfp", "STT-ttfp"),
                 ("llm_ttft", "LLM-ttft"),
                 ("tts", "TTS"),
             ]

--- a/src/voicegateway/tests/livekit_diag/test_latency.py
+++ b/src/voicegateway/tests/livekit_diag/test_latency.py
@@ -88,7 +88,14 @@ def _split_rows(room="vg-probe-x"):
 
 def test_aggregate_components_full_split():
     out = aggregate_components(_split_rows())
-    assert out == {"eou": 0.30, "stt": 0.12, "llm_ttft": 0.45, "tts": 0.09}
+    # a per-call stt ttfb wins the headline; the tail is surfaced alongside it.
+    assert out == {
+        "eou": 0.30,
+        "stt": 0.12,
+        "stt_transcription_delay": 0.08,
+        "llm_ttft": 0.45,
+        "tts": 0.09,
+    }
 
 
 def test_aggregate_components_stt_falls_back_to_transcription_delay():
@@ -102,7 +109,47 @@ def test_aggregate_components_stt_falls_back_to_transcription_delay():
         }
     ]
     out = aggregate_components(rows)
-    assert out == {"eou": 0.30, "stt": 0.08}  # no stt row -> transcription_delay
+    # no stt row and no first-partial -> headline falls back to the tail.
+    assert out == {"eou": 0.30, "stt": 0.08, "stt_transcription_delay": 0.08}
+
+
+def test_aggregate_components_stt_prefers_ttfp_over_transcription_delay():
+    """The turn's time-to-first-partial (head) is the STT headline, not the tail."""
+    rows = [
+        {
+            "modality": "eou",
+            "ttfb_ms": None,
+            "metadata": {
+                "eou": {
+                    "end_of_utterance_delay": 0.30,
+                    "transcription_delay": 0.08,
+                    "time_to_first_partial_ms": 280.0,
+                }
+            },
+        }
+    ]
+    out = aggregate_components(rows)
+    assert out == {
+        "eou": 0.30,
+        "stt": 0.28,  # first-partial, not the 0.08 transcription_delay tail
+        "stt_ttfp": 0.28,
+        "stt_transcription_delay": 0.08,
+    }
+
+
+def test_aggregate_components_percall_stt_ttfb_outranks_ttfp():
+    """A real per-call STT ttfb, if a provider emits one, wins over the turn TTFP."""
+    rows = [
+        {
+            "modality": "eou",
+            "ttfb_ms": None,
+            "metadata": {"eou": {"time_to_first_partial_ms": 280.0}},
+        },
+        {"modality": "stt", "ttfb_ms": 120.0, "metadata": {}},
+    ]
+    out = aggregate_components(rows)
+    assert out["stt"] == 0.12  # per-call ttfb is the headline
+    assert out["stt_ttfp"] == 0.28  # ...but the turn TTFP is still exposed
 
 
 def test_aggregate_components_averages_multiple_turns():
@@ -136,7 +183,13 @@ class _FakeStore:
 async def test_component_reader_reads_and_aggregates():
     reader = ComponentReader(_FakeStore([_split_rows()]))
     out = await reader.read("vg-probe-x")
-    assert out == {"eou": 0.30, "stt": 0.12, "llm_ttft": 0.45, "tts": 0.09}
+    assert out == {
+        "eou": 0.30,
+        "stt": 0.12,
+        "stt_transcription_delay": 0.08,
+        "llm_ttft": 0.45,
+        "tts": 0.09,
+    }
 
 
 async def test_component_reader_no_store_returns_none():
@@ -183,7 +236,13 @@ async def test_component_reader_returns_partial_after_exhausting_polls():
     store = _FakeStore([_partial_rows(), _partial_rows()])
     reader = ComponentReader(store, poll_attempts=2, poll_delay=0.0)
     out = await reader.read("vg-probe-x")
-    assert out == {"eou": 0.30, "stt": 0.12, "llm_ttft": 0.45}  # no tts key
+    # no tts key; the eou row's transcription_delay still surfaces as the tail
+    assert out == {
+        "eou": 0.30,
+        "stt": 0.12,
+        "stt_transcription_delay": 0.08,
+        "llm_ttft": 0.45,
+    }
     assert store.calls == 2
 
 
@@ -197,6 +256,7 @@ async def test_probe_reads_components_after_loop():
     assert result.components == {
         "eou": 0.30,
         "stt": 0.12,
+        "stt_transcription_delay": 0.08,
         "llm_ttft": 0.45,
         "tts": 0.09,
     }

--- a/src/voicegateway/tests/storage/test_requests_by_room.py
+++ b/src/voicegateway/tests/storage/test_requests_by_room.py
@@ -55,10 +55,12 @@ async def test_get_requests_for_room_returns_only_that_room(tmp_path):
     assert len(rows) == 4
     assert all(r["metadata"]["room"] == "vg-probe-a" for r in rows)
 
-    # Full read-back: the split aggregates to the expected seconds.
+    # Full read-back: the split aggregates to the expected seconds. The eou row's
+    # transcription_delay surfaces as the STT tail alongside the per-call ttfb.
     assert aggregate_components(rows) == {
         "eou": 0.30,
         "stt": 0.12,
+        "stt_transcription_delay": 0.08,
         "llm_ttft": 0.45,
         "tts": 0.09,
     }


### PR DESCRIPTION
## What

The per-agent latency probe (`voicegw livekit latency`) reads the STT/LLM/TTS + turn-detect split from the instrumented agent's captured rows. Because LiveKit's `STTMetrics` carries no first-byte, the probe's STT number was falling back to the eou row's `transcription_delay` (end-of-speech to final). That is a **tail** metric that folds in the STT provider's endpointing, not STT responsiveness.

This makes the probe report the STT **head** metric instead: the turn's time-to-first-partial (speech onset to first interim), which is the true analog of LLM `ttft` / TTS `ttfb`.

## Changes

- `aggregate_components` extracts `time_to_first_partial_ms` from the eou row and prefers it as the STT headline (`stt`), ahead of a per-call STT `ttfb` (if a provider ever emits one) and the `transcription_delay` tail.
- Surfaces `stt_ttfp` (head) and `stt_transcription_delay` (tail) separately, so a caller can show both ends of the utterance (the per-agent Test UI will want both).
- Text report gains an `STT-ttfp` line.

## Depends on

The TTFP field on the eou row comes from the capture layer in #140 (and its onset fix). This PR only reads the metadata key, so it is independently mergeable: on an agent without that capture, `time_to_first_partial_ms` is simply absent and the STT number falls back to `transcription_delay` exactly as before. The real head number appears once #140 is also deployed in the agent's VG version.

## Tests

Updated the exact-split assertions and added: TTFP preferred over transcription_delay; per-call ttfb outranks TTFP; head/tail both surfaced. Full `livekit_diag` suite green (59), ruff + mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Latency reports now provide more detailed speech-to-text timing, including time to first partial response and transcription completion delay.
  * Latency breakdowns display the new STT first-partial metric when available.
* **Bug Fixes**
  * Improved STT latency selection prioritizes per-call and first-response measurements for more accurate reporting.
  * Transcription-delay details remain available in partial latency results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->