### PR TITLE
ci: pin mypy below 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,17 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           uv venv --seed --python "$PYTHON_VERSION"
-          uv pip install -e ".[dev,dashboard]" ruff mypy types-PyYAML
+          # mypy is pinned below 2. mypy 2.x stops resolving the `livekit`
+          # namespace package's subpackages and reports `Module "livekit" has
+          # no attribute "api"/"rtc"` in livekit_diag/admin.py and client.py,
+          # on a tree that is otherwise clean. Those distributions do ship
+          # py.typed and ignore_missing_imports is already true, so this is a
+          # resolution change upstream, not a defect here. Unpinned, a new
+          # major reds this job on files no PR touched: the same way mcp 2.0.0
+          # broke this workflow, which is why mcp is capped in pyproject.toml.
+          # Revisit when livekit ships packaging mypy 2.x resolves, then drop
+          # the cap here and in the local gate command.
+          uv pip install -e ".[dev,dashboard]" ruff 'mypy<2' types-PyYAML
       - name: Ruff
         run: uv run ruff check src
       - name: Mypy

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -86,6 +86,15 @@ Run mypy:
 mypy
 ```
 
+CI pins mypy below 2. mypy 2.x stops resolving the `livekit` namespace
+package's subpackages and reports `Module "livekit" has no attribute
+"api"/"rtc"` on a tree that is otherwise clean, so install the same cap
+locally or your results will not match CI:
+
+```bash
+uv run --with 'mypy<2' --with types-PyYAML mypy
+```
+
 ### Type annotation guidelines
 
 - All public functions must have type annotations


### PR DESCRIPTION
mypy 2.3.0 stops resolving the `livekit` namespace package and reports
`Module "livekit" has no attribute "api"` in `livekit_diag/admin.py` and
`no attribute "rtc"` in `client.py`, plus three consequential errors, on a
tree that is otherwise clean.

`livekit-api`, `livekit-rtc` and `livekit-agents` all ship `py.typed`, and
`ignore_missing_imports` is already true, so this is an upstream resolution
change rather than a defect here.

CI installed mypy unpinned, so this went red on `main` without any PR
touching those files. Same failure mode as `mcp 2.0.0`, which is why mcp is
capped in `pyproject.toml`.

**Evidence:** same tree, `mypy<2` → `Success: no issues found in 269 source files`.

Also documented in the contributing guide, because an unpinned local run now
disagrees with CI.

**Merge this first.** Four other PRs follow it and will show red CI on files
they never touched until this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance with the recommended local type-checking command.
  * Documented the current compatibility limitation affecting type-checking setup.

* **Chores**
  * Improved CI reliability by aligning automated type-checking with the supported tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->