### PR TITLE
e2e prep: frontend verification gate + the four design decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -436,3 +436,6 @@ web/references/
 
 qa/
 .gstack/
+
+# G0 frontend gate screenshot artifact (scripts/e2e-frontend-gate.sh)
+.e2e-gate-*.png

--- a/docs/design/e2e-build-graph.md
+++ b/docs/design/e2e-build-graph.md
@@ -1,0 +1,125 @@
+# M0–M6 graph execution: autonomy analysis + prep
+
+## 1. The verdict up front
+
+**Autonomy is not gated by the graph. It is gated by whether each node has a trustworthy pass/fail signal.** You have two very different zones, measured:
+
+| Zone | Nodes | Gate | Autonomy |
+|---|---|---|---|
+| **A — backend** | T1, T2, T3, T5, R1, C1, C2 | `ruff check src` → `uv run mypy` → `uv run pytest -q -m "not integration"` over **199 test files** | **High.** Run unattended. |
+| **B — frontend** | V1, V2, V3, V4(ui), V5, L6 | `tsc -b` + `vite build` + `vite build --mode demo` — **compile only. Zero test runners** (no vitest/jest/playwright config) | **Low for correctness.** Code can compile, build, and render blank cards. |
+| **C — real world** | L0, L1–L5 (M5), the §10 decisions | Needs a live SIP endpoint, a real AWS account, real money, or human judgment | **None.** HITL required. |
+
+**The tension worth naming:** M0 has the best value/effort in the whole plan *and* the weakest gate — it is entirely frontend. The failure mode is already documented: `demoFixtures.ts`'s existing `DIAG_RUNS` are invented shapes matching nothing `RealProbes` returns, so typed rendering against them yields **blank cards that compile perfectly**.
+
+## 2. Prep, in order (do all of §2 before starting any node)
+
+### 2.1 Close the frontend verification gap — highest leverage item
+
+Pick one. Without it, every frontend node needs a human eyeball and autonomy collapses.
+
+- **(a) Add vitest + React Testing Library** and one render-smoke test per tab: *renders without throwing, given the real fixture shape*. Small investment, converts Zone B → Zone A.
+- **(b) Use Playwright MCP** (you already have it — `.playwright-mcp/` holds 124 console logs). Build → serve → navigate → assert the card's text is non-empty → screenshot. Behavioral, no new dep.
+- **(c) Accept HITL** on all frontend nodes.
+
+**Recommendation: (a) for unit-level + (b) as the M0 acceptance gate.** `vite build --mode demo` passing while cards render empty is exactly what (b) catches and (a) does not.
+
+### 2.2 Write the two guard tests that catch the silent failures
+
+Both documented silent-failure modes are cheaply testable, and an agent *will* hit them. See `src/voicegateway/tests/test_schema_guards.py` (written alongside this doc):
+
+- **`test_single_alembic_head`** — the chain must never fork. Head is already a two-parent merge; an agent adding a revision off the wrong parent creates a second head and nothing errors until a deploy.
+- **`test_all_models_registered`** — every `models/*_model.py` class must appear in `SQLModel.metadata`. Miss a `models/__init__.py` re-export and autogen silently skips the table.
+
+These are prerequisites, not nice-to-haves. **Add them before node 1.**
+
+### 2.3 Resolve the four §10 decisions
+
+Agents cannot make these. They block M1/M2/M3:
+
+1. **`is_probe` discriminator for load traffic** — `run_id` via `X-VG-Attempt` → participant attributes (needs `headers_to_attributes` on the trunk), or a dedicated trunk id. Without it, load traffic silently pollutes production percentiles.
+2. **Correlation-rate metric** — ship it from day one or you won't know the `sessions ↔ calls` join is failing.
+3. **Percentile policy** — new surfaces use `compute_percentiles`; anything under 10 samples renders "max of N", not "p95".
+4. **Verdict collapse version bump** — changes `voicegw livekit check` exit codes for existing users. Minor or major, plus CHANGELOG.
+
+### 2.4 Clean the launch state
+
+You're on `security/audit-2026-07` with 3 uncommitted files. Land or stash that, then branch per milestone (`feat/e2e-m0`, …). Confirm `branch-guard.sh` allows the new branches.
+
+### 2.5 Set the guardrails
+
+- **No `git push`, no PR creation** without confirmation.
+- **No `alembic upgrade head`** against any real database. Migrations verified against a throwaway SQLite file only.
+- **No AWS calls at all** in M0–M4. M5 is gated separately.
+- Let `run-affected-tests.sh` do its job — don't have agents skip it.
+
+## 3. The node graph
+
+Dependencies are hard: a node may not start until all `needs` are green.
+
+```
+                     ┌─ G1 schema-guard tests ─┐   (prep, blocks everything backend)
+                     │                          │
+ G0 frontend-gate ───┤                          │
+ (vitest/playwright) │                          │
+                     ▼                          ▼
+        V1 ──> V2 ──> V3                T1 ──> T2 ──> T4 ──> T5 ──> C1 ──> V4 ──> V5
+        (M0)         (M2 ui)             │      │            ^      ^        │
+                                         │      └────────────┘      │        └──> V6 (M6)
+                                         │                          │
+                                         ├──> R1 ───────────────────┘
+                                         │
+                                         └──> T3 ──> C2   (M4)
+
+ L0 (SIPp spike, HITL) ──> L2 ──> L3
+                            │
+ L1 ─────────────────────────┴──> L4 ──> L5 ──> L6      (M5, all HITL-gated)
+                                                  ^
+ T5 ──────────────────────────────────────────────┘
+```
+
+**Alembic chain — assign all revision ids up front**, one linear chain off `06836270c254`, so out-of-order implementation still yields one head:
+`rev1` calls+call_legs+sessions cols → `rev2` call_events → `rev3` diagnostics_runs → `rev4` node_samples → `rev5` answer latency → `rev6` managed_compute_targets → `rev7` load_runs.
+
+**Critical path: T1 → T2 → T5 → C1.** Everything the product claims as new depends on those four.
+
+## 4. Per-node autonomy and gate
+
+| Node | M | Zone | Gate command | Autonomy |
+|---|---|---|---|---|
+| G0 frontend gate | prep | B→A | new tests pass | HITL to choose approach |
+| G1 schema guards | prep | A | `pytest src/voicegateway/tests/test_schema_guards.py` | **auto** |
+| V1 tab shell + surface payloads | M0 | B | tsc + both builds + render assertions | auto **if G0 done** |
+| V2 load curve + error classes | M0 | B | same | auto if G0 |
+| T1 calls + call_legs + repo | M1 | A | ruff+mypy+pytest, G1 | **auto** |
+| T2 webhook receiver | M1 | A | same + signature-verification test | **auto** |
+| R1 persist diagnostics runs | M1 | A | same | **auto** |
+| T4 `/v1/calls/observations` | M2 | A | same + bounded-queue/drop-counter test | **auto** |
+| T5 answer latency + source | M2 | A | same + precedence unit tests | **auto** |
+| C1 correlation join | M2 | A | same + correlation-rate test | **auto** |
+| V3 layer waterfall | M2 | B | frontend gate | auto if G0 |
+| V4 gates + exit code | M3 | A+B | pytest + CLI exit-code test | **auto** (version bump = HITL) |
+| V5 report export | M3 | B | build + fixture snapshot | auto if G0 |
+| T3 prometheus scrape | M4 | A | pytest against a canned exposition fixture | **auto** |
+| C2 node correlation | M4 | A | pytest | **auto** |
+| V6 exposition endpoint | M6 | A | pytest | **auto** |
+| L0 SIPp spike | gate | C | real 200 OK + two-way audio **over TLS/SRTP** | **HITL** |
+| L1–L6 | M5 | C | real Fargate tasks, real money | **HITL each** |
+
+## 5. Recommended execution pattern
+
+**Not one long autonomous run.** Milestone-scoped autonomy with a human gate between milestones:
+
+1. **Per node**: a subagent implements + runs its gate + reports. Nodes with no dependency between them run in parallel.
+2. **Per milestone**: agents run unattended until every node is green, then **stop for review**. Review the diff, not the process.
+3. **Between milestones**: you decide whether to continue. Drift accumulates across days; a review gate every few nodes is what keeps it honest.
+
+**Where `/loop` fits:** it's good for *"keep working the graph until the next HITL gate"* — a self-paced driver that picks the next ready node, dispatches it, checks the gate, and stops at a boundary. It's the wrong tool for *"build all of M0–M6 unattended"*, because L0 and M5 need a human and the §10 decisions need judgment.
+
+**Realistic split:** M0 through M4 is genuinely autonomous once G0 and G1 exist — that's the majority of the build. L0 is a one-off human spike. M5 stays supervised because it spends money in a real AWS account.
+
+## 6. The three ways this goes wrong
+
+1. **Frontend nodes ship green and render nothing.** Compile-passes is not renders-correctly, and the existing demo fixtures actively mislead. → G0 is mandatory, not optional.
+2. **A migration forks the alembic chain** or a model misses its `__init__` re-export. Both fail silently, both surface at deploy. → G1 is mandatory.
+3. **Scope drift over a multi-day autonomous build.** The spec's "not being built" table is the guardrail — put it in the agent's context on every node, or agents will helpfully add the thing you deliberately cut.

