### PR TITLE
ci: build the dashboard frontend on PRs that touch it

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,33 @@
+name: Frontend
+
+# The Python CI (ci.yml) does not build the dashboard frontend, so a
+# frontend-only PR could merge with a TypeScript error that only surfaces
+# at `voicegw dashboard` build time. This job type-checks and builds the
+# Vite app on any PR that touches it. `npm run build` runs `tsc -b`, so a
+# type error fails the job.
+
+on:
+  pull_request:
+    paths:
+      - 'src/dashboard/frontend/**'
+      - '.github/workflows/frontend.yml'
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/dashboard/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: src/dashboard/frontend/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Build (tsc + vite)
+        run: npm run build


### PR DESCRIPTION
## Summary

Adds `.github/workflows/frontend.yml`: a path-gated job that type-checks and builds the Vite dashboard on any PR touching `src/dashboard/frontend/**`.

## Why

The Python CI (`ci.yml`) only runs on `src/voicegateway/**`, `src/dashboard/api/**`, and `pyproject.toml`. It never builds the frontend. So a frontend-only PR (like the recent good-first-issues) can merge with a TypeScript error that only surfaces later at `voicegw dashboard` build time. This job closes that gap: `npm run build` runs `tsc -b`, so a type error fails the check.

## Behavior

- Triggers only on PRs that change `src/dashboard/frontend/**` (or this workflow file), so backend PRs are unaffected.
- Steps: checkout, Node 20 with npm cache, `npm ci`, `npm run build`.
- Uses `pull_request` (not `pull_request_target`), so contributor code builds with a read-only token and no secret access. No untrusted input is interpolated into any `run:` step.

## Validation

Ran `npm ci && npm run build` locally against the current frontend: clean (`tsc -b && vite build`, exit 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated frontend build validation for pull requests affecting the dashboard frontend.
  * The check installs dependencies and verifies that the frontend builds successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->