### PR TITLE
feat(dashboard): add Server page (live LiveKit topology, cost-annotated, Phase 1)

### DIFF
--- a/docs/superpowers/specs/2026-07-23-server-page-livekit-topology-design.md
+++ b/docs/superpowers/specs/2026-07-23-server-page-livekit-topology-design.md
@@ -1,0 +1,111 @@
+# Server page: LiveKit deployment topology, cost-annotated
+
+Date: 2026-07-23
+Status: approved scope, pending build green light
+Scope decision: full control plane, new "Server" nav item (OSS dashboard, LiveKit first; Pipecat deferred)
+
+## Problem
+
+The OSS dashboard has no view of the LiveKit deployment the metered agents run on.
+The user wants a left-nav "Server" page with a Railway-style component view
+(SFU, SIP, Egress, Ingress).
+
+## The tension (and the resolution)
+
+VoiceGateway is a cost/quality profiler, not an infrastructure monitor. A raw
+topology-of-boxes duplicates LiveKit's own console. LiveKit's console, however,
+does not know cost. So the page earns its place by joining the live deployment
+map to VG's own metered cost and latency per room / per agent. That join is the
+only reason to build this instead of linking to LiveKit's console.
+
+## Honesty guardrails (non-negotiable)
+
+VG shows only data it actually has. It must NOT draw:
+
+- SFU node health, live load bars, or green/red node dots (VG has no node metrics).
+- `loss_pct` as a measured value (the probe path hardcodes 0.0).
+- Any per-component ($/SIP-trunk, $/egress) cost (those components emit no
+  attach()/guard() calls, so VG has no cost for them).
+
+The SFU tile shows live room/participant totals (real, cheap) plus a timestamped
+"last probe" line and a Run-probe button into Diagnostics. No invented gauge.
+
+## Data sources (grounded in the repo)
+
+Real and reachable today (LiveKit Server API, creds already resolved by
+`livekit_diag/config.py resolve_creds`, LIVEKIT_URL/API_KEY/API_SECRET):
+
+- Rooms + in-room participants + per-room agents (active vs dispatched), human
+  occupancy, agent age — `livekit_diag/admin.py list_agents` (zero new code).
+- Connection status + server URL — already shipped (`/api/diagnostics/creds`).
+
+Real, VG-native (not LiveKit):
+
+- Fleet roster (idle/busy/offline, region, host, version, active_sessions) —
+  workers table via the collector heartbeat `GET /v1/agents`; requires
+  VOICEGW_COLLECTOR_URL + VOICEGW_API_KEY. Degrade gracefully when unset.
+- Per-room metered cost / request count / p95 (24h) —
+  `request_log_repository.get_requests_for_room` (exists, tested).
+
+Real but net-new read code (no new pip dependency; `livekit-api` already ships
+the service clients):
+
+- Egress jobs — `EgressService.list_egress`.
+- Ingress endpoints — `IngressService.list_ingress`.
+- SIP inbound/outbound trunks + dispatch rules — `SIPService.list_sip_*`.
+
+Cannot get (and will not fake): SFU node CPU/health, per-node distribution,
+Prometheus-style time series, which LiveKit URL each agent connects to
+(LIVEKIT_URL is not stamped on metering rows).
+
+## Backend
+
+New module `src/voicegateway/server/api/dashboard/server.py`:
+
+- `router = APIRouter(prefix="/server", tags=["dashboard"])`, wired into
+  `server/routes.py` (import + `dashboard_router.include_router(...)`), gated by
+  `Depends(require_scope(ADMIN_SCOPE))` (infra data, matches Diagnostics; no-op
+  when no API keys configured).
+- `GET /api/server/overview` returns a snapshot with each section shaped
+  `{ok: bool, data, error?: str}` so one failing read does not blank the page.
+  Control-plane lists are cheap and non-billing; fetch them concurrently.
+
+Engine additions to `livekit_diag/admin.py LiveKitAdmin` (read-only): `list_egress`,
+`list_ingress`, `list_sip_inbound_trunks`, `list_sip_outbound_trunks`,
+`list_sip_dispatch_rules`, each returning a small dataclass. Exact method and
+request-type names confirmed against the LiveKit Docs MCP before implementation,
+not from memory. Handle the `[livekit]` extra being absent with a clear install
+hint (same lazy-import + graceful-degrade as Diagnostics).
+
+## Frontend
+
+- `lib/nav.ts` — add `{to: '/server', label: 'Server', id: 'server'}` to the
+  Monitor group (sidebar + command palette derive automatically).
+- `App.tsx` — import `Server`, add `<Route path="/server" element={<Server />} />`.
+- `components/NavIcon.tsx` — add a `server` glyph (server-rack) keyed by id.
+- `pages/Server.tsx` — PageHeader accent "blue"; sections as `vg-card`s;
+  a component grid of neo-cards with real counts + control-plane state;
+  rooms table annotated with cost/p95; graceful empty states per section.
+- `lib/api.ts` — `fetchServerOverview()`; `lib/types.ts` — `ServerOverview`.
+- Rebuild `src/dashboard/frontend/dist` (the daemon serves the compiled bundle).
+
+## Phasing (each its own PR)
+
+- Phase 1 (spine): nav + route + page + `/api/server/overview` with
+  connection + rooms(+cost) + in-room agents + fleet roster. Existing reads only.
+- Phase 2 (control plane): SIP + Egress + Ingress read wrappers, endpoint
+  sections, UI tiles.
+
+## Tests
+
+- Engine: unit tests for the new `list_*` wrappers with a mocked LiveKitAPI.
+- Backend: `/api/server/overview` test with a fake LiveKit client + a seeded
+  SQLite store, asserting per-section shape and graceful degrade when creds or
+  collector are absent, and admin-scope behavior. Follow the diagnostics test
+  patterns.
+- Frontend: type-check (`tsc`) and build.
+
+## Out of scope
+
+Pipecat topology, SFU node metrics / Prometheus, per-component cost attribution,
+persisted topology time series, richer SIP call metadata (from/to number, trunk id).

--- a/docs/superpowers/specs/2026-07-23-server-page-livekit-topology-design.md
+++ b/docs/superpowers/specs/2026-07-23-server-page-livekit-topology-design.md
@@ -1,7 +1,8 @@
 # Server page: LiveKit deployment topology, cost-annotated
 
 Date: 2026-07-23
-Status: approved scope, pending build green light
+Status: Phase 1 shipped (rooms + agents + fleet, cost-annotated); Phase 2 shipped
+(SIP + Egress + Ingress). Both on PR #147. Pipecat deferred.
 Scope decision: full control plane, new "Server" nav item (OSS dashboard, LiveKit first; Pipecat deferred)
 
 ## Problem
@@ -29,6 +30,12 @@ VG shows only data it actually has. It must NOT draw:
 
 The SFU tile shows live room/participant totals (real, cheap) plus a timestamped
 "last probe" line and a Run-probe button into Diagnostics. No invented gauge.
+
+Secret whitelist (Phase 2): the LiveKit egress/ingress/sip proto messages carry
+credentials (auth_password, auth_username, stream_key, RTMP url, allowed_addresses,
+headers, metadata). The engine row dataclasses copy ONLY non-sensitive identifiers,
+so no secret can reach the dashboard JSON. Enforced by allowlist-by-construction
+and asserted in tests that build a proto WITH the secret set.
 
 ## Data sources (grounded in the repo)
 

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import Settings from './pages/Settings';
 import Login from './pages/Login';
 import Latency from './pages/Latency';
 import Diagnostics from './pages/Diagnostics';
+import Server from './pages/Server';
 import Projects from './pages/Projects';
 import RateCard from './pages/RateCard';
 import ApiKeys from './pages/ApiKeys';