--- a/docs/design/end-to-end-profiling-scope.md
+++ b/docs/design/end-to-end-profiling-scope.md
@@ -1,0 +1,164 @@
+# VoiceGateway: end-to-end profiling — data model + build scope
+
+Transforming VoiceGateway from an **inference-layer** profiler into an **end-to-end** voice-agent profiler (SIP → SFU → dispatch → agent → inference → infra).
+
+Verified against the installed venv while writing: `livekit-api 1.1.0`, `livekit-protocol 1.1.7`, `livekit-agents 1.5.7`, `prometheus-client 0.25.0` (transitive, undeclared), **`boto3` MISSING**. Alembic head: `06836270c254` (a two-parent merge of `b7d2f4a9c1e3` + `d2f6b8a1c3e5`).
+
+---
+
+## 1. The problem, in the code
+
+`requests` is the atomic unit (`models/request_model.py`). `sessions` is **derived** — UPSERT'd inside `request_log_repository.log_request`, gated on `if record.session_id:`. Nothing calls `log_request` except inference capture paths, so **a call that runs no inference does not exist anywhere in the schema.**
+
+Worse: the **LiveKit room — the only identifier every layer 1–6 shares — is not a column.** `attach` stamps it into `requests.metadata` JSON, and the only way to query by it is a non-sargable `metadata LIKE` scan (`get_requests_for_room`).
+
+Making `calls` first-class, keyed on the room, written by paths that never touch inference, fixes both.
+
+## 2. What is actually observable (this bounds the whole design)
+
+Verified by introspecting the installed SDK. **Do not design columns that pretend otherwise.**
+
+| Source | Gives you | Blind to |
+|---|---|---|
+| **Webhooks** — `room_started/finished`, `participant_joined/left`, `participant_connection_aborted`, `track_published/unpublished`, `egress_*`, `ingress_*` | Room + participant + track lifecycle. `ParticipantInfo.attributes` carries `sip.callID`, `sip.callStatus`, `sip.phoneNumber`, `sip.trunkID`, `sip.ruleID`. `disconnect_reason` includes **`SIP_TRUNK_FAILURE`, `USER_UNAVAILABLE`, `USER_REJECTED`** — real layer-1 failure causes | **No `track_subscribed` event.** No `participant_attributes_changed`. |
+| **`livekit-sip` prometheus** | Fleet aggregates: `invite_requests_raw`, `invite_requests`, `invite_accepted`, `calls_active`, `calls_terminated{status}`, `call_duration` | Anything per-call |
+| **`livekit-server` prometheus** | `room_total`, `participant_total`, `packet_total/bytes{direction,transmission,country}`, `nack_total`, node CPU/load — all with `node_id`/`node_type` labels | Anything per-call |
+| **Agent / load-worker self-report** | The only per-call view of subscribe latency and true INVITE→200 wall time | Only for calls it participates in |
+
+**Four things I assumed that are not available:**
+
+1. **Subscribe latency is not server-observable.** There is no `track_subscribed` webhook. Only the subscribing process sees it.
+2. **Per-call SIP response codes are not retrievable.** `SIPCallInfo` carries `call_status_code`, `disconnect_reason`, `audio_codec`, `pcap_file_link` — but `livekit-api 1.1.0`'s `SipService` exposes **only** trunk / dispatch-rule / create-participant / transfer. No list-or-get. If a `ListSIPCallInfo` RPC ever ships, this becomes a small additive feature.
+3. **Per-call RTP loss / jitter / MOS does not exist server-side.** `livekit_packet_*` and `nack_total` are node counters. `sfu.py` already hardcodes `loss_pct = 0.0` and is honest about it. **Reserve no column** — an empty column invites a UI that renders `0.0` as "no loss".
+4. **There is no `node_id` awareness anywhere in the tree.** Layer 7 correlates by `(node, time window)`, never by FK to a call.
+
+## 3. The schema
+
+```
+calls                                  ← created by ANY event, from webhook or loadgen
+  id
+  room_sid      UNIQUE NULL            ← the TRUE per-instance key (RM_*)
+  room_name     NULLABLE               ← best-effort join key; NULL is legitimate
+  origin        webhook|loadgen|agent
+  attempt_id    UNIQUE NULL            ← loadgen correlation
+  run_id        NULL
+  project, tenant_id, agent_id, channel, direction
+  started_at_ms, ended_at_ms, duration_ms, end_reason, num_legs, is_probe
+  answer_latency_ms                    ← THE headline number
+  answer_latency_source                ← how it was derived (see §4)
+
+call_legs                              ← one per participant
+  call_id (idx), participant_sid (UNIQUE with call_id)
+  identity, kind (SIP|AGENT|STANDARD), region
+  joined_at_ms, left_at_ms, disconnect_reason, is_publisher
+  attributes_json                      ← sip.* keys only
+  first_audio_track_at_ms, audio_track_sid, audio_codec
+
+call_events        ← layer 1-3 state transitions, timestamped
+node_samples       ← layer 7, correlated by (node, time), NOT by FK
+sessions           ← EXISTS, gains nullable room_name + call_id
+turns / requests   ← EXIST, unchanged (layers 5-6)
+```
+
+**Five decisions worth defending:**
+
+- **`room_name` is NULLABLE.** A `503` on INVITE never creates a room — and that failure is the *most important row* in a load test. Key on `room_sid`; treat `room_name` as best-effort. A deployment pinning one fixed room name would otherwise collapse two concurrent calls into one.
+- **Select-then-update, not native `ON CONFLICT`.** Copying the documented reason in `workers_repository.upsert_heartbeat`: a NULL `tenant_id` makes on-conflict duplicate rows on **both** SQLite and Postgres.
+- **`upsert_call` must create-if-missing from *any* event.** Webhook delivery is neither ordered nor exactly-once.
+- **Forward-only. No backfill, no repair CLI.** A `calls` row can only exist from the moment the receiver is deployed, so an older session has nothing to join to. This deletes an entire workstream (no `json_extract` dialect branch, no batched migration scan).
+- **One linear alembic chain.** Head is already a two-parent merge; **assign all revision ids up front** and chain them, so implementing out of order still yields one head.
+
+## 4. The headline correlation
+
+Because **`livekit-sip` withholds `200 OK` until it subscribes to an audio track**, the agent's first published audio track *gates the caller's ring time*. So:
+
+```
+answer_latency_ms ≈ agent_track_published_at_ms − caller_joined_at_ms
+```
+
+That is a **webhook-only, zero-instrumentation proxy** for caller-visible answer latency, upgradeable to the real number when an agent or load worker reports it directly.
+
+**Store `answer_latency_source` alongside it.** Precedence: `sipp_rtd` (true INVITE→200 wall time) > agent self-report > webhook proxy. One number, one column, one computation — nothing else in the product computes answer latency. Storing the provenance next to the value is what keeps it honest.
+
+This is the product claim: *"the caller heard 4.1 s of ring because the agent took 3.8 s to publish audio, of which 2.9 s was LLM cold start."* Nothing on the market correlates layers 1→6 like that.
+
+## 5. Ingest wiring (follows the existing pattern exactly)
+
+Per-table pattern, smallest complete precedent to copy is `agent_probe_results`:
+`models/<x>_model.py` → **re-export from `models/__init__.py`** → `alembic/versions/<rev>.py` → `repository/<x>_repository.py` → passthrough on `services/storage_service.py` → branch in `services/retention_service.py`.
+
+- **Webhook receiver** — new router under `server/api/`. `livekit.api.WebhookReceiver` + `TokenVerifier` both exist in the installed SDK. **The signature check is the only thing guarding this endpoint** — it must run before any parsing, and no missing-creds branch may bypass it.
+- **Prometheus scraper** — periodic background worker modeled on `middleware/agent_observations_worker_middleware.py` (~110 lines). Pulls `livekit-server` + `livekit-sip` `prometheus_port` and `node_exporter` into `node_samples`.
+- **Agent/worker self-report** — `POST /v1/calls/observations`. Must be **fire-and-forget onto a bounded queue with a drop counter**, single background flusher, `VG_DISABLE_CALL_OBSERVATIONS` kill switch, every hook `try/except`-wrapped. A synchronous POST in the agent's job-start path would add latency to the exact thing being measured.
+
+**No frontend changes in the ingest tier** — these endpoints are called by LiveKit and by agents, never the SPA, so `demoFixtures.ts` stays untouched. That boundary is deliberate.
+
+## 6. Milestones
+
+| M | Name | Effort | Demoable as |
+|---|---|---|---|
+| **M0** | Stop throwing away what we already measure | L+M | Diagnostics with 5 tabs: real agent roster, SFU baseline, ramp curve with knee, saturation banner, error-class bars |
+| **L0** | SIPp spike — **blocking gate, not a feature** | S | One containerised SIPp call to livekit-sip: 200 OK, two-way audio, correct SDP `c=`, **over TLS/SRTP** |
+| **M1** | The call becomes first-class | M+M+S | Place a call with **zero inference**. A `calls` row exists, legs timelined, `disconnect_reason = SIP_TRUNK_FAILURE` readable. Today: nothing exists |
+| **M2** | The correlation ships | M+M+M+S | The one-sentence output in §4, on screen |
+| **M3** | Gates, reports, client deliverable | M+M+S | `voicegw livekit check --strict` fails CI naming `answer_latency_p95_ms`; self-contained HTML report |
+| **M4** | Node + infra layer | L+S | The knee at 25 clients correlated with `filefd_allocated` hitting `filefd_maximum` on one host |
+| **M5** | BYO-compute load orchestration | M+L+M+L+M+M | 500 concurrent calls in the operator's own AWS account, cancellable, **priced before launch** |
+| **M6** | Prometheus exposition | S | `curl /v1/metrics \| grep voicegw_diag_gate_status` |
+
+**M0 needs no migration and no backend risk** — it's pure recovered value: the backend already returns agent rosters, SFU rtt/ramp/knee, and per-agent STT/LLM/TTS splits, and `Diagnostics.tsx` throws them away (`DiagnosticCheckResult.result` is typed `unknown`). Ship it first.
+
+**M5 is roughly as large as M0–M4 combined**, and it's the only milestone optional to the monitor-first thesis. Ship M0–M3 before committing.
+
+**Critical path: T1 → T2 → T5 → C1.** Everything the product claims as new depends on those four.
+
+## 7. Lambda is rejected, not deferred
+
+You proposed Lambda for BYO-compute. It doesn't survive scrutiny:
+
+- **15-minute cap** turns a 24 h soak into 96 disjoint bursts — sustained concurrency is never actually measured, which is the whole point.
+- **Per-invocation ENI churn** moves the SIP source and the SDP media IP between segments, breaking carrier trunk allowlists.
+- **GB-seconds at 500 × 24 h** is an order of magnitude over Fargate.
+
+**Use Fargate/ECS tasks.** Same BYO-compute property (user's account, user's bill, ephemeral), no execution cap, stable ENI per task. EC2/spot is cheaper for long runs but adds AMI + user-data + ASG + termination surface a solo maintainer shouldn't own in v1.
+
+**Runs cap at 24 h.** The client's 7-day requirement is an *observation* window, met by the scrape worker — not by 7 days of continuous synthetic load. That's the single largest scope reduction here.
+
+## 8. Sharp edges
+
+- **`models/__init__.py` re-export failures are silent.** Miss one and `SQLModel.metadata` never sees the table; autogen and `create_all` both skip it and nothing errors.
+- **`_UPSERT_SESSION_PG` is derived by string replace** (`request_log_repository.py:100` does `.replace("INSTR(", "STRPOS(")`). Any edit to the SQLite text must be checked against the Postgres derivation or the two drift silently.
+- **`demoFixtures.ts` throws, it does not degrade.** `demoFetch` ends in `throw new Error(...)`. And the existing `DIAG_RUNS` fixtures are *invented shapes* matching nothing `RealProbes` returns — typed rendering against them yields blank cards, so they must be rewritten in the **same commit** as the tab work.
+- **No frontend test runner.** No test script, no vitest. Verification is `tsc -b` + `vite build` + `vite build --mode demo`.
+- **`MAX_POLLS = 180` at 2 s exactly equals `_OVERALL_RUN_TIMEOUT_SECONDS = 360`.** Coupled constants. Any run over six minutes needs both raised **and** run persistence.
+- **The ContextVar hazard, twice.** `session_id` and `tenant` are ContextVars; `attach.register_components` keeps process-global singletons. N concurrent jobs in one process without `contextvars.copy_context()` merge into one `session_id`. The mock participant avoids it by never calling `attach()` — if per-job telemetry is added, each job body must run inside `copy_context()`.
+- **`loss_pct = 0.0` is hardcoded in `sfu.py`.** Any loss series built on it renders a fabricated clean bill of health. Suppress the series; add no column.
+- **`find_knee` returns `None` for two opposite outcomes** — nothing breached, or the *first* tier breached. A chart that doesn't distinguish them labels a total failure as a pass.
+- **Counter resets look like huge negative rates.** A livekit-server restart zeroes every `_total`. Read-time diffing must emit null when `current < previous`.
+- **One process, one port.** Webhook receiver, load poller, scrape worker, and dashboard all share one uvicorn. During a 500-call burst the UI will feel dead unless ingest paths are bounded and measured. A synchronous SQLite writer absorbing a 2500-event burst is the second-highest risk in the plan — **measure it in M1, don't assume WAL absorbs it.**
+- **A crashed control plane must not leave 500 calls billing.** `VG_DEADLINE_AT` in the worker + ECS `stopTimeout`, tested by killing the daemon mid-run.
+- **Retention is mandatory.** Scraping ~10 nodes at 15 s is ~57k rows/day. Downsample on write or trim in the rollup worker.
+
+## 9. Not being built
+
+| Not built | Why |
+|---|---|
+| Any gossipper code, scenario or config | **AGPL-3.0 vs MIT.** Clean-room from the SIPp reference and RFC 3261. apt-installing the GPL SIPp *binary* alongside an MIT wheel is mere aggregation and is fine. |
+| Per-call RTP loss / jitter / MOS / DTMF | Not observable server-side. Needs a client reading its own `getStats()`. |
+| Per-call SIP response codes, INVITE→200 from LiveKit, provisional responses, BYE headers, negotiated SDP | Blocked on LiveKit: no `ListSIPCallInfo` RPC in `livekit-api 1.1.0`. |
+| Backfill of `sessions.room_name` / `call_id`, any repair CLI | Zero value — an older session has nothing to join to. |
+| A separate `load_call_attempts` table | Merged into `calls`. Two call-level tables means two percentile paths and two UIs disagreeing about one run. |
+| `livekit_diag/distributed.py` Coordinator (388 lines, written, unused) | An absolute `VG_START_AT` in the task env achieves the synchronized start with no inbound path to a control plane that is usually a laptop outside the VPC. `aggregate_vantages` is reused as a pure fold; the HTTP barrier is not. |
+| Reusing `/v1/ingest` or `RemoteCollectorSink` for load results | Those carry `RequestRecord` and get re-rated against the cost card. Call-level SIP records would corrupt the cost model. |
+| ClickHouse / DuckDB mirrors of the new tables | Premature before the SQLite shape survives a real 500-call run. |
+| SSE / WebSocket push for calls or load | The dashboard has zero WebSocket by design. Calls and load poll. |
+| PDF export, branded/scheduled reports, gate alerting | Operators who run Prometheus alert on the exposition series. VoiceGateway does not learn to alert. |
+| GCP / Azure targets, outbound PSTN dialing | Unbounded surface for a solo maintainer; outbound exercises the wrong direction for an inbound-capacity question. |
+| VoiceGateway generating load from its own process | Monitor-first. The daemon launches, watches, cancels, and ingests. **It never dials.** |
+
+## 10. Resolve before starting
+
+1. **`is_probe` cannot be set for load traffic.** For SIP-originated calls the room name comes from the operator's dispatch rule, so a probe prefix can only be *checked*, not enforced. Decide the discriminator now (`run_id` via `X-VG-Attempt` → participant attributes, requiring `headers_to_attributes` on the trunk; or a dedicated trunk id on the compute target). Without it, **load traffic silently pollutes production percentiles for every call that answers.**
+2. **Correlation coverage is unmeasured.** `sessions.room_name` comes from `record.metadata.get("room")`, which only exists when `attach` resolved a LiveKit job context — web and Pipecat sessions have none. **Ship a correlation-rate number from day one**, or you won't know the join is failing.
+3. **Percentiles.** Three algorithms coexist and disagree on small samples. New surfaces standardise on `utils/percentiles.compute_percentiles`; no retrofit (it would move published p95 numbers). **Any percentile from fewer than 10 samples must render as "max of N", not "p95"** — `MAX_LATENCY_TRIALS = 3`, so today's diagnostics p95 is *always* the max of 3.
+4. **Two verdict implementations disagree** (`service.py:_verdict` vs `report.py:check_json`). Collapse into `livekit_diag/gates.py`; stricter reading wins. This **changes `voicegw livekit check` exit codes** for existing users — needs a version-bump decision and a CHANGELOG entry.

