### PR TITLE
fix(deps): cap mcp below 2.0, which is breaking CI on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,11 @@ dashboard = [
     "pydantic-settings>=2.0",
     "asgi-correlation-id>=4.3",
     "loguru>=0.7",
-    "mcp>=1.2.0",
+    # Capped below 2.0: mcp 2.0.0 renamed Tool's ``inputSchema`` to
+    # ``input_schema`` and moved the Server.list_tools/call_tool decorators,
+    # which reds mypy on server/mcp/server.py. Same style as voice-prices
+    # above. Lift the cap in a deliberate 2.x migration, not by resolver drift.
+    "mcp>=1.2.0,<2",
 ]
 
 # Self-host the shared fleet collector: the dashboard/server plus the Postgres


### PR DESCRIPTION
**main is currently red**, and so is every open PR that touches `src/`, including contributor PRs. Nothing in those PRs caused it.

`mcp 2.0.0` shipped. The dependency was declared `"mcp>=1.2.0"`, so every fresh CI install resolves straight onto a major version with breaking API changes:

```
src/voicegateway/server/mcp/server.py:84  "Server[Any]" has no attribute "list_tools"
src/voicegateway/server/mcp/server.py:87  Unexpected keyword argument "inputSchema" for "Tool";
                                          did you mean "input_schema"?
src/voicegateway/server/mcp/server.py:96  "Server[Any]" has no attribute "call_tool"
Found 3 errors in 1 file (checked 255 source files)
```

Local venvs still pass because they hold 1.27.0 from an older resolve, which is exactly why this surfaced only in CI.

Capping at `<2` matches how `voice-prices>=0.1.0,<0.2` is already pinned, and makes CI deterministic again.

**This is a hotfix, not the migration.** Moving to 2.x means adapting the renamed schema field and the moved `Server` decorators; that deserves its own PR with real verification, not whichever branch happens to run CI next.

Merge this first — it unblocks #178, #179, #180, #175, #176 and anything else touching `src/`.