### PR TITLE
e2e M0: surface the diagnostics payloads the UI was discarding

### DIFF
--- a/scripts/e2e-frontend-gate.sh
+++ b/scripts/e2e-frontend-gate.sh
@@ -59,10 +59,23 @@ class SPAHandler(http.server.SimpleHTTPRequestHandler):
 http.server.HTTPServer(("", int(sys.argv[1])), SPAHandler).serve_forever()
 PYSRV
 
+# A stale server from a previous run holds the port and serves a deleted root,
+# which fails the next run with ERR_CONNECTION_RESET. Clear it first.
+if lsof -ti:"$PORT" >/dev/null 2>&1; then
+  echo "gate: port $PORT busy, clearing"
+  lsof -ti:"$PORT" | xargs kill 2>/dev/null || true
+  sleep 1
+fi
+
 echo "gate: serving $SERVE_ROOT on :$PORT (SPA fallback)"
-( cd "$SERVE_ROOT" && python3 serve.py "$PORT" >/dev/null 2>&1 & echo $! > "$SERVE_ROOT/.pid" )
+# `exec` matters: without it, `&` backgrounds the whole `cd && python3` compound
+# in an implicit subshell, so $! is that subshell and killing it orphans python3,
+# which then holds the port forever. exec replaces the subshell with python3, so
+# $! is the real server PID.
+( cd "$SERVE_ROOT" && exec python3 serve.py "$PORT" ) >/dev/null 2>&1 &
+SERVER_PID=$!
 cleanup() {
-  [ -f "$SERVE_ROOT/.pid" ] && kill "$(cat "$SERVE_ROOT/.pid")" 2>/dev/null || true
+  kill "$SERVER_PID" 2>/dev/null || true
   rm -rf "$SERVE_ROOT"
 }
 trap cleanup EXIT

