### PR TITLE
feat(dashboard): human-friendly times in a user-selectable timezone

### DIFF
--- a/src/dashboard/frontend/src/lib/time.ts
+++ b/src/dashboard/frontend/src/lib/time.ts
@@ -1,0 +1,129 @@
+// Human-friendly time formatting with a user-selectable timezone.
+//
+// Detail views rendered timestamps as full locale strings
+// (`new Date(x).toLocaleString()`), which is noisy: seconds, full year, the
+// works. These helpers render hours:minutes (with a short date where the day
+// matters) in a timezone the user picks in Settings. The preference is a
+// frontend-only choice persisted in localStorage; "auto" resolves to the
+// browser zone, which for a co-located dashboard is the machine hosting the
+// gateway.
+
+import { useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = 'vg.timezone';
+export const AUTO = 'auto';
+
+type TzPref = string; // 'auto' or an IANA zone id
+
+let current: TzPref = readStored();
+const listeners = new Set<() => void>();
+
+function readStored(): TzPref {
+  try {
+    return localStorage.getItem(STORAGE_KEY) || AUTO;
+  } catch {
+    return AUTO;
+  }
+}
+
+/** The stored preference ('auto' or an IANA id). */
+export function getTimeZonePref(): TzPref {
+  return current;
+}
+
+/** Persist a new preference and notify subscribers. */
+export function setTimeZonePref(tz: TzPref): void {
+  current = tz || AUTO;
+  try {
+    localStorage.setItem(STORAGE_KEY, current);
+  } catch {
+    /* private mode: keep the in-memory value */
+  }
+  listeners.forEach((l) => l());
+}
+
+/** The IANA zone actually in effect ('auto' resolves to the browser/host zone). */
+export function resolvedTimeZone(): string {
+  if (current !== AUTO) return current;
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** Re-render on timezone changes; returns the current preference. */
+export function useTimeZone(): TzPref {
+  return useSyncExternalStore(subscribe, getTimeZonePref, getTimeZonePref);
+}
+
+const FALLBACK_ZONES = [
+  'UTC',
+  'America/Los_Angeles', 'America/Denver', 'America/Chicago',
+  'America/New_York', 'America/Toronto', 'America/Sao_Paulo',
+  'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Moscow',
+  'Asia/Kolkata', 'Asia/Dubai', 'Asia/Singapore', 'Asia/Shanghai',
+  'Asia/Tokyo', 'Australia/Sydney',
+];
+
+/** Every IANA zone the runtime knows, for the picker (curated fallback). */
+export function listTimeZones(): string[] {
+  try {
+    const all = (Intl as { supportedValuesOf?: (k: string) => string[] })
+      .supportedValuesOf?.('timeZone');
+    if (Array.isArray(all) && all.length) return all;
+  } catch {
+    /* fall through to the curated list */
+  }
+  return FALLBACK_ZONES;
+}
+
+// Numbers >= this are epoch milliseconds; smaller ones are epoch seconds.
+// (ms for any date after 2001 exceeds 1e12; seconds stay well below it.)
+const MS_THRESHOLD = 1e12;
+
+function toDate(value: string | number | Date): Date | null {
+  if (value instanceof Date) return value;
+  if (typeof value === 'number') {
+    return new Date(value < MS_THRESHOLD ? value * 1000 : value);
+  }
+  const t = Date.parse(value);
+  return Number.isNaN(t) ? null : new Date(t);
+}
+
+/** Hours:minutes in the effective timezone (e.g. "14:32"). */
+export function formatTime(
+  value: string | number | Date | null | undefined,
+): string {
+  if (value == null) return '—';
+  const d = toDate(value);
+  if (!d) return String(value);
+  return d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: resolvedTimeZone(),
+  });
+}
+
+/** Short date + hours:minutes in the effective timezone (e.g. "Jul 24, 14:32"). */
+export function formatDateTime(
+  value: string | number | Date | null | undefined,
+): string {
+  if (value == null) return '—';
+  const d = toDate(value);
+  if (!d) return String(value);
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: resolvedTimeZone(),
+  });
+}

--- a/src/dashboard/frontend/src/pages/AgentDetail.tsx
+++ b/src/dashboard/frontend/src/pages/AgentDetail.tsx
@@ -12,6 +12,7 @@ import {
   formatRelativeTime,
   rosterStatusBadge,
 } from '../lib/ui';
