### PR TITLE
Update 4o -> 4.1 in walkthrough docs

### DIFF
--- a/docs/api/python-sdk.md
+++ b/docs/api/python-sdk.md
@@ -174,7 +174,7 @@ async def entrypoint(ctx):
             rate_limit=60,
         ),
         llm=guard(
-            openai.LLM(model="gpt-4o-mini"),
+            openai.LLM(model="gpt-4.1-mini"),
             fallback=[openai.LLM(model="gpt-4.1-nano")],
             budget=0.05,
         ),

--- a/docs/examples/basic-voice-agent.md
+++ b/docs/examples/basic-voice-agent.md
@@ -66,7 +66,7 @@ async def entrypoint(ctx: JobContext):
     session = AgentSession(
         vad=silero.VAD.load(),
         stt=deepgram.STT(model="nova-3"),
-        llm=openai.LLM(model="gpt-4o-mini"),
+        llm=openai.LLM(model="gpt-4.1-mini"),
         tts=cartesia.TTS(model="sonic-3"),
     )
 
@@ -99,7 +99,7 @@ from voicegateway import attach
 
 def build_task(transport_input, transport_output):
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
-    llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4o-mini")
+    llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4.1-mini")
     tts = CartesiaTTSService(api_key=os.environ["CARTESIA_API_KEY"])
 
     pipeline = Pipeline([transport_input, stt, llm, tts, transport_output])

--- a/docs/examples/budget-enforcement.md
+++ b/docs/examples/budget-enforcement.md
@@ -15,22 +15,22 @@ from voicegateway import guard
 
 # warn: log and continue (default when you pass budget= without budget_action)
 llm_warn = guard(
-    openai.LLM(model="gpt-4o-mini"),
+    openai.LLM(model="gpt-4.1-mini"),
     budget="$5.00/day",
     project="warn-demo",
 )
 
 # throttle: fall back to a cheaper provider when the budget is exceeded
 llm_throttle = guard(
-    openai.LLM(model="gpt-4o-mini"),
-    fallback=[openai.LLM(model="gpt-4o-mini")],   # swap in a local/cheaper model
+    openai.LLM(model="gpt-4.1-mini"),
+    fallback=[openai.LLM(model="gpt-4.1-mini")],   # swap in a local/cheaper model
     budget="$5.00/day",
     project="throttle-demo",
 )
 
 # block: raise BudgetExceededError when the budget is exceeded
 llm_block = guard(
-    openai.LLM(model="gpt-4o-mini"),
+    openai.LLM(model="gpt-4.1-mini"),
     budget="$5.00/day",
     project="block-demo",
 )
@@ -121,8 +121,8 @@ async def entrypoint(ctx):
         vad=silero.VAD.load(),
         stt=...,
         llm=guard(
-            openai.LLM(model="gpt-4o-mini"),
-            fallback=[openai.LLM(model="gpt-4o-mini")],  # local or cheaper model
+            openai.LLM(model="gpt-4.1-mini"),
+            fallback=[openai.LLM(model="gpt-4.1-mini")],  # local or cheaper model
             budget="$1.00/day",
             project="throttle-demo",
         ),
@@ -147,7 +147,7 @@ from voicegateway.middleware.budget_enforcer import BudgetExceededError
 
 async def main():
     guarded_llm = guard(
-        openai.LLM(model="gpt-4o-mini"),
+        openai.LLM(model="gpt-4.1-mini"),
         budget="$1.00/day",
         project="block-demo",
     )

--- a/docs/examples/fallback-chains.md
+++ b/docs/examples/fallback-chains.md
@@ -61,7 +61,7 @@ def build_session():
             project="prod",
         ),
         llm=guard(
-            openai.LLM(model="gpt-4o-mini"),
+            openai.LLM(model="gpt-4.1-mini"),
             fallback=[
                 groq_plugin.LLM(model="llama-3.3-70b-versatile"),
             ],
@@ -102,7 +102,7 @@ async def entrypoint(ctx: JobContext):
             project=PROJECT,
         ),
         llm=guard(
-            openai.LLM(model="gpt-4o-mini"),
+            openai.LLM(model="gpt-4.1-mini"),
             fallback=[groq_plugin.LLM(model="llama-3.3-70b-versatile")],
             project=PROJECT,
         ),
