### PR TITLE
test: cover parse_rate_limit unit aliases

### DIFF
--- a/src/voicegateway/tests/inference/test_guard.py
+++ b/src/voicegateway/tests/inference/test_guard.py
@@ -185,6 +185,23 @@ def test_parse_rate_limit_rejects_garbage():
         parse_rate_limit("banana")
 
 
+@pytest.mark.parametrize(
+    "spec, per_seconds",
+    [
+        ("60/sec", 1.0),
+        ("60/second", 1.0),
+        ("60/minute", 60.0),
+        ("60/m", 60.0),
+        ("5/s", 1.0),
+        ("60/MIN", 60.0),  # case-insensitive
+        (" 60 / s ", 1.0),  # whitespace tolerant
+    ],
+)
+def test_parse_rate_limit_unit_aliases(spec, per_seconds):
+    result = parse_rate_limit(spec)
+    assert result.per_seconds == per_seconds
+
+
 def test_parse_budget_dollar_per_day():
     spec = parse_budget("$5.00/day")
     assert spec.amount_usd == 5.0

--- a/src/voicegateway/tests/inference/test_guard.py
+++ b/src/voicegateway/tests/inference/test_guard.py
@@ -198,6 +198,15 @@ def test_parse_rate_limit_rejects_garbage():
     ],
 )
 def test_parse_rate_limit_unit_aliases(spec, per_seconds):
+    """Verify unit aliases parse to the expected number of seconds.
+
+    Args:
+        spec: The rate-limit specification to parse.
+        per_seconds: The expected normalized interval in seconds.
+
+    Returns:
+        None.
+    """
     result = parse_rate_limit(spec)
     assert result.per_seconds == per_seconds
 


### PR DESCRIPTION
## Summary

Adds parametrized test coverage for supported `parse_rate_limit` unit aliases, including:

- second aliases
- minute aliases
- case-insensitive input
- whitespace-tolerant input

## Testing

```text
.venv\Scripts\python.exe -m pytest src/voicegateway/tests/inference/test_guard.py
27 passed in 1.75s
```

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for rate-limit parsing.
  * Added validation for unit aliases (e.g., second/sec, minute/min), case-insensitive units, and inputs with extra whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->