### PR TITLE
fix(pipecat): capture ProcessingMetricsData as total latency (LiveKit parity)

### DIFF
--- a/src/voicegateway/inference/pipecat/observer.py
+++ b/src/voicegateway/inference/pipecat/observer.py
@@ -14,8 +14,10 @@ Mapping (``on_push_frame`` sees ``FramePushed`` events; ``frame.data`` on a
        cached=cache_read_input_tokens.
 - ``TTSUsageMetricsData`` (``.value`` is an int char count)
     -> modality=tts, input=chars.
-- ``TTFBMetricsData`` (``.value`` seconds) -> ttfb_ms; ``TTFAMetricsData``
-    (``.value`` seconds) -> total_latency_ms.
+- ``TTFBMetricsData`` (``.value`` seconds) -> ttfb_ms (first response, the ttft
+    analog); ``ProcessingMetricsData`` (``.value`` seconds) -> total_latency_ms
+    (total processing time, the LiveKit ``metric.duration`` analog). Pipecat
+    exposes no connection-acquire metric, so a Pipecat row carries no network hop.
 - STT has NO usage metric: accumulate ``AudioRawFrame`` bytes routed to each STT
   processor and derive seconds = bytes / (sample_rate * 2) (16-bit mono PCM),
   converted to minutes for input_units (the cost path multiplies back by 60).
@@ -225,13 +227,17 @@ def _lazy_frame_types() -> dict[str, Any]:
         "TTSUsageMetricsData": TTSUsageMetricsData,
         "TTFBMetricsData": TTFBMetricsData,
     }
-    # TTFAMetricsData (time-to-first-audio) is optional across versions.
+    # ProcessingMetricsData (total processing time, the Pipecat analog of
+    # LiveKit's metric.duration) is optional across versions; when present it is
+    # the total-latency source. Pipecat exposes no connection-acquire metric, so
+    # a Pipecat row's network hop is legitimately absent (unlike LiveKit's
+    # streaming STT/TTS acquire_time).
     try:
-        from pipecat.metrics.metrics import TTFAMetricsData
+        from pipecat.metrics.metrics import ProcessingMetricsData
 
-        types["TTFAMetricsData"] = TTFAMetricsData
-    except Exception:  # noqa: BLE001 - older pipecat without TTFA
-        types["TTFAMetricsData"] = ()
+        types["ProcessingMetricsData"] = ProcessingMetricsData
+    except Exception:  # noqa: BLE001 - older pipecat without ProcessingMetricsData
+        types["ProcessingMetricsData"] = ()
     # AudioRawFrame is the base of InputAudioRawFrame; matching it catches output
     # audio too, but STT accumulates only input audio, so we key on the base and
     # let the STT-processor routing decide what counts.
@@ -373,7 +379,9 @@ class VoiceGatewayObserver(BaseObserver):
         for md in data_list:
             if isinstance(md, types["TTFBMetricsData"]):
                 self._buffer_for(md).ttfb_ms = float(md.value) * 1000.0
-            elif types["TTFAMetricsData"] and isinstance(md, types["TTFAMetricsData"]):
+            elif types["ProcessingMetricsData"] and isinstance(
+                md, types["ProcessingMetricsData"]
+            ):
                 self._buffer_for(md).total_latency_ms = float(md.value) * 1000.0
         for md in data_list:
             if isinstance(md, types["LLMUsageMetricsData"]):

--- a/src/voicegateway/tests/inference/test_pipecat_observer.py
+++ b/src/voicegateway/tests/inference/test_pipecat_observer.py
@@ -32,6 +32,7 @@ from pipecat.frames.frames import (  # noqa: E402
 from pipecat.metrics.metrics import (  # noqa: E402
     LLMTokenUsage,
     LLMUsageMetricsData,
+    ProcessingMetricsData,
     TTFBMetricsData,
     TTSUsageMetricsData,
 )
@@ -202,6 +203,32 @@ async def test_ttfb_and_usage_correlate_into_one_llm_record() -> None:
     rec = sink.records[0]
     assert rec.ttfb_ms == pytest.approx(250.0)
     assert rec.input_units == 1000.0
+
+
+async def test_processing_metric_stitches_total_latency() -> None:
+    """ProcessingMetricsData (Pipecat's total processing time) -> total_latency_ms.
+
+    It is the LiveKit ``metric.duration`` analog; it rides the same per-processor
+    buffer as TTFB and flushes on the usage frame.
+    """
+    obs, sink = _make_observer()
+    llm = _StubLLM("gpt-4o")
+    usage = LLMTokenUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    await _feed(
+        obs,
+        llm,
+        MetricsFrame(
+            data=[
+                TTFBMetricsData(processor=llm.name, value=0.25),
+                ProcessingMetricsData(processor=llm.name, value=0.9),
+                LLMUsageMetricsData(processor=llm.name, value=usage),
+            ]
+        ),
+    )
+    assert len(sink.records) == 1
+    rec = sink.records[0]
+    assert rec.ttfb_ms == pytest.approx(250.0)
+    assert rec.total_latency_ms == pytest.approx(900.0)
 
 
 async def test_ttfb_and_usage_same_frame_one_record() -> None:


### PR DESCRIPTION
## What

The Pipecat observer captured first-response (`TTFBMetricsData -> ttfb_ms`) but no total latency. It mapped `TTFAMetricsData -> total_latency_ms`, which is:
- semantically wrong (TTFA is TTS *time-to-first-audio*, not a total), and
- broken against current Pipecat (`TTFAMetricsData` has `ttfa`/`ttfb`/`leading_silence`, no `.value`, so that branch would `AttributeError` if ever hit).

So a Pipecat LLM row carried no `total`, which is why the framework-neutral demo could show cost + ttft for Pipecat but not the full row LiveKit shows.

## Fix

Map `ProcessingMetricsData` (Pipecat's total processing time) `-> total_latency_ms`, the analog of LiveKit's `metric.duration`. Drop the broken TTFA branch.

Pipecat exposes **no** connection-acquire metric, so a Pipecat row legitimately carries no network hop (unlike LiveKit streaming STT/TTS `acquire_time`). That stays absent, not faked.

## Verified

- Observer test suite passes against pipecat 1.6.0, including the new `ProcessingMetricsData -> total_latency_ms` case (`test_processing_metric_stitches_total_latency`).
- full-src mypy clean (248 files), ruff clean.

Note: the pipecat observer tests are `importorskip("pipecat")` (pipecat is not a VG extra, VG is framework-agnostic), so they skip in the default CI env and are validated where pipecat is installed.