--- a/scripts/e2e-frontend-gate.sh
+++ b/scripts/e2e-frontend-gate.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# G0 frontend verification gate (decision: Playwright-style behavioural
+# assertions via gstack `browse`, not vitest/RTL, and no new npm dependency).
+#
+# Why this exists: `vite build --mode demo` passing proves the bundle compiles,
+# NOT that anything rendered. The demo fixtures can disagree with what the
+# backend actually returns and you still get a clean build with empty cards.
+# This gate builds, serves the demo bundle, navigates, and asserts that the
+# cards on a page contain real visible text.
+#
+# Usage:
+#   scripts/e2e-frontend-gate.sh                  # gate the Diagnostics page
+#   scripts/e2e-frontend-gate.sh calls            # gate another route
+#   MIN_CARDS=5 scripts/e2e-frontend-gate.sh      # require at least 5 cards
+#
+# Exit 0 = gate green. Non-zero = gate red (message on stderr).
+set -euo pipefail
+
+ROUTE="${1:-diagnostics}"
+MIN_CARDS="${MIN_CARDS:-1}"
+MIN_CHARS="${MIN_CHARS:-20}"
+PORT="${PORT:-4173}"
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND="$REPO/src/dashboard/frontend"
+
+B="$REPO/.claude/skills/gstack/browse/dist/browse"
+[ -x "$B" ] || B="$HOME/.claude/skills/gstack/browse/dist/browse"
+if [ ! -x "$B" ]; then
+  echo "gate: gstack browse binary not found; run its ./setup once" >&2
+  exit 2
+fi
+
+echo "gate: building frontend (tsc + vite + demo)"
+( cd "$FRONTEND" && npx tsc -b && npm run build && npm run build:demo ) >/dev/null
+
+# The demo bundle is built with base '/demo/', so it must be served under that
+# path or every asset 404s. Symlink rather than copy so a rebuild is picked up.
+SERVE_ROOT="$(mktemp -d)"
+ln -sfn "$FRONTEND/dist-demo" "$SERVE_ROOT/demo"
+
+# A plain http.server has no SPA fallback, so a deep link like /demo/diagnostics
+# 404s and the bundle never loads (the gate then fails for the wrong reason).
+# Fall back to index.html for unknown paths, which is what the daemon does in
+# production.
+cat > "$SERVE_ROOT/serve.py" <<'PYSRV'
+import http.server, os, sys
+
+class SPAHandler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        path = self.translate_path(self.path)
+        if not os.path.exists(path) and not self.path.startswith("/demo/assets/"):
+            self.path = "/demo/index.html"
+        return super().do_GET()
+
+    def log_message(self, *args):
+        pass
+
+http.server.HTTPServer(("", int(sys.argv[1])), SPAHandler).serve_forever()
+PYSRV
+
+echo "gate: serving $SERVE_ROOT on :$PORT (SPA fallback)"
+( cd "$SERVE_ROOT" && python3 serve.py "$PORT" >/dev/null 2>&1 & echo $! > "$SERVE_ROOT/.pid" )
+cleanup() {
+  [ -f "$SERVE_ROOT/.pid" ] && kill "$(cat "$SERVE_ROOT/.pid")" 2>/dev/null || true
+  rm -rf "$SERVE_ROOT"
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 20); do
+  curl -sf -o /dev/null "http://localhost:$PORT/demo/" && break
+  sleep 0.25
+done
+
+# browse is a long-lived daemon and its console/network logs are CUMULATIVE
+# across invocations, so a previous run's errors would fail this run. Clear both
+# before navigating or the gate reports stale failures.
+"$B" console --clear >/dev/null 2>&1 || true
+"$B" network --clear >/dev/null 2>&1 || true
+
+echo "gate: navigating to /demo/$ROUTE"
+"$B" goto "http://localhost:$PORT/demo/$ROUTE" >/dev/null
+
+mounted=$("$B" js "document.getElementById('root') ? document.getElementById('root').children.length : 0")
+if [ "$mounted" = "0" ]; then
+  echo "gate RED: #root has no children, the SPA did not mount" >&2
+  exit 1
+fi
+
+# index.html references /static/branding/favicon.svg, which the daemon serves in
+# production but is not part of dist-demo, so that one 404 is expected here and
+# is not a render failure. Everything else is a real error.
+# Match the log's own '[error]' marker, NOT a bare 'error' substring: the empty
+# result prints the literal '(no console errors)', which a substring match counts
+# as a failure.
+errors=$("$B" console --errors 2>/dev/null \
+  | grep -F "[error]" \
+  | grep -v "static/branding" \
+  | grep -c . || true)
+if [ "${errors:-0}" -gt 0 ]; then
+  echo "gate RED: console errors on /demo/$ROUTE" >&2
+  "$B" console --errors | grep -v "static/branding" >&2
+  exit 1
+fi
+
+# The real assertion: cards must carry visible text, not just exist.
+report=$("$B" js "JSON.stringify(Array.from(document.querySelectorAll('.vg-card')).map(c => c.textContent.trim().length))")
+echo "gate: card text lengths = $report"
+
+count=$("$B" js "Array.from(document.querySelectorAll('.vg-card')).filter(c => c.textContent.trim().length >= $MIN_CHARS).length")
+if [ "${count:-0}" -lt "$MIN_CARDS" ]; then
+  echo "gate RED: only ${count:-0} card(s) with >=${MIN_CHARS} chars of text, need $MIN_CARDS" >&2
+  echo "          (this is the 'builds clean but renders empty' failure mode)" >&2
+  exit 1
+fi
+
+shot="${SHOT:-$REPO/.e2e-gate-$ROUTE.png}"
+"$B" screenshot "$shot" >/dev/null
+echo "gate GREEN: $count card(s) rendered with text on /demo/$ROUTE; screenshot $shot"

