### PR TITLE
feat(dashboard): Overview agent cards with a first-byte latency waterfall

### DIFF
--- a/src/dashboard/frontend/src/components/AgentCard.tsx
+++ b/src/dashboard/frontend/src/components/AgentCard.tsx
@@ -1,0 +1,82 @@
+import { Link } from 'react-router-dom';
+import type { AgentRow } from '../lib/types';
+import {
+  agentStatus,
+  agentStatusBadgeClass,
+  formatCost,
+  rosterStatusBadge,
+} from '../lib/ui';
+import LatencyWaterfall from './LatencyWaterfall';
+
+// A single agent tile for the Overview fleet grid: identity + presence, the
+// model stack, 24h cost/requests, and the STT/LLM/TTS latency waterfall. The
+// whole card links to the agent's detail page.
+export default function AgentCard({ agent }: { agent: AgentRow }) {
+  // Live roster status (idle/busy/offline) when present, matching Server > Fleet;
+  // else the telemetry-recency status.
+  const fleet = agent.fleet_status || null;
+  const status = fleet ?? agentStatus(agent.last_seen);
+  const badgeClass = fleet
+    ? rosterStatusBadge(fleet)
+    : agentStatusBadgeClass(agentStatus(agent.last_seen));
+
+  return (
+    <Link
+      to={`/agents/${encodeURIComponent(agent.agent_id)}`}
+      className="vg-card"
+      style={{ display: 'block' }}
+    >
+      <div className="flex-row" style={{ justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
+        <div
+          className="mono"
+          style={{
+            fontWeight: 700,
+            color: 'var(--vg-ink)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={agent.agent_id}
+        >
+          {agent.agent_name || agent.agent_id}
+        </div>
+        <span className={`neo-badge ${badgeClass}`}>{status}</span>
+      </div>
+
+      <div className="flex-row gap-sm mt-sm flex-wrap">
+        {(['stt', 'llm', 'tts'] as const).map((m) => {
+          const model = agent.models?.[m] ?? null;
+          return (
+            <span
+              key={m}
+              className="neo-badge neo-badge--black"
+              title={model ? `${m.toUpperCase()}: ${model}` : `${m.toUpperCase()}: unknown`}
+              style={{ opacity: model ? 1 : 0.35, fontSize: 10 }}
+            >
+              {model ? model.split('/').pop() : '-'}
+            </span>
+          );
+        })}
+      </div>
+
+      <div className="flex-row mt-md" style={{ justifyContent: 'space-between', gap: 12 }}>
+        <div>
+          <div className="vg-card__label">Cost 24h</div>
+          <div className="mono" style={{ fontWeight: 700, marginTop: 2 }}>
+            {formatCost(agent.total_cost_usd, 4)}
+          </div>
+        </div>
+        <div>
+          <div className="vg-card__label">Requests</div>
+          <div className="mono" style={{ fontWeight: 700, marginTop: 2 }}>
+            {agent.request_count}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-md">
+        <LatencyWaterfall latency={agent.latency_ms} />
+      </div>
+    </Link>
+  );
+}

--- a/src/dashboard/frontend/src/components/LatencyWaterfall.tsx
+++ b/src/dashboard/frontend/src/components/LatencyWaterfall.tsx
@@ -1,0 +1,98 @@
+// Horizontally-stacked latency waterfall for an agent's average first-byte
+// latency. Only STT / LLM / TTS are measured (first-byte per modality); the
+// network hops and turn-detection segments of a full colocation diagram are not
+// metered, so the bar is honest about the three segments it can show.
+
+type Stack = { stt: number | null; llm: number | null; tts: number | null };
+
+const SEGMENTS = [
+  { key: 'stt', label: 'STT', color: 'var(--vg-teal)' },
+  { key: 'llm', label: 'LLM', color: 'var(--vg-green)' },
+  { key: 'tts', label: 'TTS', color: 'var(--vg-red)' },
+] as const;
+
+export default function LatencyWaterfall({ latency }: { latency?: Stack | null }) {
+  const parts = SEGMENTS.map((s) => ({ ...s, ms: latency?.[s.key] ?? 0 })).filter(
+    (s) => s.ms > 0,
+  );
+  const total = parts.reduce((sum, s) => sum + s.ms, 0);
+
+  if (total === 0) {
+    return (
+      <div style={{ fontSize: 11, color: 'var(--vg-muted-2)' }}>
+        No latency samples yet
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        className="flex-row"
+        style={{ justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}
+      >
+        <span className="vg-card__label" style={{ fontSize: 11 }}>
+          Avg first-byte latency
+        </span>
+        <span className="mono" style={{ fontSize: 12, fontWeight: 700, color: 'var(--vg-ink)' }}>
+          {Math.round(total)}ms
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          height: 22,
+          borderRadius: 'var(--vg-radius-xs)',
+          overflow: 'hidden',
+          border: '1px solid var(--vg-hairline)',
+        }}
+      >
+        {parts.map((s) => {
+          const pct = (s.ms / total) * 100;
+          return (
+            <div
+              key={s.key}
+              title={`${s.label} ${Math.round(s.ms)}ms`}
+              style={{
+                width: `${pct}%`,
+                background: s.color,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#fff',
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: 0.3,
+                minWidth: 0,
+              }}
+            >
+              {pct > 14 ? s.label : ''}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex-row flex-wrap" style={{ gap: 10, marginTop: 6 }}>
+        {parts.map((s) => (
+          <span
+            key={s.key}
+            className="mono"
+            style={{
+              fontSize: 11,
+              color: 'var(--vg-muted)',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+            }}
+          >
+            <span
+              style={{ width: 8, height: 8, borderRadius: 2, background: s.color, display: 'inline-block' }}
+            />
+            {s.label} {Math.round(s.ms)}ms
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -219,6 +219,10 @@ export interface AgentRow {
   memory_pct?: number | null;
   /** Last-seen model per modality, from /api/agents; a modality is null when unseen. */
   models?: { stt: string | null; llm: string | null; tts: string | null };
+  /** Average first-byte latency (ms) per modality over 24h, for the card
+   * waterfall; a modality is null when it metered nothing. Only STT/LLM/TTS are
+   * measured (network hops / turn detection are not metered). */
+  latency_ms?: { stt: number | null; llm: number | null; tts: number | null };
   /** Live roster presence: 'idle' | 'busy' | 'offline'; null when the agent is
    * telemetry-only (not currently a registered/heartbeating worker). */
   fleet_status?: string | null;

--- a/src/dashboard/frontend/src/pages/Overview.tsx
+++ b/src/dashboard/frontend/src/pages/Overview.tsx
@@ -4,6 +4,7 @@ import PageHeader from '../components/PageHeader';
 import StatusCard from '../components/StatusCard';
 import TrendChart from '../components/TrendChart';
 import { Skeleton, StatCardSkeleton } from '../components/Skeleton';
+import AgentCard from '../components/AgentCard';
 import { fetchJson, fetchAgents } from '../lib/api';
 import { formatCost, agentStatus } from '../lib/ui';
 import type { OverviewResponse, AgentRow } from '../lib/types';
@@ -50,9 +51,10 @@ export default function Overview() {
   }
 
   const activeCount = agents.filter((a) => agentStatus(a.last_seen) === 'active').length;
-  const topAgents = [...agents]
+  // Cards, cost-ranked. Cap the Overview grid; the full fleet lives on /agents.
+  const cardAgents = [...agents]
     .sort((a, b) => b.total_cost_usd - a.total_cost_usd)
-    .slice(0, 3);
+    .slice(0, 6);
 
   return (
     <div>
@@ -84,42 +86,24 @@ export default function Overview() {
       </div>
 
       {agents.length > 0 && (
-        <div className="mt-lg vg-card">
-          <div className="vg-card__head">
-            <div className="vg-card__label">Fleet</div>
+        <div className="mt-lg">
+          <div
+            className="flex-row"
+            style={{ justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}
+          >
+            <div className="vg-card__label">
+              Fleet · {agents.length} agent{agents.length === 1 ? '' : 's'}
+              {activeCount > 0 ? ` · ${activeCount} active` : ''}
+            </div>
             <Link className="neo-btn" to="/agents" style={{ fontSize: 12, padding: '5px 12px' }}>
               View all agents &rarr;
             </Link>
           </div>
-          <div className="flex-row flex-wrap mt-md" style={{ gap: '2.5rem' }}>
-            <div>
-              <div className="vg-stat">{agents.length}</div>
-              <div className="vg-card__label" style={{ marginTop: 4 }}>Agents</div>
-            </div>
-            <div>
-              <div className="vg-stat">{activeCount}</div>
-              <div className="vg-card__label" style={{ marginTop: 4 }}>Active now</div>
-            </div>
+          <div className="grid grid-cols-3">
+            {cardAgents.map((a) => (
+              <AgentCard key={a.agent_id} agent={a} />
+            ))}
           </div>
-          {topAgents.length > 0 && (
-            <div className="mt-md">
-              <div className="vg-card__label" style={{ marginBottom: 6 }}>
-                Top by cost (24h)
-              </div>
-              {topAgents.map((a) => (
-                <div
-                  key={a.agent_id}
-                  className="flex-row mt-sm"
-                  style={{ justifyContent: 'space-between', borderBottom: '1px solid var(--vg-hairline-2)', paddingBottom: 8 }}
-                >
-                  <Link className="mono" to={`/agents/${encodeURIComponent(a.agent_id)}`} style={{ color: 'var(--vg-teal-deep)', fontSize: 13 }}>
-                    {a.agent_id}
-                  </Link>
-                  <span className="mono" style={{ color: 'var(--vg-ink)', fontWeight: 700 }}>{formatCost(a.total_cost_usd, 4)}</span>
-                </div>
-              ))}
-            </div>
-          )}
         </div>
       )}
 

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -438,6 +438,41 @@ async def read_last_seen_models(
     return out
 
 
+async def read_avg_ttfb_by_modality(
+    session: AsyncSession,
+    agent_ids: list[str] | None = None,
+    *,
+    since: float | None = None,
+) -> dict[str, dict[str, float]]:
+    """Average first-byte latency (``ttfb_ms``) per (agent_id, modality).
+
+    Returns ``{agent_id: {modality: avg_ttfb_ms}}``. Feeds the Overview agent
+    cards' STT/LLM/TTS latency waterfall. Rows with a NULL ttfb_ms drop out of
+    the AVG. Scoped to ``since`` (epoch seconds) when given, so the index can
+    match its 24h window.
+    """
+    where = "agent_id IS NOT NULL AND ttfb_ms IS NOT NULL"
+    params: dict[str, Any] = {}
+    if agent_ids:
+        keys = ", ".join(f":a{i}" for i in range(len(agent_ids)))
+        where += f" AND agent_id IN ({keys})"
+        params = {f"a{i}": a for i, a in enumerate(agent_ids)}
+    if since is not None:
+        where += " AND timestamp >= :since"
+        params["since"] = since
+    sql = text(f"""
+        SELECT agent_id, modality, AVG(ttfb_ms) AS avg_ttfb
+        FROM requests
+        WHERE {where}
+        GROUP BY agent_id, modality
+    """)
+    result = await session.execute(sql, params)
+    out: dict[str, dict[str, float]] = {}
+    for row in result.mappings():
+        out.setdefault(row["agent_id"], {})[row["modality"]] = float(row["avg_ttfb"])
+    return out
+
+
 async def read_models_in_use(session: AsyncSession) -> list[dict[str, str]]:
     """Distinct (modality, provider, model_id) seen in requests, newest first."""
     sql = text("""
@@ -469,6 +504,7 @@ __all__ = [
     "get_requests_in_window",
     "log_audit_event",
     "log_request",
+    "read_avg_ttfb_by_modality",
     "read_last_seen_models",
     "read_models_in_use",
 ]

--- a/src/voicegateway/server/api/dashboard/agents.py
+++ b/src/voicegateway/server/api/dashboard/agents.py
@@ -50,10 +50,25 @@ def _memory_pct(rss: int | None, total: int | None) -> float | None:
     return round(rss / total * 100, 1)
 
 
+def _latency_stack(latency: dict[str, float]) -> dict[str, float | None]:
+    """Per-modality average first-byte latency for the card waterfall.
+
+    Only STT / LLM / TTS are measured (first-byte per modality); the network
+    hops and turn-detection segments in a colocation diagram are not metered, so
+    the waterfall is honest about the three segments it can show.
+    """
+    return {
+        "stt": latency.get("stt"),
+        "llm": latency.get("llm"),
+        "tts": latency.get("tts"),
+    }
+
+
 def _agent_entry(
     row: AgentObservationRow,
     memory_pct: float | None,
     models: dict[str, str],
+    latency: dict[str, float],
     *,
     fleet_status: str | None = None,
     last_seen: float | None = None,
@@ -77,6 +92,8 @@ def _agent_entry(
             "llm": models.get("llm"),
             "tts": models.get("tts"),
         },
+        # Average STT/LLM/TTS first-byte latency (24h) for the card waterfall.
+        "latency_ms": _latency_stack(latency),
         # idle/busy/offline from the worker roster; None when the agent is not
         # currently registered (telemetry-only, e.g. a past run).
         "fleet_status": fleet_status,
@@ -99,6 +116,8 @@ def _roster_only_entry(w: RosterRow) -> dict[str, Any]:
         "p95_latency_ms": None,
         "memory_pct": _memory_pct(w.memory_rss_bytes, w.memory_total_bytes),
         "models": {"stt": None, "llm": None, "tts": None},
+        # A booted-but-idle worker has metered nothing yet, so no latency stack.
+        "latency_ms": {"stt": None, "llm": None, "tts": None},
         "fleet_status": w.status,
     }
 
@@ -147,6 +166,11 @@ async def list_agents_endpoint(
         )
         agent_ids = [r.agent_id for r in rows if r.agent_id]
         cascade = await request_log_repository.read_last_seen_models(db, agent_ids)
+        # Average STT/LLM/TTS first-byte latency over the same 24h window, for the
+        # Overview cards' latency waterfall.
+        latency_by_agent = await request_log_repository.read_avg_ttfb_by_modality(
+            db, agent_ids, since=time.time() - 86400
+        )
     # Dedup the roster by agent_id, keeping the FRESHEST heartbeat. read_roster is
     # ordered last_seen DESC, so the first row per id is freshest; setdefault keeps
     # it. The full-fleet read (tenant_id=None) can return >1 row for one agent_id
@@ -169,6 +193,7 @@ async def list_agents_endpoint(
                 r,
                 memory_by_agent.get(r.agent_id) if r.agent_id else None,
                 cascade.get(r.agent_id, {}) if r.agent_id else {},
+                latency_by_agent.get(r.agent_id, {}) if r.agent_id else {},
                 fleet_status=w.status if w is not None else None,
                 last_seen=_merged_last_seen(
                     r.last_seen, w.last_seen if w is not None else None

--- a/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
+++ b/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
@@ -335,6 +335,69 @@ async def test_list_skips_offline_roster_only_worker(tmp_path, monkeypatch):
     assert not any(a["agent_id"] == "dead" for a in data["agents"])
 
 
+async def test_list_includes_avg_ttfb_latency_stack(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    now = time.time()
+    await _insert_obs(
+        gw, agent_id="lat-agent", request_count=4, total_cost_usd=0.0,
+        error_count=0, last_seen=now, window_start="ws", window_end="we",
+    )
+    # STT avg = 100, LLM = 200, TTS = 50 (first-byte per modality).
+    for i, (mod, model, ttfb) in enumerate([
+        ("stt", "deepgram/nova-3", 80.0),
+        ("stt", "deepgram/nova-3", 120.0),
+        ("llm", "openai/gpt-4o", 200.0),
+        ("tts", "cartesia/sonic", 50.0),
+    ]):
+        await gw.storage.log_request(RequestRecord(
+            id=f"r{i}", timestamp=now, modality=mod, model_id=model,
+            provider=model.split("/")[0], project="default", agent_id="lat-agent",
+            ttfb_ms=ttfb,
+        ))
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "lat-agent")
+    assert entry["latency_ms"]["stt"] == pytest.approx(100.0)
+    assert entry["latency_ms"]["llm"] == pytest.approx(200.0)
+    assert entry["latency_ms"]["tts"] == pytest.approx(50.0)
+
+
+async def test_list_latency_stack_is_windowed_to_24h(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    now = time.time()
+    await _insert_obs(
+        gw, agent_id="win-agent", request_count=2, total_cost_usd=0.0,
+        error_count=0, last_seen=now, window_start="ws", window_end="we",
+    )
+    # An ancient STT call (26h ago) must not drag the average; only the recent
+    # one counts.
+    await gw.storage.log_request(RequestRecord(
+        id="old", timestamp=now - 93600, modality="stt", model_id="deepgram/nova-3",
+        provider="deepgram", project="default", agent_id="win-agent", ttfb_ms=999.0,
+    ))
+    await gw.storage.log_request(RequestRecord(
+        id="new", timestamp=now, modality="stt", model_id="deepgram/nova-3",
+        provider="deepgram", project="default", agent_id="win-agent", ttfb_ms=100.0,
+    ))
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "win-agent")
+    assert entry["latency_ms"]["stt"] == pytest.approx(100.0)
+
+
+async def test_list_latency_stack_null_for_roster_only_worker(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    now = time.time()
+    await _insert_worker(
+        gw, agent_id="idle-lat", agent_name="idle-lat", project="default",
+        status="idle", last_seen=now,
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/agents")).json()
+    entry = next(x for x in data["agents"] if x["agent_id"] == "idle-lat")
+    assert entry["latency_ms"] == {"stt": None, "llm": None, "tts": None}
+
+
 async def test_list_q_filter_covers_roster_only_workers(tmp_path, monkeypatch):
     gw = _gateway(tmp_path, monkeypatch)
     now = time.time()


### PR DESCRIPTION
## What

The Overview's fleet section was a plain "top by cost" text list. Replace it with **agent cards**: each card shows presence (idle/busy), the model stack, 24h cost/requests, and a **horizontally-stacked STT/LLM/TTS latency waterfall** so you can see at a glance where an agent's response latency comes from. The cost trend chart stays on top.

## How

**Backend** — `/api/agents` gains `latency_ms {stt, llm, tts}`: average first-byte latency (`ttfb_ms`) per modality over the same 24h window, via a new `read_avg_ttfb_by_modality` (mirrors the existing model-cascade query, one GROUP BY). Roster-only (idle, 0-telemetry) agents carry nulls.

**Frontend** — new `LatencyWaterfall` (proportional stacked bar + legend + total) and `AgentCard` components; Overview renders a cost-ranked card grid (capped, full fleet on `/agents`).

## Honest by design

VG measures **first-byte latency per modality (STT/LLM/TTS)** and nothing else. The network hops and turn-detection segments in a full colocation diagram are **not metered**, so the waterfall shows only the three segments it can back with real data rather than fabricating them.

## Tests

3 new endpoint tests (avg stack, 24h window boundary, null for roster-only). `tsc -b && vite build` passes; mypy clean.

## Decision context

Brainstormed with the maintainer: **3 real segments** over attempting the fuller 7-segment diagram, precisely because the hops/turn segments are not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)