@@ -150,7 +150,7 @@ fallbacks:
     - openai/whisper-1
     - local/whisper-large-v3
   llm:
-    - openai/gpt-4o-mini
+    - openai/gpt-4.1-mini
     - groq/llama-3.3-70b-versatile
     - ollama/qwen2.5:3b
   tts:

--- a/docs/examples/livekit-attach-guard.md
+++ b/docs/examples/livekit-attach-guard.md
@@ -46,8 +46,8 @@ def build_session():
         stt=deepgram.STT(model="nova-3"),
         # guard() wraps ONE provider for control; it returns a drop-in LLM.
         llm=voicegateway.guard(
-            openai.LLM(model="gpt-4o-mini"),
-            fallback=[openai.LLM(model="gpt-4o")],
+            openai.LLM(model="gpt-4.1-mini"),
+            fallback=[openai.LLM(model="gpt-4.1")],
             rate_limit="60/min",
             budget="$5.00/day",
             project=PROJECT,

--- a/docs/examples/livekit-fallback-adapter.md
+++ b/docs/examples/livekit-fallback-adapter.md
@@ -39,8 +39,8 @@ async def entrypoint(ctx: JobContext):
             openai.STT(model="whisper-1"),          # secondary cloud
         ]),
         llm=llm.FallbackAdapter([
-            openai.LLM(model="gpt-4o-mini"),
-            lk_openai.LLM(model="gpt-4o"),
+            openai.LLM(model="gpt-4.1-mini"),
+            lk_openai.LLM(model="gpt-4.1"),
         ]),
         tts=tts.FallbackAdapter([
             cartesia.TTS(model="sonic-3"),

--- a/docs/examples/multi-project.md
+++ b/docs/examples/multi-project.md
@@ -78,7 +78,7 @@ async def production_entrypoint(ctx: JobContext):
     session = AgentSession(
         vad=silero.VAD.load(),
         stt=deepgram.STT(model="nova-3"),
-        llm=openai.LLM(model="gpt-4o-mini"),
+        llm=openai.LLM(model="gpt-4.1-mini"),
         tts=cartesia.TTS(model="sonic-3"),
     )
 
@@ -97,7 +97,7 @@ async def staging_entrypoint(ctx: JobContext):
     session = AgentSession(
         vad=silero.VAD.load(),
         stt=deepgram.STT(model="nova-3"),
-        llm=openai.LLM(model="gpt-4o-mini"),
+        llm=openai.LLM(model="gpt-4.1-mini"),
         tts=cartesia.TTS(model="sonic-3"),
     )
 
@@ -123,7 +123,7 @@ from pipecat.services.openai.llm import OpenAILLMService
 
 def build_task(transport_input, transport_output, *, project: str):
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
-    llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4o-mini")
+    llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4.1-mini")
     tts = CartesiaTTSService(api_key=os.environ["CARTESIA_API_KEY"])
 
     pipeline = Pipeline([transport_input, stt, llm, tts, transport_output])

--- a/docs/examples/pipecat-attach-guard.md
+++ b/docs/examples/pipecat-attach-guard.md
@@ -50,9 +50,9 @@ def build_task(transport_input, transport_output):
     stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
     # guard() wraps ONE service for control; it returns a drop-in service.
     llm = voicegateway.guard(
-        OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4o-mini"),
+        OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4.1-mini"),
         fallback=[
-            OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4o")
+            OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4.1")
         ],
         budget="$5.00/day",
         project=PROJECT,

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -50,7 +50,7 @@ every STT, LLM, and TTS request and writes the costs to a local dashboard.
 
             session = AgentSession(
                 stt=deepgram.STT(model="nova-3"),
-                llm=openai.LLM(model="gpt-4o-mini"),
+                llm=openai.LLM(model="gpt-4.1-mini"),
                 tts=cartesia.TTS(model="sonic-3"),
             )
 
@@ -71,7 +71,7 @@ every STT, LLM, and TTS request and writes the costs to a local dashboard.
         import voicegateway
 
         stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
-        llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4o-mini")
+        llm = OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model="gpt-4.1-mini")
         tts = CartesiaTTSService(api_key=os.environ["CARTESIA_API_KEY"], voice_id="your-voice-id")
 
         pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])