--- a/src/voicegateway/tests/test_schema_guards.py
+++ b/src/voicegateway/tests/test_schema_guards.py
@@ -1,0 +1,96 @@
+"""Guards for the two silent schema failures.
+
+Both of these fail quietly today: a forked alembic chain and a model that was
+never re-exported from ``models/__init__.py`` both pass every existing check and
+only surface at deploy time. These tests are prerequisites for any autonomous
+work on the schema.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlmodel import SQLModel
+
+import voicegateway.models  # noqa: F401  (import registers every re-exported model)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODELS_DIR = Path(voicegateway.models.__file__).parent
+
+
+def test_single_alembic_head() -> None:
+    """The revision chain must never fork.
+
+    The current head is itself a two-parent merge, so a new revision written
+    against the wrong ``down_revision`` creates a second head. Alembic does not
+    complain until someone runs ``upgrade head``.
+    """
+    cfg = Config(str(_REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(_REPO_ROOT / "alembic"))
+    heads = ScriptDirectory.from_config(cfg).get_heads()
+
+    assert len(heads) == 1, (
+        f"alembic has {len(heads)} heads: {heads}. "
+        "Every new revision must chain linearly; do not create a merge revision."
+    )
+
+
+def _table_backed_classes(path: Path) -> list[str]:
+    """Class names in ``path`` declared with ``table=True``, via AST (no import)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "table" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                found.append(node.name)
+    return found
+
+
+def test_all_models_registered() -> None:
+    """Every ``table=True`` model must reach ``SQLModel.metadata``.
+
+    Registration happens only as a side effect of the class being imported, and
+    ``models/__init__.py`` is what does that importing. Omit a re-export and the
+    table is invisible to ``create_all`` *and* to autogenerate -- with no error.
+    """
+    registered = {
+        cls.__name__
+        for cls in SQLModel._sa_registry._class_registry.values()  # type: ignore[attr-defined]
+        if hasattr(cls, "__tablename__")
+    }
+
+    missing: list[str] = []
+    for module_path in sorted(_MODELS_DIR.glob("*_model.py")):
+        for cls_name in _table_backed_classes(module_path):
+            if cls_name not in registered:
+                missing.append(f"{module_path.name}::{cls_name}")
+
+    assert not missing, (
+        "These table=True models never reached SQLModel.metadata: "
+        f"{missing}. Add them to src/voicegateway/models/__init__.py -- "
+        "without the re-export, alembic autogenerate silently skips the table."
+    )
+
+
+@pytest.mark.parametrize("required", ["Request", "Session"])
+def test_guard_itself_detects_known_models(required: str) -> None:
+    """Sanity check: the registry probe finds models we know are wired up.
+
+    Without this, a bug in the introspection above would make
+    ``test_all_models_registered`` vacuously pass.
+    """
+    registered = {
+        cls.__name__
+        for cls in SQLModel._sa_registry._class_registry.values()  # type: ignore[attr-defined]
+        if hasattr(cls, "__tablename__")
+    }
+    assert required in registered, (
+        f"{required} not found in SQLModel.metadata -- the registry introspection "
+        "in this module is broken, so test_all_models_registered cannot be trusted."
+    )


