### PR TITLE
fix(migrations): merge the two alembic heads breaking main

### DIFF
--- a/alembic/versions/06836270c254_merge_transcript_turns_and_agent_probe_.py
+++ b/alembic/versions/06836270c254_merge_transcript_turns_and_agent_probe_.py
@@ -1,0 +1,27 @@
+"""merge transcript_turns and agent_probe_results heads
+
+Revision ID: 06836270c254
+Revises: b7d2f4a9c1e3, d2f6b8a1c3e5
+Create Date: 2026-07-25 19:05:24.608573
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlmodel  # noqa: F401 — generated migrations may reference SQLModel types
+
+revision: str = "06836270c254"
+# Two parents: this migration merges the transcript_turns (#151) and
+# agent_probe_results (#153) heads, which both branched off worker_memory.
+down_revision: str | Sequence[str] | None = ("b7d2f4a9c1e3", "d2f6b8a1c3e5")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## The failure

The Postgres collector integration test started failing on `main` after the
v0.21.0 merges: https://github.com/mahimailabs/voicegateway/actions/runs/30178631514

## Root cause: forked migration graph → two heads

#151 and #153 each added a migration that branched off `f3c8a1d5e9b2`
(worker_memory):

```
f3c8a1d5e9b2 (worker_memory)
├─ b8f4a1c2d7e9 (dispatch_name, #152) → c9d1e5f7a2b4 (cpu_pct) → d2f6b8a1c3e5 (agent_probe_results)   [head 1]
└─ b7d2f4a9c1e3 (transcript_turns, #151)                                                              [head 2]
```

Each PR passed CI on its own branch (one head each). Merging both left `main`
with **two heads**, so `alembic upgrade head` fails with *"Multiple head
revisions are present; please specify a single head"*. The Postgres "dialect"
job runs real migrations, so it caught it; SQLite paths that use `create_all`
did not.

## Fix

A no-op **merge migration** (`06836270c254`) with both heads as parents,
unifying the graph to a single head. This is safe for every existing DB (one on
either head advances cleanly), unlike re-pointing an already-shipped migration.

## Verified
- `alembic heads` → single head `06836270c254`.
- The exact failing test (`tests/integration/test_postgres_collector.py`) **passes
  against a real Postgres 16** locally.
- Repository suite green; no test pins a head revision.

## After merge
v0.21.0 shipped with the fork, so this wants a **v0.21.1** patch tag once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated two database migration branches into a single migration path.
  * No direct user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->