### PR TITLE
ci: auto-assign issues on a .take comment

### DIFF
--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,0 +1,59 @@
+name: Assign issue on .take
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  take:
+    # Only on issues (not PRs), and only when the comment starts with ".take"
+    if: >
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '.take')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const issue = context.payload.issue;
+            const assignees = issue.assignees || [];
+
+            // Trigger only on a bare ".take" (ignore trailing whitespace).
+            if (context.payload.comment.body.trim() !== '.take') return;
+
+            // First .take wins: if already assigned to someone else, say so.
+            if (assignees.length > 0) {
+              if (assignees.some(a => a.login === commenter)) return; // already theirs
+              const current = assignees.map(a => '@' + a.login).join(', ');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `This one is already assigned to ${current}. @${commenter}, please pick another open issue, or ask here if it looks stale.`,
+              });
+              return;
+            }
+
+            // Assign the commenter.
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: issue.number, assignees: [commenter],
+            });
+
+            // GitHub silently drops assignees it won't allow, so confirm it stuck.
+            const { data: updated } = await github.rest.issues.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: issue.number,
+            });
+            const gotIt = (updated.assignees || []).some(a => a.login === commenter);
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: issue.number,
+              body: gotIt
+                ? `Assigned to @${commenter}. Thanks for taking this! Open a PR with \`Closes #${issue.number}\` when it is ready, and comment here if you get stuck.`
+                : `@${commenter} I could not auto-assign you (GitHub only allows it for people who have interacted with the repo before). A maintainer will assign you shortly.`,
+            });

--- a/alembic/versions/06836270c254_merge_transcript_turns_and_agent_probe_.py
+++ b/alembic/versions/06836270c254_merge_transcript_turns_and_agent_probe_.py
@@ -1,0 +1,27 @@
+"""merge transcript_turns and agent_probe_results heads
+
+Revision ID: 06836270c254
+Revises: b7d2f4a9c1e3, d2f6b8a1c3e5
+Create Date: 2026-07-25 19:05:24.608573
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlmodel  # noqa: F401 — generated migrations may reference SQLModel types
+
+revision: str = "06836270c254"
+# Two parents: this migration merges the transcript_turns (#151) and
+# agent_probe_results (#153) heads, which both branched off worker_memory.
+down_revision: str | Sequence[str] | None = ("b7d2f4a9c1e3", "d2f6b8a1c3e5")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

Adds `.github/workflows/take.yml` so a contributor can claim an open issue by commenting `.take`. This is the last piece of the contributor on-ramp: label good-first-issues, `.take` to claim, open a PR with `Closes #<n>`.

## Behavior

- Fires on `issue_comment` (created). The job `if:` filter skips PRs and any comment not starting with `.take`, so a runner rarely spins up.
- A bare `.take` self-assigns the commenter and posts a short confirmation.
- **First take wins:** if the issue is already assigned to someone else, a later `.take` gets a polite "pick another one" reply instead of reassigning.
- If GitHub refuses the assignment (only happens for accounts with no prior repo interaction), it posts a note instead of failing silently.

## Security

Untrusted event input (`comment.body`, `comment.user.login`) is read through the `actions/github-script` `context` object in JavaScript and used only as data (comparisons and API request bodies). It is never interpolated into a `run:` shell or into the `script:` body via `${{ }}`, so there is no command-injection surface. The single `${{ }}` use is `startsWith(github.event.comment.body, '.take')` inside the job `if:`, evaluated by the Actions expression engine.

## Permissions

Uses only the built-in `GITHUB_TOKEN` with `issues: write` (declared in the workflow). No secrets. The explicit `permissions:` block grants the needed scope even if the repo default is read-only.

## How to test

After merge, comment `.take` on any open issue. It should assign you and reply. Comment `.take` on an already-assigned issue from a different account to see the first-wins path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an issue workflow that lets users claim unassigned issues by commenting `.take`.
  * The first valid claimant is assigned automatically, with clear responses for already-assigned issues or unsuccessful assignments.

* **Chores**
  * Consolidated database migration history without changing the application schema or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->