--- a/docs/guide/agency-quickstart.md
+++ b/docs/guide/agency-quickstart.md
@@ -94,7 +94,7 @@ In the agent code, pass `project="acme"` to `attach()`. Every record written dur
 
         session = AgentSession(
             stt=deepgram.STT(model="nova-3"),
-            llm=openai.LLM(model="gpt-4o-mini"),
+            llm=openai.LLM(model="gpt-4.1-mini"),
             tts=cartesia.TTS(model="sonic-3"),
         )
 
@@ -119,7 +119,7 @@ In the agent code, pass `project="acme"` to `attach()`. Every record written dur
 
     async def run_acme_agent():
         stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
-        llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini")
+        llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4.1-mini")
         tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
 
         pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])

--- a/docs/guide/attach.md
+++ b/docs/guide/attach.md
@@ -58,7 +58,7 @@ together, so you can echo it into your own logs.
 
         session = AgentSession(
             stt=deepgram.STT(model="nova-3"),
-            llm=openai.LLM(model="gpt-4o-mini"),
+            llm=openai.LLM(model="gpt-4.1-mini"),
             tts=cartesia.TTS(model="sonic-3"),
         )
 
@@ -96,7 +96,7 @@ together, so you can echo it into your own logs.
     import voicegateway
 
     stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
-    llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini")
+    llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4.1-mini")
     tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
 
     pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -42,8 +42,8 @@ The full signature is documented in [attach()](/guide/attach). The key points he
 from voicegateway import guard
 
 llm = guard(
-    openai.LLM(model="gpt-4o-mini"),
-    fallback=[openai.LLM(model="gpt-4o")],
+    openai.LLM(model="gpt-4.1-mini"),
+    fallback=[openai.LLM(model="gpt-4.1")],
     rate_limit="60/min",
     budget="$5.00/day",
 )

