### PR TITLE
feat(cli): add 'voicegw calls' for a per-call cost view

### DIFF
--- a/docs/cli/calls.md
+++ b/docs/cli/calls.md
@@ -1,0 +1,86 @@
+---
+title: voicegw calls
+description: List recent calls with per-call cost and activity, the unit an operator thinks in.
+---
+
+# voicegw calls
+
+List recent calls with per-call cost and activity.
+
+## Synopsis
+
+`voicegw calls` shows one row per call (a session), not per model request. Where [`voicegw costs`](/cli/costs) rolls spend up by provider and model, and [`voicegw logs`](/cli/logs) tails individual STT/LLM/TTS requests, `calls` answers the operator's question: what did each call cost, and how busy was it?
+
+## Usage
+
+```bash
+voicegw calls [OPTIONS]
+```
+
+## Options
+
+| Flag | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--config` | `-c` | `string` | `null` | Path to `voicegw.yaml`. Auto-discovered if omitted. |
+| `--project` | `-p` | `string` | `null` | Filter to a specific project ID. |
+| `--limit` | `-n` | `int` | `20` | How many calls to show. |
+| `--sort` | `-s` | `string` | `recent` | Order: `recent` (newest first) or `cost` (most expensive first). |
+
+## Prerequisites
+
+Cost tracking must be enabled in `voicegw.yaml`:
+
+```yaml
+cost_tracking:
+  enabled: true
+```
+
+If cost tracking is disabled, the command prints a warning and exits.
+
+## Output
+
+A **Recent Calls** table with, per call: the call (session) id, when it started, the modalities used, the request count, and the total cost. A footer summarizes the shown calls (count, total cost, average cost per call).
+
+## Examples
+
+### Recent calls
+
+```bash
+voicegw calls
+```
+
+```
+             Recent Calls (20)
+┌──────────┬─────────────┬─────────────┬──────────┬─────────┐
+│ Call     │ Started     │ Modalities  │ Requests │    Cost │
+├──────────┼─────────────┼─────────────┼──────────┼─────────┤
+│ call-009 │ 07-23 03:52 │ stt·llm·tts │       15 │ $0.0513 │
+│ call-017 │ 07-21 20:59 │ stt·llm·tts │       18 │ $0.1055 │
+└──────────┴─────────────┴─────────────┴──────────┴─────────┘
+
+20 calls · $1.1942 total · $0.0543 avg/call
+```
+
+### The most expensive calls
+
+```bash
+voicegw calls --sort cost -n 10
+```
+
+### One project
+
+```bash
+voicegw calls --project tonys-pizza
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success (including when cost tracking is disabled; prints warning). |
+| `1` | Config failed to load. |
+| `2` | Unknown `--sort` value. |
+
+## Related
+
+[`voicegw costs`](/cli/costs) | [`voicegw logs`](/cli/logs) | [`voicegw reconcile`](/cli/reconcile)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -133,6 +133,7 @@
               "cli/dashboard",
               "cli/status",
               "cli/costs",
+              "cli/calls",
               "cli/export-costs",
               "cli/projects",
               "cli/logs",

--- a/src/voicegateway/cli/__init__.py
+++ b/src/voicegateway/cli/__init__.py
@@ -23,6 +23,7 @@ function-first by design.
 from __future__ import annotations
 
 from voicegateway.cli import brand_cli as _brand  # noqa: F401, E402
+from voicegateway.cli import calls_cli as _calls  # noqa: F401, E402
 from voicegateway.cli import check_cli as _check  # noqa: F401, E402
 from voicegateway.cli import costs_cli as _costs  # noqa: F401, E402
 from voicegateway.cli import dashboard_cli as _dashboard  # noqa: F401, E402