@@ -92,6 +93,7 @@ export default function App() {
               <Route path="/costs" element={<Costs />} />
               <Route path="/latency" element={<Latency />} />
               <Route path="/diagnostics" element={<Diagnostics />} />
+              <Route path="/server" element={<Server />} />
               <Route path="/agents" element={<Agents />} />
               <Route path="/agents/:agentId" element={<AgentDetail />} />
               <Route path="/projects" element={<Projects />} />

--- a/src/dashboard/frontend/src/components/NavIcon.tsx
+++ b/src/dashboard/frontend/src/components/NavIcon.tsx
@@ -16,6 +16,7 @@ const PATHS: Record<string, JSX.Element> = {
   apikeys: <><circle cx="8" cy="14" r="4" /><path d="M11 11l8-8M16 6l3 3M14 8l2 2" /></>,
   account: <><circle cx="12" cy="8" r="4" /><path d="M4 20c0-4 4-6 8-6s8 2 8 6" /></>,
   diagnostics: <><path d="M12 13l4-3" /><path d="M4 18a8 8 0 1 1 16 0" /><circle cx="12" cy="13" r="1.2" /></>,
+  server: <><rect x="4" y="4" width="16" height="7" rx="1.5" /><rect x="4" y="13" width="16" height="7" rx="1.5" /><path d="M7.5 7.5h.01M7.5 16.5h.01" /></>,
 };
 
 export default function NavIcon({ id, size = 17 }: { id: string; size?: number }) {

--- a/src/dashboard/frontend/src/lib/api.ts
+++ b/src/dashboard/frontend/src/lib/api.ts
@@ -99,6 +99,7 @@ import type {
   ProjectBrandingResponse,
   ReplayResponse,
   RetentionWindow,
+  ServerOverview,
   TenantFilter,
   TurnRow,
 } from './types';
@@ -285,6 +286,14 @@ export function createDiagnosticsRun(body: {
     method: 'POST',
     body: JSON.stringify({ checks: body.checks, config: body.config ?? {} }),
   });
+}
+
+// ---------------------------------------------------------------------------
+// Server page: live LiveKit topology + fleet, cost-annotated (read-only).
+// ---------------------------------------------------------------------------
+
+export function fetchServerOverview(): Promise<ServerOverview> {
+  return fetchJson<ServerOverview>('/api/server/overview');
 }
 
 /**

--- a/src/dashboard/frontend/src/lib/nav.ts
+++ b/src/dashboard/frontend/src/lib/nav.ts
@@ -19,6 +19,7 @@ export const NAV: NavEntry[] = [
       { to: '/latency', label: 'Latency', id: 'latency' },
       { to: '/calls', label: 'Calls', id: 'calls' },
       { to: '/diagnostics', label: 'Diagnostics', id: 'diagnostics' },
+      { to: '/server', label: 'Server', id: 'server' },
     ],
   },
   {

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -386,11 +386,66 @@ export interface ServerFleetSection extends ServerSection {
   counts: { total: number; idle: number; busy: number; offline: number };
 }
 
+/** An egress job (recording / streaming). Secret fields are never included. */
+export interface ServerEgressItem {
+  egress_id: string;
+  status: string;
+  source_type: string;
+  room_name: string;
+  started_at: number;
+}
+
+/** An ingress endpoint. stream_key / url (secrets) are never included. */
+export interface ServerIngressItem {
+  ingress_id: string;
+  name: string;
+  input_type: string;
+  room_name: string;
+  status: string;
+}
+
+export interface ServerSipInboundTrunk {
+  trunk_id: string;
+  name: string;
+  numbers: string[];
+}
+
+export interface ServerSipOutboundTrunk {
+  trunk_id: string;
+  name: string;
+  address: string;
+  transport: string;
+  numbers: string[];
+}
+
+export interface ServerSipDispatchRule {
+  rule_id: string;
+  name: string;
+  trunk_ids: string[];
+}
+
+export interface ServerEgressSection extends ServerSection {
+  items: ServerEgressItem[];
+}
+
+export interface ServerIngressSection extends ServerSection {
+  items: ServerIngressItem[];
+}
+
+export interface ServerSipSection extends ServerSection {
+  inbound: ServerSipInboundTrunk[];
+  outbound: ServerSipOutboundTrunk[];
+  dispatch_rules: ServerSipDispatchRule[];
+}
+
 /** GET /api/server/overview: a read-only deployment snapshot, per section. */
 export interface ServerOverview {
   generated_at: number;
   connection: ServerConnection;
   rooms: ServerRoomsSection;
+  egress: ServerEgressSection;
+  ingress: ServerIngressSection;
+  sip: ServerSipSection;
   fleet: ServerFleetSection;
 }
 

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -329,3 +329,68 @@ export interface DiagnosticRun {
   ended_at: string | null;
 }
 
+// ---------------------------------------------------------------------------
+// Server: live LiveKit deployment topology + fleet, cost-annotated.
+// ---------------------------------------------------------------------------
+
+/** LiveKit control-plane connection state. `reachable` is null until probed. */
+export interface ServerConnection {
+  configured: boolean;
+  url: string | null;
+  reachable: boolean | null;
+}
+
+/** One agent inside a live room. */
+export interface ServerRoomAgent {
+  agent_name: string;
+  identity: string | null;
+  state: string; // "active" (joined) or "dispatched" (assigned, not joined)
+  age_s: number | null;
+}
+
+/** A live room, annotated with VG's own metered cost over the last 24h. */
+export interface ServerRoom {
+  name: string;
+  humans: number;
+  agents: ServerRoomAgent[];
+  cost_usd: number;
+  request_count: number;
+  p95_latency_ms: number | null;
+}
+
+/** One registered worker from the local heartbeat roster. */
+export interface ServerWorker {
+  agent_id: string;
+  agent_name: string;
+  region: string | null;
+  host: string | null;
+  version: string | null;
+  status: string; // idle | busy | offline
+  active_sessions: number;
+  last_seen: number;
+  memory_pct: number | null;
+}
+
+/** A section that may fail independently without blanking the page. */
+export interface ServerSection {
+  ok: boolean;
+  error: string | null;
+}
+
+export interface ServerRoomsSection extends ServerSection {
+  rooms: ServerRoom[];
+}
+
+export interface ServerFleetSection extends ServerSection {
+  workers: ServerWorker[];
+  counts: { total: number; idle: number; busy: number; offline: number };
+}
+
+/** GET /api/server/overview: a read-only deployment snapshot, per section. */
+export interface ServerOverview {
+  generated_at: number;
+  connection: ServerConnection;
+  rooms: ServerRoomsSection;
+  fleet: ServerFleetSection;
+}
+

--- a/src/dashboard/frontend/src/pages/Server.tsx
+++ b/src/dashboard/frontend/src/pages/Server.tsx
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import PageHeader from '../components/PageHeader';
+import { fetchServerOverview } from '../lib/api';
+import { formatCost, formatMs, formatRelativeTime } from '../lib/ui';
+import type { ServerOverview } from '../lib/types';
+
+/**
+ * Server: a read-only, cost-annotated view of the live LiveKit deployment.
+ *
+ * Rooms + agents come from the LiveKit Server API; the fleet roster comes from
+ * VG's own heartbeats. Each is annotated with VG's metered cost, the thing
+ * LiveKit's own console cannot show. SFU health is NOT drawn here: VG can only
+ * measure it with a billed probe, which lives on the Diagnostics page. SIP /
+ * Egress / Ingress arrive in Phase 2.
+ */
+
+function connectionBadge(
+  c: ServerOverview['connection'],
+): { cls: string; text: string } {
+  if (!c.configured) return { cls: 'neo-badge--warning', text: 'Not configured' };
+  if (c.reachable === false) return { cls: 'neo-badge--red', text: 'Unreachable' };
+  if (c.reachable === true) return { cls: 'neo-badge--green', text: 'Connected' };
+  return { cls: 'neo-badge--black', text: 'Configured' };
+}
+
+function workerStatusBadge(status: string): string {
+  if (status === 'busy') return 'neo-badge--green';
+  if (status === 'idle') return 'neo-badge--blue';
+  return 'neo-badge--offline';
+}
+
+export default function Server() {
+  const mountedRef = useRef(true);
+  const [data, setData] = useState<ServerOverview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    fetchServerOverview()
+      .then((d) => {
+        if (mountedRef.current) {
+          setData(d);
+          setError(null);
+        }
+      })
+      .catch((e) => {
+        if (mountedRef.current) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (mountedRef.current) setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    load();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [load]);
+
+  const refresh = (
+    <button className="neo-btn neo-btn--primary" onClick={load} disabled={loading}>
+      {loading ? 'Refreshing...' : 'Refresh'}
+    </button>
+  );
+
+  if (!data) {
+    return (
+      <div>
+        <PageHeader
+          title="Server"
+          subtitle="Live LiveKit deployment, annotated with your metered cost"
+          accent="blue"
+          actions={refresh}
+        />
+        {error ? (
+          <div className="neo-card neo-card--strip-orange">{error}</div>
+        ) : (
+          <div className="empty-state">Loading deployment...</div>
+        )}
+      </div>
+    );
+  }
+
+  const { connection, rooms, fleet } = data;
+  const badge = connectionBadge(connection);
+  const activeAgents = rooms.rooms.reduce(
+    (n, r) => n + r.agents.filter((a) => a.state === 'active').length,
+    0,
+  );
+  const dispatchedAgents = rooms.rooms.reduce(
+    (n, r) => n + r.agents.filter((a) => a.state === 'dispatched').length,
+    0,
+  );
+
+  return (
+    <div>
+      <PageHeader
+        title="Server"
+        subtitle={`Live LiveKit deployment, annotated with your metered cost. Snapshot ${formatRelativeTime(
+          data.generated_at,
+        )}`}
+        accent="blue"
+        actions={refresh}
+      />
+
+      {/* Connection */}
+      <div className="vg-card" style={{ marginBottom: 16 }}>
+        <div className="vg-card__label" style={{ marginBottom: 10 }}>
+          LiveKit connection
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+          <span className={`neo-badge ${badge.cls}`}>{badge.text}</span>
+          {connection.url && (
+            <span className="mono" style={{ fontSize: 13, color: 'var(--vg-muted)' }}>
+              {connection.url}
+            </span>
+          )}
+        </div>
+        {!connection.configured && (
+          <p style={{ marginTop: 10, fontSize: 13, color: 'var(--vg-muted)', lineHeight: 1.5 }}>
+            Set <span className="mono">LIVEKIT_URL</span>,{' '}
+            <span className="mono">LIVEKIT_API_KEY</span> and{' '}
+            <span className="mono">LIVEKIT_API_SECRET</span> (or a{' '}
+            <span className="mono">livekit:</span> block in{' '}
+            <span className="mono">voicegw.yaml</span>), then refresh.
+          </p>
+        )}
+        {rooms.error && connection.configured && (
+          <p style={{ marginTop: 10, fontSize: 13, color: 'var(--vg-red)', lineHeight: 1.5 }}>
+            {rooms.error}
+          </p>
+        )}
+      </div>
+
+      {/* Component grid */}
+      <div className="grid grid-cols-4" style={{ marginBottom: 16 }}>
+        <div className="vg-card">
+          <div className="vg-card__label">Rooms</div>
+          <div className="vg-stat" style={{ marginTop: 6 }}>{rooms.rooms.length}</div>
+          <div style={{ marginTop: 4, fontSize: 12, color: 'var(--vg-muted)' }}>with agents</div>
+        </div>
+        <div className="vg-card">
+          <div className="vg-card__label">Agents</div>
+          <div className="vg-stat" style={{ marginTop: 6 }}>{activeAgents}</div>
+          <div style={{ marginTop: 4, fontSize: 12, color: 'var(--vg-muted)' }}>
+            active{dispatchedAgents ? ` + ${dispatchedAgents} dispatched` : ''}
+          </div>
+        </div>
+        <div className="vg-card">
+          <div className="vg-card__label">Workers</div>
+          <div className="vg-stat" style={{ marginTop: 6 }}>{fleet.counts.total}</div>
+          <div style={{ marginTop: 4, fontSize: 12, color: 'var(--vg-muted)' }}>
+            {fleet.counts.idle} idle · {fleet.counts.busy} busy · {fleet.counts.offline} offline
+          </div>
+        </div>
+        <div className="vg-card">
+          <div className="vg-card__label">SFU</div>
+          <div style={{ marginTop: 10 }}>
+            <Link className="neo-btn neo-btn--sm" to="/diagnostics">
+              Measure on Diagnostics
+            </Link>
+          </div>
+          <div style={{ marginTop: 8, fontSize: 12, color: 'var(--vg-muted)', lineHeight: 1.4 }}>
+            Health is a billed probe, not a live gauge.
+          </div>
+        </div>
+      </div>
+
+      {/* Rooms */}
+      <div className="vg-card" style={{ marginBottom: 16 }}>
+        <div className="vg-card__label" style={{ marginBottom: 12 }}>
+          Rooms (cost over last 24h)
+        </div>
+        {rooms.rooms.length === 0 ? (
+          <div className="empty-state">
+            {rooms.ok
+              ? 'No rooms with agents are live right now.'
+              : 'LiveKit is not reachable, so no rooms can be listed.'}
+          </div>
+        ) : (
+          <table className="neo-table neo-table--blue">
+            <thead>
+              <tr>
+                <th>Room</th>
+                <th>In call</th>
+                <th>Agents</th>
+                <th>Cost (24h)</th>
+                <th>Requests</th>
+                <th>p95</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rooms.rooms.map((r) => (
+                <tr key={r.name}>
+                  <td className="mono">{r.name}</td>
+                  <td>{r.humans}</td>
+                  <td>
+                    <div className="flex-row flex-wrap" style={{ gap: 4 }}>
+                      {r.agents.map((a, i) => (
+                        <span
+                          key={`${a.agent_name}-${a.identity ?? i}`}
+                          className={`neo-badge ${a.state === 'active' ? 'neo-badge--green' : 'neo-badge--yellow'}`}
+                          title={a.state}
+                        >
+                          {a.agent_name}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="mono">{formatCost(r.cost_usd, 4)}</td>
+                  <td>{r.request_count}</td>
+                  <td>{formatMs(r.p95_latency_ms)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Fleet */}
+      <div className="vg-card" style={{ marginBottom: 16 }}>
+        <div className="vg-card__label" style={{ marginBottom: 12 }}>
+          Fleet (registered workers)
+        </div>
+        {fleet.workers.length === 0 ? (
+          <div className="empty-state" style={{ lineHeight: 1.5 }}>
+            No workers are heartbeating. LiveKit's server API does not report idle
+            workers, so this roster is populated by your agents calling{' '}
+            <span className="mono">register_worker</span> (set{' '}
+            <span className="mono">VOICEGW_COLLECTOR_URL</span> and{' '}
+            <span className="mono">VOICEGW_API_KEY</span>).
+          </div>
+        ) : (
+          <table className="neo-table neo-table--green">
+            <thead>
+              <tr>
+                <th>Agent</th>
+                <th>Status</th>
+                <th>Region</th>
+                <th>Host</th>
+                <th>Version</th>
+                <th>Sessions</th>
+                <th>Mem</th>
+                <th>Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fleet.workers.map((w) => (
+                <tr key={w.agent_id}>
+                  <td className="mono">{w.agent_name || w.agent_id}</td>
+                  <td>
+                    <span className={`neo-badge ${workerStatusBadge(w.status)}`}>{w.status}</span>
+                  </td>
+                  <td>{w.region ?? '-'}</td>
+                  <td className="mono">{w.host ?? '-'}</td>
+                  <td className="mono">{w.version ?? '-'}</td>
+                  <td>{w.active_sessions}</td>
+                  <td>{w.memory_pct != null ? `${w.memory_pct}%` : '-'}</td>
+                  <td style={{ color: 'var(--vg-muted)', fontSize: 13 }}>
+                    {formatRelativeTime(w.last_seen)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <p style={{ fontSize: 12, color: 'var(--vg-muted)', lineHeight: 1.5 }}>
+        SIP trunks, Egress, and Ingress land in a follow-up. VG shows only what it
+        can measure: no SFU node health or load bars, since those need metrics VG
+        does not collect.
+      </p>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/pages/Server.tsx
+++ b/src/dashboard/frontend/src/pages/Server.tsx
@@ -30,6 +30,37 @@ function workerStatusBadge(status: string): string {
   return 'neo-badge--offline';
 }
 
+function egressStatusBadge(status: string): string {
+  if (status === 'EGRESS_ACTIVE') return 'neo-badge--green';
+  if (status === 'EGRESS_STARTING' || status === 'EGRESS_ENDING') return 'neo-badge--yellow';
+  if (status === 'EGRESS_FAILED' || status === 'EGRESS_ABORTED') return 'neo-badge--red';
+  return 'neo-badge--black';
+}
+
+function ingressStatusBadge(status: string): string {
+  if (status === 'ENDPOINT_PUBLISHING') return 'neo-badge--green';
+  if (status === 'ENDPOINT_BUFFERING') return 'neo-badge--yellow';
+  if (status === 'ENDPOINT_ERROR') return 'neo-badge--red';
+  return 'neo-badge--black';
+}
+
+/**
+ * A LiveKit enum name rendered as its distinctive last token, lowercased:
+ * "EGRESS_ACTIVE" -> "active", "SIP_TRANSPORT_TCP" -> "tcp",
+ * "ENDPOINT_PUBLISHING" -> "publishing", "RTMP_INPUT" -> "rtmp". An unknown
+ * numeric value (the backend fallback) passes through unchanged (e.g. "9").
+ */
+function enumLabel(s: string): string {
+  const last = s.replace(/_INPUT$/, '').split('_').pop() ?? s;
+  return last.toLowerCase();
+}
+
+/** Egress started_at is unix nanoseconds; render a local time or a dash. */
+function fmtNs(ns: number): string {
+  if (!ns) return '-';
+  return new Date(ns / 1e6).toLocaleString();
+}
+
 export default function Server() {
   const mountedRef = useRef(true);
   const [data, setData] = useState<ServerOverview | null>(null);
@@ -85,7 +116,7 @@ export default function Server() {
     );
   }
 
-  const { connection, rooms, fleet } = data;
+  const { connection, rooms, egress, ingress, sip, fleet } = data;
   const badge = connectionBadge(connection);
   const activeAgents = rooms.rooms.reduce(
     (n, r) => n + r.agents.filter((a) => a.state === 'active').length,
@@ -95,6 +126,11 @@ export default function Server() {
     (n, r) => n + r.agents.filter((a) => a.state === 'dispatched').length,
     0,
   );
+  const sipTrunks = sip.inbound.length + sip.outbound.length;
+  const sipEmpty = sipTrunks + sip.dispatch_rules.length === 0;
+  // Count only when the section actually answered, so an unconfigured/unreachable
+  // deployment shows "-" rather than a misleading 0.
+  const tileCount = (ok: boolean, n: number) => (ok ? n : '-');
 
   return (
     <div>
@@ -168,6 +204,23 @@ export default function Server() {
             Health is a billed probe, not a live gauge.
           </div>
         </div>
+        <div className="vg-card">
+          <div className="vg-card__label">Egress</div>
+          <div className="vg-stat" style={{ marginTop: 6 }}>{tileCount(egress.ok, egress.items.length)}</div>
+          <div style={{ marginTop: 4, fontSize: 12, color: 'var(--vg-muted)' }}>jobs</div>
+        </div>
+        <div className="vg-card">
+          <div className="vg-card__label">Ingress</div>
+          <div className="vg-stat" style={{ marginTop: 6 }}>{tileCount(ingress.ok, ingress.items.length)}</div>
+          <div style={{ marginTop: 4, fontSize: 12, color: 'var(--vg-muted)' }}>endpoints</div>
+        </div>
+        <div className="vg-card">
+          <div className="vg-card__label">SIP</div>
+          <div className="vg-stat" style={{ marginTop: 6 }}>{tileCount(sip.ok, sipTrunks)}</div>
+          <div style={{ marginTop: 4, fontSize: 12, color: 'var(--vg-muted)' }}>
+            trunks · {sip.ok ? sip.dispatch_rules.length : '-'} rules
+          </div>
+        </div>
       </div>
 
       {/* Rooms */}
@@ -221,6 +274,141 @@ export default function Server() {
         )}
       </div>
 
+      {/* SIP / Egress / Ingress: only when LiveKit is configured (the connection
+          card already explains an unconfigured deployment). */}
+      {connection.configured && (
+        <>
+          {/* SIP */}
+          <div className="vg-card" style={{ marginBottom: 16 }}>
+            <div className="vg-card__label" style={{ marginBottom: 12 }}>
+              SIP · telephony
+              {sip.ok
+                ? ` (${sip.inbound.length} inbound · ${sip.outbound.length} outbound · ${sip.dispatch_rules.length} rules)`
+                : ''}
+            </div>
+            {!sip.ok ? (
+              <div className="empty-state">{sip.error ?? 'SIP is not available on this deployment.'}</div>
+            ) : sipEmpty ? (
+              <div className="empty-state">No SIP trunks or dispatch rules configured.</div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                {sip.inbound.length > 0 && (
+                  <div>
+                    <div className="label" style={{ marginBottom: 6 }}>Inbound trunks</div>
+                    <table className="neo-table neo-table--orange">
+                      <thead><tr><th>Trunk</th><th>Name</th><th>Numbers</th></tr></thead>
+                      <tbody>
+                        {sip.inbound.map((t) => (
+                          <tr key={t.trunk_id}>
+                            <td className="mono">{t.trunk_id}</td>
+                            <td>{t.name || '-'}</td>
+                            <td className="mono">{t.numbers.join(', ') || '-'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+                {sip.outbound.length > 0 && (
+                  <div>
+                    <div className="label" style={{ marginBottom: 6 }}>Outbound trunks</div>
+                    <table className="neo-table neo-table--orange">
+                      <thead><tr><th>Trunk</th><th>Name</th><th>Address</th><th>Transport</th><th>Numbers</th></tr></thead>
+                      <tbody>
+                        {sip.outbound.map((t) => (
+                          <tr key={t.trunk_id}>
+                            <td className="mono">{t.trunk_id}</td>
+                            <td>{t.name || '-'}</td>
+                            <td className="mono">{t.address || '-'}</td>
+                            <td>{enumLabel(t.transport)}</td>
+                            <td className="mono">{t.numbers.join(', ') || '-'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+                {sip.dispatch_rules.length > 0 && (
+                  <div>
+                    <div className="label" style={{ marginBottom: 6 }}>Dispatch rules</div>
+                    <table className="neo-table neo-table--orange">
+                      <thead><tr><th>Rule</th><th>Name</th><th>Trunks</th></tr></thead>
+                      <tbody>
+                        {sip.dispatch_rules.map((r) => (
+                          <tr key={r.rule_id}>
+                            <td className="mono">{r.rule_id}</td>
+                            <td>{r.name || '-'}</td>
+                            <td className="mono">{r.trunk_ids.join(', ') || 'any'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Egress */}
+          <div className="vg-card" style={{ marginBottom: 16 }}>
+            <div className="vg-card__label" style={{ marginBottom: 12 }}>
+              Egress{egress.ok ? ` (${egress.items.length})` : ''}
+            </div>
+            {!egress.ok ? (
+              <div className="empty-state">{egress.error ?? 'Egress is not available.'}</div>
+            ) : egress.items.length === 0 ? (
+              <div className="empty-state">No egress jobs.</div>
+            ) : (
+              <table className="neo-table neo-table--pink">
+                <thead><tr><th>Egress</th><th>Status</th><th>Room</th><th>Source</th><th>Started</th></tr></thead>
+                <tbody>
+                  {egress.items.map((e) => (
+                    <tr key={e.egress_id}>
+                      <td className="mono">{e.egress_id}</td>
+                      <td><span className={`neo-badge ${egressStatusBadge(e.status)}`}>{enumLabel(e.status)}</span></td>
+                      <td className="mono">{e.room_name || '-'}</td>
+                      <td>{enumLabel(e.source_type)}</td>
+                      <td style={{ color: 'var(--vg-muted)', fontSize: 13 }}>{fmtNs(e.started_at)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {/* Ingress */}
+          <div className="vg-card" style={{ marginBottom: 16 }}>
+            <div className="vg-card__label" style={{ marginBottom: 12 }}>
+              Ingress{ingress.ok ? ` (${ingress.items.length})` : ''}
+            </div>
+            {!ingress.ok ? (
+              <div className="empty-state">{ingress.error ?? 'Ingress is not available.'}</div>
+            ) : ingress.items.length === 0 ? (
+              <div className="empty-state">No ingress endpoints.</div>
+            ) : (
+              <table className="neo-table neo-table--yellow">
+                <thead><tr><th>Ingress</th><th>Name</th><th>Input</th><th>Room</th><th>Status</th></tr></thead>
+                <tbody>
+                  {ingress.items.map((i) => (
+                    <tr key={i.ingress_id}>
+                      <td className="mono">{i.ingress_id}</td>
+                      <td>{i.name || '-'}</td>
+                      <td>{enumLabel(i.input_type)}</td>
+                      <td className="mono">{i.room_name || '-'}</td>
+                      <td>
+                        <span className={`neo-badge ${ingressStatusBadge(i.status)}`}>
+                          {i.status ? enumLabel(i.status) : '-'}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </>
+      )}
+
       {/* Fleet */}
       <div className="vg-card" style={{ marginBottom: 16 }}>
         <div className="vg-card__label" style={{ marginBottom: 12 }}>
@@ -271,9 +459,9 @@ export default function Server() {
       </div>
 
       <p style={{ fontSize: 12, color: 'var(--vg-muted)', lineHeight: 1.5 }}>
-        SIP trunks, Egress, and Ingress land in a follow-up. VG shows only what it
-        can measure: no SFU node health or load bars, since those need metrics VG
-        does not collect.
+        VG shows only what it can measure: no SFU node health or load bars, since
+        those need metrics VG does not collect. SIP auth and ingress stream keys are
+        never read into the dashboard.
       </p>
     </div>
   );

--- a/src/voicegateway/livekit_diag/admin.py
+++ b/src/voicegateway/livekit_diag/admin.py
@@ -32,6 +32,51 @@ class AgentRow:
     age_s: float | None
 
 
+# The control-plane component rows below deliberately carry only non-sensitive
+# identifiers. LiveKit's egress/ingress/sip info messages also hold secrets
+# (auth_password, auth_username, stream_key, url, allowed_addresses, headers);
+# those are NEVER copied onto these rows, so the dashboard cannot leak them.
+@dataclass(frozen=True)
+class EgressRow:
+    egress_id: str
+    status: str  # EgressStatus name, e.g. "EGRESS_ACTIVE"
+    source_type: str  # EgressSourceType name
+    room_name: str
+    started_at: int  # unix ns (0 when unset)
+
+
+@dataclass(frozen=True)
+class IngressRow:
+    ingress_id: str
+    name: str
+    input_type: str  # IngressInput name, e.g. "RTMP_INPUT"
+    room_name: str
+    status: str  # IngressState.Status name, "" when no state reported
+
+
+@dataclass(frozen=True)
+class SipInboundTrunkRow:
+    trunk_id: str
+    name: str
+    numbers: list[str]
+
+
+@dataclass(frozen=True)
+class SipOutboundTrunkRow:
+    trunk_id: str
+    name: str
+    address: str
+    transport: str  # SIPTransport name
+    numbers: list[str]
+
+
+@dataclass(frozen=True)
+class SipDispatchRuleRow:
+    rule_id: str
+    name: str
+    trunk_ids: list[str]
+
+
 class LiveKitAdmin:
     def __init__(self, creds: LiveKitCreds, *, api: Any | None = None) -> None:
         self._creds = creds
@@ -80,6 +125,71 @@ class LiveKitAdmin:
                 )
         return sorted(seen.values(), key=lambda r: (r.agent_name, r.room))
 
+    # --- Control-plane component reads (read-only, non-billing) --------------
+
+    async def list_egress(self) -> list[EgressRow]:
+        resp = await self._api.egress.list_egress(_req("ListEgressRequest"))
+        return [
+            EgressRow(
+                egress_id=e.egress_id,
+                status=_enum_name(e, "status"),
+                source_type=_enum_name(e, "source_type"),
+                room_name=e.room_name,
+                started_at=e.started_at,
+            )
+            for e in resp.items
+        ]
+
+    async def list_ingress(self) -> list[IngressRow]:
+        resp = await self._api.ingress.list_ingress(_req("ListIngressRequest"))
+        return [
+            IngressRow(
+                ingress_id=i.ingress_id,
+                name=i.name,
+                input_type=_enum_name(i, "input_type"),
+                room_name=i.room_name,
+                status=_enum_name(i.state, "status") if i.HasField("state") else "",
+            )
+            for i in resp.items
+        ]
+
+    async def list_sip_inbound_trunks(self) -> list[SipInboundTrunkRow]:
+        resp = await self._api.sip.list_sip_inbound_trunk(
+            _req("ListSIPInboundTrunkRequest")
+        )
+        return [
+            SipInboundTrunkRow(
+                trunk_id=t.sip_trunk_id, name=t.name, numbers=list(t.numbers)
+            )
+            for t in resp.items
+        ]
+
+    async def list_sip_outbound_trunks(self) -> list[SipOutboundTrunkRow]:
+        resp = await self._api.sip.list_sip_outbound_trunk(
+            _req("ListSIPOutboundTrunkRequest")
+        )
+        return [
+            SipOutboundTrunkRow(
+                trunk_id=t.sip_trunk_id,
+                name=t.name,
+                address=t.address,
+                transport=_enum_name(t, "transport"),
+                numbers=list(t.numbers),
+            )
+            for t in resp.items
+        ]
+
+    async def list_sip_dispatch_rules(self) -> list[SipDispatchRuleRow]:
+        resp = await self._api.sip.list_sip_dispatch_rule(
+            _req("ListSIPDispatchRuleRequest")
+        )
+        return [
+            SipDispatchRuleRow(
+                rule_id=r.sip_dispatch_rule_id, name=r.name, trunk_ids=list(r.trunk_ids)
+            )
+            for r in resp.items
+        ]
+
     async def create_room(self, name: str) -> None:
         await self._api.room.create_room(_req("CreateRoomRequest", name=name))
 
@@ -118,3 +228,18 @@ def _req(cls_name: str, **kwargs):
     # The param name must not collide with request fields (e.g. CreateRoomRequest
     # has a `name` field), so it is cls_name, not name.
     return getattr(api, cls_name)(**kwargs)
+
+
+def _enum_name(msg: Any, field: str) -> str:
+    """Human-readable name for an enum field on a proto message.
+
+    Falls back to the raw integer (as a string) for a value the descriptor does
+    not know, so a newer server enum never raises here.
+    """
+    value = getattr(msg, field)
+    descriptor = msg.DESCRIPTOR.fields_by_name.get(field)
+    enum_type = descriptor.enum_type if descriptor is not None else None
+    if enum_type is None:
+        return str(value)
+    entry = enum_type.values_by_number.get(value)
+    return entry.name if entry is not None else str(value)

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -338,6 +338,7 @@ async def get_recent_requests(
 async def get_requests_for_room(
     session: AsyncSession,
     room: str,
+    since: float | None = None,
 ) -> list[dict[str, Any]]:
     """Return every request row tagged ``metadata.room == room``.
 
@@ -348,6 +349,12 @@ async def get_requests_for_room(
     parsed match rejects any incidental substring hit. The ``LIKE`` only ever
     widens the candidate set (``_`` / ``%`` in a room name match more, never
     fewer), so the exact match below never drops a true row.
+
+    ``since`` bounds the scan to ``timestamp >= since`` (epoch seconds). The
+    metadata ``LIKE`` is a non-sargable full scan, so a time bound lets the
+    ``idx_requests_timestamp`` index cut the rows read: use it when rolling up a
+    long-lived room over a window (the Server-page cost annotation). ``None``
+    keeps the original unbounded behavior for the ephemeral-probe caller.
     """
     column_list = ", ".join(_REQUEST_COLUMNS)
     # Build the needle with json.dumps so it matches the write path byte-for-byte,
@@ -356,11 +363,13 @@ async def get_requests_for_room(
     # the object braces, leaving the exact ``"room": "<escaped>"`` substring.
     key = json.dumps({"room": room})[1:-1]
     like = f"%{key}%"
-    query = (
-        f"SELECT {column_list} FROM requests WHERE metadata LIKE :like "
-        "ORDER BY timestamp ASC"
-    )
-    result = await session.execute(text(query), {"like": like})
+    params: dict[str, Any] = {"like": like}
+    where = "metadata LIKE :like"
+    if since is not None:
+        where += " AND timestamp >= :since"
+        params["since"] = since
+    query = f"SELECT {column_list} FROM requests WHERE {where} ORDER BY timestamp ASC"
+    result = await session.execute(text(query), params)
     rows = [_row_to_dict(row) for row in result]
     return [
         r

--- a/src/voicegateway/server/api/dashboard/server.py
+++ b/src/voicegateway/server/api/dashboard/server.py
@@ -20,6 +20,7 @@ number VG can produce is a timestamped, billed probe, which lives on Diagnostics
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import time
 from typing import TYPE_CHECKING, Any
@@ -103,44 +104,12 @@ async def _room_cost(gateway: Gateway, room: str, now: float) -> dict[str, Any]:
     }
 
 
-async def _rooms_section(
-    gateway: Gateway, creds: LiveKitCreds | None, now: float
-) -> tuple[dict[str, Any], bool | None]:
-    """Live rooms + in-room agents from the LiveKit Server API, cost-annotated.
-
-    Returns ``(section, reachable)``. ``reachable`` is a concrete True/False only
-    when a control-plane read was actually attempted, so a False genuinely means
-    the server did not answer. It stays ``None`` when nothing probed the
-    deployment (creds absent, or the ``[livekit]`` extra not installed), so the
-    UI never reports an "unreachable" state VG never measured.
-    """
-    if creds is None:
-        return {"ok": False, "error": "LiveKit not configured", "rooms": []}, None
-    try:
-        admin = _make_admin(creds)
-    except Exception as exc:  # noqa: BLE001 - client construction must not 500
-        return {"ok": False, "error": str(exc), "rooms": []}, False
-    if admin is None:
-        return (
-            {
-                "ok": False,
-                "error": "LiveKit SDK not installed. Install voicegateway[livekit].",
-                "rooms": [],
-            },
-            None,
-        )
+async def _rooms_section(admin: Any, gateway: Gateway, now: float) -> dict[str, Any]:
+    """Live rooms + in-room agents (LiveKit Server API), annotated with VG cost."""
     try:
         agent_rows = await admin.list_agents()
     except Exception as exc:  # noqa: BLE001 - a control-plane read degrades, never 500s
-        return {"ok": False, "error": str(exc), "rooms": []}, False
-    finally:
-        # Best-effort teardown: a transport-close error must neither discard the
-        # section return above nor 500 the endpoint.
-        try:
-            await admin.aclose()
-        except Exception:  # noqa: BLE001
-            logger.debug("LiveKitAdmin.aclose() failed", exc_info=True)
-
+        return {"ok": False, "error": str(exc), "rooms": []}
     grouped: dict[str, dict[str, Any]] = {}
     for r in agent_rows:
         room = grouped.setdefault(
@@ -159,7 +128,107 @@ async def _rooms_section(
     costs = await asyncio.gather(*(_room_cost(gateway, r["name"], now) for r in rooms))
     for room, cost in zip(rooms, costs, strict=True):
         room.update(cost)
-    return {"ok": True, "error": None, "rooms": rooms}, True
+    return {"ok": True, "error": None, "rooms": rooms}
+
+
+async def _egress_section(admin: Any) -> dict[str, Any]:
+    """Active/recent egress jobs (recording/streaming)."""
+    try:
+        rows = await admin.list_egress()
+    except Exception as exc:  # noqa: BLE001 - a control-plane read degrades, never 500s
+        return {"ok": False, "error": str(exc), "items": []}
+    return {"ok": True, "error": None, "items": [dataclasses.asdict(r) for r in rows]}
+
+
+async def _ingress_section(admin: Any) -> dict[str, Any]:
+    """Configured ingress endpoints (WHIP / RTMP / URL)."""
+    try:
+        rows = await admin.list_ingress()
+    except Exception as exc:  # noqa: BLE001 - a control-plane read degrades, never 500s
+        return {"ok": False, "error": str(exc), "items": []}
+    return {"ok": True, "error": None, "items": [dataclasses.asdict(r) for r in rows]}
+
+
+async def _sip_section(admin: Any) -> dict[str, Any]:
+    """SIP inbound/outbound trunks and dispatch rules (telephony wiring)."""
+    try:
+        inbound, outbound, rules = await asyncio.gather(
+            admin.list_sip_inbound_trunks(),
+            admin.list_sip_outbound_trunks(),
+            admin.list_sip_dispatch_rules(),
+        )
+    except Exception as exc:  # noqa: BLE001 - a control-plane read degrades, never 500s
+        return {
+            "ok": False,
+            "error": str(exc),
+            "inbound": [],
+            "outbound": [],
+            "dispatch_rules": [],
+        }
+    return {
+        "ok": True,
+        "error": None,
+        "inbound": [dataclasses.asdict(r) for r in inbound],
+        "outbound": [dataclasses.asdict(r) for r in outbound],
+        "dispatch_rules": [dataclasses.asdict(r) for r in rules],
+    }
+
+
+def _absent_sections(error: str) -> dict[str, dict[str, Any]]:
+    """The LiveKit section shapes when nothing could be read (creds/SDK absent)."""
+    return {
+        "rooms": {"ok": False, "error": error, "rooms": []},
+        "egress": {"ok": False, "error": error, "items": []},
+        "ingress": {"ok": False, "error": error, "items": []},
+        "sip": {
+            "ok": False,
+            "error": error,
+            "inbound": [],
+            "outbound": [],
+            "dispatch_rules": [],
+        },
+    }
+
+
+async def _livekit_snapshot(
+    gateway: Gateway, creds: LiveKitCreds | None, now: float
+) -> tuple[dict[str, dict[str, Any]], bool | None]:
+    """Every LiveKit control-plane read through ONE admin client.
+
+    Returns ``(sections, reachable)`` where sections = {rooms, egress, ingress,
+    sip}. ``reachable`` is a concrete True/False only when reads were attempted
+    (True if any section answered), and stays ``None`` when nothing probed the
+    deployment (creds absent, or the ``[livekit]`` extra missing), so the UI
+    never reports an "unreachable" state VG never measured.
+    """
+    if creds is None:
+        return _absent_sections("LiveKit not configured"), None
+    try:
+        admin = _make_admin(creds)
+    except Exception as exc:  # noqa: BLE001 - client construction must not 500
+        return _absent_sections(str(exc)), False
+    if admin is None:
+        return (
+            _absent_sections("LiveKit SDK not installed. Install voicegateway[livekit]."),
+            None,
+        )
+    try:
+        rooms, egress, ingress, sip = await asyncio.gather(
+            _rooms_section(admin, gateway, now),
+            _egress_section(admin),
+            _ingress_section(admin),
+            _sip_section(admin),
+        )
+    finally:
+        # Best-effort teardown: a transport-close error must neither discard the
+        # sections above nor 500 the endpoint.
+        try:
+            await admin.aclose()
+        except Exception:  # noqa: BLE001
+            logger.debug("LiveKitAdmin.aclose() failed", exc_info=True)
+    sections = {"rooms": rooms, "egress": egress, "ingress": ingress, "sip": sip}
+    reachable = any(s["ok"] for s in sections.values())
+    return sections, reachable
 
 
 def _worker_entry(w: RosterRow) -> dict[str, Any]:
@@ -233,7 +302,7 @@ async def get_server_overview(
         else {"configured": False, "url": None}
     )
 
-    rooms, reachable = await _rooms_section(gateway, creds, now)
+    sections, reachable = await _livekit_snapshot(gateway, creds, now)
     fleet = await _fleet_section(gateway, now)
     # reachable is None unless a control-plane read was actually attempted, so
     # the UI never labels an unmeasured deployment "unreachable".
@@ -241,6 +310,9 @@ async def get_server_overview(
     return {
         "generated_at": now,
         "connection": connection,
-        "rooms": rooms,
+        "rooms": sections["rooms"],
+        "egress": sections["egress"],
+        "ingress": sections["ingress"],
+        "sip": sections["sip"],
         "fleet": fleet,
     }

--- a/src/voicegateway/server/api/dashboard/server.py
+++ b/src/voicegateway/server/api/dashboard/server.py
@@ -1,0 +1,246 @@
+"""Dashboard endpoint: GET /api/server/overview.
+
+A read-only, non-billing snapshot of the LiveKit deployment the metered agents
+run on, annotated with VoiceGateway's own cost / latency. LiveKit's own console
+shows the topology; it does not know cost, so this page joins the two.
+
+Sections are shaped ``{ok, error, ...}`` independently so one failing read never
+blanks the page. Everything here is a cheap control-plane list or a local DB
+read: NO synthetic probes and NO billed calls (those stay on Diagnostics).
+
+Gated behind ``require_scope(ADMIN_SCOPE)`` like Diagnostics: it reveals the
+LiveKit URL and the deployment's control-plane topology. That gate is a no-op
+when no API keys are configured (the local single-operator default), and
+enforces the admin scope once auth is enabled.
+
+Honesty: this endpoint never fabricates SFU node health or load. The only SFU
+number VG can produce is a timestamped, billed probe, which lives on Diagnostics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends
+
+from voicegateway.core.auth import ADMIN_SCOPE
+from voicegateway.livekit_diag.config import CredsError, LiveKitCreds, resolve_creds
+from voicegateway.repository import workers_repository
+from voicegateway.repository.workers_repository import DEFAULT_TTL_SECONDS
+from voicegateway.server.api._deps import get_gateway, require_scope
+from voicegateway.utils.percentiles import compute_percentiles
+
+if TYPE_CHECKING:
+    from voicegateway.core.gateway import Gateway
+    from voicegateway.repository.workers_repository import RosterRow
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/server", tags=["dashboard"])
+
+# Cost / latency annotation window for a live room (last 24h).
+_ROOM_WINDOW_SECONDS = 86_400.0
+
+
+# Seams for tests to override (monkeypatch), mirror diagnostics._resolve_creds.
+def _resolve_creds() -> LiveKitCreds:
+    return resolve_creds(None, None, None)
+
+
+def _make_admin(creds: LiveKitCreds) -> Any | None:
+    """Construct a LiveKitAdmin, or None when the ``[livekit]`` extra is absent.
+
+    The livekit server SDK ships with the ``[livekit]`` extra, so import it lazily
+    here rather than at module top: a missing dependency must degrade the rooms
+    section to an install hint, never crash the dashboard router import.
+    """
+    try:
+        from voicegateway.livekit_diag.admin import LiveKitAdmin
+    except ImportError:
+        return None
+    return LiveKitAdmin(creds)
+
+
+def _memory_pct(rss: int | None, total: int | None) -> float | None:
+    """RSS as a percentage of the memory ceiling (None when unavailable)."""
+    if not rss or not total:
+        return None
+    return round(rss / total * 100, 1)
+
+
+async def _room_cost(gateway: Gateway, room: str, now: float) -> dict[str, Any]:
+    """Aggregate VG's metered cost / requests / p95 latency for a room (24h).
+
+    Best-effort enrichment: any read failure yields zeros rather than failing the
+    whole rooms section. This is the wedge LiveKit's own console cannot show.
+    """
+    empty: dict[str, Any] = {"cost_usd": 0.0, "request_count": 0, "p95_latency_ms": None}
+    storage = gateway.storage
+    if storage is None:
+        return empty
+    try:
+        # Bound the scan in SQL (timestamp >= cutoff) so a long-lived room's
+        # roll-up stays cheap as the requests table grows.
+        rows = await storage.get_requests_for_room(room, since=now - _ROOM_WINDOW_SECONDS)
+    except Exception:  # noqa: BLE001 - cost annotation must never blank the page
+        return empty
+    cost = sum((r.get("cost_usd") or 0.0) for r in rows)
+    latencies = [
+        float(r["total_latency_ms"])
+        for r in rows
+        if r.get("total_latency_ms") is not None
+    ]
+    # Use the shared percentile helper so a room's p95 matches the p95 the
+    # Latency / Agents pages compute for the same underlying rows.
+    p95 = compute_percentiles(latencies, [95.0])["p95"] if latencies else None
+    return {
+        "cost_usd": round(cost, 6),
+        "request_count": len(rows),
+        "p95_latency_ms": p95,
+    }
+
+
+async def _rooms_section(
+    gateway: Gateway, creds: LiveKitCreds | None, now: float
+) -> tuple[dict[str, Any], bool | None]:
+    """Live rooms + in-room agents from the LiveKit Server API, cost-annotated.
+
+    Returns ``(section, reachable)``. ``reachable`` is a concrete True/False only
+    when a control-plane read was actually attempted, so a False genuinely means
+    the server did not answer. It stays ``None`` when nothing probed the
+    deployment (creds absent, or the ``[livekit]`` extra not installed), so the
+    UI never reports an "unreachable" state VG never measured.
+    """
+    if creds is None:
+        return {"ok": False, "error": "LiveKit not configured", "rooms": []}, None
+    try:
+        admin = _make_admin(creds)
+    except Exception as exc:  # noqa: BLE001 - client construction must not 500
+        return {"ok": False, "error": str(exc), "rooms": []}, False
+    if admin is None:
+        return (
+            {
+                "ok": False,
+                "error": "LiveKit SDK not installed. Install voicegateway[livekit].",
+                "rooms": [],
+            },
+            None,
+        )
+    try:
+        agent_rows = await admin.list_agents()
+    except Exception as exc:  # noqa: BLE001 - a control-plane read degrades, never 500s
+        return {"ok": False, "error": str(exc), "rooms": []}, False
+    finally:
+        # Best-effort teardown: a transport-close error must neither discard the
+        # section return above nor 500 the endpoint.
+        try:
+            await admin.aclose()
+        except Exception:  # noqa: BLE001
+            logger.debug("LiveKitAdmin.aclose() failed", exc_info=True)
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for r in agent_rows:
+        room = grouped.setdefault(
+            r.room, {"name": r.room, "humans": r.humans, "agents": []}
+        )
+        room["agents"].append(
+            {
+                "agent_name": r.agent_name,
+                "identity": r.identity,
+                "state": r.state,
+                "age_s": r.age_s,
+            }
+        )
+    rooms = sorted(grouped.values(), key=lambda x: x["name"])
+    # Enrich concurrently: each _room_cost is an independent windowed read.
+    costs = await asyncio.gather(*(_room_cost(gateway, r["name"], now) for r in rooms))
+    for room, cost in zip(rooms, costs, strict=True):
+        room.update(cost)
+    return {"ok": True, "error": None, "rooms": rooms}, True
+
+
+def _worker_entry(w: RosterRow) -> dict[str, Any]:
+    return {
+        "agent_id": w.agent_id,
+        "agent_name": w.agent_name,
+        "region": w.region,
+        "host": w.host,
+        "version": w.version,
+        "status": w.status,
+        "active_sessions": w.active_sessions,
+        "last_seen": w.last_seen,
+        "memory_pct": _memory_pct(w.memory_rss_bytes, w.memory_total_bytes),
+    }
+
+
+def _fleet_counts(roster: list[RosterRow]) -> dict[str, int]:
+    counts = {"total": len(roster), "idle": 0, "busy": 0, "offline": 0}
+    for w in roster:
+        if w.status in counts:
+            counts[w.status] += 1
+    return counts
+
+
+async def _fleet_section(gateway: Gateway, now: float) -> dict[str, Any]:
+    """Registered worker roster from the local DB heartbeats (idle/busy/offline).
+
+    This is VG-native, not a LiveKit call: the LiveKit Server API does not report
+    idle/registered workers. Empty when no agents heartbeat to this collector.
+    """
+    storage = gateway.storage
+    if storage is None:
+        return {"ok": True, "error": None, "workers": [], "counts": _fleet_counts([])}
+    try:
+        await storage._ensure_initialized()
+        async with storage._conn.session() as db:
+            roster = await workers_repository.read_roster(
+                db, tenant_id=None, now=now, ttl_seconds=DEFAULT_TTL_SECONDS
+            )
+    except Exception as exc:  # noqa: BLE001 - a section read degrades, never 500s
+        return {
+            "ok": False,
+            "error": str(exc),
+            "workers": [],
+            "counts": _fleet_counts([]),
+        }
+    return {
+        "ok": True,
+        "error": None,
+        "workers": [_worker_entry(w) for w in roster],
+        "counts": _fleet_counts(roster),
+    }
+
+
+@router.get("/overview")
+async def get_server_overview(
+    gateway: Gateway = Depends(get_gateway),
+    _auth: None = Depends(require_scope(ADMIN_SCOPE)),
+) -> dict[str, Any]:
+    """Read-only snapshot of the LiveKit deployment + VG-metered cost, per section."""
+    now = time.time()
+    creds: LiveKitCreds | None
+    try:
+        creds = _resolve_creds()
+    except CredsError:
+        creds = None
+
+    connection: dict[str, Any] = (
+        {"configured": True, "url": creds.url}
+        if creds is not None
+        else {"configured": False, "url": None}
+    )
+
+    rooms, reachable = await _rooms_section(gateway, creds, now)
+    fleet = await _fleet_section(gateway, now)
+    # reachable is None unless a control-plane read was actually attempted, so
+    # the UI never labels an unmeasured deployment "unreachable".
+    connection["reachable"] = reachable
+    return {
+        "generated_at": now,
+        "connection": connection,
+        "rooms": rooms,
+        "fleet": fleet,
+    }

--- a/src/voicegateway/server/routes.py
+++ b/src/voicegateway/server/routes.py
@@ -65,6 +65,9 @@ from voicegateway.server.api.dashboard import (
     replay as dashboard_replay,
 )
 from voicegateway.server.api.dashboard import (
+    server as dashboard_server,
+)
+from voicegateway.server.api.dashboard import (
     sessions as dashboard_sessions,
 )
 from voicegateway.server.api.dashboard import (
@@ -100,6 +103,7 @@ dashboard_router.include_router(dashboard_metrics.router)
 dashboard_router.include_router(dashboard_replay.router)
 dashboard_router.include_router(dashboard_agents.router)
 dashboard_router.include_router(dashboard_diagnostics.router)
+dashboard_router.include_router(dashboard_server.router)
 dashboard_router.include_router(dashboard_api_keys.router)
 dashboard_router.include_router(dashboard_branding.router)
 

--- a/src/voicegateway/services/request_log_service.py
+++ b/src/voicegateway/services/request_log_service.py
@@ -61,10 +61,15 @@ class RequestLogService:
                 s, limit, modality, project, tenant, agent
             )
 
-    async def get_requests_for_room(self, room: str) -> list[dict[str, Any]]:
-        """Return every request row tagged with ``metadata.room == room``."""
+    async def get_requests_for_room(
+        self, room: str, since: float | None = None
+    ) -> list[dict[str, Any]]:
+        """Return every request row tagged with ``metadata.room == room``.
+
+        ``since`` bounds the scan to ``timestamp >= since`` (epoch seconds).
+        """
         async with self._db.session() as s:
-            return await repo.get_requests_for_room(s, room)
+            return await repo.get_requests_for_room(s, room, since)
 
     async def get_requests_in_window(
         self,

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -279,10 +279,12 @@ class StorageService:
             limit, modality, project, tenant, agent
         )
 
-    async def get_requests_for_room(self, room: str) -> list[dict[str, Any]]:
+    async def get_requests_for_room(
+        self, room: str, since: float | None = None
+    ) -> list[dict[str, Any]]:
         """Delegate to RequestLogService.get_requests_for_room."""
         await self._ensure_initialized()
-        return await self._request_log_service.get_requests_for_room(room)
+        return await self._request_log_service.get_requests_for_room(room, since)
 
     async def get_project_stats(self, project: str) -> dict[str, Any]:
         """Delegate to CostService.get_project_stats."""

--- a/src/voicegateway/tests/livekit_diag/test_admin.py
+++ b/src/voicegateway/tests/livekit_diag/test_admin.py
@@ -1,4 +1,9 @@
+import dataclasses
 from types import SimpleNamespace
+
+from livekit.protocol import egress as egpb
+from livekit.protocol import ingress as inpb
+from livekit.protocol import sip as sippb
 
 from voicegateway.livekit_diag.admin import LiveKitAdmin
 from voicegateway.livekit_diag.config import LiveKitCreds
@@ -28,10 +33,91 @@ class _Dispatch:
         return [SimpleNamespace(agent_name="concierge")] if room_name == "r2" else []
 
 
+class _Egress:
+    async def list_egress(self, _req):
+        return SimpleNamespace(
+            items=[
+                egpb.EgressInfo(
+                    egress_id="eg1",
+                    status=egpb.EgressStatus.EGRESS_ACTIVE,
+                    source_type=egpb.EgressSourceType.EGRESS_SOURCE_TYPE_WEB,
+                    room_name="r1",
+                    started_at=123,
+                    # A nested secret (the RTMP push URL embeds the stream key):
+                    # the row must never carry it.
+                    stream_results=[
+                        egpb.StreamInfo(url="rtmp://secret.example/live/SECRET-KEY")
+                    ],
+                )
+            ]
+        )
+
+
+class _Ingress:
+    async def list_ingress(self, _req):
+        return SimpleNamespace(
+            items=[
+                inpb.IngressInfo(
+                    ingress_id="in1",
+                    name="stream",
+                    input_type=inpb.IngressInput.RTMP_INPUT,
+                    room_name="r2",
+                    # Secrets the row must NOT surface:
+                    stream_key="SECRET-STREAM-KEY",
+                    url="rtmp://secret.example/live",
+                    state=inpb.IngressState(
+                        status=inpb.IngressState.Status.ENDPOINT_PUBLISHING
+                    ),
+                )
+            ]
+        )
+
+
+class _Sip:
+    async def list_sip_inbound_trunk(self, _req):
+        return SimpleNamespace(
+            items=[
+                sippb.SIPInboundTrunkInfo(
+                    sip_trunk_id="tin1",
+                    name="main-in",
+                    numbers=["+15551234567"],
+                    auth_username="SECRET-USER",
+                    auth_password="SECRET-PASS",
+                )
+            ]
+        )
+
+    async def list_sip_outbound_trunk(self, _req):
+        return SimpleNamespace(
+            items=[
+                sippb.SIPOutboundTrunkInfo(
+                    sip_trunk_id="tout1",
+                    name="main-out",
+                    address="sip.example.com",
+                    transport=sippb.SIPTransport.SIP_TRANSPORT_TCP,
+                    numbers=["+15559876543"],
+                    auth_password="SECRET-PASS",
+                )
+            ]
+        )
+
+    async def list_sip_dispatch_rule(self, _req):
+        return SimpleNamespace(
+            items=[
+                sippb.SIPDispatchRuleInfo(
+                    sip_dispatch_rule_id="dr1", name="rule", trunk_ids=["tin1"]
+                )
+            ]
+        )
+
+
 class _FakeApi:
     def __init__(self):
         self.room = _Rooms()
         self.agent_dispatch = _Dispatch()
+        self.egress = _Egress()
+        self.ingress = _Ingress()
+        self.sip = _Sip()
 
     async def aclose(self):
         pass
@@ -52,3 +138,96 @@ async def test_join_token_is_a_jwt():
     admin = LiveKitAdmin(LiveKitCreds("u", "k", "s"), api=_FakeApi())
     token = admin.join_token("room1", "probe")
     assert token.count(".") == 2  # header.payload.signature
+
+
+async def test_list_egress_maps_status_and_source_enums():
+    admin = LiveKitAdmin(LiveKitCreds("u", "k", "s"), api=_FakeApi())
+    rows = await admin.list_egress()
+    assert len(rows) == 1
+    assert rows[0].egress_id == "eg1"
+    assert rows[0].status == "EGRESS_ACTIVE"
+    assert rows[0].source_type == "EGRESS_SOURCE_TYPE_WEB"
+    assert rows[0].room_name == "r1"
+    assert rows[0].started_at == 123
+    # The nested stream URL (a secret) never reaches the row.
+    keys = dataclasses.asdict(rows[0]).keys()
+    assert "url" not in keys and "stream_results" not in keys
+
+
+async def test_list_egress_unknown_enum_falls_back_to_int():
+    """A server enum value the local descriptor does not know renders as its int."""
+
+    class _EgUnknown:
+        async def list_egress(self, _req):
+            return SimpleNamespace(
+                items=[
+                    egpb.EgressInfo(
+                        egress_id="e9",
+                        status=999,  # not a known EgressStatus value
+                        source_type=egpb.EgressSourceType.EGRESS_SOURCE_TYPE_WEB,
+                        room_name="r",
+                        started_at=0,
+                    )
+                ]
+            )
+
+    api = _FakeApi()
+    api.egress = _EgUnknown()
+    admin = LiveKitAdmin(LiveKitCreds("u", "k", "s"), api=api)
+    rows = await admin.list_egress()
+    assert rows[0].status == "999"
+
+
+async def test_list_ingress_without_state_yields_blank_status():
+    """An ingress with no state message reports an empty status, not a crash."""
+
+    class _InNoState:
+        async def list_ingress(self, _req):
+            return SimpleNamespace(
+                items=[
+                    inpb.IngressInfo(
+                        ingress_id="in9",
+                        name="x",
+                        input_type=inpb.IngressInput.WHIP_INPUT,
+                        room_name="r",
+                    )
+                ]
+            )
+
+    api = _FakeApi()
+    api.ingress = _InNoState()
+    admin = LiveKitAdmin(LiveKitCreds("u", "k", "s"), api=api)
+    rows = await admin.list_ingress()
+    assert rows[0].status == ""
+    assert rows[0].input_type == "WHIP_INPUT"
+
+
+async def test_list_ingress_maps_enums_and_excludes_secrets():
+    admin = LiveKitAdmin(LiveKitCreds("u", "k", "s"), api=_FakeApi())
+    rows = await admin.list_ingress()
+    assert rows[0].ingress_id == "in1"
+    assert rows[0].input_type == "RTMP_INPUT"
+    assert rows[0].status == "ENDPOINT_PUBLISHING"
+    # The stream key and url are secrets and must never reach the row.
+    keys = dataclasses.asdict(rows[0]).keys()
+    assert "stream_key" not in keys and "url" not in keys
+
+
+async def test_list_sip_excludes_auth_secrets():
+    admin = LiveKitAdmin(LiveKitCreds("u", "k", "s"), api=_FakeApi())
+    inbound = await admin.list_sip_inbound_trunks()
+    outbound = await admin.list_sip_outbound_trunks()
+    rules = await admin.list_sip_dispatch_rules()
+
+    assert inbound[0].trunk_id == "tin1"
+    assert inbound[0].numbers == ["+15551234567"]
+    assert outbound[0].address == "sip.example.com"
+    assert outbound[0].transport == "SIP_TRANSPORT_TCP"
+    assert rules[0].rule_id == "dr1"
+    assert rules[0].trunk_ids == ["tin1"]
+
+    # No auth credential fields leak onto any trunk row.
+    for row in (inbound[0], outbound[0]):
+        keys = dataclasses.asdict(row).keys()
+        assert "auth_username" not in keys
+        assert "auth_password" not in keys

--- a/src/voicegateway/tests/server/test_server_api.py
+++ b/src/voicegateway/tests/server/test_server_api.py
@@ -18,6 +18,13 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from voicegateway.core.gateway import Gateway
+from voicegateway.livekit_diag.admin import (
+    EgressRow,
+    IngressRow,
+    SipDispatchRuleRow,
+    SipInboundTrunkRow,
+    SipOutboundTrunkRow,
+)
 from voicegateway.livekit_diag.config import CredsError, LiveKitCreds
 from voicegateway.models.request_model import RequestRecord
 from voicegateway.repository import workers_repository
@@ -58,23 +65,67 @@ def _not_configured(monkeypatch) -> None:
 
 
 class _FakeAdmin:
-    """A LiveKitAdmin stand-in that returns canned rows without a real server."""
+    """A LiveKitAdmin stand-in that returns canned rows without a real server.
+
+    ``raises`` fails EVERY control-plane read (a down/unreachable server);
+    ``agents_raises`` fails only list_agents (one section down, others fine).
+    """
 
     def __init__(
         self,
         rows: list[Any] | None = None,
         raises: Exception | None = None,
+        agents_raises: Exception | None = None,
+        sip_raises: Exception | None = None,
         aclose_raises: Exception | None = None,
+        egress: list[Any] | None = None,
+        ingress: list[Any] | None = None,
+        sip: dict[str, list[Any]] | None = None,
     ):
         self._rows = rows or []
         self._raises = raises
+        self._agents_raises = agents_raises
+        self._sip_raises = sip_raises
         self._aclose_raises = aclose_raises
+        self._egress = egress or []
+        self._ingress = ingress or []
+        self._sip = sip or {"inbound": [], "outbound": [], "dispatch_rules": []}
         self.closed = False
 
-    async def list_agents(self) -> list[Any]:
+    def _guard(self) -> None:
         if self._raises is not None:
             raise self._raises
+
+    def _sip_guard(self) -> None:
+        self._guard()
+        if self._sip_raises is not None:
+            raise self._sip_raises
+
+    async def list_agents(self) -> list[Any]:
+        self._guard()
+        if self._agents_raises is not None:
+            raise self._agents_raises
         return self._rows
+
+    async def list_egress(self) -> list[Any]:
+        self._guard()
+        return self._egress
+
+    async def list_ingress(self) -> list[Any]:
+        self._guard()
+        return self._ingress
+
+    async def list_sip_inbound_trunks(self) -> list[Any]:
+        self._sip_guard()
+        return self._sip["inbound"]
+
+    async def list_sip_outbound_trunks(self) -> list[Any]:
+        self._sip_guard()
+        return self._sip["outbound"]
+
+    async def list_sip_dispatch_rules(self) -> list[Any]:
+        self._sip_guard()
+        return self._sip["dispatch_rules"]
 
     async def aclose(self) -> None:
         self.closed = True
@@ -143,6 +194,11 @@ async def test_overview_not_configured(client, monkeypatch):
     assert data["rooms"]["ok"] is False
     assert "not configured" in data["rooms"]["error"].lower()
     assert data["rooms"]["rooms"] == []
+    # Every LiveKit section degrades together when creds are absent.
+    for sec in ("egress", "ingress", "sip"):
+        assert data[sec]["ok"] is False
+    assert data["egress"]["items"] == []
+    assert data["sip"]["inbound"] == []
     # Fleet is a local DB read, so it is fine even when LiveKit is not configured.
     assert data["fleet"]["ok"] is True
     assert data["fleet"]["workers"] == []
@@ -243,22 +299,43 @@ async def test_overview_room_cost_windowed_real_db(client, gateway, monkeypatch)
     assert room["p95_latency_ms"] == pytest.approx(290.0)
 
 
-async def test_overview_rooms_degrade_on_read_error(client, monkeypatch):
+async def test_overview_rooms_degrade_but_others_ok(client, monkeypatch):
+    """One failing LiveKit read is a section error; the others still answer."""
     _configured(monkeypatch)
     admin = _capture_admin(
-        monkeypatch, _FakeAdmin(raises=RuntimeError("livekit unreachable"))
+        monkeypatch, _FakeAdmin(agents_raises=RuntimeError("agents read boom"))
     )
     resp = await client.get("/api/server/overview")
     # The endpoint must never 500: a failed control-plane read is a section error.
     assert resp.status_code == 200
     data = resp.json()
     assert data["rooms"]["ok"] is False
-    assert "unreachable" in data["rooms"]["error"]
-    # A read was attempted and the server did not answer: reachable is False.
-    assert data["connection"]["reachable"] is False
+    assert "boom" in data["rooms"]["error"]
+    # egress/ingress/sip answered, so the deployment is reachable.
+    assert data["egress"]["ok"] is True
+    assert data["ingress"]["ok"] is True
+    assert data["sip"]["ok"] is True
+    assert data["connection"]["reachable"] is True
     # Fleet still succeeds independently.
     assert data["fleet"]["ok"] is True
     # The client is closed even on the error path (finally guard).
+    assert admin.closed is True
+
+
+async def test_overview_unreachable_when_all_reads_fail(client, monkeypatch):
+    """Every control-plane read failing means the server is unreachable."""
+    _configured(monkeypatch)
+    admin = _capture_admin(
+        monkeypatch, _FakeAdmin(raises=RuntimeError("connection refused"))
+    )
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    for sec in ("rooms", "egress", "ingress", "sip"):
+        assert data[sec]["ok"] is False
+    assert data["connection"]["reachable"] is False
+    # Fleet is a local read, unaffected by LiveKit being down.
+    assert data["fleet"]["ok"] is True
     assert admin.closed is True
 
 
@@ -289,6 +366,10 @@ async def test_overview_sdk_absent(client, monkeypatch):
     data = resp.json()
     assert data["rooms"]["ok"] is False
     assert "not installed" in data["rooms"]["error"].lower()
+    # Every LiveKit section carries the same install hint.
+    for sec in ("egress", "ingress", "sip"):
+        assert data[sec]["ok"] is False
+        assert "not installed" in data[sec]["error"].lower()
     # The SDK was never even loaded, so nothing probed the control plane:
     # reachable stays null (the UI shows "Configured", not "Unreachable").
     assert data["connection"]["reachable"] is None
@@ -311,6 +392,113 @@ async def test_overview_fleet_roster(client, gateway, monkeypatch):
     assert by_id["agent-idle"]["region"] == "us-east"
     assert by_id["agent-idle"]["memory_pct"] == 10.0
     assert by_id["agent-gone"]["status"] == "offline"
+
+
+async def test_overview_livekit_sections_populated(client, monkeypatch):
+    """Egress / Ingress / SIP serialize their whitelisted rows; no secrets leak."""
+    _configured(monkeypatch)
+    _capture_admin(
+        monkeypatch,
+        _FakeAdmin(
+            rows=[],
+            egress=[
+                EgressRow(
+                    egress_id="eg1",
+                    status="EGRESS_ACTIVE",
+                    source_type="EGRESS_SOURCE_TYPE_WEB",
+                    room_name="r1",
+                    started_at=123,
+                )
+            ],
+            ingress=[
+                IngressRow(
+                    ingress_id="in1",
+                    name="stream",
+                    input_type="RTMP_INPUT",
+                    room_name="r2",
+                    status="ENDPOINT_PUBLISHING",
+                )
+            ],
+            sip={
+                "inbound": [
+                    SipInboundTrunkRow(
+                        trunk_id="tin1", name="main-in", numbers=["+15551234567"]
+                    )
+                ],
+                "outbound": [
+                    SipOutboundTrunkRow(
+                        trunk_id="tout1",
+                        name="main-out",
+                        address="sip.example.com",
+                        transport="SIP_TRANSPORT_TCP",
+                        numbers=["+15559876543"],
+                    )
+                ],
+                "dispatch_rules": [
+                    SipDispatchRuleRow(rule_id="dr1", name="rule", trunk_ids=["tin1"])
+                ],
+            },
+        ),
+    )
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Exact-dict equality doubles as a secret tripwire: any extra serialized
+    # field (a leaked secret, a schema drift) fails the test.
+    assert data["egress"]["ok"] is True
+    assert data["egress"]["items"][0] == {
+        "egress_id": "eg1",
+        "status": "EGRESS_ACTIVE",
+        "source_type": "EGRESS_SOURCE_TYPE_WEB",
+        "room_name": "r1",
+        "started_at": 123,
+    }
+    assert data["ingress"]["items"][0] == {
+        "ingress_id": "in1",
+        "name": "stream",
+        "input_type": "RTMP_INPUT",
+        "room_name": "r2",
+        "status": "ENDPOINT_PUBLISHING",
+    }
+    sip = data["sip"]
+    assert sip["inbound"][0] == {
+        "trunk_id": "tin1",
+        "name": "main-in",
+        "numbers": ["+15551234567"],
+    }
+    assert sip["outbound"][0] == {
+        "trunk_id": "tout1",
+        "name": "main-out",
+        "address": "sip.example.com",
+        "transport": "SIP_TRANSPORT_TCP",
+        "numbers": ["+15559876543"],
+    }
+    assert sip["dispatch_rules"][0] == {
+        "rule_id": "dr1",
+        "name": "rule",
+        "trunk_ids": ["tin1"],
+    }
+
+
+async def test_overview_sip_degrades_but_others_ok(client, monkeypatch):
+    """A SIP sub-read failure degrades only SIP; rooms/egress/ingress still answer."""
+    _configured(monkeypatch)
+    admin = _capture_admin(
+        monkeypatch, _FakeAdmin(sip_raises=RuntimeError("sip service disabled"))
+    )
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sip"]["ok"] is False
+    assert "sip service disabled" in data["sip"]["error"]
+    assert data["sip"]["inbound"] == []
+    # The other LiveKit reads still succeeded, so the deployment is reachable.
+    assert data["rooms"]["ok"] is True
+    assert data["egress"]["ok"] is True
+    assert data["ingress"]["ok"] is True
+    assert data["connection"]["reachable"] is True
+    assert admin.closed is True
 
 
 async def test_overview_fleet_degrades_on_read_error(client, monkeypatch):

--- a/src/voicegateway/tests/server/test_server_api.py
+++ b/src/voicegateway/tests/server/test_server_api.py
@@ -1,0 +1,379 @@
+"""Tests for the dashboard ``GET /api/server/overview`` endpoint.
+
+The Server page is a read-only, non-billing snapshot: live LiveKit rooms/agents
+(control-plane reads) + the local worker roster, each annotated with VG cost.
+Tests monkeypatch the two seams (``_resolve_creds`` and ``_make_admin``) so no
+real LiveKit server or the optional ``[livekit]`` extra is required, and seed the
+worker roster / room cost through the gateway's own storage.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.livekit_diag.config import CredsError, LiveKitCreds
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.repository import workers_repository
+from voicegateway.server.api.dashboard import server as server_api
+from voicegateway.server.main import build_app
+
+_FAKE_CREDS = LiveKitCreds("wss://lk.example", "k", "s")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gateway(temp_config, tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "server-test.db"))
+    return Gateway(config_path=temp_config)
+
+
+@pytest.fixture
+async def client(gateway):
+    app = build_app(gateway, enable_mcp_sse=False, enable_dashboard=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _configured(monkeypatch) -> None:
+    monkeypatch.setattr(server_api, "_resolve_creds", lambda: _FAKE_CREDS)
+
+
+def _not_configured(monkeypatch) -> None:
+    def _raise() -> LiveKitCreds:
+        raise CredsError("no creds")
+
+    monkeypatch.setattr(server_api, "_resolve_creds", _raise)
+
+
+class _FakeAdmin:
+    """A LiveKitAdmin stand-in that returns canned rows without a real server."""
+
+    def __init__(
+        self,
+        rows: list[Any] | None = None,
+        raises: Exception | None = None,
+        aclose_raises: Exception | None = None,
+    ):
+        self._rows = rows or []
+        self._raises = raises
+        self._aclose_raises = aclose_raises
+        self.closed = False
+
+    async def list_agents(self) -> list[Any]:
+        if self._raises is not None:
+            raise self._raises
+        return self._rows
+
+    async def aclose(self) -> None:
+        self.closed = True
+        if self._aclose_raises is not None:
+            raise self._aclose_raises
+
+
+def _capture_admin(monkeypatch, admin: _FakeAdmin) -> _FakeAdmin:
+    """Install a _make_admin seam returning ``admin`` and hand it back for asserts."""
+    monkeypatch.setattr(server_api, "_make_admin", lambda creds: admin)
+    return admin
+
+
+def _agent_row(agent_name: str, room: str, state: str, humans: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        agent_name=agent_name,
+        room=room,
+        identity=f"{agent_name}-id",
+        state=state,
+        humans=humans,
+        age_s=12.0,
+    )
+
+
+async def _seed_worker(
+    gateway: Gateway,
+    agent_id: str,
+    status: str,
+    region: str,
+    *,
+    stale: bool = False,
+) -> None:
+    # A stale heartbeat (aged past the TTL) must be served "offline" by
+    # read_roster regardless of its seeded status.
+    ts = time.time() - 3600 if stale else time.time()
+    await gateway.storage._ensure_initialized()
+    async with gateway.storage._conn.session() as db:
+        await workers_repository.upsert_heartbeat(
+            db,
+            {
+                "agent_id": agent_id,
+                "agent_name": agent_id,
+                "region": region,
+                "version": "0.4.0",
+                "host": "host-1",
+                "active_sessions": 1 if status == "busy" else 0,
+                "status": status,
+                "memory_rss_bytes": 100,
+                "memory_total_bytes": 1000,
+                "ts": ts,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_overview_not_configured(client, monkeypatch):
+    _not_configured(monkeypatch)
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["connection"] == {"configured": False, "url": None, "reachable": None}
+    assert data["rooms"]["ok"] is False
+    assert "not configured" in data["rooms"]["error"].lower()
+    assert data["rooms"]["rooms"] == []
+    # Fleet is a local DB read, so it is fine even when LiveKit is not configured.
+    assert data["fleet"]["ok"] is True
+    assert data["fleet"]["workers"] == []
+
+
+async def test_overview_rooms_grouped_and_cost_annotated(client, gateway, monkeypatch):
+    _configured(monkeypatch)
+    rows = [
+        _agent_row("receptionist", "room-a", "active", humans=2),
+        _agent_row("scheduler", "room-a", "dispatched", humans=2),
+        _agent_row("receptionist", "room-b", "active", humans=1),
+    ]
+    admin = _capture_admin(monkeypatch, _FakeAdmin(rows))
+
+    now = time.time()
+
+    async def _fake_room_requests(room: str, since: float | None = None):
+        canned = {
+            "room-a": [
+                {"timestamp": now, "cost_usd": 0.01, "total_latency_ms": 100.0},
+                {"timestamp": now, "cost_usd": 0.02, "total_latency_ms": 300.0},
+                # A stale row outside the 24h window: the SQL `since` bound drops it.
+                {"timestamp": now - 200_000, "cost_usd": 5.0, "total_latency_ms": 900.0},
+            ]
+        }.get(room, [])
+        # Mirror the repository's `since` semantics so this test exercises that
+        # _room_cost passes the window cutoff, not just that it sums rows.
+        return [r for r in canned if since is None or r["timestamp"] >= since]
+
+    monkeypatch.setattr(gateway.storage, "get_requests_for_room", _fake_room_requests)
+
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["connection"]["configured"] is True
+    assert data["connection"]["url"] == "wss://lk.example"
+    assert data["connection"]["reachable"] is True
+    assert data["rooms"]["ok"] is True
+
+    rooms = {r["name"]: r for r in data["rooms"]["rooms"]}
+    assert set(rooms) == {"room-a", "room-b"}
+    room_a = rooms["room-a"]
+    assert room_a["humans"] == 2
+    assert {a["agent_name"] for a in room_a["agents"]} == {"receptionist", "scheduler"}
+    # Cost sums only the two in-window rows (the 200k-second-old row is dropped).
+    assert room_a["cost_usd"] == pytest.approx(0.03)
+    assert room_a["request_count"] == 2
+    # p95 via the shared linear-interpolation helper: p95 of [100, 300] = 290.0
+    # (must match the Latency / Agents pages, not a bespoke nearest-rank).
+    assert room_a["p95_latency_ms"] == pytest.approx(290.0)
+    # room-b has no metered requests: zero cost, not a crash.
+    assert rooms["room-b"]["cost_usd"] == 0.0
+    assert rooms["room-b"]["request_count"] == 0
+    # The LiveKit client is closed after a successful read.
+    assert admin.closed is True
+
+
+async def test_overview_room_cost_windowed_real_db(client, gateway, monkeypatch):
+    """End-to-end: per-room cost is bounded by the 24h SQL window (real DB read).
+
+    Unlike the grouped test (which stubs get_requests_for_room), this seeds real
+    request rows and lets _room_cost run the actual `since`-bounded query, proving
+    the stale row is dropped in SQL, not just in Python.
+    """
+    _configured(monkeypatch)
+    _capture_admin(
+        monkeypatch, _FakeAdmin([_agent_row("bot", "room-real", "active", humans=1)])
+    )
+    now = time.time()
+
+    async def _log(ts: float, cost: float, latency: float) -> None:
+        await gateway.storage.log_request(
+            RequestRecord(
+                id=str(uuid.uuid4()),
+                timestamp=ts,
+                modality="llm",
+                model_id="openai/gpt-4o-mini",
+                provider="openai",
+                project="default",
+                cost_usd=cost,
+                total_latency_ms=latency,
+                metadata={"room": "room-real"},
+                session_id=f"vg-{uuid.uuid4()}",
+            )
+        )
+
+    await _log(now, 0.01, 100.0)  # in window
+    await _log(now - 1_000, 0.02, 300.0)  # in window (older, still < 24h)
+    await _log(now - 200_000, 5.0, 900.0)  # > 24h old: dropped by the SQL `since`
+
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    rooms = {r["name"]: r for r in resp.json()["rooms"]["rooms"]}
+    room = rooms["room-real"]
+    assert room["request_count"] == 2
+    assert room["cost_usd"] == pytest.approx(0.03)
+    assert room["p95_latency_ms"] == pytest.approx(290.0)
+
+
+async def test_overview_rooms_degrade_on_read_error(client, monkeypatch):
+    _configured(monkeypatch)
+    admin = _capture_admin(
+        monkeypatch, _FakeAdmin(raises=RuntimeError("livekit unreachable"))
+    )
+    resp = await client.get("/api/server/overview")
+    # The endpoint must never 500: a failed control-plane read is a section error.
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rooms"]["ok"] is False
+    assert "unreachable" in data["rooms"]["error"]
+    # A read was attempted and the server did not answer: reachable is False.
+    assert data["connection"]["reachable"] is False
+    # Fleet still succeeds independently.
+    assert data["fleet"]["ok"] is True
+    # The client is closed even on the error path (finally guard).
+    assert admin.closed is True
+
+
+async def test_overview_survives_aclose_error(client, monkeypatch):
+    """A transport-close error during teardown must not 500 the endpoint."""
+    _configured(monkeypatch)
+    admin = _capture_admin(
+        monkeypatch,
+        _FakeAdmin(
+            rows=[_agent_row("a", "room-a", "active", humans=1)],
+            aclose_raises=RuntimeError("teardown boom"),
+        ),
+    )
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    # list_agents succeeded, so the section is ok despite the teardown error.
+    assert data["rooms"]["ok"] is True
+    assert {r["name"] for r in data["rooms"]["rooms"]} == {"room-a"}
+    assert admin.closed is True
+
+
+async def test_overview_sdk_absent(client, monkeypatch):
+    _configured(monkeypatch)
+    monkeypatch.setattr(server_api, "_make_admin", lambda creds: None)
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rooms"]["ok"] is False
+    assert "not installed" in data["rooms"]["error"].lower()
+    # The SDK was never even loaded, so nothing probed the control plane:
+    # reachable stays null (the UI shows "Configured", not "Unreachable").
+    assert data["connection"]["reachable"] is None
+
+
+async def test_overview_fleet_roster(client, gateway, monkeypatch):
+    _not_configured(monkeypatch)  # focus on fleet; rooms section is empty
+    await _seed_worker(gateway, "agent-idle", "idle", "us-east")
+    await _seed_worker(gateway, "agent-busy", "busy", "eu-west")
+    # A stale heartbeat is derived offline at read time, regardless of status.
+    await _seed_worker(gateway, "agent-gone", "idle", "ap-south", stale=True)
+
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    fleet = resp.json()["fleet"]
+    assert fleet["ok"] is True
+    assert fleet["counts"] == {"total": 3, "idle": 1, "busy": 1, "offline": 1}
+    by_id = {w["agent_id"]: w for w in fleet["workers"]}
+    assert by_id["agent-busy"]["active_sessions"] == 1
+    assert by_id["agent-idle"]["region"] == "us-east"
+    assert by_id["agent-idle"]["memory_pct"] == 10.0
+    assert by_id["agent-gone"]["status"] == "offline"
+
+
+async def test_overview_fleet_degrades_on_read_error(client, monkeypatch):
+    """A failing fleet read is a section error, not a 500 (symmetric with rooms)."""
+    _not_configured(monkeypatch)
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(workers_repository, "read_roster", _boom)
+    resp = await client.get("/api/server/overview")
+    assert resp.status_code == 200
+    fleet = resp.json()["fleet"]
+    assert fleet["ok"] is False
+    assert "exploded" in fleet["error"]
+    assert fleet["workers"] == []
+    assert fleet["counts"] == {"total": 0, "idle": 0, "busy": 0, "offline": 0}
+
+
+async def test_overview_requires_admin_when_auth_enabled(gateway, monkeypatch):
+    """With static keys configured, the endpoint rejects unauthenticated callers.
+
+    require_scope(ADMIN_SCOPE) is a no-op when no keys are configured (the local
+    OSS default). Once keys exist it enforces admin, so an unauthenticated caller
+    cannot read the configured LiveKit URL or deployment topology.
+    """
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+
+    _not_configured(monkeypatch)
+    app = build_app(gateway, enable_mcp_sse=False, enable_dashboard=True)
+    app.state.api_keys = [
+        ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,))
+    ]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        assert (await c.get("/api/server/overview")).status_code == 401
+        ok = await c.get(
+            "/api/server/overview",
+            headers={"Authorization": "Bearer admin-secret-token"},
+        )
+        assert ok.status_code == 200
+        assert ok.json()["connection"]["configured"] is False
+
+
+async def test_overview_forbids_non_admin_scope_when_auth_enabled(gateway, monkeypatch):
+    """A valid key lacking ADMIN_SCOPE is authenticated but forbidden (403).
+
+    Guards the endpoint's deliberate ADMIN_SCOPE choice (it exposes the LiveKit
+    URL + topology): a regression that downgraded it to a read scope would let a
+    read-only key through, and this is the only test that would catch it.
+    """
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+
+    _not_configured(monkeypatch)
+    app = build_app(gateway, enable_mcp_sse=False, enable_dashboard=True)
+    app.state.api_keys = [
+        ApiKey(token="admin-token", name="ops", scopes=(ADMIN_SCOPE,)),
+        ApiKey(token="read-token", name="viewer", scopes=("read",)),
+    ]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        forbidden = await c.get(
+            "/api/server/overview",
+            headers={"Authorization": "Bearer read-token"},
+        )
+        assert forbidden.status_code == 403

--- a/src/voicegateway/tests/storage/test_requests_by_room.py
+++ b/src/voicegateway/tests/storage/test_requests_by_room.py
@@ -17,7 +17,14 @@ from voicegateway.models.request_model import RequestRecord
 from voicegateway.services.storage_service import StorageService
 
 
-def _rec(modality: str, *, room: str | None, ttfb: float | None = None, eou=None):
+def _rec(
+    modality: str,
+    *,
+    room: str | None,
+    ttfb: float | None = None,
+    eou=None,
+    ts: float | None = None,
+):
     metadata: dict = {}
     if room is not None:
         metadata["room"] = room
@@ -25,7 +32,7 @@ def _rec(modality: str, *, room: str | None, ttfb: float | None = None, eou=None
         metadata["eou"] = eou
     return RequestRecord(
         id=str(uuid.uuid4()),
-        timestamp=time.time(),
+        timestamp=ts if ts is not None else time.time(),
         modality=modality,
         model_id="openai/gpt-4o-mini" if modality == "llm" else "",
         provider="openai" if modality == "llm" else "",
@@ -81,3 +88,20 @@ async def test_get_requests_for_room_empty_when_absent(tmp_path):
     storage = StorageService(str(tmp_path / "none.db"))
     await storage.log_request(_rec("llm", room="vg-probe-a", ttfb=100.0))
     assert await storage.get_requests_for_room("nope") == []
+
+
+async def test_get_requests_for_room_respects_since_window(tmp_path):
+    """``since`` bounds the scan to ``timestamp >= since`` (inclusive lower edge)."""
+    storage = StorageService(str(tmp_path / "since.db"))
+    now = time.time()
+    cutoff = now - 3600.0
+    await storage.log_request(_rec("llm", room="vg-win", ttfb=10.0, ts=cutoff + 1))
+    await storage.log_request(_rec("llm", room="vg-win", ttfb=20.0, ts=cutoff))
+    await storage.log_request(_rec("llm", room="vg-win", ttfb=30.0, ts=cutoff - 1))
+
+    # Unbounded read (the probe caller) still sees every row.
+    assert len(await storage.get_requests_for_room("vg-win")) == 3
+
+    # Windowed read includes the boundary row (>=) and drops the older one.
+    windowed = await storage.get_requests_for_room("vg-win", since=cutoff)
+    assert sorted(r["timestamp"] for r in windowed) == [cutoff, cutoff + 1]


### PR DESCRIPTION
## Server page (Phase 1): live LiveKit topology, cost-annotated

Adds a new **Server** nav item (Monitor group) backed by `GET /api/server/overview`: a read-only, non-billing snapshot of the LiveKit deployment the metered agents run on, annotated with VoiceGateway's own cost and latency.

### Why
LiveKit's own console already shows deployment topology. It does not know your dollars. This page joins the live deployment map to VG's metered cost/latency per room, which is the only reason to build it instead of linking to LiveKit's console.

### What Phase 1 ships
- **Rooms + in-room agents** from the LiveKit Server API (`livekit_diag.admin`), grouped by room, each annotated with 24h cost, request count, and p95.
- **Fleet roster** (idle / busy / offline, region, host, version, sessions, memory) from the local worker heartbeats.
- **Per-section `{ok, error}` shape** so one failing read never blanks the page.
- **Component summary grid** + rooms table + fleet table, neo-brutalism.

### Honesty guardrails (deliberate)
- No SFU node health, no live load bars, no fabricated `loss_pct` (VG cannot measure these). The SFU tile shows live room/participant totals and links to the billed Diagnostics probe.
- `connection.reachable` stays `null` until a control-plane read is actually attempted, so the UI never labels an unmeasured deployment "Unreachable".

### Notable backend changes
- `get_requests_for_room` gains an optional `since` window so the per-room cost roll-up is bounded in SQL (uses `idx_requests_timestamp`) instead of an unbounded full scan; the per-room reads run concurrently via `asyncio.gather`. Backward compatible (the latency-probe caller passes no `since`).
- p95 uses the shared `compute_percentiles` helper so a room's p95 matches the Latency and Agents pages (dropped a bespoke nearest-rank).
- Endpoint is `ADMIN_SCOPE`-gated (matches Diagnostics; no-op in the local single-operator default).

### Tests
- New `test_server_api.py` (11 cases): not-configured, rooms grouped + cost, real-DB 24h window, rooms degrade (no 500) + client closed, survives `aclose()` error, SDK-absent (`reachable=null`), fleet roster incl. offline-TTL, fleet degrade, admin-gate 401/200, wrong-scope 403.
- `test_requests_by_room.py`: `since` window boundary (inclusive `>=`).
- mypy clean, ruff clean, frontend builds.

The frontend `dist` bundle is gitignored and rebuilt by the release pipeline; source only here.

### Follow-up (Phase 2)
SIP trunks, Egress, and Ingress via read-only Server API calls (no new dependency), then Pipecat.

Spec: `docs/superpowers/specs/2026-07-23-server-page-livekit-topology-design.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Server page showing LiveKit deployment status, active rooms, connected agents, worker fleet, metered costs, request counts, and latency.
  * Added Server navigation and routing, with manual refresh support.
  * Added graceful handling for unavailable configuration or partial data.

* **Bug Fixes**
  * Room metrics now support accurate rolling 24-hour filtering.

* **Documentation**
  * Added design documentation outlining topology visualization, data sources, and display limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->