### PR TITLE
fix(pipecat): STT records also carry total_latency_ms

### DIFF
--- a/src/voicegateway/inference/pipecat/observer.py
+++ b/src/voicegateway/inference/pipecat/observer.py
@@ -534,6 +534,7 @@ class VoiceGatewayObserver(BaseObserver):
         minutes = seconds / 60.0
         pending = self._pending.pop(name, None)
         ttfb_ms = pending.ttfb_ms if pending is not None else None
+        total_latency_ms = pending.total_latency_ms if pending is not None else None
         record = self._cost_tracker.create_record(
             model_id=_model_id(provider, model),
             modality="stt",
@@ -541,6 +542,7 @@ class VoiceGatewayObserver(BaseObserver):
             project=self._project,
             input_units=minutes,
             ttfb_ms=ttfb_ms,
+            total_latency_ms=total_latency_ms,
             session_id=self._session_id,
             agent_id=self._agent_id,
         )

--- a/src/voicegateway/tests/inference/test_pipecat_observer.py
+++ b/src/voicegateway/tests/inference/test_pipecat_observer.py
@@ -308,6 +308,41 @@ async def test_stt_transcription_frame_is_also_a_boundary() -> None:
     assert sink.records[0].input_units == pytest.approx(1.0 / 60.0)
 
 
+async def test_stt_processing_metric_stitches_total_latency() -> None:
+    """ProcessingMetricsData on an STT processor lands as total_latency_ms.
+
+    Regression: the STT flush previously read only ttfb_ms from the buffer, so a
+    Pipecat STT row carried no total latency even though the observer buffered
+    the ProcessingMetricsData (LLM/TTS rows did get it).
+    """
+    obs, sink = _make_observer()
+    stt = _StubSTT("nova-3")
+    obs.register_stt(stt)
+    sr = 16000
+    await _feed(
+        obs,
+        stt,
+        InputAudioRawFrame(audio=b"\x00\x01" * sr, sample_rate=sr, num_channels=1),
+    )
+    await _feed(
+        obs,
+        stt,
+        MetricsFrame(
+            data=[
+                TTFBMetricsData(processor=stt.name, value=0.22),
+                ProcessingMetricsData(processor=stt.name, value=0.4),
+            ]
+        ),
+    )
+    await _feed(obs, stt, UserStoppedSpeakingFrame())
+
+    assert len(sink.records) == 1
+    rec = sink.records[0]
+    assert rec.modality == "stt"
+    assert rec.ttfb_ms == pytest.approx(220.0)
+    assert rec.total_latency_ms == pytest.approx(400.0)
+
+
 # --- metadata stamping -----------------------------------------------------
 
 


### PR DESCRIPTION
## What

Follow-on to #143. That fix wired `ProcessingMetricsData -> total_latency_ms` for LLM/TTS, but the STT flush path (`_flush_one_stt`) read only `ttfb_ms` from the per-processor buffer and dropped `total_latency_ms`. So a Pipecat STT row carried no total latency even though the observer already buffered the STT `ProcessingMetricsData`.

## Fix

Stitch `total_latency_ms` onto the STT record too, symmetric with the LLM/TTS emit path. One line, plus a regression test.

## Verified
- Observer suite passes against pipecat 1.6.0, including the new `test_stt_processing_metric_stitches_total_latency`.
- full-src mypy clean (248 files), ruff clean.

Enables the framework-neutral demo to show the full row (cost + first + total) for STT on both LiveKit and Pipecat. Pipecat still exposes no connection metric, so a Pipecat row has no network hop (correctly n/a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * STT records now include total processing latency, providing a more complete view of request performance.
* **Tests**
  * Added regression coverage to verify that STT timing metrics correctly include both time to first byte and total latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->