### PR TITLE
feat(dashboard): call transcripts (attach transcript=True default-on) with retention + kill-switch

### DIFF
--- a/alembic/versions/b7d2f4a9c1e3_transcript_turns.py
+++ b/alembic/versions/b7d2f4a9c1e3_transcript_turns.py
@@ -1,0 +1,55 @@
+"""create transcript_turns table
+
+Revision ID: b7d2f4a9c1e3
+Revises: f3c8a1d5e9b2
+Create Date: 2026-07-24 18:00:00.000000
+
+Per-turn call transcripts, captured best-effort from the framework's
+conversation history when a call ends (default on; disable with attach(
+transcript=False) or the VOICEGW_TRANSCRIPTS kill-switch). One row per user or
+agent turn; ``seq`` orders them within a session. Ages out with the session via
+the retention worker (transcript_turns is a session child table).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401 - migrations may reference SQLModel types
+
+from alembic import op
+
+revision: str = "b7d2f4a9c1e3"
+down_revision: str | None = "f3c8a1d5e9b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "transcript_turns",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("session_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("role", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("text", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column(
+            "created_at",
+            sqlmodel.sql.sqltypes.AutoString(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("tenant_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("transcript_turns", schema=None) as batch_op:
+        batch_op.create_index(
+            "idx_transcript_turns_session_id", ["session_id"], unique=False
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("transcript_turns", schema=None) as batch_op:
+        batch_op.drop_index("idx_transcript_turns_session_id")
+    op.drop_table("transcript_turns")

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -104,6 +104,15 @@ export interface SessionDetail extends SessionRow {
   providers: string[];
 }
 
+/** One captured transcript turn for a call (from /api/sessions/{id}/transcript). */
+export interface TranscriptTurn {
+  session_id: string;
+  seq: number;
+  role: string; // 'user' | 'agent'
+  text: string;
+  created_at?: string | null;
+}
+
 export type SessionOrderBy =
   | 'started_at_desc'
   | 'started_at_asc'

--- a/src/dashboard/frontend/src/pages/Sessions.tsx
+++ b/src/dashboard/frontend/src/pages/Sessions.tsx
@@ -16,6 +16,7 @@ import type {
   SessionDetail,
   SessionOrderBy,
   SessionRow,
+  TranscriptTurn,
 } from '../lib/types';
 
 interface ProjectEntry {
@@ -361,12 +362,92 @@ function SessionDetailModal({
           </div>
         </div>
 
+        <TranscriptPane sessionId={session.id} />
+
         <div className="flex-row mt-lg">
           <button className="neo-btn neo-btn--primary" onClick={onClose}>
             Close
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+// Turn-by-turn call transcript, lazily fetched when the modal opens. Rendered as
+// role-aligned bubbles (agent left, user right). No per-turn timestamp: turns are
+// persisted together when the call ends, so a per-turn time would be misleading.
+function TranscriptPane({ sessionId }: { sessionId: string }) {
+  const [turns, setTurns] = useState<TranscriptTurn[] | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setTurns(null);
+    fetchJson<{ session_id: string; turns: TranscriptTurn[] }>(
+      `/api/sessions/${encodeURIComponent(sessionId)}/transcript`,
+    )
+      .then((d) => alive && setTurns(d.turns))
+      .catch(() => alive && setTurns([]));
+    return () => {
+      alive = false;
+    };
+  }, [sessionId]);
+
+  return (
+    <div className="mt-lg">
+      <div className="label">Transcript</div>
+      {turns === null ? (
+        <div className="empty-state mt-sm">Loading transcript...</div>
+      ) : turns.length === 0 ? (
+        <div className="empty-state mt-sm">No transcript captured for this call.</div>
+      ) : (
+        <div
+          className="mt-sm"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            maxHeight: 320,
+            overflowY: 'auto',
+          }}
+        >
+          {turns.map((t) => {
+            const isAgent = t.role === 'agent';
+            return (
+              <div
+                key={t.seq}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: isAgent ? 'flex-start' : 'flex-end',
+                }}
+              >
+                <span
+                  className="vg-card__label"
+                  style={{ fontSize: 10, marginBottom: 2 }}
+                >
+                  {isAgent ? 'Agent' : 'User'}
+                </span>
+                <span
+                  style={{
+                    maxWidth: '82%',
+                    padding: '8px 12px',
+                    borderRadius: 'var(--vg-radius-sm)',
+                    background: isAgent ? 'var(--vg-teal-tint)' : 'var(--vg-hairline-2)',
+                    color: 'var(--vg-ink)',
+                    fontSize: 13,
+                    lineHeight: 1.45,
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {t.text}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -304,6 +304,7 @@ def attach(
     sink: Sink | None = None,
     room: str | None = None,
     heartbeat: bool = False,
+    transcript: bool = True,
 ) -> str:
     """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
 