--- a/src/dashboard/frontend/src/components/ErrorClassChart.tsx
+++ b/src/dashboard/frontend/src/components/ErrorClassChart.tsx
@@ -1,0 +1,96 @@
+// Horizontal bars of failures grouped by class, with the first couple of real
+// messages under each bar.
+//
+// The bars are proportional to the LARGEST class in the set, not to the number of
+// runs: this answers "which failure dominates", and the count next to each label
+// is the absolute number so the relative bar cannot be misread as a rate.
+// Nothing is drawn for a class with zero failures - an empty bar would suggest
+// something was checked and found clean, which is a different claim.
+
+import {
+  ERROR_CLASS_COLOR,
+  ERROR_CLASS_LABEL,
+  ERROR_CLASS_ORDER,
+  type ClassifiedError,
+  type ErrorClass,
+} from '../lib/errorClass';
+
+interface ClassBar {
+  klass: ErrorClass;
+  count: number;
+  examples: string[];
+}
+
+/** Group in display order, dropping the classes nothing landed in. */
+function toBars(errors: ClassifiedError[]): ClassBar[] {
+  return ERROR_CLASS_ORDER.map((klass) => {
+    const hits = errors.filter((e) => e.klass === klass);
+    return {
+      klass,
+      count: hits.length,
+      examples: hits.map((e) => `${e.where}: ${e.message}`),
+    };
+  }).filter((bar) => bar.count > 0);
+}
+
+function truncate(text: string, max = 130): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+export default function ErrorClassChart({ errors }: { errors: ClassifiedError[] }) {
+  const bars = toBars(errors);
+  const max = bars.reduce((m, b) => Math.max(m, b.count), 0);
+
+  if (bars.length === 0) return null;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {bars.map((bar) => (
+        <div key={bar.klass}>
+          <div
+            className="flex-row"
+            style={{ justifyContent: 'space-between', alignItems: 'baseline', gap: 10 }}
+          >
+            <span style={{ fontSize: 13, fontWeight: 600 }}>{ERROR_CLASS_LABEL[bar.klass]}</span>
+            <span className="mono" style={{ fontSize: 13, fontWeight: 700 }}>
+              {bar.count}
+            </span>
+          </div>
+          <div
+            style={{
+              height: 10,
+              marginTop: 5,
+              borderRadius: 'var(--vg-radius-xs)',
+              background: 'var(--vg-hairline)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                width: `${max === 0 ? 0 : (bar.count / max) * 100}%`,
+                height: '100%',
+                background: ERROR_CLASS_COLOR[bar.klass],
+              }}
+            />
+          </div>
+          <div style={{ marginTop: 5 }}>
+            {bar.examples.slice(0, 2).map((example, i) => (
+              <div
+                key={i}
+                className="mono"
+                style={{ fontSize: 11, color: 'var(--vg-muted)', lineHeight: 1.5 }}
+              >
+                {truncate(example)}
+              </div>
+            ))}
+            {bar.examples.length > 2 && (
+              <div style={{ fontSize: 11, color: 'var(--vg-muted-2)' }}>
+                +{bar.examples.length - 2} more like this
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/LoadCurveChart.tsx
+++ b/src/dashboard/frontend/src/components/LoadCurveChart.tsx
@@ -1,0 +1,133 @@
+// The concurrency curve from an SFU load ramp: data-channel round trip against
+// the number of synthetic clients in the room, with the budget and the knee
+// marked on it.
+//
+// Two honesty rules live in this component rather than in its callers, so no
+// caller can render the curve without them.
+//
+// 1. The Y axis is LABELLED, and it is labelled "SFU data-channel RTT (ms)".
+//    This is what the prober measured by bouncing a message through the SFU's
+//    data channel. It is NOT the latency a caller hears: LiveKit gives no
+//    `track_subscribed` webhook and no per-call SIP timing, so answer latency
+//    cannot be derived from this run at all. An axis of bare milliseconds reads
+//    as answer latency to anyone glancing at it, which would misstate what
+//    VoiceGateway measured. The series name says the same thing in the tooltip.
+// 2. There is no loss series and there is no loss axis. `sfu.py` hardcodes
+//    `loss_pct = 0.0`, so a loss line would draw a flat 0% clean bill of health
+//    that nobody measured.
+//
+// Percentiles are also absent by construction: a tier is one rtt sample, so
+// there is nothing here that could be labelled p95.
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import NeoTooltip from './NeoTooltip';
+import type { DiagSfuStep } from '../lib/types';
+
+const TEAL = '#1F96AA';
+
+/** What the Y axis measures. Stated once, used for the axis and the tooltip. */
+export const RTT_AXIS_LABEL = 'SFU data-channel RTT (ms)';
+
+export default function LoadCurveChart({
+  ramp,
+  targetRttMs,
+  knee,
+  height = 250,
+  emptyText = 'No ramp tier was measured, so there is no curve to plot.',
+}: {
+  /** The measured tiers, ascending by client count. */
+  ramp: DiagSfuStep[];
+  /** The rtt budget the knee was computed against, drawn as a reference line. */
+  targetRttMs: number;
+  /**
+   * The last healthy tier, or null when there is no knee. The caller must have
+   * already resolved WHICH null this is (nothing breached vs the first tier
+   * breached) - this component only marks a knee it is given, it never implies
+   * that a missing knee means a healthy ramp.
+   */
+  knee: number | null;
+  height?: number;
+  emptyText?: string;
+}) {
+  const data = ramp.map((s) => ({
+    clients: s.clients,
+    rtt: Number(s.rtt_ms.toFixed(1)),
+  }));
+
+  if (data.length === 0) {
+    return <div style={{ fontSize: 12, color: 'var(--vg-muted-2)' }}>{emptyText}</div>;
+  }
+
+  return (
+    <div style={{ width: '100%', height, marginTop: 16 }}>
+      <ResponsiveContainer>
+        <LineChart data={data} margin={{ top: 16, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid strokeDasharray="4 4" stroke="var(--vg-hairline-2)" />
+          <XAxis
+            dataKey="clients"
+            type="number"
+            domain={[0, 'dataMax']}
+            ticks={ramp.map((s) => s.clients)}
+            tick={{ fontSize: 11, fontWeight: 600 }}
+            label={{ value: 'concurrent clients', position: 'insideBottom', offset: -6, fontSize: 11 }}
+          />
+          <YAxis
+            tick={{ fontSize: 11, fontWeight: 600 }}
+            width={68}
+            tickFormatter={(v) => `${v}`}
+            label={{
+              value: RTT_AXIS_LABEL,
+              angle: -90,
+              position: 'insideLeft',
+              offset: 12,
+              fontSize: 11,
+              style: { textAnchor: 'middle' },
+            }}
+          />
+          <Tooltip content={<NeoTooltip />} cursor={{ stroke: TEAL, strokeWidth: 1 }} />
+          <ReferenceLine
+            y={targetRttMs}
+            stroke="var(--vg-amber)"
+            strokeDasharray="5 4"
+            label={{
+              value: `${targetRttMs.toFixed(0)} ms budget`,
+              position: 'insideTopRight',
+              fontSize: 11,
+              fill: 'var(--vg-amber)',
+            }}
+          />
+          {knee !== null && (
+            <ReferenceLine
+              x={knee}
+              stroke="var(--vg-red)"
+              strokeDasharray="3 3"
+              label={{
+                value: `knee ${knee}`,
+                position: 'top',
+                fontSize: 11,
+                fill: 'var(--vg-red)',
+              }}
+            />
+          )}
+          <Line
+            type="monotone"
+            dataKey="rtt"
+            name={RTT_AXIS_LABEL}
+            stroke={TEAL}
+            strokeWidth={2}
+            dot={{ r: 3, fill: TEAL }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/lib/demoFixtures.ts
+++ b/src/dashboard/frontend/src/lib/demoFixtures.ts
@@ -1099,41 +1099,256 @@ const DIAG_CREDS: DiagnosticsCreds = {
   url: 'wss://demo-voicegw.livekit.cloud',
 };
 
+// Runs are shaped exactly as livekit_diag.service.RealProbes returns them, check
+// by check: `agents` carries the in-room rows plus the heartbeat roster, `sfu` /
+// `sfu_load` carry the baseline, the ramp, the knee, the budget the knee was
+// computed against and the prober's own resource sample, and `latency` carries
+// per-agent stats (seconds) plus the split read back from the agent's own rows.
+//
+// Three deliberate properties, so the demo shows the honest cases and not just
+// the happy one:
+//   - The newest run's verdict is PASS while one probed agent answered nothing.
+//     That is what today's `_verdict` really does (it only compares averages
+//     against target_ms), and the Errors tab is what surfaces the no-reply.
+//   - The two older runs each carry one real failure string, so the error-class
+//     bars have something to group: a per-check timeout and a dispatch that found
+//     no worker.
+//   - The oldest run has `roster: []` (a configured collector reporting nothing)
+//     against the newest run's populated roster: two different answers that must
+//     never collapse into "0 workers".
 const DIAG_RUNS: DiagnosticRun[] = [
   {
-    run_id: 'diag_run_002',
+    run_id: 'diag_run_003',
     status: 'done',
-    checks: ['agents', 'sfu'],
-    config: {},
+    checks: ['agents', 'latency', 'sfu', 'sfu_load'],
+    config: { target_ms: 1500, ramp: [2, 10, 25], duration: 10, trials: 3 },
     results: {
       checks: {
-        agents: { ok: true, result: { rooms: 2, agents: 3 } },
-        sfu: { ok: true, result: { region: 'us-east-1', rtt_ms: 24 } },
+        agents: {
+          ok: true,
+          result: {
+            agents: [
+              {
+                agent_name: 'support-voice',
+                room: 'support-call-7f21',
+                identity: 'agent-support-01',
+                state: 'active',
+                humans: 1,
+                age_s: 132,
+              },
+              {
+                agent_name: 'reception',
+                room: 'reception-inbound-a903',
+                identity: 'agent-reception-02',
+                state: 'active',
+                humans: 1,
+                age_s: 54,
+              },
+              {
+                // Assigned by LiveKit but not joined: a dispatch nobody took yet.
+                agent_name: 'reception',
+                room: 'reception-inbound-a903',
+                identity: null,
+                state: 'dispatched',
+                humans: 1,
+                age_s: null,
+              },
+            ],
+            roster: [
+              {
+                agent_id: 'support-voice',
+                agent_name: 'support-voice',
+                status: 'busy',
+                region: 'us-east-1',
+                host: 'worker-01',
+                version: '0.20.1',
+                active_sessions: 2,
+                last_seen: BASE_EPOCH - 45,
+              },
+              {
+                agent_id: 'reception',
+                agent_name: 'reception',
+                status: 'busy',
+                region: 'us-east-1',
+                host: 'worker-02',
+                version: '0.20.1',
+                active_sessions: 1,
+                last_seen: BASE_EPOCH - 12,
+              },
+              {
+                // Idle: registered and heartbeating, in no room, so LiveKit's
+                // server API cannot see it at all. This row is the whole point.
+                agent_id: 'outbound-sales',
+                agent_name: 'outbound-sales',
+                status: 'idle',
+                region: 'us-west-2',
+                host: 'worker-03',
+                version: '0.20.0',
+                active_sessions: 0,
+                last_seen: BASE_EPOCH - 22 * MIN,
+              },
+              {
+                agent_id: 'nightly-batch',
+                agent_name: 'nightly-batch',
+                status: 'offline',
+                region: 'us-west-2',
+                host: 'worker-04',
+                version: '0.20.0',
+                active_sessions: 0,
+                last_seen: BASE_EPOCH - 9 * HOUR,
+              },
+            ],
+          },
+        },
+        sfu: {
+          ok: true,
+          result: {
+            baseline: { rtt_ms: 18.4, loss_pct: 0.0, quality: 'Excellent' },
+            ramp: [],
+            knee: null,
+            target_rtt_ms: 50.0,
+            resource: null, // nothing is sampled without a ramp
+          },
+        },
+        sfu_load: {
+          ok: true,
+          result: {
+            baseline: { rtt_ms: 19.1, loss_pct: 0.0, quality: 'Excellent' },
+            ramp: [
+              { clients: 2, rtt_ms: 14.6, loss_pct: 0.0, quality: 'Excellent' },
+              { clients: 10, rtt_ms: 31.2, loss_pct: 0.0, quality: 'Good' },
+              { clients: 25, rtt_ms: 68.9, loss_pct: 0.0, quality: 'Poor' },
+            ],
+            // 25 clients broke the 50 ms budget, so the last healthy tier is 10.
+            knee: 10,
+            target_rtt_ms: 50.0,
+            resource: {
+              cpu_peak: 71.4,
+              mem_peak_mb: 842.6,
+              net_kbps_up: 4180.5,
+              saturated: false,
+              per_client: { cpu_pct: 2.856, kbps_up: 167.2 },
+              sustainable_n: 29,
+            },
+          },
+        },
+        latency: {
+          ok: true,
+          result: {
+            agents: [
+              {
+                // Times are SECONDS. p95 is present on the wire and deliberately
+                // not rendered: 3 trials cannot support a percentile.
+                agent: 'support-voice',
+                stats: {
+                  avg: 0.912,
+                  p50: 0.884,
+                  p95: 1.043,
+                  min: 0.83,
+                  max: 1.043,
+                  trials: 3,
+                },
+                components: {
+                  eou: 0.412,
+                  stt: 0.168,
+                  stt_ttfp: 0.168,
+                  stt_transcription_delay: 0.334,
+                  llm_ttft: 0.402,
+                  tts: 0.214,
+                },
+              },
+              {
+                // Answered nothing: every number is 0 with trials 0, which the UI
+                // must render as "not measured", never as an instant reply.
+                agent: 'reception',
+                stats: { avg: 0, p50: 0, p95: 0, min: 0, max: 0, trials: 0 },
+                components: null,
+              },
+            ],
+          },
+        },
       },
       verdict: 'PASS',
     },
     verdict: 'PASS',
     error: null,
+    created_at: iso(BASE_EPOCH - 12 * MIN),
+    started_at: iso(BASE_EPOCH - 12 * MIN),
+    ended_at: iso(BASE_EPOCH - 12 * MIN + 96),
+  },
+  {
+    run_id: 'diag_run_002',
+    status: 'done',
+    checks: ['agents', 'sfu_load'],
+    config: { target_ms: 1500, ramp: [2, 10, 25], duration: 10, trials: 2 },
+    results: {
+      checks: {
+        agents: {
+          ok: true,
+          result: {
+            agents: [
+              {
+                agent_name: 'support-voice',
+                room: 'support-call-1c04',
+                identity: 'agent-support-01',
+                state: 'active',
+                humans: 1,
+                age_s: 61,
+              },
+            ],
+            roster: [
+              {
+                agent_id: 'support-voice',
+                agent_name: 'support-voice',
+                status: 'busy',
+                region: 'us-east-1',
+                host: 'worker-01',
+                version: '0.20.1',
+                active_sessions: 1,
+                last_seen: BASE_EPOCH - 90 * MIN,
+              },
+            ],
+          },
+        },
+        // The per-check timeout string, verbatim from service.execute_run.
+        sfu_load: { ok: false, error: 'check timed out' },
+      },
+      verdict: 'FAIL',
+    },
+    verdict: 'FAIL',
+    error: null,
     created_at: iso(BASE_EPOCH - 90 * MIN),
     started_at: iso(BASE_EPOCH - 90 * MIN),
-    ended_at: iso(BASE_EPOCH - 90 * MIN + 6),
+    ended_at: iso(BASE_EPOCH - 90 * MIN + 128),
   },
   {
     run_id: 'diag_run_001',
     status: 'done',
-    checks: ['agents'],
-    config: {},
+    checks: ['agents', 'latency'],
+    config: { target_ms: 1500, ramp: [2, 10, 25], duration: 10, trials: 1 },
     results: {
       checks: {
-        agents: { ok: true, result: { rooms: 1, agents: 1 } },
+        agents: {
+          ok: true,
+          result: {
+            agents: [],
+            // Configured collector, nothing reported: NOT the same as null.
+            roster: [],
+          },
+        },
+        latency: {
+          ok: false,
+          error:
+            "dispatched to 'outbound-sales' but no worker joined within 8s: that name is how the worker registered (register_worker / @server.rtc_session agent_name); check a worker with that name is running",
+        },
       },
-      verdict: 'PASS',
+      verdict: 'FAIL',
     },
-    verdict: 'PASS',
+    verdict: 'FAIL',
     error: null,
     created_at: iso(BASE_EPOCH - 1 * DAY),
     started_at: iso(BASE_EPOCH - 1 * DAY),
-    ended_at: iso(BASE_EPOCH - 1 * DAY + 3),
+    ended_at: iso(BASE_EPOCH - 1 * DAY + 19),
   },
 ];
 

--- a/src/dashboard/frontend/src/lib/errorClass.ts
+++ b/src/dashboard/frontend/src/lib/errorClass.ts
@@ -1,0 +1,93 @@
+// The failure taxonomy the Diagnostics error bars are grouped by.
+//
+// Every class here is decided by substring-matching an error string that a check
+// (or a run) actually reported. Nothing is inferred: an error that matches
+// nothing stays `other` rather than being guessed into a bucket, because a wrong
+// cause is worse than an unclassified one when someone is debugging a deployment.
+//
+// Kept in `lib/` and not in the tab so the taxonomy has exactly one definition:
+// the bars, and anything that later counts the same failures, cannot drift apart.
+
+export type ErrorClass =
+  | 'timeout'
+  | 'no_worker'
+  | 'no_reply'
+  | 'auth'
+  | 'config'
+  | 'connect'
+  | 'other';
+
+export const ERROR_CLASS_LABEL: Record<ErrorClass, string> = {
+  timeout: 'Timed out',
+  no_worker: 'No worker joined',
+  no_reply: 'No reply from agent',
+  auth: 'Auth rejected',
+  config: 'Not configured',
+  connect: 'Could not connect',
+  other: 'Other',
+};
+
+export const ERROR_CLASS_COLOR: Record<ErrorClass, string> = {
+  timeout: 'var(--vg-amber)',
+  no_worker: 'var(--vg-red)',
+  no_reply: 'var(--vg-red)',
+  auth: 'var(--vg-red)',
+  config: 'var(--vg-muted)',
+  connect: 'var(--vg-amber)',
+  other: 'var(--vg-muted-2)',
+};
+
+/** Display order: the classes an operator can act on first, `other` last. */
+export const ERROR_CLASS_ORDER: ErrorClass[] = [
+  'timeout',
+  'no_worker',
+  'no_reply',
+  'auth',
+  'connect',
+  'config',
+  'other',
+];
+
+/**
+ * Bucket one error string. Substring matching only: no cause is invented.
+ *
+ * `no_reply` is deliberately NOT reachable from here. It is not a reported error
+ * at all - it is a latency check that succeeded while measuring zero trials, so
+ * only the caller that can see the trial count may assign it.
+ */
+export function classifyError(message: string): ErrorClass {
+  const m = message.toLowerCase();
+  if (m.includes('timed out') || m.includes('timeout')) return 'timeout';
+  if (m.includes('no worker joined') || m.includes('worker joined')) return 'no_worker';
+  if (
+    m.includes('401') ||
+    m.includes('403') ||
+    m.includes('unauthorized') ||
+    m.includes('forbidden') ||
+    m.includes('invalid api key')
+  ) {
+    return 'auth';
+  }
+  if (m.includes('not configured') || m.includes('missing livekit credentials')) return 'config';
+  if (
+    m.includes('connect') ||
+    m.includes('connection') ||
+    m.includes('refused') ||
+    m.includes('unreachable') ||
+    m.includes('dns') ||
+    m.includes('handshake') ||
+    m.includes('ssl') ||
+    m.includes('tls')
+  ) {
+    return 'connect';
+  }
+  return 'other';
+}
+
+/** One failure after classification: what class, where it came from, what it said. */
+export interface ClassifiedError {
+  /** The check name that reported it, or `run` for a whole-run error. */
+  where: string;
+  message: string;
+  klass: ErrorClass;
+}

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -418,11 +418,186 @@ export interface DiagnosticsCreds {
   url: string | null;
 }
 
-/** Per-check result inside a DiagnosticRun's results map. */
-export interface DiagnosticCheckResult {
+/** The checks a run can request. Also the key each result is filed under. */
+export type DiagCheckName = 'agents' | 'sfu' | 'sfu_load' | 'latency';
+
+/**
+ * One agent seen inside a live room (`livekit_diag.admin.AgentRow`).
+ *
+ * This is the IN-ROOM population only: LiveKit's server API reports a worker
+ * only once it has joined a room, so an idle registered worker never appears
+ * here. `DiagAgentsResult.roster` is the other half.
+ */
+export interface DiagAgentRow {
+  agent_name: string;
+  room: string;
+  identity: string | null;
+  /** 'active' (joined the room) or 'dispatched' (assigned, has not joined yet). */
+  state: string;
+  /** Non-agent participants in the same room. */
+  humans: number;
+  /** Seconds since the agent joined; null when the server reported no join time. */
+  age_s: number | null;
+}
+
+/**
+ * One registered worker from the collector's heartbeat roster.
+ *
+ * Every field is optional because this JSON is produced by whatever collector
+ * the operator pointed at (`VOICEGW_COLLECTOR_URL`), not by this build, so the
+ * UI must tolerate a missing key rather than render `undefined`.
+ */
+export interface DiagRosterWorker {
+  agent_id?: string | null;
+  agent_name?: string | null;
+  /** idle | busy | offline, as reported by the worker's own heartbeat. */
+  status?: string | null;
+  region?: string | null;
+  host?: string | null;
+  version?: string | null;
+  active_sessions?: number | null;
+  /** Epoch seconds of the last heartbeat. */
+  last_seen?: number | null;
+}
+
+/** `agents` check result. */
+export interface DiagAgentsResult {
+  agents: DiagAgentRow[];
+  /**
+   * The heartbeat roster, or null when NO collector is configured.
+   *
+   * The distinction is load-bearing: `null` means nobody was asked (so the UI
+   * says how to enable it), `[]` means the collector was asked and reported no
+   * workers (or could not be reached). Collapsing the two would render "not
+   * configured" as "you have zero workers".
+   */
+  roster: DiagRosterWorker[] | null;
+}
+
+/** The SFU baseline: 2 synthetic clients talking through the SFU. */
+export interface DiagSfuBaseline {
+  /** Data-channel round trip through the SFU, in ms (no clock sync needed). */
+  rtt_ms: number;
+  /**
+   * NOT A MEASUREMENT. `sfu.py` hardcodes 0.0 because the SDK does not expose
+   * per-connection loss here. Never render it as a number and never build a
+   * series on it: a flat 0% loss line reads as a clean bill of health nobody
+   * measured. `quality` is the coarse signal that is real.
+   */
+  loss_pct: number;
+  /** Connection quality from the SDK: Excellent | Good | Poor | Lost | Unknown. */
+  quality: string;
+}
+
+/** One ramp tier: `clients` synthetic clients in one room for the step duration. */
+export interface DiagSfuStep extends DiagSfuBaseline {
+  clients: number;
+}
+
+/**
+ * The PROBER host's own load during the ramp (not the SFU's).
+ *
+ * Null fields mean "not sampled", never "idle": the backend maps
+ * `ResourceReport`'s 0.0 defaults to null so an unsampled CPU cannot render as a
+ * host with infinite headroom. `saturated` is null for the same reason - with no
+ * CPU sample, saturation is unknown, not false.
+ */
+export interface DiagResourceReport {
+  cpu_peak: number | null;
+  mem_peak_mb: number | null;
+  net_kbps_up: number | null;
+  saturated: boolean | null;
+  per_client: { cpu_pct: number | null; kbps_up: number | null };
+  /** Clients this host could sustain before it is CPU-bound; null when unknown. */
+  sustainable_n: number | null;
+}
+
+/** `sfu` and `sfu_load` check result (the ramp is empty for the plain `sfu` check). */
+export interface DiagSfuResult {
+  baseline: DiagSfuBaseline;
+  ramp: DiagSfuStep[];
+  /**
+   * The last healthy client count before the first tier that broke the budget.
+   *
+   * **Null is ambiguous on its own**: `find_knee` returns null both when nothing
+   * breached AND when the FIRST tier breached. Compare `ramp` against
+   * `target_rtt_ms` to tell a clean ramp from a total failure.
+   */
+  knee: number | null;
+  /** The rtt budget the knee was computed against, in ms. */
+  target_rtt_ms: number;
+  /** Null when the run did not include the load check (no ramp, nothing sampled). */
+  resource: DiagResourceReport | null;
+}
+
+/**
+ * Per-leg split for one probed agent, in SECONDS, read back from the rows the
+ * agent itself wrote for the probe room. A leg the run did not produce (or that
+ * this host never saw) is absent - never zero.
+ */
+export interface DiagComponentSplit {
+  eou?: number;
+  stt?: number;
+  stt_ttfp?: number;
+  stt_transcription_delay?: number;
+  llm_ttft?: number;
+  tts?: number;
+}
+
+/**
+ * End-to-end reply timings for one agent, in SECONDS.
+ *
+ * `p50`/`p95` come from `livekit_diag.latency.summarize` over at most
+ * `MAX_LATENCY_TRIALS = 3` samples. Three samples cannot support a percentile,
+ * so the UI must render `max` labelled "max of N" - never "p95".
+ */
+export interface DiagLatencyStats {
+  avg: number;
+  p50: number;
+  p95: number;
+  min: number;
+  max: number;
+  /** Successful trials. 0 means nothing was measured for this agent. */
+  trials: number;
+}
+
+export interface DiagLatencyAgent {
+  agent: string;
+  stats: DiagLatencyStats;
+  /** Null when the agent does not write telemetry to this host. */
+  components: DiagComponentSplit | null;
+}
+
+/** `latency` check result. */
+export interface DiagLatencyResult {
+  agents: DiagLatencyAgent[];
+}
+
+/** Any check's payload, for code that only reads `ok` / `error`. */
+export type DiagCheckPayload = DiagAgentsResult | DiagSfuResult | DiagLatencyResult;
+
+/**
+ * Per-check result inside a DiagnosticRun's results map.
+ *
+ * `result` is present only when `ok`; a failed check carries `error` instead.
+ */
+export interface DiagnosticCheckResult<R = DiagCheckPayload> {
   ok: boolean;
-  result?: unknown;
+  result?: R;
   error?: string;
+}
+
+/** The per-check map, keyed by check name: only requested checks are present. */
+export interface DiagnosticRunChecks {
+  agents?: DiagnosticCheckResult<DiagAgentsResult>;
+  sfu?: DiagnosticCheckResult<DiagSfuResult>;
+  sfu_load?: DiagnosticCheckResult<DiagSfuResult>;
+  latency?: DiagnosticCheckResult<DiagLatencyResult>;
+}
+
+export interface DiagnosticRunResults {
+  checks: DiagnosticRunChecks;
+  verdict: string;
 }
 
 /** One diagnostic run record from the backend. */
@@ -431,7 +606,7 @@ export interface DiagnosticRun {
   status: 'queued' | 'running' | 'done' | 'failed';
   checks: string[];
   config: Record<string, unknown>;
-  results: { checks: Record<string, DiagnosticCheckResult>; verdict: string } | null;
+  results: DiagnosticRunResults | null;
   verdict: string | null;
   error: string | null;
   created_at: string | null;

--- a/src/dashboard/frontend/src/pages/Diagnostics.tsx
+++ b/src/dashboard/frontend/src/pages/Diagnostics.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import PageHeader from '../components/PageHeader';
 import {
   createDiagnosticsRun,
@@ -7,7 +7,14 @@ import {
   fetchDiagnosticsRuns,
 } from '../lib/api';
 import { DEMO_MODE } from '../lib/demo';
-import type { DiagnosticRun, DiagnosticsCreds } from '../lib/types';
+import { formatDateTime } from '../lib/time';
+import type { DiagCheckName, DiagnosticRun, DiagnosticsCreds } from '../lib/types';
+import AgentsTab from './diagnostics/AgentsTab';
+import ErrorsTab from './diagnostics/ErrorsTab';
+import LatencyTab from './diagnostics/LatencyTab';
+import LoadTab from './diagnostics/LoadTab';
+import { Note } from './diagnostics/shared';
+import SfuTab from './diagnostics/SfuTab';
 
 const CHECK_OPTS = [
   { key: 'agents', label: 'Agents in rooms' },
@@ -17,6 +24,20 @@ const CHECK_OPTS = [
 ] as const;
 
 const MAX_POLLS = 180;
+
+// Result tabs. Each renders exactly one check's payload, and says so when that
+// check was not part of the run rather than rendering an empty card.
+const TABS = ['Agents', 'SFU', 'Load', 'Latency', 'Errors'] as const;
+type Tab = (typeof TABS)[number];
+
+const CHECK_LABEL: Record<DiagCheckName, string> = {
+  agents: 'agents',
+  sfu: 'sfu baseline',
+  sfu_load: 'sfu load',
+  latency: 'latency',
+};
+
+const CHECK_ORDER: DiagCheckName[] = ['agents', 'sfu', 'sfu_load', 'latency'];
 
 function verdictBadgeClass(v: string | null): string {
   if (v === 'PASS') return 'neo-badge--green';
@@ -40,6 +61,7 @@ export default function Diagnostics() {
   const [selected, setSelected] = useState<Set<string>>(new Set(['agents', 'sfu']));
   const [inFlight, setInFlight] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('Agents');
 
   // Load creds status + run history on mount.
   useEffect(() => {
@@ -56,6 +78,16 @@ export default function Diagnostics() {
   // Demo build is read-only: never allow starting a (billed, long-polling) run.
   const canRun = configured && selected.size > 0 && !inFlight && !DEMO_MODE;
 
+  // The run being inspected, and the history the error classes are counted over.
+  // An in-flight run is not in `runs` until it finishes, so it is prepended here
+  // rather than waiting: its partial results are still the newest thing measured.
+  const allRuns = useMemo(() => {
+    if (run && !runs.some((r) => r.run_id === run.run_id)) return [run, ...runs];
+    return runs;
+  }, [run, runs]);
+  const current = run ?? allRuns[0] ?? null;
+  const checks = current?.results?.checks;
+
   const toggleCheck = (key: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -69,8 +101,8 @@ export default function Diagnostics() {
     setInFlight(true);
     setRunError(null);
     try {
-      const checks = Array.from(selected);
-      const { run_id } = await createDiagnosticsRun({ checks, config: {} });
+      const checkList = Array.from(selected);
+      const { run_id } = await createDiagnosticsRun({ checks: checkList, config: {} });
 
       let rec = await fetchDiagnosticsRun(run_id);
       if (mountedRef.current) setRun(rec);
@@ -216,66 +248,58 @@ export default function Diagnostics() {
         </div>
       </div>
 
-      {/* Latest run card */}
-      {run && (
+      {/* Results: the run summary, then one tab per check payload. */}
+      {current === null ? (
         <div className="vg-card" style={{ marginBottom: 16 }}>
-          <div
-            style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}
-          >
-            <span className="vg-card__label">
-              Latest run
-              {(run.status === 'queued' || run.status === 'running') && ' (in progress)'}
-            </span>
-            {run.verdict && (
-              <span className={`neo-badge ${verdictBadgeClass(run.verdict)}`}>
-                {run.verdict}
-              </span>
-            )}
-          </div>
-          {run.results ? (
-            <table className="neo-table neo-table--blue">
-              <thead>
-                <tr>
-                  <th>Check</th>
-                  <th>Result</th>
-                </tr>
-              </thead>
-              <tbody>
-                {Object.entries(run.results.checks).map(([name, result]) => (
-                  <tr key={name}>
-                    <td style={{ fontWeight: 500 }}>{name}</td>
-                    <td>
-                      {result.ok ? (
-                        <span className="neo-badge neo-badge--green">ok</span>
-                      ) : (
-                        <span className="neo-badge neo-badge--red">
-                          {result.error ? `error: ${result.error}` : 'error'}
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          ) : run.error ? (
-            <div
-              style={{
-                padding: '10px 14px',
-                borderRadius: 6,
-                border: '1.5px solid var(--vg-red, #e53e3e)',
-                background: 'rgba(229, 62, 62, 0.07)',
-                color: 'var(--vg-red, #c53030)',
-                fontSize: 13,
-              }}
-            >
-              {run.error}
+          <div className="vg-card__label" style={{ marginBottom: 10 }}>Results</div>
+          <Note>
+            No diagnostics run has been recorded yet. Pick the checks above and run them: the
+            results land here, one tab per check, and nothing is shown that was not measured.
+          </Note>
+        </div>
+      ) : (
+        <>
+          <RunSummary run={current} />
+
+          {current.results === null ? (
+            <div className="vg-card" style={{ marginBottom: 16 }}>
+              <div className="vg-card__label" style={{ marginBottom: 10 }}>Results</div>
+              {current.status === 'queued' || current.status === 'running' ? (
+                <Note>
+                  The checks are still running. Results appear per check as the run completes; a run
+                  is capped at six minutes.
+                </Note>
+              ) : (
+                <Note tone="bad">
+                  This run recorded no results: {current.error ?? 'the reason was not reported'}
+                </Note>
+              )}
             </div>
           ) : (
-            <div style={{ color: 'var(--vg-muted)', fontSize: 13 }}>
-              Waiting for results...
-            </div>
+            <>
+              <div className="neo-tabs">
+                {TABS.map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    className={`neo-tab${activeTab === t ? ' neo-tab--active' : ''}`}
+                    onClick={() => setActiveTab(t)}
+                  >
+                    {t}
+                  </button>
+                ))}
+              </div>
+
+              {activeTab === 'Agents' && <AgentsTab check={checks?.agents} />}
+              {/* The plain sfu check and the load check both measure a baseline;
+                  prefer the dedicated one, fall back to the load run's. */}
+              {activeTab === 'SFU' && <SfuTab check={checks?.sfu ?? checks?.sfu_load} />}
+              {activeTab === 'Load' && <LoadTab check={checks?.sfu_load} />}
+              {activeTab === 'Latency' && <LatencyTab check={checks?.latency} />}
+              {activeTab === 'Errors' && <ErrorsTab runs={allRuns} />}
+            </>
           )}
-        </div>
+        </>
       )}
 
       {/* Run history card */}
@@ -312,6 +336,59 @@ export default function Diagnostics() {
           </table>
         </div>
       )}
+    </div>
+  );
+}
+
+/** Header card for the run the tabs below are showing: when, what, and how it went. */
+function RunSummary({ run }: { run: DiagnosticRun }) {
+  const checks = run.results?.checks;
+  const ran = CHECK_ORDER.filter((name) => checks?.[name] !== undefined);
+
+  return (
+    <div className="vg-card" style={{ marginBottom: 16 }}>
+      <div
+        className="flex-row"
+        style={{ justifyContent: 'space-between', alignItems: 'center', gap: 10, marginBottom: 10 }}
+      >
+        <div className="vg-card__label">
+          Latest run
+          {(run.status === 'queued' || run.status === 'running') && ' (in progress)'}
+        </div>
+        <span className={`neo-badge ${verdictBadgeClass(run.verdict)}`}>
+          {run.verdict ?? run.status}
+        </span>
+      </div>
+
+      <div className="flex-row flex-wrap" style={{ gap: 18, fontSize: 12, color: 'var(--vg-muted)' }}>
+        <span>Started {run.created_at ? formatDateTime(run.created_at) : 'at an unrecorded time'}</span>
+        {run.ended_at && <span>Ended {formatDateTime(run.ended_at)}</span>}
+        {/* Run ids are a uuid4 hex; 12 chars is enough to tell two runs apart
+            without wrapping the line. */}
+        <span className="mono">run {run.run_id.slice(0, 12)}</span>
+      </div>
+
+      <div className="flex-row flex-wrap" style={{ gap: 8, marginTop: 12 }}>
+        {ran.length === 0 ? (
+          <span style={{ fontSize: 13, color: 'var(--vg-muted)' }}>
+            No check has reported a result for this run yet.
+          </span>
+        ) : (
+          ran.map((name) => {
+            const check = checks?.[name];
+            const ok = check?.ok === true;
+            return (
+              <span
+                key={name}
+                className={`neo-badge ${ok ? 'neo-badge--green' : 'neo-badge--red'}`}
+                title={ok ? 'the check completed' : (check?.error ?? 'the check failed')}
+              >
+                {CHECK_LABEL[name]} {ok ? 'ok' : `failed: ${check?.error ?? 'no reason reported'}`}
+              </span>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 }

--- a/src/dashboard/frontend/src/pages/diagnostics/AgentsTab.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/AgentsTab.tsx
@@ -1,0 +1,177 @@
+// Diagnostics > Agents: the two agent populations, side by side.
+//
+// They are NOT the same list, and conflating them is the mistake this tab
+// exists to prevent. `agents` is what LiveKit's server API can see: a worker
+// only appears once it has JOINED a room. `roster` is what the workers say about
+// themselves through their own heartbeat, which is the only way an idle
+// registered worker is visible at all.
+
+import type { DiagAgentsResult, DiagnosticCheckResult } from '../../lib/types';
+import { formatRelativeTime, rosterStatusBadge } from '../../lib/ui';
+import { Card, CheckGate, Note } from './shared';
+
+const ROSTER_NOTE =
+  'Idle and registered workers are not reported by LiveKit’s server API, so this run could only see agents already in a room. Set VOICEGW_COLLECTOR_URL and VOICEGW_API_KEY, and call register_worker() in your agents, to list the heartbeat roster here too.';
+
+function formatAge(ageSeconds: number | null): string {
+  if (ageSeconds == null) return '—'; // the server reported no join time
+  if (ageSeconds < 60) return `${Math.round(ageSeconds)}s`;
+  const minutes = Math.floor(ageSeconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.floor(minutes / 60)}h`;
+}
+
+export default function AgentsTab({
+  check,
+}: {
+  check: DiagnosticCheckResult<DiagAgentsResult> | undefined;
+}) {
+  return (
+    <CheckGate
+      check={check}
+      label="Agents in rooms"
+      missingHint="Tick “Agents in rooms” above and run the checks again."
+    >
+      {(result) => (
+        <>
+          <InRoomCard agents={result.agents} />
+          <RosterCard roster={result.roster} />
+        </>
+      )}
+    </CheckGate>
+  );
+}
+
+function InRoomCard({ agents }: { agents: DiagAgentsResult['agents'] }) {
+  const rooms = new Set(agents.map((a) => a.room)).size;
+  return (
+    <Card
+      label="In-room agents (LiveKit server API)"
+      right={
+        <span className="neo-badge neo-badge--blue">
+          {agents.length} in {rooms} {rooms === 1 ? 'room' : 'rooms'}
+        </span>
+      }
+    >
+      {agents.length === 0 ? (
+        <Note>
+          No agent was in a room when this check ran. LiveKit reports a worker only once it has
+          joined a room, so an idle worker that is running fine looks identical to no worker at
+          all here: the heartbeat roster below is what tells them apart.
+        </Note>
+      ) : (
+        <>
+          <table className="neo-table neo-table--blue">
+            <thead>
+              <tr>
+                <th>Agent</th>
+                <th>Room</th>
+                <th>State</th>
+                <th>Humans</th>
+                <th>Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agents.map((a) => (
+                <tr key={`${a.agent_name}:${a.room}:${a.identity ?? ''}`}>
+                  <td style={{ fontWeight: 600 }}>{a.agent_name}</td>
+                  <td className="mono" style={{ fontSize: 12 }}>{a.room}</td>
+                  <td>
+                    <span
+                      className={`neo-badge ${a.state === 'active' ? 'neo-badge--green' : 'neo-badge--yellow'}`}
+                      title={
+                        a.state === 'active'
+                          ? 'the worker joined the room'
+                          : 'the job was assigned but no worker has joined yet'
+                      }
+                    >
+                      {a.state}
+                    </span>
+                  </td>
+                  <td className="mono">{a.humans}</td>
+                  <td className="mono" style={{ color: 'var(--vg-muted)' }}>{formatAge(a.age_s)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div style={{ marginTop: 10 }}>
+            <Note>
+              “dispatched” means LiveKit assigned the job but no worker has joined the room yet.
+              Humans counts the non-agent participants sharing that room.
+            </Note>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}
+
+function RosterCard({ roster }: { roster: DiagAgentsResult['roster'] }) {
+  // null and [] are different answers: nobody was asked, versus asked and told
+  // nothing. Rendering both as "0 workers" would report a missing collector as
+  // an empty fleet.
+  if (roster === null) {
+    return (
+      <Card
+        label="Registered workers (heartbeat roster)"
+        right={<span className="neo-badge neo-badge--black">not configured</span>}
+      >
+        <Note>{ROSTER_NOTE}</Note>
+      </Card>
+    );
+  }
+
+  const counts = {
+    idle: roster.filter((w) => w.status === 'idle').length,
+    busy: roster.filter((w) => w.status === 'busy').length,
+    offline: roster.filter((w) => w.status === 'offline').length,
+  };
+
+  return (
+    <Card
+      label="Registered workers (heartbeat roster)"
+      right={
+        <span className="neo-badge neo-badge--blue">
+          {roster.length} registered · {counts.idle} idle · {counts.busy} busy · {counts.offline} offline
+        </span>
+      }
+    >
+      {roster.length === 0 ? (
+        <Note>
+          The collector is configured but reported no workers. Either none have sent a heartbeat
+          yet, or it could not be reached on this run: a roster fetch is best-effort and never
+          fails the check.
+        </Note>
+      ) : (
+        <table className="neo-table neo-table--blue">
+          <thead>
+            <tr>
+              <th>Worker</th>
+              <th>Status</th>
+              <th>Region</th>
+              <th>Version</th>
+              <th>Last heartbeat</th>
+            </tr>
+          </thead>
+          <tbody>
+            {roster.map((w, i) => (
+              <tr key={w.agent_id ?? w.agent_name ?? i}>
+                <td style={{ fontWeight: 600 }}>{w.agent_name || w.agent_id || 'unnamed worker'}</td>
+                <td>
+                  <span className={`neo-badge ${rosterStatusBadge(w.status ?? 'offline')}`}>
+                    {w.status ?? 'unknown'}
+                  </span>
+                </td>
+                <td className="mono" style={{ fontSize: 12 }}>{w.region ?? '—'}</td>
+                <td className="mono" style={{ fontSize: 12 }}>{w.version ?? '—'}</td>
+                <td className="mono" style={{ fontSize: 12, color: 'var(--vg-muted)' }}>
+                  {formatRelativeTime(w.last_seen ?? null)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  );
+}

--- a/src/dashboard/frontend/src/pages/diagnostics/ErrorsTab.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/ErrorsTab.tsx
@@ -1,0 +1,216 @@
+// Diagnostics > Errors: what failed, grouped by cause, across the run history.
+//
+// A single run's verdict says PASS or FAIL. It does not say whether the same
+// thing keeps failing, which is the question an operator actually has. These bars
+// group every failure the history holds by class, so "the collector times out
+// every run" and "one auth error last Tuesday" stop looking the same.
+//
+// Two sources, both already on the wire: a failed check's own error string, and a
+// latency check where an agent answered zero of its trials (measured nothing,
+// which is a failure even though the check itself succeeded). Nothing here is
+// inferred beyond matching those strings.
+
+import type { DiagnosticRun } from '../../lib/types';
+import { Card, Note } from './shared';
+
+type ClassKey = 'timeout' | 'no_worker' | 'no_reply' | 'auth' | 'config' | 'connect' | 'other';
+
+const CLASS_LABEL: Record<ClassKey, string> = {
+  timeout: 'Timed out',
+  no_worker: 'No worker joined',
+  no_reply: 'No reply from agent',
+  auth: 'Auth rejected',
+  config: 'Not configured',
+  connect: 'Could not connect',
+  other: 'Other',
+};
+
+const CLASS_COLOR: Record<ClassKey, string> = {
+  timeout: 'var(--vg-amber)',
+  no_worker: 'var(--vg-red)',
+  no_reply: 'var(--vg-red)',
+  auth: 'var(--vg-red)',
+  config: 'var(--vg-muted)',
+  connect: 'var(--vg-amber)',
+  other: 'var(--vg-muted-2)',
+};
+
+const ORDER: ClassKey[] = [
+  'timeout',
+  'no_worker',
+  'no_reply',
+  'auth',
+  'connect',
+  'config',
+  'other',
+];
+
+/** Bucket one error string. Substring matching only: no cause is invented. */
+function classify(message: string): ClassKey {
+  const m = message.toLowerCase();
+  if (m.includes('timed out') || m.includes('timeout')) return 'timeout';
+  if (m.includes('no worker joined') || m.includes('worker joined')) return 'no_worker';
+  if (
+    m.includes('401') ||
+    m.includes('403') ||
+    m.includes('unauthorized') ||
+    m.includes('forbidden') ||
+    m.includes('invalid api key')
+  ) {
+    return 'auth';
+  }
+  if (m.includes('not configured') || m.includes('missing livekit credentials')) return 'config';
+  if (
+    m.includes('connect') ||
+    m.includes('connection') ||
+    m.includes('refused') ||
+    m.includes('unreachable') ||
+    m.includes('dns') ||
+    m.includes('handshake') ||
+    m.includes('ssl') ||
+    m.includes('tls')
+  ) {
+    return 'connect';
+  }
+  return 'other';
+}
+
+interface Failure {
+  runId: string;
+  where: string;
+  message: string;
+  klass: ClassKey;
+}
+
+/** Every failure the history holds, in run order (newest run first). */
+function collectFailures(runs: DiagnosticRun[]): Failure[] {
+  const out: Failure[] = [];
+  for (const run of runs) {
+    if (run.error) {
+      out.push({
+        runId: run.run_id,
+        where: 'run',
+        message: run.error,
+        klass: classify(run.error),
+      });
+    }
+    const checks = run.results?.checks;
+    if (!checks) continue;
+    for (const [name, check] of Object.entries(checks)) {
+      if (check === undefined) continue;
+      if (!check.ok) {
+        const message = check.error ?? 'the check reported no result';
+        out.push({ runId: run.run_id, where: name, message, klass: classify(message) });
+      }
+    }
+    // A latency check can succeed while measuring nothing: the call was placed
+    // and no trial ever got a reply. That is a failure of the agent, not of the
+    // check, and it is the single most common thing an operator needs to see.
+    const latency = checks.latency;
+    if (latency?.ok && latency.result) {
+      for (const agent of latency.result.agents) {
+        if (agent.stats.trials === 0) {
+          out.push({
+            runId: run.run_id,
+            where: 'latency',
+            message: `${agent.agent}: no trial produced a reply`,
+            klass: 'no_reply',
+          });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function truncate(text: string, max = 130): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+export default function ErrorsTab({ runs }: { runs: DiagnosticRun[] }) {
+  const failures = collectFailures(runs);
+  const counts = ORDER.map((key) => ({
+    key,
+    count: failures.filter((f) => f.klass === key).length,
+    examples: failures.filter((f) => f.klass === key).map((f) => `${f.where}: ${f.message}`),
+  })).filter((c) => c.count > 0);
+  const max = counts.reduce((m, c) => Math.max(m, c.count), 0);
+
+  return (
+    <Card
+      label="Failures by class"
+      right={
+        <span className={`neo-badge ${failures.length === 0 ? 'neo-badge--green' : 'neo-badge--red'}`}>
+          {failures.length} across {runs.length} {runs.length === 1 ? 'run' : 'runs'}
+        </span>
+      }
+    >
+      {counts.length === 0 ? (
+        <Note tone="good">
+          No failed check in the {runs.length} {runs.length === 1 ? 'run' : 'runs'} this dashboard
+          is holding. Run history lives in memory and is capped at the newest 20 runs, so it starts
+          empty again after a restart.
+        </Note>
+      ) : (
+        <>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            {counts.map((c) => (
+              <div key={c.key}>
+                <div
+                  className="flex-row"
+                  style={{ justifyContent: 'space-between', alignItems: 'baseline', gap: 10 }}
+                >
+                  <span style={{ fontSize: 13, fontWeight: 600 }}>{CLASS_LABEL[c.key]}</span>
+                  <span className="mono" style={{ fontSize: 13, fontWeight: 700 }}>
+                    {c.count}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 10,
+                    marginTop: 5,
+                    borderRadius: 'var(--vg-radius-xs)',
+                    background: 'var(--vg-hairline)',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${max === 0 ? 0 : (c.count / max) * 100}%`,
+                      height: '100%',
+                      background: CLASS_COLOR[c.key],
+                    }}
+                  />
+                </div>
+                <div style={{ marginTop: 5 }}>
+                  {c.examples.slice(0, 2).map((example, i) => (
+                    <div
+                      key={i}
+                      className="mono"
+                      style={{ fontSize: 11, color: 'var(--vg-muted)', lineHeight: 1.5 }}
+                    >
+                      {truncate(example)}
+                    </div>
+                  ))}
+                  {c.examples.length > 2 && (
+                    <div style={{ fontSize: 11, color: 'var(--vg-muted-2)' }}>
+                      +{c.examples.length - 2} more like this
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ marginTop: 16 }}>
+            <Note>
+              Counted over the {runs.length} {runs.length === 1 ? 'run' : 'runs'} in this history
+              (in memory, newest 20). A latency check that ran fine but got no reply from an agent
+              counts here as well: it measured nothing, which no verdict on its own would tell you.
+            </Note>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/src/dashboard/frontend/src/pages/diagnostics/ErrorsTab.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/ErrorsTab.tsx
@@ -10,76 +10,14 @@
 // which is a failure even though the check itself succeeded). Nothing here is
 // inferred beyond matching those strings.
 
+import ErrorClassChart from '../../components/ErrorClassChart';
+import { classifyError, type ClassifiedError } from '../../lib/errorClass';
 import type { DiagnosticRun } from '../../lib/types';
 import { Card, Note } from './shared';
 
-type ClassKey = 'timeout' | 'no_worker' | 'no_reply' | 'auth' | 'config' | 'connect' | 'other';
-
-const CLASS_LABEL: Record<ClassKey, string> = {
-  timeout: 'Timed out',
-  no_worker: 'No worker joined',
-  no_reply: 'No reply from agent',
-  auth: 'Auth rejected',
-  config: 'Not configured',
-  connect: 'Could not connect',
-  other: 'Other',
-};
-
-const CLASS_COLOR: Record<ClassKey, string> = {
-  timeout: 'var(--vg-amber)',
-  no_worker: 'var(--vg-red)',
-  no_reply: 'var(--vg-red)',
-  auth: 'var(--vg-red)',
-  config: 'var(--vg-muted)',
-  connect: 'var(--vg-amber)',
-  other: 'var(--vg-muted-2)',
-};
-
-const ORDER: ClassKey[] = [
-  'timeout',
-  'no_worker',
-  'no_reply',
-  'auth',
-  'connect',
-  'config',
-  'other',
-];
-
-/** Bucket one error string. Substring matching only: no cause is invented. */
-function classify(message: string): ClassKey {
-  const m = message.toLowerCase();
-  if (m.includes('timed out') || m.includes('timeout')) return 'timeout';
-  if (m.includes('no worker joined') || m.includes('worker joined')) return 'no_worker';
-  if (
-    m.includes('401') ||
-    m.includes('403') ||
-    m.includes('unauthorized') ||
-    m.includes('forbidden') ||
-    m.includes('invalid api key')
-  ) {
-    return 'auth';
-  }
-  if (m.includes('not configured') || m.includes('missing livekit credentials')) return 'config';
-  if (
-    m.includes('connect') ||
-    m.includes('connection') ||
-    m.includes('refused') ||
-    m.includes('unreachable') ||
-    m.includes('dns') ||
-    m.includes('handshake') ||
-    m.includes('ssl') ||
-    m.includes('tls')
-  ) {
-    return 'connect';
-  }
-  return 'other';
-}
-
-interface Failure {
+/** A classified failure plus the run it came from. */
+interface Failure extends ClassifiedError {
   runId: string;
-  where: string;
-  message: string;
-  klass: ClassKey;
 }
 
 /** Every failure the history holds, in run order (newest run first). */
@@ -91,7 +29,7 @@ function collectFailures(runs: DiagnosticRun[]): Failure[] {
         runId: run.run_id,
         where: 'run',
         message: run.error,
-        klass: classify(run.error),
+        klass: classifyError(run.error),
       });
     }
     const checks = run.results?.checks;
@@ -100,7 +38,7 @@ function collectFailures(runs: DiagnosticRun[]): Failure[] {
       if (check === undefined) continue;
       if (!check.ok) {
         const message = check.error ?? 'the check reported no result';
-        out.push({ runId: run.run_id, where: name, message, klass: classify(message) });
+        out.push({ runId: run.run_id, where: name, message, klass: classifyError(message) });
       }
     }
     // A latency check can succeed while measuring nothing: the call was placed
@@ -123,18 +61,8 @@ function collectFailures(runs: DiagnosticRun[]): Failure[] {
   return out;
 }
 
-function truncate(text: string, max = 130): string {
-  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
-}
-
 export default function ErrorsTab({ runs }: { runs: DiagnosticRun[] }) {
   const failures = collectFailures(runs);
-  const counts = ORDER.map((key) => ({
-    key,
-    count: failures.filter((f) => f.klass === key).length,
-    examples: failures.filter((f) => f.klass === key).map((f) => `${f.where}: ${f.message}`),
-  })).filter((c) => c.count > 0);
-  const max = counts.reduce((m, c) => Math.max(m, c.count), 0);
 
   return (
     <Card
@@ -145,7 +73,7 @@ export default function ErrorsTab({ runs }: { runs: DiagnosticRun[] }) {
         </span>
       }
     >
-      {counts.length === 0 ? (
+      {failures.length === 0 ? (
         <Note tone="good">
           No failed check in the {runs.length} {runs.length === 1 ? 'run' : 'runs'} this dashboard
           is holding. Run history lives in memory and is capped at the newest 20 runs, so it starts
@@ -153,54 +81,7 @@ export default function ErrorsTab({ runs }: { runs: DiagnosticRun[] }) {
         </Note>
       ) : (
         <>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-            {counts.map((c) => (
-              <div key={c.key}>
-                <div
-                  className="flex-row"
-                  style={{ justifyContent: 'space-between', alignItems: 'baseline', gap: 10 }}
-                >
-                  <span style={{ fontSize: 13, fontWeight: 600 }}>{CLASS_LABEL[c.key]}</span>
-                  <span className="mono" style={{ fontSize: 13, fontWeight: 700 }}>
-                    {c.count}
-                  </span>
-                </div>
-                <div
-                  style={{
-                    height: 10,
-                    marginTop: 5,
-                    borderRadius: 'var(--vg-radius-xs)',
-                    background: 'var(--vg-hairline)',
-                    overflow: 'hidden',
-                  }}
-                >
-                  <div
-                    style={{
-                      width: `${max === 0 ? 0 : (c.count / max) * 100}%`,
-                      height: '100%',
-                      background: CLASS_COLOR[c.key],
-                    }}
-                  />
-                </div>
-                <div style={{ marginTop: 5 }}>
-                  {c.examples.slice(0, 2).map((example, i) => (
-                    <div
-                      key={i}
-                      className="mono"
-                      style={{ fontSize: 11, color: 'var(--vg-muted)', lineHeight: 1.5 }}
-                    >
-                      {truncate(example)}
-                    </div>
-                  ))}
-                  {c.examples.length > 2 && (
-                    <div style={{ fontSize: 11, color: 'var(--vg-muted-2)' }}>
-                      +{c.examples.length - 2} more like this
-                    </div>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+          <ErrorClassChart errors={failures} />
 
           <div style={{ marginTop: 16 }}>
             <Note>

--- a/src/dashboard/frontend/src/pages/diagnostics/LatencyTab.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/LatencyTab.tsx
@@ -1,0 +1,136 @@
+// Diagnostics > Latency: real calls placed to every agent found in a room.
+//
+// The headline is deliberately "max of N", not "p95". A diagnostics run places at
+// most MAX_LATENCY_TRIALS = 3 calls per agent, and a percentile computed from
+// three samples is not a percentile: it is the max wearing a more confident
+// label. The backend does return `p95` (from `summarize`), and this tab does not
+// render it.
+//
+// The per-leg split is only available when the probed agent writes its telemetry
+// to THIS host: it is read back out of the rows the agent itself wrote for the
+// probe room. An agent reporting to a remote collector says so, rather than
+// showing zeros.
+
+import LatencyWaterfall from '../../components/LatencyWaterfall';
+import type {
+  DiagLatencyAgent,
+  DiagLatencyResult,
+  DiagnosticCheckResult,
+} from '../../lib/types';
+import { Card, CheckGate, Note, NOT_MEASURED, Row } from './shared';
+
+/** Percentiles need at least 10 samples; below that we show "max of N". */
+const MIN_SAMPLES_FOR_PERCENTILE = 10;
+
+/** Probe times come back in seconds; the rest of the dashboard speaks ms. */
+function toMs(seconds: number | undefined): number | null {
+  return seconds == null ? null : seconds * 1000;
+}
+
+export default function LatencyTab({
+  check,
+}: {
+  check: DiagnosticCheckResult<DiagLatencyResult> | undefined;
+}) {
+  return (
+    <CheckGate
+      check={check}
+      label="Latency (real calls)"
+      missingHint="Tick “Latency (real calls)” above and run the checks again. Every trial is a real, billed call through the agent’s own providers."
+    >
+      {(result) =>
+        result.agents.length === 0 ? (
+          <Card label="Latency (real calls)">
+            <Note>
+              No agent was in a room to call, so no latency was measured. The run probes the
+              agents the LiveKit server reported; it never invents a target to dial.
+            </Note>
+          </Card>
+        ) : (
+          <>
+            {result.agents.map((a) => (
+              <AgentCard key={a.agent} agent={a} />
+            ))}
+          </>
+        )
+      }
+    </CheckGate>
+  );
+}
+
+function AgentCard({ agent }: { agent: DiagLatencyAgent }) {
+  const { stats, components } = agent;
+  const measured = stats.trials > 0;
+  const split = {
+    stt: toMs(components?.stt),
+    llm: toMs(components?.llm_ttft),
+    tts: toMs(components?.tts),
+  };
+
+  return (
+    <Card
+      label={`Reply latency · ${agent.agent}`}
+      right={
+        // `stats.trials` counts the trials that ANSWERED, not the trials placed
+        // (the payload does not carry the attempted count), so the badge states
+        // successes without implying a denominator it cannot know.
+        <span className={`neo-badge ${measured ? 'neo-badge--blue' : 'neo-badge--red'}`}>
+          {measured
+            ? `${stats.trials} ${stats.trials === 1 ? 'trial' : 'trials'} answered`
+            : 'no trial answered'}
+        </span>
+      }
+    >
+      {!measured ? (
+        <Note tone="bad">
+          Nothing was measured for this agent: no trial produced a reply. The end-to-end time is
+          reported as {NOT_MEASURED} rather than as a zero, which would read as an instant answer.
+        </Note>
+      ) : (
+        <>
+          <div className="flex-row" style={{ gap: 28, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+            <div>
+              <div className="mono" style={{ fontSize: 30, fontWeight: 800, lineHeight: 1.1 }}>
+                {Math.round(stats.max * 1000)}
+                <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--vg-muted)' }}> ms</span>
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--vg-muted)', marginTop: 4 }}>
+                max of {stats.trials} — slowest reply, end to end
+              </div>
+            </div>
+            <div style={{ minWidth: 220, flex: 1 }}>
+              <Row label="Average reply" value={`${Math.round(stats.avg * 1000)} ms`} />
+              <Row label="Fastest reply" value={`${Math.round(stats.min * 1000)} ms`} />
+              <Row
+                label="Turn detection (end of utterance)"
+                value={
+                  components?.eou == null
+                    ? NOT_MEASURED
+                    : `${Math.round(components.eou * 1000)} ms`
+                }
+                muted={components?.eou == null}
+              />
+            </div>
+          </div>
+
+          <div style={{ marginTop: 16 }}>
+            <LatencyWaterfall
+              latency={split}
+              label="First-byte split, measured on these calls"
+              emptyText="Split not measured: this agent does not write its telemetry to this host, so the STT/LLM/TTS legs were never recorded here."
+            />
+          </div>
+
+          <div style={{ marginTop: 12 }}>
+            <Note>
+              {stats.trials} {stats.trials === 1 ? 'sample is' : 'samples are'} below the{' '}
+              {MIN_SAMPLES_FOR_PERCENTILE} a percentile needs, so the headline is the max of{' '}
+              {stats.trials} rather than a p95. A run places at most 3 calls per agent, because
+              each one is billed.
+            </Note>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/src/dashboard/frontend/src/pages/diagnostics/LoadTab.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/LoadTab.tsx
@@ -1,0 +1,337 @@
+// Diagnostics > Load: the client ramp, its knee, and the prober's own load.
+//
+// Two honesty rules bind this tab.
+//
+// 1. `find_knee` returns null for two OPPOSITE outcomes: nothing breached the
+//    budget, or the FIRST tier already breached it. A chart that shows only
+//    "knee: none" labels a total failure as a pass, so the ramp is compared
+//    against `target_rtt_ms` here and the two cases are named differently.
+// 2. The curve is rtt only. Loss is a hardcoded placeholder in `sfu.py`, so there
+//    is no loss series and no loss column anywhere on this tab.
+//
+// The saturation card is not decoration either: a laptop that pegged its own CPU
+// at 25 clients draws the same curve as an SFU that ran out of headroom, and this
+// is the only block that says which one happened.
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import NeoTooltip from '../../components/NeoTooltip';
+import type { DiagSfuResult, DiagSfuStep, DiagnosticCheckResult } from '../../lib/types';
+import { Card, CheckGate, Note, NOT_MEASURED, qualityBadgeClass, Row } from './shared';
+
+const TEAL = '#1F96AA';
+
+type KneeState =
+  | { kind: 'no-ramp' }
+  | { kind: 'knee'; knee: number; breach: DiagSfuStep }
+  | { kind: 'all-healthy'; maxClients: number }
+  | { kind: 'first-tier-breached'; step: DiagSfuStep };
+
+/**
+ * Resolve `knee` against the ramp so a null knee is never ambiguous.
+ *
+ * Loss plays no part: it is not measured, so rtt against `target_rtt_ms` is the
+ * whole test, exactly as `find_knee` computed it.
+ */
+function classifyKnee(result: DiagSfuResult): KneeState {
+  const { ramp, knee, target_rtt_ms } = result;
+  if (ramp.length === 0) return { kind: 'no-ramp' };
+  const breach = ramp.find((s) => s.rtt_ms > target_rtt_ms);
+  if (knee !== null) {
+    return { kind: 'knee', knee, breach: breach ?? ramp[ramp.length - 1] };
+  }
+  if (breach === undefined) {
+    return { kind: 'all-healthy', maxClients: Math.max(...ramp.map((s) => s.clients)) };
+  }
+  return { kind: 'first-tier-breached', step: breach };
+}
+
+export default function LoadTab({
+  check,
+}: {
+  check: DiagnosticCheckResult<DiagSfuResult> | undefined;
+}) {
+  return (
+    <CheckGate
+      check={check}
+      label="SFU load"
+      missingHint="Tick “SFU load” above and run the checks again. It opens real connections, so it is billed by your LiveKit deployment."
+    >
+      {(result) => (
+        <>
+          <RampCard result={result} />
+          <SaturationCard resource={result.resource} ramp={result.ramp} />
+        </>
+      )}
+    </CheckGate>
+  );
+}
+
+function KneeBanner({ state, target }: { state: KneeState; target: number }) {
+  if (state.kind === 'no-ramp') {
+    return (
+      <Note>
+        This run measured the baseline but no ramp, so there is no capacity curve and no knee to
+        report. Nothing is inferred from an absent measurement.
+      </Note>
+    );
+  }
+  if (state.kind === 'knee') {
+    return (
+      <Note tone="warn">
+        Knee at {state.knee} clients: every tier up to {state.knee} stayed inside the{' '}
+        {target.toFixed(0)} ms budget, and {state.breach.clients} clients broke it at{' '}
+        {state.breach.rtt_ms.toFixed(1)} ms ({state.breach.quality}).
+      </Note>
+    );
+  }
+  if (state.kind === 'all-healthy') {
+    return (
+      <Note tone="good">
+        No knee inside this ramp: every tier up to {state.maxClients} clients stayed under the{' '}
+        {target.toFixed(0)} ms budget. That is a floor on capacity, not a ceiling — the ramp
+        stopped at {state.maxClients}, it did not find a limit.
+      </Note>
+    );
+  }
+  return (
+    <Note tone="bad">
+      No healthy tier in this ramp: the smallest tier ({state.step.clients} clients) already
+      exceeded the {target.toFixed(0)} ms budget at {state.step.rtt_ms.toFixed(1)} ms (
+      {state.step.quality}). There is no knee because nothing passed, which is the opposite of a
+      clean ramp.
+    </Note>
+  );
+}
+
+function RampCard({ result }: { result: DiagSfuResult }) {
+  const state = classifyKnee(result);
+  const data = result.ramp.map((s) => ({
+    clients: s.clients,
+    rtt: Number(s.rtt_ms.toFixed(1)),
+  }));
+  const knee = state.kind === 'knee' ? state.knee : null;
+
+  return (
+    <Card
+      label="Client ramp (round-trip vs concurrent clients)"
+      right={
+        <span className="neo-badge neo-badge--blue">
+          {result.ramp.length} {result.ramp.length === 1 ? 'tier' : 'tiers'}
+        </span>
+      }
+    >
+      <KneeBanner state={state} target={result.target_rtt_ms} />
+
+      {data.length > 0 && (
+        <>
+          <div style={{ width: '100%', height: 250, marginTop: 16 }}>
+            <ResponsiveContainer>
+              <LineChart data={data} margin={{ top: 16, right: 16, left: 0, bottom: 8 }}>
+                <CartesianGrid strokeDasharray="4 4" stroke="var(--vg-hairline-2)" />
+                <XAxis
+                  dataKey="clients"
+                  type="number"
+                  domain={[0, 'dataMax']}
+                  ticks={result.ramp.map((s) => s.clients)}
+                  tick={{ fontSize: 11, fontWeight: 600 }}
+                  label={{ value: 'concurrent clients', position: 'insideBottom', offset: -6, fontSize: 11 }}
+                />
+                <YAxis
+                  tick={{ fontSize: 11, fontWeight: 600 }}
+                  width={48}
+                  tickFormatter={(v) => `${v}`}
+                />
+                <Tooltip content={<NeoTooltip />} cursor={{ stroke: TEAL, strokeWidth: 1 }} />
+                <ReferenceLine
+                  y={result.target_rtt_ms}
+                  stroke="var(--vg-amber)"
+                  strokeDasharray="5 4"
+                  label={{
+                    value: `${result.target_rtt_ms.toFixed(0)} ms budget`,
+                    position: 'insideTopRight',
+                    fontSize: 11,
+                    fill: 'var(--vg-amber)',
+                  }}
+                />
+                {knee !== null && (
+                  <ReferenceLine
+                    x={knee}
+                    stroke="var(--vg-red)"
+                    strokeDasharray="3 3"
+                    label={{
+                      value: `knee ${knee}`,
+                      position: 'top',
+                      fontSize: 11,
+                      fill: 'var(--vg-red)',
+                    }}
+                  />
+                )}
+                <Line
+                  type="monotone"
+                  dataKey="rtt"
+                  name="Round trip (ms)"
+                  stroke={TEAL}
+                  strokeWidth={2}
+                  dot={{ r: 3, fill: TEAL }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <table className="neo-table neo-table--blue" style={{ marginTop: 8 }}>
+            <thead>
+              <tr>
+                <th>Clients</th>
+                <th>Round trip</th>
+                <th>Quality</th>
+                <th>Against budget</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.ramp.map((s) => {
+                const over = s.rtt_ms > result.target_rtt_ms;
+                return (
+                  <tr key={s.clients}>
+                    <td className="mono" style={{ fontWeight: 700 }}>{s.clients}</td>
+                    <td className="mono">{s.rtt_ms.toFixed(1)} ms</td>
+                    <td>
+                      <span className={`neo-badge ${qualityBadgeClass(s.quality)}`}>{s.quality}</span>
+                    </td>
+                    <td>
+                      <span className={`neo-badge ${over ? 'neo-badge--red' : 'neo-badge--green'}`}>
+                        {over ? 'over' : 'within'}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          <div style={{ marginTop: 10 }}>
+            <Note>
+              Round trip and quality are the only measured columns. Packet loss is {NOT_MEASURED} at
+              every tier, so no loss series is plotted and no loss column is shown.
+            </Note>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}
+
+function SaturationCard({
+  resource,
+  ramp,
+}: {
+  resource: DiagSfuResult['resource'];
+  ramp: DiagSfuStep[];
+}) {
+  if (resource === null) {
+    return (
+      <Card label="Prober host during the ramp">
+        <Note>
+          The prober’s own CPU, memory and uplink are sampled only while the load ramp runs, so
+          this run has no host sample to attribute its numbers with.
+        </Note>
+      </Card>
+    );
+  }
+
+  const cpu = resource.cpu_peak;
+  const perCpu = resource.per_client.cpu_pct;
+  const perKbps = resource.per_client.kbps_up;
+  const topTier = ramp.length > 0 ? Math.max(...ramp.map((s) => s.clients)) : null;
+
+  return (
+    <Card
+      label="Prober host during the ramp"
+      right={
+        <span
+          className={`neo-badge ${
+            resource.saturated === true
+              ? 'neo-badge--red'
+              : resource.saturated === false
+                ? 'neo-badge--green'
+                : 'neo-badge--black'
+          }`}
+        >
+          {resource.saturated === true
+            ? 'saturated'
+            : resource.saturated === false
+              ? 'not saturated'
+              : 'saturation unknown'}
+        </span>
+      }
+    >
+      {resource.saturated === true ? (
+        <Note tone="bad">
+          This host saturated during the ramp (peak CPU {cpu?.toFixed(1)}%). The curve above
+          describes THIS machine, not your SFU: re-run from a larger host, or with lower tiers,
+          before treating the knee as a server limit.
+        </Note>
+      ) : resource.saturated === false ? (
+        <Note tone="good">
+          This host did not saturate (peak CPU {cpu?.toFixed(1)}%), so the ramp above is a
+          measurement of the SFU rather than of the prober.
+        </Note>
+      ) : (
+        <Note tone="warn">
+          Saturation is unknown for this run: no usable CPU sample was taken, so we cannot say
+          whether the prober or the SFU was the limit. It is not reported as “not saturated”,
+          because nobody measured that.
+        </Note>
+      )}
+
+      <div style={{ marginTop: 14 }}>
+        <Row
+          label="Peak CPU on this host"
+          value={cpu == null ? NOT_MEASURED : `${cpu.toFixed(1)}%`}
+          muted={cpu == null}
+        />
+        <Row
+          label="Peak memory (RSS)"
+          value={
+            resource.mem_peak_mb == null ? NOT_MEASURED : `${resource.mem_peak_mb.toFixed(0)} MB`
+          }
+          muted={resource.mem_peak_mb == null}
+        />
+        <Row
+          label="Uplink during the ramp"
+          value={
+            resource.net_kbps_up == null
+              ? NOT_MEASURED
+              : `${resource.net_kbps_up.toFixed(0)} kbps`
+          }
+          muted={resource.net_kbps_up == null}
+        />
+        <Row
+          label={`CPU per client${topTier ? ` (at ${topTier} clients)` : ''}`}
+          value={perCpu == null ? NOT_MEASURED : `${perCpu.toFixed(2)}%`}
+          muted={perCpu == null}
+        />
+        <Row
+          label="Uplink per client"
+          value={perKbps == null ? NOT_MEASURED : `${perKbps.toFixed(1)} kbps`}
+          muted={perKbps == null}
+        />
+        <Row
+          label="Clients this host sustains"
+          value={
+            resource.sustainable_n == null ? NOT_MEASURED : `~${resource.sustainable_n} before CPU-bound`
+          }
+          muted={resource.sustainable_n == null}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/src/dashboard/frontend/src/pages/diagnostics/LoadTab.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/LoadTab.tsx
@@ -1,6 +1,6 @@
 // Diagnostics > Load: the client ramp, its knee, and the prober's own load.
 //
-// Two honesty rules bind this tab.
+// Three honesty rules bind this tab.
 //
 // 1. `find_knee` returns null for two OPPOSITE outcomes: nothing breached the
 //    budget, or the FIRST tier already breached it. A chart that shows only
@@ -8,26 +8,17 @@
 //    against `target_rtt_ms` here and the two cases are named differently.
 // 2. The curve is rtt only. Loss is a hardcoded placeholder in `sfu.py`, so there
 //    is no loss series and no loss column anywhere on this tab.
+// 3. That rtt is the prober's round trip through the SFU's data channel, not the
+//    latency a caller hears. `LoadCurveChart` labels its own Y axis with exactly
+//    that, and the card label and the closing note say it in words.
 //
 // The saturation card is not decoration either: a laptop that pegged its own CPU
 // at 25 clients draws the same curve as an SFU that ran out of headroom, and this
 // is the only block that says which one happened.
 
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ReferenceLine,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
-import NeoTooltip from '../../components/NeoTooltip';
+import LoadCurveChart from '../../components/LoadCurveChart';
 import type { DiagSfuResult, DiagSfuStep, DiagnosticCheckResult } from '../../lib/types';
 import { Card, CheckGate, Note, NOT_MEASURED, qualityBadgeClass, Row } from './shared';
-
-const TEAL = '#1F96AA';
 
 type KneeState =
   | { kind: 'no-ramp' }
@@ -114,15 +105,13 @@ function KneeBanner({ state, target }: { state: KneeState; target: number }) {
 
 function RampCard({ result }: { result: DiagSfuResult }) {
   const state = classifyKnee(result);
-  const data = result.ramp.map((s) => ({
-    clients: s.clients,
-    rtt: Number(s.rtt_ms.toFixed(1)),
-  }));
+  // Only a resolved knee is marked on the curve. A null knee is ambiguous and is
+  // explained by KneeBanner instead, so an unmarked chart never reads as a pass.
   const knee = state.kind === 'knee' ? state.knee : null;
 
   return (
     <Card
-      label="Client ramp (round-trip vs concurrent clients)"
+      label="Client ramp (SFU data-channel RTT vs concurrent clients)"
       right={
         <span className="neo-badge neo-badge--blue">
           {result.ramp.length} {result.ramp.length === 1 ? 'tier' : 'tiers'}
@@ -131,61 +120,13 @@ function RampCard({ result }: { result: DiagSfuResult }) {
     >
       <KneeBanner state={state} target={result.target_rtt_ms} />
 
-      {data.length > 0 && (
+      {result.ramp.length > 0 && (
         <>
-          <div style={{ width: '100%', height: 250, marginTop: 16 }}>
-            <ResponsiveContainer>
-              <LineChart data={data} margin={{ top: 16, right: 16, left: 0, bottom: 8 }}>
-                <CartesianGrid strokeDasharray="4 4" stroke="var(--vg-hairline-2)" />
-                <XAxis
-                  dataKey="clients"
-                  type="number"
-                  domain={[0, 'dataMax']}
-                  ticks={result.ramp.map((s) => s.clients)}
-                  tick={{ fontSize: 11, fontWeight: 600 }}
-                  label={{ value: 'concurrent clients', position: 'insideBottom', offset: -6, fontSize: 11 }}
-                />
-                <YAxis
-                  tick={{ fontSize: 11, fontWeight: 600 }}
-                  width={48}
-                  tickFormatter={(v) => `${v}`}
-                />
-                <Tooltip content={<NeoTooltip />} cursor={{ stroke: TEAL, strokeWidth: 1 }} />
-                <ReferenceLine
-                  y={result.target_rtt_ms}
-                  stroke="var(--vg-amber)"
-                  strokeDasharray="5 4"
-                  label={{
-                    value: `${result.target_rtt_ms.toFixed(0)} ms budget`,
-                    position: 'insideTopRight',
-                    fontSize: 11,
-                    fill: 'var(--vg-amber)',
-                  }}
-                />
-                {knee !== null && (
-                  <ReferenceLine
-                    x={knee}
-                    stroke="var(--vg-red)"
-                    strokeDasharray="3 3"
-                    label={{
-                      value: `knee ${knee}`,
-                      position: 'top',
-                      fontSize: 11,
-                      fill: 'var(--vg-red)',
-                    }}
-                  />
-                )}
-                <Line
-                  type="monotone"
-                  dataKey="rtt"
-                  name="Round trip (ms)"
-                  stroke={TEAL}
-                  strokeWidth={2}
-                  dot={{ r: 3, fill: TEAL }}
-                />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
+          <LoadCurveChart
+            ramp={result.ramp}
+            targetRttMs={result.target_rtt_ms}
+            knee={knee}
+          />
 
           <table className="neo-table neo-table--blue" style={{ marginTop: 8 }}>
             <thead>
@@ -219,8 +160,10 @@ function RampCard({ result }: { result: DiagSfuResult }) {
 
           <div style={{ marginTop: 10 }}>
             <Note>
-              Round trip and quality are the only measured columns. Packet loss is {NOT_MEASURED} at
-              every tier, so no loss series is plotted and no loss column is shown.
+              Round trip and quality are the only measured columns, and the round trip is the
+              prober’s own message going through the SFU’s data channel and back — not the latency a
+              caller hears an agent answer with. Packet loss is {NOT_MEASURED} at every tier, so no
+              loss series is plotted and no loss column is shown.
             </Note>
           </div>
         </>

--- a/src/dashboard/frontend/src/pages/diagnostics/SfuTab.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/SfuTab.tsx
@@ -1,0 +1,69 @@
+// Diagnostics > SFU: the idle baseline, two synthetic clients through the SFU.
+//
+// One measured number (a data-channel round trip, which needs no clock sync
+// between the two clients) and one coarse SDK signal (quality). Packet loss is
+// deliberately absent: `sfu.py` reports a hardcoded 0.0 because the SDK does not
+// expose per-connection loss, and drawing that as a flat 0% line would be a
+// fabricated clean bill of health. It is labelled "not measured" instead.
+
+import type { DiagSfuResult, DiagnosticCheckResult } from '../../lib/types';
+import { Card, CheckGate, Note, NOT_MEASURED, qualityBadgeClass, Row, Stat } from './shared';
+
+export default function SfuTab({
+  check,
+}: {
+  check: DiagnosticCheckResult<DiagSfuResult> | undefined;
+}) {
+  return (
+    <CheckGate
+      check={check}
+      label="SFU baseline"
+      missingHint="Tick “SFU baseline” above and run the checks again."
+    >
+      {(result) => <BaselineCard result={result} />}
+    </CheckGate>
+  );
+}
+
+function BaselineCard({ result }: { result: DiagSfuResult }) {
+  const { rtt_ms, quality } = result.baseline;
+  const degraded = quality === 'Poor' || quality === 'Lost';
+  return (
+    <Card
+      label="SFU baseline (2 clients, idle)"
+      right={<span className={`neo-badge ${qualityBadgeClass(quality)}`}>{quality}</span>}
+    >
+      <Stat
+        value={rtt_ms.toFixed(1)}
+        unit="ms"
+        caption="Round trip through the SFU, measured on the data channel between two synthetic clients"
+      />
+
+      <div style={{ marginTop: 14 }}>
+        <Row label="Connection quality (SDK)" value={quality} />
+        <Row label="Packet loss" value={NOT_MEASURED} muted />
+        <Row
+          label="Budget used for the ramp knee"
+          value={`${result.target_rtt_ms.toFixed(0)} ms`}
+        />
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <Note>
+          Loss is not measured and no loss series is drawn: the client SDK does not expose
+          per-connection loss here, so the probe reports a placeholder rather than a number.
+          Quality is the coarse signal that is real.
+        </Note>
+      </div>
+
+      {degraded && (
+        <div style={{ marginTop: 12 }}>
+          <Note tone="warn">
+            A baseline quality of {quality} with no load on the SFU is what turns this run’s
+            verdict to WARN. Fix the idle path before reading anything into the ramp.
+          </Note>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/dashboard/frontend/src/pages/diagnostics/shared.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/shared.tsx
@@ -1,0 +1,163 @@
+// Shared primitives for the Diagnostics result tabs.
+//
+// Each tab renders the payload of ONE check from one run, and each has to answer
+// three states honestly: the check was never part of the run, the check ran and
+// failed, or the check produced data. `CheckGate` is that fork in one place, so
+// no tab can quietly render an empty card for a check nobody ran (the failure
+// mode a compile-only frontend gate cannot see).
+
+import type { ReactNode } from 'react';
+import type { DiagnosticCheckResult } from '../../lib/types';
+
+/** What a value says when it was not measured. Never render 0 in its place. */
+export const NOT_MEASURED = 'not measured';
+
+export type Tone = 'muted' | 'good' | 'warn' | 'bad';
+
+const TONE_COLOR: Record<Tone, string> = {
+  muted: 'var(--vg-muted)',
+  good: 'var(--vg-green)',
+  warn: 'var(--vg-amber)',
+  bad: 'var(--vg-red)',
+};
+
+const TONE_TINT: Record<Tone, string> = {
+  muted: 'transparent',
+  good: 'var(--vg-green-tint)',
+  warn: 'var(--vg-amber-tint)',
+  bad: 'var(--vg-red-tint)',
+};
+
+export function Card({
+  label,
+  right,
+  children,
+}: {
+  label: string;
+  right?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="vg-card" style={{ marginBottom: 16 }}>
+      <div
+        className="flex-row"
+        style={{ justifyContent: 'space-between', alignItems: 'center', gap: 10, marginBottom: 10 }}
+      >
+        <div className="vg-card__label">{label}</div>
+        {right}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** A paragraph of explanation. `muted` is plain text; the rest are banners. */
+export function Note({ tone = 'muted', children }: { tone?: Tone; children: ReactNode }) {
+  const banner = tone !== 'muted';
+  return (
+    <div
+      style={{
+        fontSize: 13,
+        lineHeight: 1.55,
+        color: TONE_COLOR[tone],
+        background: TONE_TINT[tone],
+        borderLeft: banner ? `3px solid ${TONE_COLOR[tone]}` : undefined,
+        padding: banner ? '9px 12px' : 0,
+        borderRadius: banner ? 'var(--vg-radius-xs)' : undefined,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** A label/value pair. `muted` marks a value that could not be measured. */
+export function Row({
+  label,
+  value,
+  muted,
+}: {
+  label: string;
+  value: ReactNode;
+  muted?: boolean;
+}) {
+  return (
+    <div
+      className="flex-row"
+      style={{ justifyContent: 'space-between', alignItems: 'baseline', gap: 12, padding: '3px 0' }}
+    >
+      <span style={{ fontSize: 12, color: 'var(--vg-muted)' }}>{label}</span>
+      <span
+        className="mono"
+        style={{
+          fontSize: 13,
+          fontWeight: 700,
+          color: muted ? 'var(--vg-muted-2)' : 'var(--vg-ink)',
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/** Big single number with its unit and a caption underneath. */
+export function Stat({
+  value,
+  unit,
+  caption,
+}: {
+  value: string;
+  unit?: string;
+  caption: string;
+}) {
+  return (
+    <div>
+      <div className="mono" style={{ fontSize: 30, fontWeight: 800, lineHeight: 1.1 }}>
+        {value}
+        {unit && (
+          <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--vg-muted)' }}> {unit}</span>
+        )}
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--vg-muted)', marginTop: 4 }}>{caption}</div>
+    </div>
+  );
+}
+
+/** Badge class for the SDK's coarse connection quality. */
+export function qualityBadgeClass(quality: string): string {
+  if (quality === 'Excellent' || quality === 'Good') return 'neo-badge--green';
+  if (quality === 'Poor' || quality === 'Lost') return 'neo-badge--red';
+  return 'neo-badge--black'; // Unknown: the SDK reported nothing usable
+}
+
+export function CheckGate<R>({
+  check,
+  label,
+  missingHint,
+  children,
+}: {
+  check: DiagnosticCheckResult<R> | undefined;
+  label: string;
+  /** What the operator should do to get this surface populated. */
+  missingHint: string;
+  children: (result: R) => ReactNode;
+}) {
+  if (check === undefined) {
+    return (
+      <Card label={label}>
+        <Note>This run did not include the check, so there is nothing measured to show. {missingHint}</Note>
+      </Card>
+    );
+  }
+  if (!check.ok || check.result === undefined) {
+    return (
+      <Card label={label} right={<span className="neo-badge neo-badge--red">failed</span>}>
+        <Note tone="bad">
+          The check did not complete: {check.error ?? 'no result was recorded for it'}
+        </Note>
+      </Card>
+    );
+  }
+  return <>{children(check.result)}</>;
+}

--- a/src/voicegateway/livekit_diag/service.py
+++ b/src/voicegateway/livekit_diag/service.py
@@ -9,6 +9,7 @@ Tests inject a fake `probes` object with the same async method surface.
 from __future__ import annotations
 
 import asyncio
+import os
 import pathlib
 import re
 from typing import Any
@@ -20,6 +21,12 @@ MAX_LATENCY_TRIALS = 3
 _DEFAULT_RAMP = [2, 10, 25]
 _TARGET_RTT_MS = 50.0
 _MAX_LOSS = 1.0
+# The roster is an optional HTTP enrichment on top of the agents check, so it
+# gets a budget of its own well inside PER_CHECK_TIMEOUT_SECONDS: a collector
+# that hangs must cost the roster, never the in-room agent list that was already
+# read successfully. fetch_roster's own httpx timeout is 10s; this is the
+# backstop for a hang it cannot see (DNS, TLS, a proxy holding the socket).
+_ROSTER_TIMEOUT_SECONDS = 15.0
 
 
 def _safe_int(v: Any, default: int) -> int:
@@ -90,6 +97,7 @@ def _diag() -> Any:
         )
         from voicegateway.livekit_diag.report import agents_json
         from voicegateway.livekit_diag.resources import ResourceMonitor
+        from voicegateway.livekit_diag.roster import fetch_roster
         from voicegateway.livekit_diag.sfu import SfuProbe, find_knee
 
         _diag_cache = SimpleNamespace(
@@ -104,6 +112,7 @@ def _diag() -> Any:
             ResourceMonitor=ResourceMonitor,
             SfuProbe=SfuProbe,
             find_knee=find_knee,
+            fetch_roster=fetch_roster,
         )
     return _diag_cache
 
@@ -134,6 +143,37 @@ def _component_reader(store: Any) -> Any:
     )
 
 
+def _resource_json(report: Any) -> dict[str, Any] | None:
+    """Serialize a ResourceReport, with its "not sampled" zeros turned into None.
+
+    ``ResourceReport`` defaults an unsampled metric to 0.0 (``max(..., default=0.0)``
+    over an empty list, a net delta that needs two samples, and psutil's first
+    ``cpu_percent(interval=None)`` call which always returns 0.0). A 0 here
+    therefore means "not measured", not "idle" - and a fabricated 0% CPU printed
+    next to a 25-client ramp reads as a host with infinite headroom, which is the
+    opposite of what this block exists to say. ``saturated`` follows the CPU
+    sample because it is derived from it: with no sample, saturation is unknown,
+    not False.
+    """
+    if report is None:
+        return None
+    per_client = dict(report.per_client or {})
+    cpu_peak = float(report.cpu_peak) if report.cpu_peak else None
+    net_kbps_up = float(report.net_kbps_up) if report.net_kbps_up else None
+    return {
+        "cpu_peak": cpu_peak,
+        "mem_peak_mb": float(report.mem_peak_mb) if report.mem_peak_mb else None,
+        "net_kbps_up": net_kbps_up,
+        "saturated": bool(report.saturated) if cpu_peak is not None else None,
+        "per_client": {
+            "cpu_pct": per_client.get("cpu_pct") if cpu_peak is not None else None,
+            "kbps_up": per_client.get("kbps_up") if net_kbps_up is not None else None,
+        },
+        # Already None when the per-client CPU share was not measurable.
+        "sustainable_n": report.sustainable_n,
+    }
+
+
 class RealProbes:
     """Runs the engine probes against a live LiveKit server.
 
@@ -148,6 +188,16 @@ class RealProbes:
         self._store = store
 
     async def agents(self, creds) -> dict[str, Any]:
+        """In-room agents from the LiveKit server API, plus the heartbeat roster.
+
+        The two are different populations, and the roster is the one that closes
+        the gap: LiveKit's server API only reports a worker once it is IN a room,
+        so an idle registered worker is invisible to ``list_agents``. The roster
+        comes from the agents' own ``register_worker`` heartbeat via the
+        collector, and is a best-effort enrichment: ``roster`` is None when no
+        collector is configured (the UI then says how to enable it) and a list
+        when it is, so "not configured" never renders as "zero workers".
+        """
         d = _diag()
         admin = d.LiveKitAdmin(creds)
         admin.url = creds.url
@@ -155,20 +205,59 @@ class RealProbes:
             rows = await admin.list_agents()
         finally:
             await admin.aclose()
-        return {"agents": d.agents_json(rows)}
+        return {"agents": d.agents_json(rows), "roster": await self._roster()}
+
+    async def _roster(self) -> list[dict[str, Any]] | None:
+        """The collector's worker roster, or None when there is no collector.
+
+        Bounded and non-raising on purpose: this runs inside the agents check,
+        whose in-room result is already measured by the time we get here, so a
+        slow or broken collector must degrade to "no roster" rather than time the
+        whole check out and throw the agent list away with it.
+        """
+        collector = os.environ.get("VOICEGW_COLLECTOR_URL")
+        if not collector:
+            return None
+        try:
+            rows = await asyncio.wait_for(
+                _diag().fetch_roster(collector, os.environ.get("VOICEGW_API_KEY")),
+                _ROSTER_TIMEOUT_SECONDS,
+            )
+        except Exception:  # noqa: BLE001 - the roster must never fail the check
+            return []
+        return list(rows)
 
     async def sfu(self, creds, load: bool, config: dict[str, Any]) -> dict[str, Any]:
+        """SFU baseline, and (when ``load``) the ramp plus the prober's own load.
+
+        ``resource`` is the prober host's CPU/mem/net during the ramp. It is
+        reported, not dropped, because without it a knee is unattributable: a
+        laptop that pegged its own CPU at 25 clients produces exactly the same
+        rtt curve as an SFU that ran out of headroom, and only this block says
+        which one happened.
+
+        ``target_rtt_ms`` is the threshold ``knee`` was computed against.
+        ``find_knee`` returns None for two opposite outcomes (no tier breached,
+        or the FIRST tier breached), so a reader that cannot compare the steps
+        against the threshold cannot tell a clean ramp from a total failure.
+
+        ``loss_pct`` is carried through as the SDK reported it, which today is a
+        hardcoded 0.0 in ``sfu.py`` (per-connection loss is not exposed). It is
+        not a measurement and must not be rendered as one; ``quality`` is the
+        coarse signal that is real.
+        """
         d = _diag()
         admin = d.LiveKitAdmin(creds)
         admin.url = creds.url
         probe = d.SfuProbe(
             admin, lambda u, t: d.SyntheticClient(u, t), d.ResourceMonitor()
         )
+        steps: list[Any] = []
+        resource: Any = None
         try:
             base = await probe.baseline("vg-diag-sfu")
-            steps, _resource = ([], None)
             if load:
-                steps, _resource = await probe.ramp(
+                steps, resource = await probe.ramp(
                     "vg-diag-sfu",
                     config["ramp"],
                     config["duration"],
@@ -185,10 +274,17 @@ class RealProbes:
                 "quality": base.quality,
             },
             "ramp": [
-                {"clients": s.clients, "rtt_ms": s.rtt_ms, "loss_pct": s.loss_pct}
+                {
+                    "clients": s.clients,
+                    "rtt_ms": s.rtt_ms,
+                    "loss_pct": s.loss_pct,
+                    "quality": s.quality,
+                }
                 for s in steps
             ],
             "knee": knee,
+            "target_rtt_ms": _TARGET_RTT_MS,
+            "resource": _resource_json(resource),
         }
 
     async def latency(self, creds, config: dict[str, Any]) -> dict[str, Any]:

--- a/src/voicegateway/tests/livekit_diag/test_service.py
+++ b/src/voicegateway/tests/livekit_diag/test_service.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 from voicegateway.livekit_diag import service as probes
+from voicegateway.livekit_diag.config import LiveKitCreds
+from voicegateway.livekit_diag.resources import ResourceReport
+from voicegateway.livekit_diag.sfu import RampStep, find_knee
 
 
 def test_clamp_config_enforces_caps():
@@ -121,3 +125,172 @@ async def test_verdict_warns_on_slow_latency():
     )
     assert out["checks"]["latency"]["ok"] is True
     assert out["verdict"] == "WARN"
+
+
+# ---------------------------------------------------------------------------
+# RealProbes payloads: what the dashboard can actually render.
+#
+# These pin the three things the probes measured and used to drop on the floor:
+# the heartbeat roster (idle workers are invisible to LiveKit's server API), the
+# per-step connection quality, and the prober's own resource report (without
+# which a knee cannot be attributed to the SFU rather than to this host).
+# ---------------------------------------------------------------------------
+
+_CREDS = LiveKitCreds("wss://x", "k", "s")
+
+
+class _FakeAdmin:
+    def __init__(self, creds) -> None:
+        self.url = ""
+        self.closed = False
+
+    async def list_agents(self):
+        return ["agent-a"]
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _FakeSfuProbe:
+    """Returns real RampStep / ResourceReport objects, so the shapes stay honest."""
+
+    def __init__(self, admin, client_factory, monitor) -> None:
+        pass
+
+    async def baseline(self, room, seconds: float = 10.0):
+        return RampStep(2, 11.4, 0.0, "Excellent")
+
+    async def ramp(self, room, steps, duration, target_rtt_ms, max_loss, **kwargs):
+        return (
+            [
+                RampStep(2, 12.0, 0.0, "Excellent"),
+                RampStep(10, 61.0, 0.0, "Poor"),
+            ],
+            ResourceReport(
+                cpu_peak=91.2,
+                mem_peak_mb=812.5,
+                net_kbps_up=4200.0,
+                saturated=True,
+                per_client={"cpu_pct": 3.6, "kbps_up": 168.0},
+                sustainable_n=23,
+            ),
+        )
+
+
+def _fake_diag(**overrides):
+    ns = {
+        "LiveKitAdmin": _FakeAdmin,
+        "agents_json": lambda rows: [{"agent_name": r} for r in rows],
+        "fetch_roster": None,
+        "SfuProbe": _FakeSfuProbe,
+        "SyntheticClient": lambda url, token: object(),
+        "ResourceMonitor": lambda: object(),
+        "find_knee": find_knee,
+    }
+    ns.update(overrides)
+    return SimpleNamespace(**ns)
+
+
+async def test_agents_check_returns_none_roster_without_a_collector(monkeypatch):
+    """No collector configured is None, never an empty list.
+
+    [] would claim "the collector is up and nobody has registered"; None is the
+    honest "nobody asked", which is what lets the UI print how to enable it.
+    """
+    monkeypatch.delenv("VOICEGW_COLLECTOR_URL", raising=False)
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag())
+    out = await probes.RealProbes().agents(_CREDS)
+    assert out["agents"] == [{"agent_name": "agent-a"}]
+    assert out["roster"] is None
+
+
+async def test_agents_check_includes_the_heartbeat_roster(monkeypatch):
+    seen: list[tuple[str, str | None]] = []
+
+    async def _fetch(collector, api_key):
+        seen.append((collector, api_key))
+        return [{"agent_name": "idle-worker", "status": "idle"}]
+
+    monkeypatch.setenv("VOICEGW_COLLECTOR_URL", "https://collector.test")
+    monkeypatch.setenv("VOICEGW_API_KEY", "vk_secret")
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(fetch_roster=_fetch))
+
+    out = await probes.RealProbes().agents(_CREDS)
+    assert seen == [("https://collector.test", "vk_secret")]
+    assert out["roster"] == [{"agent_name": "idle-worker", "status": "idle"}]
+    # The in-room view is unaffected by the enrichment.
+    assert out["agents"] == [{"agent_name": "agent-a"}]
+
+
+async def test_agents_check_survives_a_hanging_collector(monkeypatch):
+    """A collector that never answers costs the roster, not the whole check."""
+
+    async def _hang(collector, api_key):
+        await asyncio.sleep(10)
+        return []
+
+    monkeypatch.setenv("VOICEGW_COLLECTOR_URL", "https://collector.test")
+    monkeypatch.setattr(probes, "_ROSTER_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(fetch_roster=_hang))
+
+    out = await probes.RealProbes().agents(_CREDS)
+    assert out["roster"] == []
+    assert out["agents"] == [{"agent_name": "agent-a"}]
+
+
+async def test_sfu_load_payload_carries_quality_resource_and_threshold(monkeypatch):
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag())
+    out = await probes.RealProbes().sfu(_CREDS, True, probes.clamp_config({}))
+
+    # Per-step quality is the only real connection signal (loss is not measured).
+    assert [s["quality"] for s in out["ramp"]] == ["Excellent", "Poor"]
+    # 10 clients breached 50ms, so the last healthy tier is 2.
+    assert out["knee"] == 2
+    # The threshold the knee was computed against must travel with it: without it
+    # a knee of None is ambiguous (nothing breached vs the FIRST tier breached).
+    assert out["target_rtt_ms"] == probes._TARGET_RTT_MS
+    assert out["resource"]["saturated"] is True
+    assert out["resource"]["cpu_peak"] == 91.2
+    assert out["resource"]["per_client"]["cpu_pct"] == 3.6
+    assert out["resource"]["sustainable_n"] == 23
+
+
+async def test_sfu_baseline_only_has_no_ramp_and_no_resource(monkeypatch):
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag())
+    out = await probes.RealProbes().sfu(_CREDS, False, probes.clamp_config({}))
+    assert out["ramp"] == []
+    assert out["knee"] is None
+    assert out["resource"] is None
+    assert out["baseline"] == {"rtt_ms": 11.4, "loss_pct": 0.0, "quality": "Excellent"}
+
+
+def test_resource_json_reports_unsampled_metrics_as_none():
+    """An unsampled metric is None, not 0.
+
+    ResourceReport defaults every unsampled metric to 0.0 (and psutil's first
+    cpu_percent call always returns 0.0), so a 0 would render as "this host was
+    idle under load" - the exact opposite of what an unmeasured sample means.
+    """
+    out = probes._resource_json(
+        ResourceReport(
+            cpu_peak=0.0,
+            mem_peak_mb=0.0,
+            net_kbps_up=0.0,
+            saturated=False,
+            per_client={"cpu_pct": 0.0, "kbps_up": 0.0},
+            sustainable_n=None,
+        )
+    )
+    assert out is not None
+    assert out["cpu_peak"] is None
+    assert out["net_kbps_up"] is None
+    assert out["mem_peak_mb"] is None
+    # Saturation is derived from the CPU sample: with no sample it is unknown,
+    # not False (False would be a clean bill of health nobody measured).
+    assert out["saturated"] is None
+    assert out["per_client"] == {"cpu_pct": None, "kbps_up": None}
+    assert out["sustainable_n"] is None
+
+
+def test_resource_json_is_none_without_a_report():
+    assert probes._resource_json(None) is None


### PR DESCRIPTION
Stacked on #177. **Merge #177 first.**

M0 is pure recovered value: the backend already returned agent rosters, SFU rtt/ramp/knee and per-agent STT/LLM/TTS splits, and `Diagnostics.tsx` threw them away (`DiagnosticCheckResult.result` was typed `unknown`). No migration, no backend risk.

## What changed

Diagnostics went from 3 cards and 4 checkboxes to a 5-tab profiler: in-room agents plus the heartbeat roster, SFU baseline, ramp curve with knee and saturation banner, latency splits, error-class bars. Three backend unlocks: `RealProbes.agents` now calls `roster.fetch_roster` (bounded, non-raising, `None` = no collector vs `[]` = asked-and-empty), ramp steps carry `quality`, and the `ResourceReport` is serialized instead of dropped. `DIAG_RUNS` is rewritten in the same commit, as the spec requires, because the old fixtures matched nothing `RealProbes` returns.

## The honesty work is the part worth reviewing

Each of these was verified rendered in a browser, not just compiled:

- The ramp chart's Y axis had **no label** — bare milliseconds a reader could take for answer latency. It now reads **"SFU data-channel RTT (ms)"**, with prose stating it is not the latency a caller hears.
- `find_knee` returns `None` for two **opposite** outcomes. "No knee inside this ramp" (nothing breached, a floor on capacity) now reads differently from "No healthy tier in this ramp" (the smallest tier already breached), so a total failure can no longer render as a pass.
- Loss stays **"not measured"**: `sfu.py` hardcodes `loss_pct = 0.0`, and a flat green line reads as a clean bill of health.
- The latency headline is **"max of 3"**, never p95 — `MAX_LATENCY_TRIALS = 3`, and a percentile from 3 samples is not a percentile.
- Unmeasured never renders as zero: `ResourceReport`'s `0.0` defaults map to `null`, and `saturated` stays `null` when unknown.

Gates: `tsc` + both vite builds green; behavioural gate green with 6 rendered cards; ruff and mypy clean; pytest 1863 passed.