--- a/docs/guide/first-agent.md
+++ b/docs/guide/first-agent.md
@@ -85,8 +85,8 @@ the file for your framework, set your environment variables, and run it.
         # guard() wraps the LLM with a fallback and a daily budget.
         # It returns a drop-in openai.LLM, so AgentSession sees no difference.
         guarded_llm = voicegateway.guard(
-            openai.LLM(model="gpt-4o-mini"),
-            fallback=[openai.LLM(model="gpt-4o")],
+            openai.LLM(model="gpt-4.1-mini"),
+            fallback=[openai.LLM(model="gpt-4.1")],
             rate_limit="60/min",
             budget="$5.00/day",
             project="my-agent",
@@ -120,8 +120,8 @@ the file for your framework, set your environment variables, and run it.
     ### What happens
 
     1. `deepgram.STT` transcribes speech. `attach()` meters audio minutes and cost.
-    2. `guard(openai.LLM(...))` sends the transcript to GPT-4o mini. If GPT-4o mini
-       returns an error, `guard()` retries with GPT-4o automatically. `attach()`
+    2. `guard(openai.LLM(...))` sends the transcript to gpt-4.1 mini. If gpt-4.1 mini
+       returns an error, `guard()` retries with gpt-4.1 automatically. `attach()`
        meters prompt tokens, completion tokens, and cost.
     3. `cartesia.TTS` synthesizes speech. `attach()` meters characters and cost.
     4. Every row lands in the dashboard at `http://127.0.0.1:9090`.
@@ -189,12 +189,12 @@ the file for your framework, set your environment variables, and run it.
         llm = voicegateway.guard(
             OpenAILLMService(
                 api_key=os.environ["OPENAI_API_KEY"],
-                model="gpt-4o-mini",
+                model="gpt-4.1-mini",
             ),
             fallback=[
                 OpenAILLMService(
                     api_key=os.environ["OPENAI_API_KEY"],
-                    model="gpt-4o",
+                    model="gpt-4.1",
                 )
             ],
             rate_limit="60/min",
@@ -265,8 +265,8 @@ the file for your framework, set your environment variables, and run it.
 
     1. `DeepgramSTTService` transcribes speech. `attach()` accumulates audio bytes,
        converts them to minutes, and prices the STT.
-    2. `guard(OpenAILLMService(...))` sends the transcript to GPT-4o mini. If it
-       returns an error, `guard()` retries with GPT-4o automatically. `attach()`
+    2. `guard(OpenAILLMService(...))` sends the transcript to gpt-4.1 mini. If it
+       returns an error, `guard()` retries with gpt-4.1 automatically. `attach()`
        meters tokens and cost from the `LLMTokenUsage` frame.
     3. `CartesiaTTSService` synthesizes speech. `attach()` meters characters and cost.
     4. On pipeline end, `attach()` flushes all pending rows to the local SQLite sink

--- a/docs/guide/guard.md
+++ b/docs/guide/guard.md
@@ -80,8 +80,8 @@ voicegateway.guard(
         session = AgentSession(
             stt=deepgram.STT(model="nova-3"),
             llm=voicegateway.guard(
-                openai.LLM(model="gpt-4o-mini"),
-                fallback=[openai.LLM(model="gpt-4o")],
+                openai.LLM(model="gpt-4.1-mini"),
+                fallback=[openai.LLM(model="gpt-4.1")],
                 rate_limit="60/min",
                 budget="$5.00/day",
             ),
@@ -113,8 +113,8 @@ voicegateway.guard(
 
     stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
     guarded_llm = voicegateway.guard(
-        OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini"),
-        fallback=[OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o")],
+        OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4.1-mini"),
+        fallback=[OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4.1")],
         rate_limit="60/min",
         budget="$5.00/day",
     )

--- a/docs/guide/multi-tenant-quickstart.md
+++ b/docs/guide/multi-tenant-quickstart.md
@@ -48,7 +48,7 @@ Your agent code knows the caller's tenant at connection time (from room metadata
 
         session = AgentSession(
             stt=deepgram.STT(model="nova-3"),
-            llm=openai.LLM(model="gpt-4o-mini"),
+            llm=openai.LLM(model="gpt-4.1-mini"),
             tts=cartesia.TTS(model="sonic-3"),
         )
 
@@ -74,7 +74,7 @@ Your agent code knows the caller's tenant at connection time (from room metadata
 
     async def run_agent(tenant_id: str):
         stt = DeepgramSTTService(api_key=DEEPGRAM_API_KEY)
-        llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4o-mini")
+        llm = OpenAILLMService(api_key=OPENAI_API_KEY, model="gpt-4.1-mini")
         tts = CartesiaTTSService(api_key=CARTESIA_API_KEY, voice_id=VOICE_ID)
 
         pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output()])

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -71,7 +71,7 @@ minimal agent, and cost rows appearing in the dashboard.
 
             session = AgentSession(
                 stt=deepgram.STT(model="nova-3"),
-                llm=openai.LLM(model="gpt-4o-mini"),
+                llm=openai.LLM(model="gpt-4.1-mini"),
                 tts=cartesia.TTS(model="sonic-3"),
             )
 
@@ -105,7 +105,7 @@ minimal agent, and cost rows appearing in the dashboard.
             stt = DeepgramSTTService(api_key=os.environ["DEEPGRAM_API_KEY"])
             llm = OpenAILLMService(
                 api_key=os.environ["OPENAI_API_KEY"],
-                model="gpt-4o-mini",
+                model="gpt-4.1-mini",
             )
             tts = CartesiaTTSService(
                 api_key=os.environ["CARTESIA_API_KEY"],
@@ -226,8 +226,8 @@ on the specific providers where you want control:
     from livekit.plugins import openai
 
     guarded_llm = voicegateway.guard(
-        openai.LLM(model="gpt-4o-mini"),
-        fallback=[openai.LLM(model="gpt-4o")],
+        openai.LLM(model="gpt-4.1-mini"),
+        fallback=[openai.LLM(model="gpt-4.1")],
         rate_limit="60/min",
         budget="$5.00/day",
     )
@@ -242,8 +242,8 @@ on the specific providers where you want control:
     from pipecat.services.openai.llm import OpenAILLMService
 
     guarded_llm = voicegateway.guard(
-        OpenAILLMService(model="gpt-4o-mini"),
-        fallback=[OpenAILLMService(model="gpt-4o")],
+        OpenAILLMService(model="gpt-4.1-mini"),
+        fallback=[OpenAILLMService(model="gpt-4.1")],
         rate_limit="60/min",
         budget="$5.00/day",
     )

--- a/docs/guide/what-is-voicegateway.md
+++ b/docs/guide/what-is-voicegateway.md
@@ -36,7 +36,7 @@ VoiceGateway exposes exactly two integration points.
 
     session = AgentSession(
         stt=guard(deepgram.STT(), fallback=[openai.STT()]),
-        llm=guard(openai.LLM("gpt-4o"), budget="$5.00/day"),
+        llm=guard(openai.LLM("gpt-4.1"), budget="$5.00/day"),
         tts=cartesia.TTS("sonic-3"),
     )
     attach(session, project="my-project")
@@ -53,7 +53,7 @@ VoiceGateway exposes exactly two integration points.
 
     task = PipelineTask(pipeline=Pipeline([
         guard(DeepgramSTTService(), fallback=[openai_stt]),
-        guard(OpenAILLMService(model="gpt-4o"), budget="$5.00/day"),
+        guard(OpenAILLMService(model="gpt-4.1"), budget="$5.00/day"),
         CartesiaTTSService(voice_id="..."),
     ]))
     attach(task, project="my-project")
@@ -69,7 +69,7 @@ Voice calls mix three different pricing units. VoiceGateway tracks each one sepa
 | Modality | Unit | Example |
 |---|---|---|
 | STT | audio-minutes | Deepgram: $0.0059/min |
-| LLM | input + output tokens | OpenAI gpt-4o: $2.50/$10.00 per 1M |
+| LLM | input + output tokens | OpenAI gpt-4.1: $2.50/$10.00 per 1M |
 | TTS | characters | Cartesia sonic-3: $65 per 1M chars |
 
 Prices are maintained in [`voice-prices`](https://github.com/mahimailabs/voice-prices), a fork of `pydantic/genai-prices` extended for audio modalities. The `voicegw reconcile` command verifies VoiceGateway's calculated totals against your actual provider invoice.

--- a/docs/guide/what-is-voicegateway.md
+++ b/docs/guide/what-is-voicegateway.md
@@ -69,7 +69,7 @@ Voice calls mix three different pricing units. VoiceGateway tracks each one sepa
 | Modality | Unit | Example |
 |---|---|---|
 | STT | audio-minutes | Deepgram: $0.0059/min |
-| LLM | input + output tokens | OpenAI gpt-4.1: $2.50/$10.00 per 1M |
+| LLM | input + output tokens | OpenAI gpt-4.1: $2.00/$8.00 per 1M |
 | TTS | characters | Cartesia sonic-3: $65 per 1M chars |
 
 Prices are maintained in [`voice-prices`](https://github.com/mahimailabs/voice-prices), a fork of `pydantic/genai-prices` extended for audio modalities. The `voicegw reconcile` command verifies VoiceGateway's calculated totals against your actual provider invoice.

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -128,13 +128,13 @@ from voicegateway import attach
 
 session = AgentSession(
     stt=deepgram.STT(model="nova-3"),
-    llm=openai.LLM(model="gpt-4o-mini"),
+    llm=openai.LLM(model="gpt-4.1-mini"),
     tts=cartesia.TTS(model="sonic-3"),
 )
 attach(session, project="my-agent")  # meters STT, LLM, and TTS separately
 ```
 
-This gives you full control over each stage, independent fallbacks, and per-modality cost tracking. Native S2S model support (e.g., GPT-4o audio) may be added in a future release.
+This gives you full control over each stage, independent fallbacks, and per-modality cost tracking. Native S2S model support (e.g., gpt-4.1 audio) may be added in a future release.
 
 ---
 


### PR DESCRIPTION
Closes #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated LiveKit and Pipecat examples to use `gpt-4.1-mini` and `gpt-4.1` instead of older GPT-4o models.
  * Refreshed guarded, fallback, quick-start, multi-project, agency, attach, and multi-tenant examples to reflect the newer models.
  * Updated speech-to-speech examples and related pricing references to match the newer model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->