--- a/src/voicegateway/cli/calls_cli.py
+++ b/src/voicegateway/cli/calls_cli.py
@@ -1,0 +1,78 @@
+"""``voicegw calls`` command: cost + activity per call, the unit an operator
+actually thinks in (a call/session), not per model request."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import typer
+from rich.table import Table
+
+from voicegateway.cli._app import app, console
+from voicegateway.cli.base_cli import BaseCli
+
+_cli = BaseCli()
+
+_SORTS = {"recent": "started_at_desc", "cost": "cost_desc"}
+
+
+def _fmt_started(value: object) -> str:
+    """Format an ISO started_at into a short ``MM-DD HH:MM``; pass through junk."""
+    if not isinstance(value, str) or not value:
+        return "-"
+    try:
+        return datetime.fromisoformat(value).strftime("%m-%d %H:%M")
+    except ValueError:
+        return value[:16]
+
+
+@app.command()
+def calls(
+    config: str = typer.Option(None, "--config", "-c", help="Path to voicegw.yaml"),
+    project: str = typer.Option(None, "--project", "-p", help="Filter by project ID"),
+    limit: int = typer.Option(20, "--limit", "-n", help="How many calls to show"),
+    sort: str = typer.Option(
+        "recent", "--sort", "-s", help="Order: recent (default) or cost"
+    ),
+) -> None:
+    """List recent calls with per-call cost and activity."""
+    gw = _cli.require_gateway(config)
+    if gw.storage is None:
+        _cli.warn("Cost tracking is not enabled in voicegw.yaml")
+        raise typer.Exit(0)
+
+    order_by = _SORTS.get(sort)
+    if order_by is None:
+        _cli.fail(f"Unknown sort: {sort}. Use recent or cost.", code=2)
+
+    rows = _cli.async_run(
+        gw.storage.list_sessions(limit=limit, project=project, order_by=order_by)
+    )
+    if not rows:
+        console.print("[dim]No calls recorded yet.[/dim]")
+        raise typer.Exit(0)
+
+    table = Table(title=f"Recent Calls ({len(rows)})")
+    table.add_column("Call", style="cyan")
+    table.add_column("Started")
+    table.add_column("Modalities")
+    table.add_column("Requests", justify="right")
+    table.add_column("Cost", style="green", justify="right")
+    total = 0.0
+    for r in rows:
+        cost = float(r.get("total_cost_usd") or 0.0)
+        total += cost
+        modalities = r.get("modalities") or []
+        table.add_row(
+            str(r.get("id", "-")),
+            _fmt_started(r.get("started_at")),
+            "·".join(modalities) if isinstance(modalities, list) else str(modalities),
+            str(int(r.get("request_count") or 0)),
+            f"${cost:.4f}",
+        )
+    console.print(table)
+
+    avg = total / len(rows) if rows else 0.0
+    console.print(
+        f"\n[dim]{len(rows)} calls · ${total:.4f} total · ${avg:.4f} avg/call[/dim]"
+    )

--- a/src/voicegateway/tests/cli/test_calls_cli.py
+++ b/src/voicegateway/tests/cli/test_calls_cli.py
@@ -1,0 +1,81 @@
+"""``voicegw calls``: per-call cost/activity view."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import yaml
+from typer.testing import CliRunner
+
+from voicegateway.cli._app import app
+from voicegateway.cli.calls_cli import _fmt_started
+from voicegateway.core.gateway import Gateway
+from voicegateway.models.request_model import RequestRecord
+
+runner = CliRunner()
+
+
+def _strip(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def test_fmt_started_short_and_passthrough() -> None:
+    assert _fmt_started("2026-07-23T03:52:46.871326+00:00") == "07-23 03:52"
+    assert _fmt_started("") == "-"
+    assert _fmt_started(None) == "-"
+    assert _fmt_started("not-a-date") == "not-a-date"  # unparseable -> first 16 chars
+
+
+def _rec(session_id: str, modality: str, model_id: str, provider: str,
+         cost: float, ts: float) -> RequestRecord:
+    return RequestRecord(
+        id=f"{session_id}-{modality}-{ts}", timestamp=ts, project="default",
+        modality=modality, model_id=model_id, provider=provider,
+        input_units=1, output_units=0, cost_usd=cost, pricing_source="test",
+        ttfb_ms=None, total_latency_ms=100.0, status="success", session_id=session_id,
+    )
+
+
+def _seed(tmp_path, monkeypatch) -> str:
+    db = tmp_path / "calls.db"
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(db))
+    cfg = tmp_path / "voicegw.yaml"
+    cfg.write_text(yaml.dump({
+        "providers": {"openai": {"api_key": "x"}},
+        "models": {"stt": {}, "llm": {}, "tts": {}},
+        "projects": {},
+        "cost_tracking": {"enabled": True},
+    }))
+    gw = Gateway(config_path=str(cfg))
+
+    async def seed() -> None:
+        await gw.storage._ensure_initialized()
+        turn = [
+            ("stt", "deepgram/nova-3", "deepgram", 0.001),
+            ("llm", "openai/gpt-4o", "openai", 0.020),
+            ("tts", "cartesia/sonic-3", "cartesia", 0.010),
+        ]
+        for i, (mod, model, prov, cost) in enumerate(turn):
+            await gw.storage.log_request(_rec("call-001", mod, model, prov, cost, 1_700_000 + i))
+
+    asyncio.run(seed())
+    return str(cfg)
+
+
+def test_calls_lists_one_row_per_call(tmp_path, monkeypatch) -> None:
+    cfg = _seed(tmp_path, monkeypatch)
+    result = runner.invoke(app, ["calls", "-c", cfg])
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "call-001" in out
+    assert "Recent Calls" in out
+    assert "1 calls" in out  # three requests collapse into ONE call row
+    assert "$0.0310" in out  # 0.001 + 0.020 + 0.010 total for the call
+
+
+def test_calls_rejects_unknown_sort(tmp_path, monkeypatch) -> None:
+    cfg = _seed(tmp_path, monkeypatch)
+    result = runner.invoke(app, ["calls", "-c", cfg, "--sort", "bogus"])
+    assert result.exit_code == 2
+    assert "Unknown sort" in _strip(result.output)

