### PR TITLE
feat(fleet): local-DB heartbeat + attach(heartbeat=True) for co-located idle presence

### DIFF
--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -204,6 +204,9 @@ export type TenantFilter = string | null;
 /** One row in the agent index (the fleet table + agent-filter feed). */
 export interface AgentRow {
   agent_id: string;
+  /** Friendly worker label from the roster (matches Server > Fleet); null for a
+   * telemetry-only agent, where the UI falls back to agent_id. */
+  agent_name?: string | null;
   request_count: number;
   total_cost_usd: number;
   /** Epoch seconds of the agent's most recent request, or null. */
@@ -216,6 +219,9 @@ export interface AgentRow {
   memory_pct?: number | null;
   /** Last-seen model per modality, from /api/agents; a modality is null when unseen. */
   models?: { stt: string | null; llm: string | null; tts: string | null };
+  /** Live roster presence: 'idle' | 'busy' | 'offline'; null when the agent is
+   * telemetry-only (not currently a registered/heartbeating worker). */
+  fleet_status?: string | null;
 }
 
 /** Aggregates for the implicit `agent_id IS NULL` bucket. */

--- a/src/dashboard/frontend/src/lib/ui.ts
+++ b/src/dashboard/frontend/src/lib/ui.ts
@@ -53,6 +53,13 @@ export function agentStatusBadgeClass(status: AgentStatus): string {
   return 'neo-badge--offline';
 }
 
+/** Badge class for a live roster status (idle/busy/offline), matching Server > Fleet. */
+export function rosterStatusBadge(status: string): string {
+  if (status === 'busy') return 'neo-badge--green';
+  if (status === 'idle') return 'neo-badge--blue';
+  return 'neo-badge--offline'; // offline
+}
+
 /** Compact "Ns / Nm / Nh / Nd ago" from an epoch-seconds timestamp. */
 export function formatRelativeTime(lastSeen: number | null | undefined): string {
   if (lastSeen == null) return '—';

--- a/src/dashboard/frontend/src/pages/AgentDetail.tsx
+++ b/src/dashboard/frontend/src/pages/AgentDetail.tsx
@@ -10,6 +10,7 @@ import {
   formatCost,
   formatMs,
   formatRelativeTime,
+  rosterStatusBadge,
 } from '../lib/ui';
 
 /** Detail view for a single agent: 24h metrics, model stack, recent calls. */
@@ -56,19 +57,25 @@ export default function AgentDetail() {
     );
   }
 
-  const status = agentStatus(agent.last_seen);
+  // Match the Agents list: live roster status (idle/busy/offline) when present,
+  // else the telemetry-recency status. `|| null` keeps label and color in sync.
+  const fleet = agent.fleet_status || null;
+  const status = fleet ?? agentStatus(agent.last_seen);
+  const badgeClass = fleet
+    ? rosterStatusBadge(fleet)
+    : agentStatusBadgeClass(agentStatus(agent.last_seen));
 
   return (
     <div>
       <PageHeader
-        title={agent.agent_id}
+        title={agent.agent_name || agent.agent_id}
         subtitle={`Last seen ${formatRelativeTime(agent.last_seen)} · metrics over the last 24h`}
         accent="blue"
         actions={<Link className="neo-btn" to="/agents">← All agents</Link>}
       />
 
       <div className="flex-row gap-sm mb-md" style={{ alignItems: 'center' }}>
-        <span className={`neo-badge ${agentStatusBadgeClass(status)}`}>{status}</span>
+        <span className={`neo-badge ${badgeClass}`}>{status}</span>
         {(['stt', 'llm', 'tts'] as const).map((m) => {
           const model = agent.models?.[m] ?? null;
           return (

--- a/src/dashboard/frontend/src/pages/Agents.tsx
+++ b/src/dashboard/frontend/src/pages/Agents.tsx
@@ -9,6 +9,7 @@ import {
   formatCost,
   formatMs,
   formatRelativeTime,
+  rosterStatusBadge,
 } from '../lib/ui';
 
 type SortKey =
@@ -36,6 +37,7 @@ function memoryBarColor(pct: number): string {
   if (pct >= 75) return '#f59e0b';
   return 'var(--vg-teal, #1F96AA)';
 }
+
 
 export default function Agents() {
   const [agents, setAgents] = useState<AgentRow[]>([]);
@@ -101,9 +103,9 @@ export default function Agents() {
 
       {sorted.length === 0 ? (
         <div className="empty-state mt-md">
-          No agents yet. Agents appear here once they push telemetry to the
-          collector (via <span className="mono">voicegateway.attach()</span> or a
-          remote sink).
+          No agents yet. Agents appear here once they register (via{' '}
+          <span className="mono">voicegateway.register_worker()</span>) or push
+          telemetry (via <span className="mono">voicegateway.attach()</span>).
         </div>
       ) : (
         <div className="vg-card" style={{ padding: 0, overflow: 'hidden' }}>
@@ -136,17 +138,23 @@ export default function Agents() {
             </thead>
             <tbody>
               {sorted.map((a) => {
-                const status = agentStatus(a.last_seen);
+                // Registered workers show their live roster status (idle/busy/
+                // offline), matching Server > Fleet; telemetry-only agents fall
+                // back to the telemetry-recency status (active/idle/dormant).
+                // `|| null` normalizes so the label and color never diverge.
+                const fleet = a.fleet_status || null;
+                const status = fleet ?? agentStatus(a.last_seen);
+                const badgeClass = fleet
+                  ? rosterStatusBadge(fleet)
+                  : agentStatusBadgeClass(agentStatus(a.last_seen));
                 return (
                   <tr key={a.agent_id}>
                     <td>
-                      <span className={`neo-badge ${agentStatusBadgeClass(status)}`}>
-                        {status}
-                      </span>
+                      <span className={`neo-badge ${badgeClass}`}>{status}</span>
                     </td>
                     <td className="mono">
                       <Link to={`/agents/${encodeURIComponent(a.agent_id)}`}>
-                        {a.agent_id}
+                        {a.agent_name || a.agent_id}
                       </Link>
                     </td>
                     <td>

--- a/src/voicegateway/core/database.py
+++ b/src/voicegateway/core/database.py
@@ -27,6 +27,27 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = "~/.config/voicegateway/voicegw.db"
 
+# aiosqlite and alembic both log every operation at DEBUG. Embedded in a LiveKit
+# agent (voicegateway.attach, or the fleet heartbeat thread), a ``console``/``dev``
+# run sets the root logger to DEBUG, so that per-query chatter (every SELECT /
+# UPDATE the aiosqlite thread runs) floods the host's terminal. Quiet the two noisy
+# dependency loggers, but only when the caller has not picked a level themselves
+# (NOTSET = "inherit", which is what produces the flood).
+_NOISY_EMBEDDED_LOGGERS = ("aiosqlite", "alembic")
+
+
+def quiet_embedded_dependency_loggers() -> None:
+    """Raise the noisy aiosqlite/alembic loggers to WARNING, unless set already.
+
+    Called from ``Database.__init__`` so it covers every path that builds an engine
+    (the cost sink, the dashboard, and the local-mode fleet heartbeat thread that
+    constructs a ``Database`` directly), not just the ``StorageService`` facade.
+    """
+    for name in _NOISY_EMBEDDED_LOGGERS:
+        dep_logger = logging.getLogger(name)
+        if dep_logger.level == logging.NOTSET:
+            dep_logger.setLevel(logging.WARNING)
+
 
 def resolve_database_url(config: GatewayConfig) -> str:
     """Compute the SQLAlchemy URL from the gateway config.
@@ -110,6 +131,7 @@ class Database:
     """Async SQLAlchemy engine + session factory bound to a config."""
 
     def __init__(self, config: GatewayConfig) -> None:
+        quiet_embedded_dependency_loggers()
         self.config = config
         url = resolve_database_url(config)
         self._db_file_path = _resolve_db_file_path(config)

--- a/src/voicegateway/fleet/worker.py
+++ b/src/voicegateway/fleet/worker.py
@@ -3,22 +3,43 @@
 The LiveKit server API lists agents that are IN a room, but not the idle/registered
 worker pool, so ``voicegw livekit agents`` can only ever show busy agents. This
 closes that gap from the agent side: a worker calls :func:`register_worker` once at
-boot, and the process then pushes a periodic heartbeat to the collector's
-``/v1/agents/heartbeat``. The heartbeat carries an idle/busy status that
-``voicegateway.attach`` keeps accurate by bumping an active-session counter on each
-session open/close, plus the version, project, host, and region the LiveKit server
-never knows.
+boot, and the process then heartbeats a periodic presence carrying an idle/busy
+status that ``voicegateway.attach`` keeps accurate (bumping an active-session
+counter on each session open/close), plus the version, project, host, and region
+the LiveKit server never knows.
 
-Best-effort by design: it never blocks or breaks the agent. No collector configured
-means the registry still tracks status locally but nothing is pushed.
+Two heartbeat transports, chosen by whether a collector is configured:
+
+- **Collector mode** (``collector_url`` / ``VOICEGW_COLLECTOR_URL`` set): an asyncio
+  task pushes to the collector's ``/v1/agents/heartbeat``. Needs a running event
+  loop (starts on the first ``bump_active`` in an async context if registered early).
+- **Local mode** (no collector): a background daemon thread writes the presence row
+  straight to the shared SQLite (``VOICEGW_DB_PATH`` / the default), which the
+  co-located dashboard reads. The thread needs no event loop, so a worker
+  registered at ``__main__`` boot is visible in the roster while idle, immediately.
+
+Best-effort by design: it never blocks or breaks the agent. A failed push/write is
+swallowed.
+
+One writer per agent identity. In the LiveKit process-executor model (``agent
+dev``/``start``) the worker is the MAIN process and per-call work runs in spawned
+JOB SUBPROCESSES, so register the worker once in your ``__main__`` block (the main
+process) with ``register_worker("agent", local=True)`` and do NOT also pass
+``attach(heartbeat=True)`` there: the subprocess would become a second writer of the
+same ``(tenant=None, agent_id)`` row, which the get-then-insert upsert cannot
+coalesce. ``attach(heartbeat=True)`` is for SINGLE-process agents (Pipecat / the
+LiveKit thread executor), where attach runs in the one process and is the sole
+writer.
 """
 
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 import os
 import socket
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -27,8 +48,12 @@ logger = logging.getLogger(__name__)
 
 # Milliseconds is overkill for presence; a quarter-minute keeps the roster fresh
 # without hammering the collector. The read side ages a worker out after a small
-# multiple of this (see the cloud /v1/agents TTL).
+# multiple of this (see the /v1/agents TTL).
 _DEFAULT_INTERVAL = 15.0
+
+# Kept in sync with core.database.DEFAULT_DB_PATH; defined here so importing this
+# module (which attach imports) stays free of the SQLAlchemy import chain.
+_DEFAULT_DB_PATH = "~/.config/voicegateway/voicegw.db"
 
 
 @dataclass
@@ -70,11 +95,15 @@ class _Worker:
 
 # Process-wide singletons. One worker per process (a worker registers one agent).
 _worker: _Worker | None = None
-_pusher: asyncio.Task | None = None
+_pusher: asyncio.Task | None = None  # collector-mode asyncio task
 _collector_url: str | None = None
 _api_key: str | None = None
 _interval: float = _DEFAULT_INTERVAL
 _client: Any = None
+_local_db_path: str | None = None
+_local_enabled: bool = False  # opt-in: write presence to the local DB when no collector
+_local_thread: threading.Thread | None = None  # local-mode daemon thread
+_local_stop: threading.Event | None = None
 
 
 def _agent_id() -> str:
@@ -91,15 +120,23 @@ def register_worker(
     region: str | None = None,
     version: str | None = None,
     interval: float = _DEFAULT_INTERVAL,
+    local: bool = False,
+    db_path: str | None = None,
 ) -> str:
     """Register this process as an agent worker and start heartbeating.
 
-    Call once at worker boot (ideally inside the running event loop, so the periodic
-    push starts immediately and an idle worker is visible before its first call).
-    ``collector_url`` / ``api_key`` fall back to ``VOICEGW_COLLECTOR_URL`` /
+    Call once at worker boot. A collector (``collector_url`` /
+    ``VOICEGW_COLLECTOR_URL``) takes precedence and pushes to its
+    ``/v1/agents/heartbeat`` (needs a running event loop; call from your async
+    entrypoint to appear while idle). With ``local=True`` and no collector it uses
+    **local mode**: a background thread writes presence straight to the shared
+    SQLite (``db_path`` / ``VOICEGW_DB_PATH`` / the default), which needs no event
+    loop, so a worker registered in a plain ``__main__`` block is visible while idle
+    right away. Without a collector and without ``local``, the worker is tracked in
+    this process but nothing is pushed. ``api_key`` falls back to
     ``VOICEGW_API_KEY``; ``region`` to ``VOICEGW_REGION``. Returns the agent id.
     """
-    global _worker, _collector_url, _api_key, _interval
+    global _worker, _collector_url, _api_key, _interval, _local_db_path, _local_enabled
     from voicegateway._version import __version__
 
     _worker = _Worker(
@@ -115,33 +152,94 @@ def register_worker(
     _collector_url = collector_url or os.environ.get("VOICEGW_COLLECTOR_URL")
     _api_key = api_key or os.environ.get("VOICEGW_API_KEY")
     _interval = interval
-    _ensure_pusher()
+    _local_enabled = local
+    _local_db_path = db_path or os.environ.get("VOICEGW_DB_PATH") or _DEFAULT_DB_PATH
+    _ensure_running()
     if _collector_url and _pusher is None:
-        # Registered outside a running event loop: the idle heartbeat can't start
-        # yet, so this worker stays invisible in the roster until its first
-        # session (attach -> bump_active) spins the pusher up. Call from your
-        # async entrypoint to be visible while idle.
+        # Collector mode registered outside a running event loop: the idle heartbeat
+        # can't start yet, so this worker stays invisible until its first session
+        # (attach -> bump_active) spins the pusher up. Local mode has no such caveat.
         logger.warning(
-            "register_worker(%s): no running event loop; the idle heartbeat will "
-            "not start until the first session. Call register_worker from your "
-            "async agent entrypoint to appear in the roster while idle.",
+            "register_worker(%s): collector configured but no running event loop; "
+            "the idle heartbeat starts on the first session. Call from your async "
+            "entrypoint (or drop the collector to use the local-DB heartbeat).",
             _worker.agent_id,
         )
     return _worker.agent_id
+
+
+def ensure_registered(
+    agent_name: str,
+    *,
+    project: str = "default",
+    tenant_id: str | None = None,
+    collector_url: str | None = None,
+    api_key: str | None = None,
+    region: str | None = None,
+    version: str | None = None,
+    interval: float = _DEFAULT_INTERVAL,
+    local: bool = False,
+    db_path: str | None = None,
+) -> str:
+    """Register + heartbeat only if this process has no worker yet.
+
+    ``attach(heartbeat=True)`` calls this so it never clobbers an explicit
+    ``register_worker`` done at ``__main__`` boot; if one exists, it just makes sure
+    the heartbeat is running and returns its agent id.
+    """
+    if _worker is not None:
+        _ensure_running()
+        return _worker.agent_id
+    return register_worker(
+        agent_name,
+        project=project,
+        tenant_id=tenant_id,
+        collector_url=collector_url,
+        api_key=api_key,
+        region=region,
+        version=version,
+        interval=interval,
+        local=local,
+        db_path=db_path,
+    )
+
+
+def is_registered() -> bool:
+    """Whether this process has a registered worker."""
+    return _worker is not None
 
 
 def bump_active(delta: int) -> None:
     """Move the active-session count (attach() calls +1 on open, -1 on close).
 
     A no-op when no worker is registered, so attach() stays decoupled from whether
-    the agent opted into the fleet roster. Also (re)starts the pusher, so a worker
+    the agent opted into the fleet roster. Also (re)starts the heartbeat, so a worker
     that registered before its loop was running still begins heartbeating on its
     first session.
     """
     if _worker is None:
         return
     _worker.active_sessions = max(0, _worker.active_sessions + delta)
-    _ensure_pusher()
+    _ensure_running()
+
+
+def _ensure_running() -> None:
+    """Start the heartbeat transport for the configured mode (idempotent).
+
+    A collector takes precedence; else local mode runs only when opted in
+    (``local=True``); else the worker is tracked but nothing is pushed.
+    """
+    if _worker is None:
+        return
+    if _collector_url:
+        _ensure_pusher()
+    elif _local_enabled:
+        _ensure_local_thread()
+
+
+# ---------------------------------------------------------------------------
+# Collector mode (asyncio push to /v1/agents/heartbeat)
+# ---------------------------------------------------------------------------
 
 
 def _ensure_pusher() -> None:
@@ -165,7 +263,7 @@ async def _run() -> None:
 
 
 async def push_once() -> None:
-    """Push one presence heartbeat. Best-effort: a failure is swallowed."""
+    """Push one presence heartbeat to the collector. Best-effort."""
     global _client
     if _worker is None or not _collector_url:
         return
@@ -184,9 +282,92 @@ async def push_once() -> None:
         logger.debug("worker heartbeat push failed", exc_info=True)
 
 
+# ---------------------------------------------------------------------------
+# Local mode (daemon thread writing to the shared SQLite)
+# ---------------------------------------------------------------------------
+
+
+_atexit_registered = False
+
+
+def _atexit_stop() -> None:
+    """Signal + join the heartbeat thread on interpreter exit.
+
+    Runs its ``finally`` (dispose the aiosqlite engine) rather than leaving the
+    daemon thread's loop to be torn down abruptly, which avoids shutdown-time
+    "Event loop is closed" noise on the agent's console. Best-effort.
+    """
+    if _local_stop is not None:
+        _local_stop.set()
+    if _local_thread is not None:
+        _local_thread.join(timeout=2.0)
+
+
+def _ensure_local_thread() -> None:
+    global _local_thread, _local_stop, _atexit_registered
+    if _local_thread is not None and _local_thread.is_alive():
+        return
+    if _worker is None or _local_db_path is None:
+        return
+    _local_stop = threading.Event()
+    _local_thread = threading.Thread(
+        target=_local_run,
+        args=(_local_stop, _local_db_path, _interval),
+        name="voicegw-fleet-heartbeat",
+        daemon=True,
+    )
+    _local_thread.start()
+    if not _atexit_registered:
+        atexit.register(_atexit_stop)
+        _atexit_registered = True
+
+
+def _local_run(stop: threading.Event, db_path: str, interval: float) -> None:
+    """Thread body: own event loop, write presence to the shared DB each interval.
+
+    Does NOT create tables. The shared ``voicegw.db`` schema is owned by alembic
+    (the dashboard, and the agent's own cost sink, migrate it via
+    ``run_migrations``); seeding it here with ``create_all`` would create the 18
+    tables un-stamped and poison a later ``alembic upgrade head`` (breaking cost
+    tracking + the dashboard on that file). So the heartbeat write is best-effort:
+    it fails silently until something with alembic has created the ``workers``
+    table, then succeeds on a later interval. In the co-located case the dashboard
+    is running, so the table already exists.
+    """
+    from voicegateway.core.config import GatewayConfig
+    from voicegateway.core.database import Database
+    from voicegateway.repository import workers_repository
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    conn = Database(GatewayConfig(cost_tracking={"db_path": os.path.expanduser(db_path)}))
+
+    async def _write() -> None:
+        w = _worker
+        if w is None:
+            return
+        async with conn.session() as db:
+            await workers_repository.upsert_heartbeat(db, w.presence())
+
+    try:
+        while not stop.is_set():
+            if _worker is not None:
+                try:
+                    loop.run_until_complete(_write())
+                except Exception:  # noqa: BLE001 - presence is never load-bearing
+                    logger.debug("local heartbeat write failed", exc_info=True)
+            stop.wait(interval)
+    finally:
+        try:
+            loop.run_until_complete(conn.dispose())
+        except Exception:  # noqa: BLE001
+            pass
+        loop.close()
+
+
 async def aclose() -> None:
-    """Stop the pusher and close the client (call on worker shutdown)."""
-    global _pusher, _client
+    """Stop every heartbeat transport (call on worker shutdown)."""
+    global _pusher, _client, _local_thread, _local_stop
     if _pusher is not None:
         _pusher.cancel()
         try:
@@ -200,3 +381,12 @@ async def aclose() -> None:
         except Exception:  # noqa: BLE001
             pass
         _client = None
+    if _local_stop is not None:
+        _local_stop.set()
+    if _local_thread is not None:
+        try:
+            await asyncio.to_thread(_local_thread.join, 2.0)
+        except Exception:  # noqa: BLE001
+            pass
+        _local_thread = None
+        _local_stop = None

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -303,6 +303,7 @@ def attach(
     api_key: str | None = None,
     sink: Sink | None = None,
     room: str | None = None,
+    heartbeat: bool = False,
 ) -> str:
     """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
 
@@ -334,6 +335,18 @@ def attach(
         room: LiveKit room name for probe correlation; auto-resolved from the
             running job context when omitted (``voicegw livekit latency`` reads
             the STT/LLM/TTS split back by this). Ignored on the Pipecat path.
+        heartbeat: register this process in the fleet roster and heartbeat its
+            presence, so it shows in the dashboard's Fleet/Agents view. Uses the
+            collector when one is configured, else writes to the shared local DB
+            (``VOICEGW_DB_PATH`` / the default) the co-located dashboard reads. On
+            LiveKit it also flips idle<->busy per session; on Pipecat it reports
+            presence only. Best for SINGLE-process agents (Pipecat / the LiveKit
+            thread executor), where attach is the sole writer. In the LiveKit
+            process-executor model (``agent dev``) attach runs in a per-call job
+            subprocess, so to show the worker while idle call
+            ``register_worker("agent", local=True)`` at your ``__main__`` boot
+            instead, and do not also pass ``heartbeat=True`` there (the subprocess
+            would become a second writer of the same roster row).
 
     Returns:
         The correlation session id stamped on every captured row.
@@ -352,6 +365,7 @@ def attach(
             collector_url=collector_url,
             api_key=api_key,
             sink=sink,
+            heartbeat=heartbeat,
         )
     return _attach_livekit(
         session,
@@ -362,6 +376,7 @@ def attach(
         api_key=api_key,
         sink=sink,
         room=room,
+        heartbeat=heartbeat,
     )
 
 
@@ -375,6 +390,7 @@ def _attach_livekit(
     api_key: str | None = None,
     sink: Sink | None = None,
     room: str | None = None,
+    heartbeat: bool = False,
 ) -> str:
     """LiveKit ``attach()`` body: bind ``MetricCapture`` to an ``AgentSession``."""
     import asyncio
@@ -434,12 +450,27 @@ def _attach_livekit(
         except Exception:  # noqa: BLE001 - real session may forbid attribute set
             pass
 
+    if heartbeat:
+        # Opt into the fleet roster: register + start the heartbeat (local-DB or
+        # collector per env). ensure_registered never clobbers a register_worker
+        # already done at __main__ boot, so both can coexist.
+        from voicegateway.fleet.worker import ensure_registered
+
+        ensure_registered(
+            resolved_agent_id,
+            project=project,
+            tenant_id=tenant_id,
+            collector_url=resolved_collector,
+            api_key=resolved_key,
+            local=True,
+        )
+
     on = getattr(session, "on", None)
     if callable(on):
         # Only mark this worker busy for the fleet roster once we have a close
         # handler to drop it back toward idle; pairing the +1 with the -1 means a
         # session that cannot signal close never pins the worker "busy" forever.
-        # (No-op unless register_worker was called.)
+        # (No-op unless register_worker/ensure_registered ran.)
         bump_active(1)
         on("close", _on_close)
 
@@ -540,6 +571,7 @@ def _attach_pipecat(
     collector_url: str | None = None,
     api_key: str | None = None,
     sink: Sink | None = None,
+    heartbeat: bool = False,
 ) -> str:
     """Register a ``VoiceGatewayObserver`` on a Pipecat ``PipelineTask``.
 
@@ -590,6 +622,20 @@ def _attach_pipecat(
         task._vg_observer = observer
     except Exception:  # noqa: BLE001 - real task may forbid attribute set
         logger.debug("attach(pipecat): could not stash observer on task", exc_info=True)
+
+    if heartbeat:
+        # Fleet presence for a Pipecat worker. (Pipecat has no session open/close
+        # counter, so this reports presence; idle<->busy bumping is LiveKit-only.)
+        from voicegateway.fleet.worker import ensure_registered
+
+        ensure_registered(
+            resolved_agent_id,
+            project=project,
+            tenant_id=tenant_id,
+            collector_url=resolved_collector,
+            api_key=resolved_key,
+            local=True,
+        )
 
     return session_id
 

--- a/src/voicegateway/server/api/dashboard/agents.py
+++ b/src/voicegateway/server/api/dashboard/agents.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from voicegateway.repository.agent_observations_repository import (
         AgentObservationRow,
     )
+    from voicegateway.repository.workers_repository import RosterRow
 
 router = APIRouter(prefix="/agents", tags=["dashboard"])
 
@@ -50,13 +51,24 @@ def _memory_pct(rss: int | None, total: int | None) -> float | None:
 
 
 def _agent_entry(
-    row: AgentObservationRow, memory_pct: float | None, models: dict[str, str]
+    row: AgentObservationRow,
+    memory_pct: float | None,
+    models: dict[str, str],
+    *,
+    fleet_status: str | None = None,
+    last_seen: float | None = None,
+    agent_name: str | None = None,
 ) -> dict[str, Any]:
     return {
         "agent_id": row.agent_id,
+        # Friendly label from the worker roster (matches Server > Fleet); None for
+        # a telemetry-only agent, where the UI falls back to agent_id.
+        "agent_name": agent_name,
         "request_count": row.request_count,
         "total_cost_usd": row.total_cost_usd,
-        "last_seen": row.last_seen,
+        # A registered agent's heartbeat is fresher than its last request, so the
+        # merged last_seen keeps a live-but-idle agent from reading as dormant.
+        "last_seen": last_seen if last_seen is not None else row.last_seen,
         "error_rate": _error_rate(row.error_count, row.request_count),
         "p95_latency_ms": row.p95_ms,
         "memory_pct": memory_pct,
@@ -65,7 +77,35 @@ def _agent_entry(
             "llm": models.get("llm"),
             "tts": models.get("tts"),
         },
+        # idle/busy/offline from the worker roster; None when the agent is not
+        # currently registered (telemetry-only, e.g. a past run).
+        "fleet_status": fleet_status,
     }
+
+
+def _roster_only_entry(w: RosterRow) -> dict[str, Any]:
+    """A registered worker that has not written any telemetry yet (0 requests).
+
+    Lets a booted-but-idle agent show on the Agents page (matching Server > Fleet)
+    instead of appearing only once it has handled a call.
+    """
+    return {
+        "agent_id": w.agent_id,
+        "agent_name": w.agent_name,
+        "request_count": 0,
+        "total_cost_usd": 0.0,
+        "last_seen": w.last_seen,
+        "error_rate": 0.0,
+        "p95_latency_ms": None,
+        "memory_pct": _memory_pct(w.memory_rss_bytes, w.memory_total_bytes),
+        "models": {"stt": None, "llm": None, "tts": None},
+        "fleet_status": w.status,
+    }
+
+
+def _merged_last_seen(rollup: float | None, roster: float | None) -> float | None:
+    vals = [v for v in (rollup, roster) if v is not None]
+    return max(vals) if vals else None
 
 
 def _unattributed_entry(row: AgentObservationRow | None) -> dict[str, Any]:
@@ -85,12 +125,14 @@ async def list_agents_endpoint(
     q: str | None = Query(None, max_length=128),
     gateway: Gateway = Depends(get_gateway),
 ) -> dict[str, Any]:
-    """Return the fleet index over the last 24h, read from the rollup.
+    """Return the fleet index over the last 24h: telemetry rollup + live roster.
 
-    Served from the ``agent_observations`` rollup (refreshed every 15 minutes),
-    not a live requests scan, so cost / requests / p95 / error_rate all cover the
-    same window. ``q`` is a substring match against agent_id; the unattributed
-    bucket (NULL agent_id) is returned separately.
+    Telemetry-derived agents come from the ``agent_observations`` rollup (refreshed
+    every 15 minutes) so cost / requests / p95 / error_rate all cover the same
+    window. Registered workers from the live heartbeat roster are merged in, so a
+    booted-but-idle agent (0 requests) still appears (with an idle/busy/offline
+    ``fleet_status``), matching Server > Fleet. ``q`` is a substring match against
+    agent_id; the unattributed bucket (NULL agent_id) is returned separately.
     """
     if gateway.storage is None:
         return {"agents": [], "unattributed": dict(_EMPTY_UNATTRIBUTED)}
@@ -98,28 +140,57 @@ async def list_agents_endpoint(
     async with gateway.storage._conn.session() as db:
         rows = await agent_obs.read_agents(db, limit=limit, query=q)
         unattributed = await agent_obs.read_unattributed(db)
-        # Live worker roster carries per-agent memory headroom. tenant_id=None
-        # returns the full fleet, which is what the self-hosted dashboard wants.
+        # Live worker roster: per-agent memory headroom + idle/busy presence, and
+        # the source for registered-but-idle agents. tenant_id=None = full fleet.
         roster = await workers_repository.read_roster(
             db, tenant_id=None, now=time.time(), ttl_seconds=DEFAULT_TTL_SECONDS
         )
         agent_ids = [r.agent_id for r in rows if r.agent_id]
         cascade = await request_log_repository.read_last_seen_models(db, agent_ids)
+    # Dedup the roster by agent_id, keeping the FRESHEST heartbeat. read_roster is
+    # ordered last_seen DESC, so the first row per id is freshest; setdefault keeps
+    # it. The full-fleet read (tenant_id=None) can return >1 row for one agent_id
+    # across tenants, so without this a both-sources agent would take the stalest
+    # tenant's status/memory and a roster-only id would be emitted twice.
+    roster_by_id: dict[str, RosterRow] = {}
+    for rw in roster:
+        roster_by_id.setdefault(rw.agent_id, rw)
     memory_by_agent = {
-        r.agent_id: _memory_pct(r.memory_rss_bytes, r.memory_total_bytes)
-        for r in roster
+        aid: _memory_pct(w.memory_rss_bytes, w.memory_total_bytes)
+        for aid, w in roster_by_id.items()
     }
-    return {
-        "agents": [
+
+    agents_out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for r in rows:
+        w = roster_by_id.get(r.agent_id) if r.agent_id else None
+        agents_out.append(
             _agent_entry(
                 r,
                 memory_by_agent.get(r.agent_id) if r.agent_id else None,
                 cascade.get(r.agent_id, {}) if r.agent_id else {},
+                fleet_status=w.status if w is not None else None,
+                last_seen=_merged_last_seen(
+                    r.last_seen, w.last_seen if w is not None else None
+                ),
+                agent_name=w.agent_name if w is not None else None,
             )
-            for r in rows
-        ],
-        "unattributed": _unattributed_entry(unattributed),
-    }
+        )
+        if r.agent_id:
+            seen.add(r.agent_id)
+
+    # Registered workers with no telemetry rows yet (respect the q filter). Skip
+    # offline roster-only workers: a dead process that never metered anything is
+    # noise on the fleet index (telemetry agents still show regardless of status).
+    ql = q.lower() if q else None
+    for w in roster_by_id.values():
+        if w.agent_id in seen or w.status == "offline":
+            continue
+        if ql is not None and ql not in w.agent_id.lower():
+            continue
+        agents_out.append(_roster_only_entry(w))
+
+    return {"agents": agents_out[:limit], "unattributed": _unattributed_entry(unattributed)}
 
 
 @router.get("/{agent_id}")

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -21,27 +21,13 @@ _DEFAULT_PERCENTILES: list[float] = [50.0, 95.0, 99.0]
 
 _logger = logging.getLogger(__name__)
 
-# aiosqlite and alembic both log every operation at DEBUG. Embedded in a
-# LiveKit agent (voicegateway.attach), a ``console``/``dev`` run sets the root
-# logger to DEBUG, so that per-query chatter floods the host's terminal. Quiet
-# the two noisy dependency loggers, but only when the caller has not picked a
-# level themselves (NOTSET = "inherit", which is what produces the flood).
-_NOISY_EMBEDDED_LOGGERS = ("aiosqlite", "alembic")
-
-
-def _quiet_embedded_dependency_loggers() -> None:
-    """Raise the noisy aiosqlite/alembic loggers to WARNING, unless set already."""
-    for name in _NOISY_EMBEDDED_LOGGERS:
-        logger = logging.getLogger(name)
-        if logger.level == logging.NOTSET:
-            logger.setLevel(logging.WARNING)
-
 
 class StorageService:
     """Aggregates per-domain services over one SQLite database."""
 
     def __init__(self, db_path: str | Path) -> None:
-        _quiet_embedded_dependency_loggers()
+        # Database.__init__ quiets the noisy aiosqlite/alembic loggers now, so this
+        # facade no longer needs its own call.
         self._db_path = Path(db_path).expanduser()
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         cfg = GatewayConfig(cost_tracking={"db_path": str(self._db_path)})

--- a/src/voicegateway/tests/core/test_database_logging.py
+++ b/src/voicegateway/tests/core/test_database_logging.py
@@ -1,0 +1,51 @@
+"""Building a Database must quiet aiosqlite/alembic, on every construction path.
+
+Regression: the local-mode fleet heartbeat thread constructs a ``Database``
+directly (not via the ``StorageService`` facade) and writes presence every 15s.
+Under a LiveKit ``dev``/``console`` run (root logger at DEBUG) that flooded the
+agent's terminal with per-query aiosqlite chatter, because only ``StorageService``
+quieted the noisy loggers. The quieting now lives in ``Database.__init__`` so the
+heartbeat path (and any other direct engine build) is covered too.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from voicegateway.core.config import GatewayConfig
+from voicegateway.core.database import Database
+
+
+def _config(tmp_path) -> GatewayConfig:
+    return GatewayConfig(cost_tracking={"db_path": str(tmp_path / "hb.db")})
+
+
+def test_database_quiets_unconfigured_aiosqlite_logger(tmp_path):
+    lg = logging.getLogger("aiosqlite")
+    lg.setLevel(logging.NOTSET)  # inherits root (DEBUG under console mode)
+    try:
+        Database(_config(tmp_path))
+        assert lg.level == logging.WARNING
+    finally:
+        lg.setLevel(logging.NOTSET)
+
+
+def test_database_quiets_unconfigured_alembic_logger(tmp_path):
+    lg = logging.getLogger("alembic")
+    lg.setLevel(logging.NOTSET)
+    try:
+        Database(_config(tmp_path))
+        assert lg.level == logging.WARNING
+    finally:
+        lg.setLevel(logging.NOTSET)
+
+
+def test_database_respects_an_explicit_aiosqlite_level(tmp_path):
+    """A developer who deliberately turns aiosqlite up keeps their setting."""
+    lg = logging.getLogger("aiosqlite")
+    lg.setLevel(logging.DEBUG)
+    try:
+        Database(_config(tmp_path))
+        assert lg.level == logging.DEBUG
+    finally:
+        lg.setLevel(logging.NOTSET)

--- a/src/voicegateway/tests/fleet/test_worker.py
+++ b/src/voicegateway/tests/fleet/test_worker.py
@@ -7,17 +7,28 @@ import pytest
 from voicegateway.fleet import worker
 
 
-@pytest.fixture(autouse=True)
-def _reset():
+def _clear():
+    # Stop any local-mode heartbeat thread before wiping the globals it reads.
+    if worker._local_stop is not None:
+        worker._local_stop.set()
+    if worker._local_thread is not None:
+        worker._local_thread.join(timeout=3.0)
     worker._worker = None
     worker._pusher = None
     worker._collector_url = None
     worker._api_key = None
     worker._client = None
+    worker._local_enabled = False
+    worker._local_db_path = None
+    worker._local_thread = None
+    worker._local_stop = None
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _clear()
     yield
-    worker._worker = None
-    worker._pusher = None
-    worker._client = None
+    _clear()
 
 
 def test_register_populates_presence(monkeypatch):
@@ -91,3 +102,188 @@ async def test_push_once_noop_without_collector(monkeypatch):
     worker._client = _FakeClient()
     await worker.push_once()
     assert posts == []
+
+
+# ---------------------------------------------------------------------------
+# Local mode: thread heartbeat writing to the shared SQLite (co-located dashboard)
+# ---------------------------------------------------------------------------
+
+
+def _db(db_path: str):
+    from voicegateway.core.config import GatewayConfig
+    from voicegateway.core.database import Database
+
+    return Database(GatewayConfig(cost_tracking={"db_path": db_path}))
+
+
+async def _ensure_db(db_path: str) -> None:
+    """Create the tables once up front, so the writer thread and reader never
+    race on create_all."""
+    conn = _db(db_path)
+    try:
+        await conn.create_all()
+    finally:
+        await conn.dispose()
+
+
+async def _read_roster(db_path: str):
+    import time
+
+    from voicegateway.repository import workers_repository
+
+    conn = _db(db_path)
+    try:
+        async with conn.session() as db:
+            return await workers_repository.read_roster(
+                db, tenant_id=None, now=time.time(), ttl_seconds=1e9
+            )
+    finally:
+        await conn.dispose()
+
+
+async def _wait_for(db_path: str, predicate, timeout: float = 5.0):
+    import asyncio
+    import time
+
+    deadline = time.time() + timeout
+    rows: list = []
+    while time.time() < deadline:
+        rows = await _read_roster(db_path)
+        match = next((r for r in rows if predicate(r)), None)
+        if match is not None:
+            return match
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"no matching worker within {timeout}s (rows={rows})")
+
+
+def test_register_without_collector_or_local_is_silent(monkeypatch):
+    """Backward compat: no collector and no local flag pushes nothing."""
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w-silent")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    worker.register_worker("agent")
+    assert worker.is_registered() is True
+    assert worker._local_thread is None  # no local heartbeat started
+    assert worker._pusher is None
+
+
+def test_register_local_starts_thread_without_event_loop(tmp_path, monkeypatch):
+    """The local heartbeat is thread-based, so it starts from a plain sync call
+    (a __main__ block) with no running event loop."""
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w-boot")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    worker.register_worker(
+        "agent", local=True, db_path=str(tmp_path / "boot.db"), interval=0.05
+    )
+    assert worker._local_thread is not None
+    assert worker._local_thread.is_alive()
+
+
+async def test_local_heartbeat_writes_worker_row(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w-local")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    db = str(tmp_path / "hb.db")
+    await _ensure_db(db)
+    worker.register_worker("agent", local=True, db_path=db, interval=0.05)
+    row = await _wait_for(db, lambda r: r.agent_id == "w-local")
+    assert row.agent_name == "agent"
+    assert row.status == "idle"
+
+
+async def test_local_heartbeat_reflects_busy_after_bump(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w-busy")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    db = str(tmp_path / "busy.db")
+    await _ensure_db(db)
+    worker.register_worker("agent", local=True, db_path=db, interval=0.05)
+    worker.bump_active(1)
+    row = await _wait_for(db, lambda r: r.agent_id == "w-busy" and r.status == "busy")
+    assert row.active_sessions >= 1
+
+
+async def test_ensure_registered_does_not_clobber(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w-idem")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    db = str(tmp_path / "idem.db")
+    await _ensure_db(db)
+    worker.register_worker("first", local=True, db_path=db, interval=0.05)
+    # attach(heartbeat=True) path: must not overwrite the __main__ registration.
+    worker.ensure_registered("second", local=True, db_path=db)
+    assert worker._worker.agent_name == "first"
+    row = await _wait_for(db, lambda r: r.agent_id == "w-idem")
+    assert row.agent_name == "first"
+
+
+def _table_exists(db_path: str, table: str) -> bool:
+    import os
+    import sqlite3
+
+    if not os.path.exists(db_path):
+        return False
+    con = sqlite3.connect(db_path)
+    try:
+        cur = con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        )
+        return cur.fetchone() is not None
+    finally:
+        con.close()
+
+
+async def test_local_heartbeat_does_not_seed_schema(tmp_path, monkeypatch):
+    """Regression: the heartbeat must NEVER create tables on the shared file.
+
+    create_all would seed all tables un-stamped and poison a later `alembic
+    upgrade head` (the dashboard's and the agent's own cost sink's migration),
+    permanently breaking that DB. The heartbeat writes best-effort into a schema
+    alembic owns; it must not create it.
+    """
+    import asyncio
+
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w-noseed")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    db = str(tmp_path / "fresh.db")
+    worker.register_worker("agent", local=True, db_path=db, interval=0.02)
+    # Several heartbeat intervals against a fresh, schema-less file.
+    await asyncio.sleep(0.25)
+    assert not _table_exists(db, "workers")
+
+
+def test_collector_takes_precedence_over_local(tmp_path, monkeypatch):
+    """local=True + a collector => collector wins; no local SQLite thread starts.
+
+    This is the exact combination attach(heartbeat=True) produces in fleet mode
+    (it forwards both collector_url and local=True)."""
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w-prec")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    worker.register_worker(
+        "agent",
+        collector_url="http://c",
+        local=True,
+        db_path=str(tmp_path / "prec.db"),
+        interval=0.05,
+    )
+    assert worker._local_thread is None
+    assert worker._collector_url == "http://c"
+
+
+def test_attach_heartbeat_wires_ensure_registered_local(monkeypatch):
+    """attach(session, heartbeat=True) forwards to ensure_registered(local=True)."""
+    import voicegateway
+    import voicegateway._frameworks as fw
+
+    monkeypatch.setenv("VOICEGW_AGENT_ID", "w-attach")
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    # Force the LiveKit path; spy on ensure_registered so no real DB/thread is used.
+    monkeypatch.setattr(fw, "detect_framework", lambda _s: "livekit")
+    calls: list = []
+    monkeypatch.setattr(
+        worker, "ensure_registered", lambda name, **kw: calls.append((name, kw)) or "w-attach"
+    )
+
+    class _FakeSession:
+        def on(self, *_a, **_k):
+            pass
+
+    voicegateway.attach(_FakeSession(), heartbeat=True)
+    assert calls, "attach(heartbeat=True) did not call ensure_registered"
+    assert calls[0][1].get("local") is True

--- a/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
+++ b/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
@@ -7,6 +7,9 @@ The DETAIL endpoint stays all-time (reads requests).
 
 from __future__ import annotations
 
+import time
+
+import pytest
 import yaml
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
@@ -213,3 +216,135 @@ async def test_list_attaches_last_seen_model_cascade(tmp_path, monkeypatch) -> N
         "llm": "openai/gpt-4o",   # last-seen (ts 200 > 100)
         "tts": "cartesia/sonic",
     }
+
+
+# ---------------------------------------------------------------------------
+# Merge the live worker roster into the LIST, so a registered-but-idle agent
+# (0 telemetry) appears too, matching Server > Fleet.
+# ---------------------------------------------------------------------------
+
+
+async def test_list_includes_registered_worker_without_telemetry(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    now = time.time()
+    # A registered worker with NO rollup row: it must still appear, with zero
+    # telemetry and an idle fleet_status.
+    await _insert_worker(
+        gw,
+        agent_id="idle-bot",
+        agent_name="idle-bot",
+        project="default",
+        status="idle",
+        last_seen=now,
+        memory_rss_bytes=1073741824,
+        memory_total_bytes=4294967296,
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "idle-bot")
+    assert entry["request_count"] == 0
+    assert entry["total_cost_usd"] == 0.0
+    assert entry["p95_latency_ms"] is None
+    assert entry["error_rate"] == 0.0
+    assert entry["fleet_status"] == "idle"
+    assert entry["memory_pct"] == 25.0
+    assert entry["agent_name"] == "idle-bot"
+
+
+async def test_list_registered_agent_gets_status_and_fresher_last_seen(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    now = time.time()
+    await _insert_obs(
+        gw,
+        agent_id="worker-a",
+        request_count=5,
+        total_cost_usd=0.2,
+        error_count=0,
+        p95_ms=250,
+        last_seen=now - 3600,  # last request an hour ago
+        window_start="ws",
+        window_end="we",
+    )
+    await _insert_worker(
+        gw,
+        agent_id="worker-a",
+        agent_name="worker-a",
+        project="default",
+        status="busy",
+        last_seen=now,
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "worker-a")
+    assert entry["request_count"] == 5  # telemetry preserved
+    assert entry["fleet_status"] == "busy"
+    assert entry["agent_name"] == "worker-a"  # friendly label from the roster
+    # The fresher heartbeat wins over the hour-old last request.
+    assert entry["last_seen"] == pytest.approx(now)
+
+
+async def test_list_dedups_same_agent_id_across_tenants_keeping_freshest(
+    tmp_path, monkeypatch
+):
+    gw = _gateway(tmp_path, monkeypatch)
+    now = time.time()
+    # The full-fleet read (tenant_id=None) returns both tenant rows for one id.
+    await _insert_worker(
+        gw, agent_id="dup", agent_name="dup", project="default",
+        tenant_id=None, status="idle", last_seen=now - 10,
+    )
+    await _insert_worker(
+        gw, agent_id="dup", agent_name="dup", project="default",
+        tenant_id="t1", status="busy", last_seen=now,
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    dups = [a for a in data["agents"] if a["agent_id"] == "dup"]
+    assert len(dups) == 1  # deduped, not doubled
+    assert dups[0]["fleet_status"] == "busy"  # freshest heartbeat wins
+
+
+async def test_list_fleet_status_null_for_telemetry_only(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    await _insert_obs(
+        gw,
+        agent_id="past-run",
+        request_count=2,
+        total_cost_usd=0.0,
+        error_count=0,
+        last_seen=1000.0,
+        window_start="ws",
+        window_end="we",
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "past-run")
+    assert entry["fleet_status"] is None
+
+
+async def test_list_skips_offline_roster_only_worker(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    # A registered worker gone offline (ancient heartbeat) with no telemetry:
+    # read_roster derives 'offline', and it must not clutter the fleet index.
+    await _insert_worker(
+        gw, agent_id="dead", agent_name="dead", project="default",
+        status="idle", last_seen=1000.0,
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    assert not any(a["agent_id"] == "dead" for a in data["agents"])
+
+
+async def test_list_q_filter_covers_roster_only_workers(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    now = time.time()
+    for name in ("alpha", "beta"):
+        await _insert_worker(
+            gw, agent_id=name, agent_name=name, project="default",
+            status="idle", last_seen=now,
+        )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents?q=alph")).json()
+    ids = {a["agent_id"] for a in data["agents"]}
+    assert "alpha" in ids
+    assert "beta" not in ids


### PR DESCRIPTION
## Fleet idle presence: local-DB heartbeat + `attach(heartbeat=True)`

The LiveKit Server API lists agents that are **in a room**, never the idle/registered worker pool. This adds an agent-side heartbeat so a voice agent shows in the dashboard's **Fleet/Agents** view **while idle**, in the self-hosted co-located case (agent + dashboard share `~/.config/voicegateway/voicegw.db`), with no collector.

### API
- **`register_worker("agent", local=True)`** — a background daemon thread writes the worker presence straight to the shared SQLite. It needs no event loop, so calling it in a plain `__main__` block shows the worker **idle the instant `agent dev` connects** (the primary use case). A collector (`VOICEGW_COLLECTOR_URL`) still takes precedence. Without a collector and without `local=True`, the worker is tracked but nothing is pushed (**unchanged, backward compatible**).
- **`attach(session, heartbeat=True)`** — one-param opt-in for **single-process** agents (Pipecat / the LiveKit thread executor); flips idle↔busy per session on the LiveKit path.

### Honesty / correctness (from adversarial review)
- **The heartbeat never creates tables.** The shared schema is owned by alembic (the dashboard and the agent's own cost sink migrate it). Seeding it with `create_all` would leave the tables un-stamped and **poison a later `alembic upgrade head`**, permanently breaking cost tracking + the dashboard on that file. Writes are best-effort against the alembic-owned schema instead. (This was a real bug the review caught; there's a regression test locking it: `test_local_heartbeat_does_not_seed_schema`.)
- **One writer per identity.** In the LiveKit process-executor model (`agent dev`) the worker is the main process and calls run in per-call **job subprocesses**. Register at `__main__` (main process); do **not** also pass `attach(heartbeat=True)` there — the subprocess would double-write the same `(tenant=None, agent_id)` roster row, which the get-then-insert upsert can't coalesce. Documented in both docstrings.
- Thread is stopped via `atexit` for a clean shutdown (no "event loop closed" noise).

### Tests
`tests/fleet/test_worker.py` (+9): thread writes the row to a real DB, idle→busy after `bump_active`, `ensure_registered` doesn't clobber a `__main__` registration, backward-compat "silent" path, starts without an event loop, **does-not-seed-schema** regression, collector-precedence, and the `attach(heartbeat=True)` → `ensure_registered(local=True)` wiring. mypy clean (250 files), ruff clean.

The 15 pre-existing `tests/inference` failures are the bare-`StorageService` local-DB gotcha (identical on `main`; pass in CI's migration job), unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional fleet presence heartbeat, including a local heartbeat mode when no collector is configured.
  * Extended worker registration/ensuring APIs to support local heartbeat and database-backed presence.
  * Added a `heartbeat` option to session attachment for automatic worker registration and presence updates.
  * Dashboard now shows live roster status via new `agent_name` and `fleet_status` fields, with updated status badges.

* **Bug Fixes**
  * Collector configuration takes precedence over local mode.
  * Improved worker heartbeat startup/shutdown behavior during worker and session lifecycle.

* **Chores / Tests**
  * Reduced noisy embedded database logging and expanded coverage for roster merge and heartbeat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->