### PR DESCRIPTION
First of four **stacked** PRs building end-to-end profiling (SIP → SFU → dispatch → agent → inference). Spec: `docs/superpowers/specs/2026-07-29-end-to-end-profiling-scope.md`.

> **Merge bottom-up, in order: this PR → #(m0) → #(m1) → #(m2).** The later PRs add alembic revisions that chain linearly (`e4a7c2f9b1d3` → `f7c3b9d2e845` → `d4b1f6c8a927`). Merging them out of order forks the migration graph into two heads, which is green on SQLite and fails on Postgres at deploy. That already happened once on this repo.

## What this unblocks

Two prep blockers gated the entire 19-node graph.

**G0 — the frontend verification gate.** `vite build --mode demo` passing proves the bundle compiles, not that anything rendered. The demo fixtures could disagree with what the backend returns and still build clean, with empty cards. `scripts/e2e-frontend-gate.sh` now builds, serves `dist-demo` behind an SPA fallback, navigates, and asserts `.vg-card` elements carry real visible text. Proven non-vacuous: green on diagnostics, red at `MIN_CARDS=99`.

Dogfooding it caught three bugs that would have made it useless: `python3 -m http.server` has no SPA fallback so deep links 404; the headless browser is a persistent daemon whose console log is cumulative, so a previous run's errors failed the current one; and the error count matched the literal string `(no console errors)`.

**D0 — four design decisions** an agent cannot make, recorded in the build manifest: dedicated load-test trunk as the `is_probe` discriminator; correlation rate shipped day one with a warn threshold; percentiles under 10 samples render "max of N" not "p95"; one minor version bump plus CHANGELOG for the verdict collapse.

Also tracks the design specs and the schema-guard tests (single alembic head, all models registered), which were untracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated frontend end-to-end verification gate that checks app loading, visible content, browser errors, and screenshots.
  - Added safeguards to detect migration issues and unregistered database tables.

- **Documentation**
  - Added design documentation covering execution-graph validation, autonomy boundaries, profiling scope, telemetry, milestones, and deployment considerations.

- **Chores**
  - Excluded frontend verification screenshots from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->