### PR TITLE
fix: announce Agents table sort order

### DIFF
--- a/src/dashboard/frontend/src/pages/Agents.tsx
+++ b/src/dashboard/frontend/src/pages/Agents.tsx
@@ -256,6 +256,7 @@ export default function Agents() {
                 {COLUMNS.slice(0, 1).map((c) => (
                   <th
                     key={c.key}
+                    aria-sort={sortKey === c.key ? (sortAsc ? 'ascending' : 'descending') : 'none'}
                     onClick={() => onSort(c.key)}
                     style={{ cursor: 'pointer', userSelect: 'none' }}
                   >
@@ -267,6 +268,7 @@ export default function Agents() {
                 {COLUMNS.slice(1).map((c) => (
                   <th
                     key={c.key}
+                    aria-sort={sortKey === c.key ? (sortAsc ? 'ascending' : 'descending') : 'none'}
                     onClick={() => onSort(c.key)}
                     style={{ cursor: 'pointer', userSelect: 'none' }}
                   >


### PR DESCRIPTION
## Summary
- add `aria-sort` to each sortable Agents table header
- expose ascending/descending state for the active column and `none` for the remaining sortable columns
- leave non-sortable headers and visual behavior unchanged

Closes #158

## Validation
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added sort direction indicators to sortable table headers, improving screen reader support when navigating agent lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->