--- a/src/voicegateway/tests/cli/test_imports.py
+++ b/src/voicegateway/tests/cli/test_imports.py
@@ -133,6 +133,10 @@ _V030_COMMAND_NAMES: frozenset[str] = frozenset({"replay"})
 # name lives on as a hidden alias, so it stays in the _V005 set above).
 _FRAMEWORK_AGNOSTIC_COMMAND_NAMES: frozenset[str] = frozenset({"check"})
 
+# Operator-centric read views added on top: `calls` (per-call cost, the unit an
+# operator thinks in, alongside the provider/model rollup in `costs`).
+_OPERATOR_VIEW_COMMAND_NAMES: frozenset[str] = frozenset({"calls"})
+
 
 def _registered_command_names() -> set[str]:
     """Names every Typer command registered on ``app`` answers to."""
@@ -176,6 +180,7 @@ def test_command_count_matches_documented_surface() -> None:
         | _V011_COMMAND_NAMES
         | _V030_COMMAND_NAMES
         | _FRAMEWORK_AGNOSTIC_COMMAND_NAMES
+        | _OPERATOR_VIEW_COMMAND_NAMES
     )
     registered = _registered_command_names()
     assert registered == expected, (


### PR DESCRIPTION
## Why

`voicegw costs` rolls spend up by provider/model, and `voicegw logs` tails individual STT/LLM/TTS requests. Neither answers the question an operator actually asks: what did each call cost? The atomic unit for a voice agent is a call (a session of many turns, each turn = stt + llm + tts requests), not a model request.

## What

`voicegw calls` lists one row per call: the call id, when it started, the modalities used, the request count, and the total cost, with a `N calls / total / avg per call` footer. `--sort cost` surfaces the most expensive calls; `--limit` / `--project` filter.

Reuses `storage.list_sessions` (the same per-call aggregation the dashboard Calls page uses), so it is DRY, not a parallel query path.

## Tests + docs
- Unit test for the timestamp formatter; CliRunner integration tests (one-row-per-call, unknown-sort rejection).
- New `docs/cli/calls.md` + nav entry; docs validator PASS.
- full-src mypy clean (249 files), ruff clean.