@@ -347,6 +348,14 @@ def attach(
             ``register_worker("agent", local=True)`` at your ``__main__`` boot
             instead, and do not also pass ``heartbeat=True`` there (the subprocess
             would become a second writer of the same roster row).
+        transcript: capture the call transcript (default on). On close, the
+            user/agent text turns are read from the framework's conversation
+            history and written to the local store, so the Calls page can show
+            the conversation. Pass ``transcript=False`` to disable per attach, or
+            set ``VOICEGW_TRANSCRIPTS=0`` to disable capture fleet-wide (the
+            kill-switch wins over the argument). Captures to the local SQLite the
+            co-located dashboard reads; currently LiveKit-only (the Pipecat path
+            accepts the flag but does not capture transcripts yet).
 
     Returns:
         The correlation session id stamped on every captured row.
@@ -366,6 +375,7 @@ def attach(
             api_key=api_key,
             sink=sink,
             heartbeat=heartbeat,
+            transcript=transcript,
         )
     return _attach_livekit(
         session,
@@ -377,7 +387,44 @@ def attach(
         sink=sink,
         room=room,
         heartbeat=heartbeat,
+        transcript=transcript,
     )
+
+
+def _transcripts_enabled(param: bool) -> bool:
+    """Whether to capture transcripts: the ``attach(transcript=)`` flag, unless
+    the ``VOICEGW_TRANSCRIPTS`` kill-switch explicitly disables it fleet-wide."""
+    env = os.environ.get("VOICEGW_TRANSCRIPTS")
+    if env is not None and env.strip().lower() in ("0", "false", "no", "off"):
+        return False
+    return param
+
+
+async def _capture_transcript_from_history(
+    session: Any, session_id: str, storage: Any, tenant_id: str | None
+) -> None:
+    """Best-effort: persist the call transcript from the framework history.
+
+    Reads the AgentSession's conversation history (populated by close time), keeps
+    the user/agent text turns (mapping the ``assistant`` role to ``agent``), and
+    writes them to the local transcript store. Never raises: a capture failure
+    must not affect the agent.
+    """
+    try:
+        history = getattr(session, "history", None)
+        items = getattr(history, "items", None)
+        if not items:
+            return
+        turns: list[tuple[str, str]] = []
+        for item in items:
+            role = getattr(item, "role", None)
+            body = getattr(item, "text_content", None)
+            if role in ("user", "assistant") and isinstance(body, str) and body.strip():
+                turns.append(("agent" if role == "assistant" else "user", body))
+        if turns:
+            await storage.write_transcript(session_id, turns, tenant_id=tenant_id)
+    except Exception:  # noqa: BLE001 - transcripts are never load-bearing
+        logger.debug("attach: transcript capture failed", exc_info=True)
 
 
 def _attach_livekit(
@@ -391,6 +438,7 @@ def _attach_livekit(
     sink: Sink | None = None,
     room: str | None = None,
     heartbeat: bool = False,
+    transcript: bool = True,
 ) -> str:
     """LiveKit ``attach()`` body: bind ``MetricCapture`` to an ``AgentSession``."""
     import asyncio
@@ -429,6 +477,8 @@ def _attach_livekit(
     except Exception:  # noqa: BLE001 - real session may forbid attribute set
         logger.debug("attach: could not stash capture on session", exc_info=True)
 
+    transcript_on = _transcripts_enabled(transcript)
+
     async def _finish() -> None:
         # Reconcile cumulative session.usage against the per-call rows, drain
         # in-flight writes, then flush the sink so a buffered RemoteCollectorSink
@@ -437,6 +487,14 @@ def _attach_livekit(
         await capture.reconcile(session)
         await capture.drain()
         await sink.flush()
+        if transcript_on:
+            # LocalSqliteSink exposes the storage the co-located dashboard reads;
+            # remote/ClickHouse sinks have no local transcript store (None -> skip).
+            storage = getattr(sink, "_storage", None)
+            if storage is not None:
+                await _capture_transcript_from_history(
+                    session, session_id, storage, tenant_id
+                )
 
     def _on_close(*_args: Any, **_kwargs: Any) -> None:
         try:
@@ -572,13 +630,19 @@ def _attach_pipecat(
     api_key: str | None = None,
     sink: Sink | None = None,
     heartbeat: bool = False,
+    transcript: bool = True,
 ) -> str:
     """Register a ``VoiceGatewayObserver`` on a Pipecat ``PipelineTask``.
 
     Mirrors the LiveKit ``attach`` path: builds the same sink, stamps the tenant
     ContextVar, and returns the correlation session id. The observer is the sole
     meter; it finalizes itself on the pipeline ``EndFrame`` (drain + flush).
+
+    ``transcript`` is accepted for signature parity with the LiveKit path but is
+    not captured on Pipecat yet (its transcript would come from transcription
+    frames, a separate hook); it is a no-op here.
     """
+    _ = transcript  # reserved: Pipecat transcript capture is a future step
     from voicegateway.inference.pipecat.observer import VoiceGatewayObserver
 
     resolved_agent_id = agent_id or _default_agent_id()

--- a/src/voicegateway/models/__init__.py
+++ b/src/voicegateway/models/__init__.py
@@ -26,6 +26,7 @@ from voicegateway.models.replay_event_model import (
 from voicegateway.models.request_model import Request, RequestRecord
 from voicegateway.models.session_model import Session
 from voicegateway.models.tenant_model import Tenant
+from voicegateway.models.transcript_turn_model import TranscriptTurn
 from voicegateway.models.turn_model import Turn
 from voicegateway.models.worker_model import Worker
 
@@ -48,6 +49,7 @@ __all__ = [
     "RequestRecord",
     "Session",
     "Tenant",
+    "TranscriptTurn",
     "Turn",
     "Worker",
     "ApiKey",

--- a/src/voicegateway/models/transcript_turn_model.py
+++ b/src/voicegateway/models/transcript_turn_model.py
@@ -1,0 +1,31 @@
+"""ORM model for the ``transcript_turns`` table."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sqlalchemy import Index
+from sqlalchemy import text as sa_text
+from sqlmodel import Field, SQLModel
+
+
+class TranscriptTurn(SQLModel, table=True):
+    """One spoken turn's transcript within a voice session (user or agent).
+
+    Captured best-effort from the framework's conversation history when a call
+    ends. ``seq`` orders the turns within a session; ``role`` is ``user`` or
+    ``agent``.
+    """
+
+    __tablename__: ClassVar[str] = "transcript_turns"
+    __table_args__ = (Index("idx_transcript_turns_session_id", "session_id"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    session_id: str
+    seq: int
+    role: str  # 'user' | 'agent'
+    text: str
+    created_at: str = Field(
+        sa_column_kwargs={"server_default": sa_text("CURRENT_TIMESTAMP")}
+    )
+    tenant_id: str | None = None

--- a/src/voicegateway/repository/transcript_turns_repository.py
+++ b/src/voicegateway/repository/transcript_turns_repository.py
@@ -1,0 +1,93 @@
+"""Async repo for the ``transcript_turns`` table (per-call transcripts)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from voicegateway.inference.session.context import current_tenant
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclass
+class TranscriptTurnRow:
+    """One transcript turn as returned to the API/UI."""
+
+    session_id: str
+    seq: int
+    role: str
+    text: str
+    created_at: str | None = None
+
+
+_INSERT = text(
+    "INSERT INTO transcript_turns (session_id, seq, role, text, tenant_id) "
+    "VALUES (:session_id, :seq, :role, :text, :tenant_id)"
+)
+
+
+async def create_transcript_bulk(
+    session: AsyncSession,
+    session_id: str,
+    turns: list[tuple[str, str]],
+    *,
+    tenant_id: str | None = None,
+) -> int:
+    """Replace a session's transcript with ``turns`` (a list of (role, text)).
+
+    Deletes any existing rows for the session first, so a re-capture (e.g. a
+    close handler that runs twice) is idempotent rather than doubling the
+    transcript. ``seq`` is assigned from list order. Returns the count inserted.
+    """
+    resolved = tenant_id if tenant_id is not None else current_tenant()
+    await session.execute(
+        text("DELETE FROM transcript_turns WHERE session_id = :session_id"),
+        {"session_id": session_id},
+    )
+    if not turns:
+        await session.commit()
+        return 0
+    params = [
+        {
+            "session_id": session_id,
+            "seq": i,
+            "role": role,
+            "text": body,
+            "tenant_id": resolved,
+        }
+        for i, (role, body) in enumerate(turns)
+    ]
+    await session.execute(_INSERT, params)
+    await session.commit()
+    return len(params)
+
+
+async def list_transcript_by_session(
+    session: AsyncSession, session_id: str
+) -> list[TranscriptTurnRow]:
+    """Return a session's transcript turns, ordered by ``seq`` ASC."""
+    result = await session.execute(
+        text(
+            "SELECT session_id, seq, role, text, created_at "
+            "FROM transcript_turns WHERE session_id = :session_id "
+            "ORDER BY seq ASC"
+        ),
+        {"session_id": session_id},
+    )
+    return [
+        TranscriptTurnRow(
+            session_id=row[0], seq=row[1], role=row[2], text=row[3], created_at=row[4]
+        )
+        for row in result
+    ]
+
+
+__all__ = [
+    "TranscriptTurnRow",
+    "create_transcript_bulk",
+    "list_transcript_by_session",
+]

--- a/src/voicegateway/server/api/dashboard/sessions.py
+++ b/src/voicegateway/server/api/dashboard/sessions.py
@@ -3,6 +3,7 @@
 - GET /api/sessions: list recent sessions
 - GET /api/sessions/{id}: single-session details
 - GET /api/sessions/{id}/turns: per-turn rows
+- GET /api/sessions/{id}/transcript: per-turn call transcript
 - GET /api/sessions/{id}/dead_air: dead-air events for one session
 
 The replay endpoints on /api/sessions/{id}/replay live in
@@ -115,6 +116,22 @@ async def get_session_turns(
         "session_id": session_id,
         "turns": [dataclasses.asdict(t) for t in rows],
     }
+
+
+@router.get("/{session_id}/transcript")
+async def get_session_transcript(
+    session_id: str, gateway: Gateway = Depends(get_gateway)
+) -> dict[str, Any]:
+    """Return the ordered per-turn transcript for a call.
+
+    Populated when transcript capture is on (``attach(transcript=True)``, the
+    default). Returns an empty list (not a 404) when a call has no captured
+    transcript, so the UI can show a clean empty state.
+    """
+    if gateway.storage is None:
+        return {"session_id": session_id, "turns": []}
+    turns = await gateway.storage.get_transcript(session_id)
+    return {"session_id": session_id, "turns": turns}
 
 
 @router.get("/{session_id}/dead_air")

--- a/src/voicegateway/services/retention_service.py
+++ b/src/voicegateway/services/retention_service.py
@@ -33,6 +33,7 @@ _DEFAULT_BATCH_SIZE: Final[int] = 500
 _SESSION_CHILD_TABLES: Final[tuple[str, ...]] = (
     "turns",
     "dead_air_events",
+    "transcript_turns",
 )
 
 

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -315,6 +315,39 @@ class StorageService:
         await self._session_service.finalize_replay(session_id)
 
     # ------------------------------------------------------------------
+    # Transcripts
+    # ------------------------------------------------------------------
+
+    async def write_transcript(
+        self,
+        session_id: str,
+        turns: list[tuple[str, str]],
+        *,
+        tenant_id: str | None = None,
+    ) -> int:
+        """Replace a session's transcript with ``turns`` ((role, text) list)."""
+        from voicegateway.repository import transcript_turns_repository
+
+        await self._ensure_initialized()
+        async with self._conn.session() as db:
+            return await transcript_turns_repository.create_transcript_bulk(
+                db, session_id, turns, tenant_id=tenant_id
+            )
+
+    async def get_transcript(self, session_id: str) -> list[dict[str, Any]]:
+        """Return a session's transcript turns, ordered, as dicts."""
+        import dataclasses
+
+        from voicegateway.repository import transcript_turns_repository
+
+        await self._ensure_initialized()
+        async with self._conn.session() as db:
+            rows = await transcript_turns_repository.list_transcript_by_session(
+                db, session_id
+            )
+        return [dataclasses.asdict(r) for r in rows]
+
+    # ------------------------------------------------------------------
     # Managed providers / models / projects
     # ------------------------------------------------------------------
 

--- a/src/voicegateway/tests/inference/test_transcript_capture.py
+++ b/src/voicegateway/tests/inference/test_transcript_capture.py
@@ -1,0 +1,84 @@
+"""attach transcript capture: history extraction + kill-switch."""
+
+from __future__ import annotations
+
+from voicegateway.inference.session.attach import (
+    _capture_transcript_from_history,
+    _transcripts_enabled,
+)
+
+
+class _Msg:
+    def __init__(self, role, text_content):
+        self.role = role
+        self.text_content = text_content
+
+
+class _History:
+    def __init__(self, items):
+        self.items = items
+
+
+class _Session:
+    def __init__(self, items):
+        self.history = _History(items)
+
+
+class _FakeStorage:
+    def __init__(self):
+        self.calls = []
+
+    async def write_transcript(self, session_id, turns, *, tenant_id=None):
+        self.calls.append((session_id, turns, tenant_id))
+        return len(turns)
+
+
+async def test_capture_extracts_user_and_agent_text():
+    session = _Session(
+        [
+            _Msg("user", "hello"),
+            _Msg("assistant", "hi there"),
+            _Msg("system", "you are a bot"),  # non-conversational role: dropped
+            _Msg("user", "   "),  # blank: dropped
+            _Msg("user", "bye"),
+        ]
+    )
+    storage = _FakeStorage()
+    await _capture_transcript_from_history(session, "s1", storage, "acme")
+    assert storage.calls == [
+        ("s1", [("user", "hello"), ("agent", "hi there"), ("user", "bye")], "acme")
+    ]
+
+
+async def test_capture_no_history_is_noop():
+    storage = _FakeStorage()
+    await _capture_transcript_from_history(_Session(None), "s1", storage, None)
+    assert storage.calls == []
+
+
+async def test_capture_never_raises_on_bad_storage():
+    class Boom:
+        async def write_transcript(self, *a, **k):
+            raise RuntimeError("db down")
+
+    # A capture failure must be swallowed, never surfaced to the agent.
+    await _capture_transcript_from_history(
+        _Session([_Msg("user", "hi")]), "s1", Boom(), None
+    )
+
+
+def test_transcripts_enabled_defaults_to_param(monkeypatch):
+    monkeypatch.delenv("VOICEGW_TRANSCRIPTS", raising=False)
+    assert _transcripts_enabled(True) is True
+    assert _transcripts_enabled(False) is False
+
+
+def test_transcripts_killswitch_disables(monkeypatch):
+    for v in ("0", "false", "no", "off", "OFF"):
+        monkeypatch.setenv("VOICEGW_TRANSCRIPTS", v)
+        assert _transcripts_enabled(True) is False
+
+
+def test_transcripts_killswitch_truthy_keeps_param(monkeypatch):
+    monkeypatch.setenv("VOICEGW_TRANSCRIPTS", "1")
+    assert _transcripts_enabled(True) is True

--- a/src/voicegateway/tests/repository/test_transcript_turns_repository.py
+++ b/src/voicegateway/tests/repository/test_transcript_turns_repository.py
@@ -1,0 +1,59 @@
+"""TDD for transcript_turns_repository: replace-on-write + ordered read."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel
+
+from voicegateway.models.transcript_turn_model import (  # noqa: F401 - registers table
+    TranscriptTurn,
+)
+from voicegateway.repository import transcript_turns_repository as tr
+
+
+@pytest.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    session = AsyncSession(engine)
+    try:
+        yield session
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+async def test_create_and_list_preserves_order(db):
+    n = await tr.create_transcript_bulk(
+        db, "s1", [("user", "hi"), ("agent", "hello"), ("user", "bye")]
+    )
+    assert n == 3
+    rows = await tr.list_transcript_by_session(db, "s1")
+    assert [(r.seq, r.role, r.text) for r in rows] == [
+        (0, "user", "hi"),
+        (1, "agent", "hello"),
+        (2, "user", "bye"),
+    ]
+
+
+async def test_rewrite_replaces_not_appends(db):
+    await tr.create_transcript_bulk(db, "s1", [("user", "first")])
+    await tr.create_transcript_bulk(db, "s1", [("user", "again"), ("agent", "ok")])
+    rows = await tr.list_transcript_by_session(db, "s1")
+    assert [(r.role, r.text) for r in rows] == [("user", "again"), ("agent", "ok")]
+
+
+async def test_empty_turns_clears(db):
+    await tr.create_transcript_bulk(db, "s1", [("user", "hi")])
+    n = await tr.create_transcript_bulk(db, "s1", [])
+    assert n == 0
+    assert await tr.list_transcript_by_session(db, "s1") == []
+
+
+async def test_scoped_to_session(db):
+    await tr.create_transcript_bulk(db, "s1", [("user", "a")])
+    await tr.create_transcript_bulk(db, "s2", [("user", "b")])
+    assert len(await tr.list_transcript_by_session(db, "s1")) == 1
+    assert len(await tr.list_transcript_by_session(db, "s2")) == 1

--- a/src/voicegateway/tests/server/test_sessions_transcript_endpoint.py
+++ b/src/voicegateway/tests/server/test_sessions_transcript_endpoint.py
@@ -1,0 +1,44 @@
+"""GET /api/sessions/{id}/transcript serves stored transcript turns."""
+
+from __future__ import annotations
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+
+
+def _gateway(tmp_path, monkeypatch) -> Gateway:
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "transcript.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump({"cost_tracking": {"enabled": True}}))
+    return Gateway(config_path=str(path))
+
+
+def _client(gw: Gateway) -> AsyncClient:
+    return AsyncClient(
+        transport=ASGITransport(app=build_app(gw)), base_url="http://test"
+    )
+
+
+async def test_transcript_endpoint_returns_ordered_turns(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    await gw.storage.write_transcript(
+        "call-1", [("user", "hi"), ("agent", "hello there")]
+    )
+    async with _client(gw) as c:
+        data = (await c.get("/api/sessions/call-1/transcript")).json()
+    assert data["session_id"] == "call-1"
+    assert [(t["role"], t["text"]) for t in data["turns"]] == [
+        ("user", "hi"),
+        ("agent", "hello there"),
+    ]
+
+
+async def test_transcript_endpoint_empty_for_unknown_call(tmp_path, monkeypatch):
+    gw = _gateway(tmp_path, monkeypatch)
+    async with _client(gw) as c:
+        data = (await c.get("/api/sessions/nope/transcript")).json()
+    assert data == {"session_id": "nope", "turns": []}

--- a/src/voicegateway/tests/services/test_retention_transcript_child.py
+++ b/src/voicegateway/tests/services/test_retention_transcript_child.py
@@ -1,0 +1,9 @@
+"""transcript_turns must age out with its session, like turns/dead_air."""
+
+from __future__ import annotations
+
+from voicegateway.services.retention_service import _SESSION_CHILD_TABLES
+
+
+def test_transcript_turns_is_a_session_child_table():
+    assert "transcript_turns" in _SESSION_CHILD_TABLES


### PR DESCRIPTION
## What

Capture and display **per-call transcripts** for easier analysis. On a LiveKit call's close, the user/agent text turns are read from the AgentSession's conversation history and persisted; the **Calls detail modal** shows them as role-aligned bubbles (agent left, user right).

Transcript capture is **on by default**, as requested.

## Privacy posture (please review)

VG is a cost profiler, and default-on capture writes raw user utterance text (PII) into the local DB. This ships with the agreed safeguards:

- **`attach(transcript=False)`** disables it per agent.
- **`VOICEGW_TRANSCRIPTS=0`** is a fleet-wide kill-switch that **wins over** the argument.
- **Retention**: `transcript_turns` is a session child table, so it ages out with the call via the retention worker (no unbounded PII growth).

## How

**Backend**
- New `TranscriptTurn` model + migration `b7d2f4a9c1e3` (single head, off `worker_memory`).
- `transcript_turns_repository`: **replace-on-write** (a close handler that runs twice can't double the transcript) + ordered read.
- `StorageService.write_transcript` / `get_transcript`; `GET /api/sessions/{id}/transcript` (returns an empty list, not 404, so the UI shows a clean empty state).
- `attach`: `transcript` param threaded through the LiveKit + Pipecat paths. Capture reads `session.history` on close, keeps user/agent text turns (maps `assistant`→`agent`), and writes best-effort (a failure is swallowed, never surfaced to the agent).

**Frontend** — a Transcript pane in the Calls detail modal, lazily fetched. No per-turn timestamp (turns are persisted together at close, so a per-turn time would mislead).

## Scope

- Captures to the **local co-located sink** (`LocalSqliteSink`) the dashboard reads. Remote / ClickHouse sinks have no local transcript store and skip capture.
- **LiveKit-only** for now; the Pipecat path accepts the flag as a documented no-op (its transcript would come from transcription frames, a separate hook).

## Tests

New: repo (replace/order/scope), capture (history extraction, role mapping, kill-switch, swallow-on-error), endpoint (ordered turns, empty for unknown), retention (child-table). Migration proven to apply by the endpoint test running `alembic upgrade`. mypy clean; `tsc -b && vite build` passes.

## Not auto-merged

Held for your review: this is a schema migration + a privacy-posture change, so I did not enable auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)