+import { formatDateTime } from '../lib/time';
 
 /** Detail view for a single agent: 24h metrics, model stack, recent calls. */
 export default function AgentDetail() {
@@ -117,7 +118,7 @@ export default function AgentDetail() {
               {calls.map((c) => (
                 <tr key={c.id}>
                   <td className="mono">{c.id}</td>
-                  <td>{new Date(c.started_at).toLocaleString()}</td>
+                  <td>{formatDateTime(c.started_at)}</td>
                   <td>{c.modalities.join(' · ')}</td>
                   <td>{c.request_count}</td>
                   <td className="mono">{formatCost(c.total_cost_usd, 4)}</td>

--- a/src/dashboard/frontend/src/pages/Server.tsx
+++ b/src/dashboard/frontend/src/pages/Server.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import PageHeader from '../components/PageHeader';
 import { fetchServerOverview } from '../lib/api';
 import { formatCost, formatMs, formatRelativeTime } from '../lib/ui';
+import { formatDateTime } from '../lib/time';
 import type { ServerOverview } from '../lib/types';
 
 /**
@@ -55,10 +56,10 @@ function enumLabel(s: string): string {
   return last.toLowerCase();
 }
 
-/** Egress started_at is unix nanoseconds; render a local time or a dash. */
+/** Egress started_at is unix nanoseconds; render a short date+time or a dash. */
 function fmtNs(ns: number): string {
   if (!ns) return '-';
-  return new Date(ns / 1e6).toLocaleString();
+  return formatDateTime(ns / 1e6);
 }
 
 export default function Server() {

--- a/src/dashboard/frontend/src/pages/Sessions.tsx
+++ b/src/dashboard/frontend/src/pages/Sessions.tsx
@@ -11,6 +11,7 @@ import FilterBar, { useTenantFilter, useAgentFilter } from '../components/Filter
 import PageHeader from '../components/PageHeader';
 import { fetchJson } from '../lib/api';
 import { formatCost } from '../lib/ui';
+import { formatDateTime } from '../lib/time';
 import type {
   SessionDetail,
   SessionOrderBy,
@@ -292,13 +293,13 @@ function SessionDetailModal({
           <div>
             <div className="label">Started</div>
             <div className="mt-sm mono" style={{ fontSize: 12 }}>
-              {session.started_at}
+              {formatDateTime(session.started_at)}
             </div>
           </div>
           <div>
             <div className="label">Ended (last activity)</div>
             <div className="mt-sm mono" style={{ fontSize: 12 }}>
-              {session.ended_at ?? '—'}
+              {session.ended_at ? formatDateTime(session.ended_at) : '—'}
             </div>
           </div>
         </div>

--- a/src/dashboard/frontend/src/pages/Settings.tsx
+++ b/src/dashboard/frontend/src/pages/Settings.tsx
@@ -2,6 +2,14 @@ import { useEffect, useState } from 'react';
 import PageHeader from '../components/PageHeader';
 import SourceBadge from '../components/SourceBadge';
 import { fetchJson } from '../lib/api';
+import {
+  AUTO,
+  formatDateTime,
+  listTimeZones,
+  resolvedTimeZone,
+  setTimeZonePref,
+  useTimeZone,
+} from '../lib/time';
 import Projects from './Projects';
 import ApiKeys from './ApiKeys';
 
@@ -77,7 +85,8 @@ function GeneralTab() {
 
   return (
     <div className="mt-lg">
-      <div className="neo-card">
+      <TimeZoneCard />
+      <div className="neo-card mt-lg">
         <div className="label">Gateway Info</div>
         <table className="info-table mt-md">
           <tbody>
@@ -87,6 +96,38 @@ function GeneralTab() {
             <tr><td className="label">Total Cost (All Time)</td><td>${data.total_cost_all.toFixed(4)}</td></tr>
           </tbody>
         </table>
+      </div>
+    </div>
+  );
+}
+
+// Timezone preference: a frontend-only choice (localStorage) that every
+// dashboard timestamp renders in. "Auto" resolves to the browser zone, which
+// on a co-located dashboard is the machine hosting the gateway.
+function TimeZoneCard() {
+  const pref = useTimeZone();
+  const zones = listTimeZones();
+  const resolved = resolvedTimeZone();
+  return (
+    <div className="neo-card">
+      <div className="label">Timezone</div>
+      <div style={{ marginTop: 6, fontSize: 13, color: 'var(--vg-muted)' }}>
+        All dashboard times render in this zone.
+      </div>
+      <div className="flex-row gap-sm mt-md" style={{ alignItems: 'center', flexWrap: 'wrap' }}>
+        <select
+          className="neo-select"
+          value={pref}
+          onChange={(e) => setTimeZonePref(e.target.value)}
+        >
+          <option value={AUTO}>Auto (browser: {resolved})</option>
+          {zones.map((z) => (
+            <option key={z} value={z}>{z}</option>
+          ))}
+        </select>
+        <span className="mono" style={{ fontSize: 13, color: 'var(--vg-ink)' }}>
+          now {formatDateTime(Date.now())}
+        </span>
       </div>
     </div>
   );
@@ -128,7 +169,7 @@ function AuditLogTab() {
         <tbody>
           {entries.map((e) => (
             <tr key={e.id}>
-              <td className="mono">{new Date(e.timestamp * 1000).toLocaleString()}</td>
+              <td className="mono">{formatDateTime(e.timestamp * 1000)}</td>
               <td><span className="neo-badge neo-badge--black">{e.action}</span></td>
               <td>{e.entity_type}</td>
               <td className="mono">{e.entity_id}</td>


### PR DESCRIPTION
## What

Dashboard detail views showed noisy timestamps: the **Calls detail** rendered the raw `started_at` ISO string, and agent-call rows, the audit log, and Server egress times used `toLocaleString()` (full date, seconds, the works). This renders **hours:minutes** instead (with a short date where the day matters), in a timezone the viewer picks.

## How

- **`lib/time.ts`** (new): a localStorage-backed timezone preference. Default `auto` resolves to the browser zone, which on a co-located dashboard is the machine hosting the gateway. Exposes `useTimeZone()` (a `useSyncExternalStore` hook so every timestamp re-renders on change) plus `formatTime` (HH:MM) and `formatDateTime` (short date + HH:MM). Accepts ISO strings, epoch seconds, or epoch ms.
- **Settings → General**: a Timezone picker (Auto + every IANA zone via `Intl.supportedValuesOf`, curated fallback) with a live "now" preview.
- **Render sites swapped** to `formatDateTime`: Calls detail (Started / Ended), AgentDetail call list, the audit log, and Server egress start times.

Frontend-only; no backend or API change. `tsc -b && vite build` passes.

## Decision context

Brainstormed with the maintainer: timezone resolves via **browser auto-detect + override** (zero backend; browser == host for a co-located dashboard) rather than a backend-reported host zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)