### PR TITLE
fix(security): gate the ungated write and read paths

### DIFF
--- a/docs/api/dashboard-api.md
+++ b/docs/api/dashboard-api.md
@@ -219,6 +219,30 @@ Authentication follows the other dashboard reads: with no API keys configured (t
 curl "http://localhost:8080/api/calls?limit=6"
 ```
 
+## Session reads
+
+The list endpoint plus five reads that hang off a session id back the dashboard's call drill-down:
+
+| Endpoint | Returns |
+|---|---|
+| `GET /api/sessions` | Recent sessions, newest first. Takes `limit`, `project`, `tenant`, `agent` and `order_by`. |
+| `GET /api/sessions/{id}` | One session with its per-modality cost breakdown and provider list. |
+| `GET /api/sessions/{id}/turns` | Ordered per-turn rows (latency, response speed). |
+| `GET /api/sessions/{id}/transcript` | The captured call transcript, one row per turn. |
+| `GET /api/sessions/{id}/dead_air` | Dead-air events for the call, oldest first. |
+| `GET /api/sessions/{id}/replay` | The full time-ordered replay: the STT, LLM and TTS payloads of the call. |
+
+**Authentication:** all six require the same read authentication as the other dashboard reads (`/api/costs`, `/api/calls`). As there, the gate is a **no-op while no API keys are configured** (the self-hosted default) and enforces as soon as auth is enabled, when an unauthenticated request gets `401`. Only the list endpoint was gated before, so a session id alone was enough to read the detail, the turns, the transcript, the dead air and the replay of any call on the deployment.
+
+**Tenant scoping:** a tenant-scoped key reads only its own sessions. The per-session routes take no `tenant` parameter (the id is the whole request), so the check runs on the fetched session row. A session belonging to another tenant returns `404` with the same body as a session id that does not exist: a `403` would confirm the id is real. The self-hosted operator (no credential, or a static config key) is an admin principal and keeps reading every session, unchanged.
+
+**Example:**
+
+```bash
+curl "http://localhost:8080/api/sessions?limit=20"
+curl "http://localhost:8080/api/sessions/vg-8f1c/transcript"
+```
+
 ## GET /api/agents
 
 Return the fleet index over the last 24 hours: the telemetry rollup merged with the live worker roster. Agents that have metered traffic come from the rollup; registered-but-idle workers (0 requests) are merged in so a booted agent appears before it has handled its first call.

--- a/docs/api/dashboard-api.md
+++ b/docs/api/dashboard-api.md
@@ -372,6 +372,18 @@ List all configured projects with today's stats.
 curl http://localhost:8080/api/projects
 ```
 
+## API keys
+
+`GET /api/api_keys`, `POST /api/api_keys`, and `POST /api/api_keys/{key_id}/revoke` back the dashboard's API keys screen: list, mint, and soft-revoke the virtual keys (`vk_...`) that authenticate callers.
+
+**Authentication:** every route under `/api/api_keys` requires the `admin` scope, declared on the router so no route can miss it. As with Diagnostics and the Server overview, the gate is a **no-op while no API keys are configured** (the self-hosted default), and it enforces the admin scope as soon as auth is enabled. An unauthenticated request then gets `401`, and a valid token without the `admin` scope gets `403`. The dashboard already sends its bearer token on these calls.
+
+This gate matters because a minted key is issued with the wildcard scope. An ungated mint is a write escalation onto every `/v1` endpoint. A key minted here defaults to `role: tenant`, so **a minted key cannot mint another key** (`403`).
+
+`POST /api/api_keys` takes `name` (required), `tenant_id` (optional), and `issued_by` (optional), and returns `plaintext` exactly once at creation; the dashboard shows the "save this key" modal and discards it. Subsequent list responses expose only `key_prefix`, never the plaintext or the bcrypt hash. Revoke is soft: the row stays for audit with `revoked_at` set, and revoking an already-revoked key returns `404`.
+
+For the equivalent endpoints on the public API, see the [HTTP API](/api/http-api).
+
 ## Static File Serving
 
 The dashboard also serves the React frontend's built assets. If the frontend has been built (`src/dashboard/frontend/dist/` exists), the daemon serves:

--- a/docs/api/dashboard-api.md
+++ b/docs/api/dashboard-api.md
@@ -243,6 +243,22 @@ curl "http://localhost:8080/api/sessions?limit=20"
 curl "http://localhost:8080/api/sessions/vg-8f1c/transcript"
 ```
 
+The same rows are served by `GET /v1/sessions` and `GET /v1/sessions/{id}` on the [HTTP API](/api/http-api), under the same authentication and the same tenant scoping.
+
+## Replay writes and storage
+
+Three endpoints beside the `GET /api/sessions/{id}/replay` read above:
+
+| Endpoint | Does |
+|---|---|
+| `DELETE /api/sessions/{id}/replay` | Delete every replay row for the call, cascading across the four `replay_*` tables in one transaction. Returns the row count. |
+| `GET /api/replay/storage` | Per-project sum of `sessions.replay_size_bytes`, plus the deployment total. |
+| `POST /api/projects/{id}/replay/retention` | Set that project's retention window, `{"retention_days": N}` with N in 1-365. Applied in memory for the retention worker; not persisted to `voicegw.yaml`. |
+
+**Authentication:** the two writes require the **`admin` scope**, the scope every write on a dashboard router takes (API keys, diagnostics runs, the agent probe, the branding logo upload). One destroys captured payloads outright and the other sets how long any of them survive. `GET /api/replay/storage` is a read and takes the same read authentication as the reads above: a read-scoped key is enough. All three gates are **no-ops while no API keys are configured** (the self-hosted default). With auth enabled, an unauthenticated caller gets `401` and a read-scoped key attempting either write gets `403`.
+
+**Tenant scoping:** `GET /api/replay/storage` aggregates every session row, so the tenant resolved from the key becomes a predicate on the query. A tenant-scoped key is told its own footprint only, and the total matches the breakdown it can see. There is no id to `404` on here: what the scoping protects is the size of another tenant's captured traffic and the names of the projects producing it.
+
 ## GET /api/agents
 
 Return the fleet index over the last 24 hours: the telemetry rollup merged with the live worker roster. Agents that have metered traffic come from the rollup; registered-but-idle workers (0 requests) are merged in so a booted agent appears before it has handled its first call.
@@ -407,6 +423,14 @@ This gate matters because a minted key is issued with the wildcard scope. An ung
 `POST /api/api_keys` takes `name` (required), `tenant_id` (optional), and `issued_by` (optional), and returns `plaintext` exactly once at creation; the dashboard shows the "save this key" modal and discards it. Subsequent list responses expose only `key_prefix`, never the plaintext or the bcrypt hash. Revoke is soft: the row stays for audit with `revoked_at` set, and revoking an already-revoked key returns `404`.
 
 For the equivalent endpoints on the public API, see the [HTTP API](/api/http-api).
+
+## Branding
+
+`GET /api/projects/{id}/branding` returns the project's white-label payload (`logo_url`, `accent_color`, `product_name`), `POST /api/projects/{id}/branding` upserts it, and `POST /api/projects/{id}/branding/logo` uploads a PNG or SVG logo.
+
+**Authentication:** both POSTs require the `admin` scope; the GET does not. White-label branding is an operator/agency setting: the write stamps the `logo_url` every dashboard page renders and the `product_name` it renders as its own name. The **GET stays open to any authenticated reader on purpose**: every dashboard layout mount calls it to apply the brand, and the frontend treats a `403` exactly like a `401` (it clears the stored token and shows the login gate), so gating it behind the admin scope would log out a read-scoped operator on page load. That is why the gate sits on the two write routes and not on the router. Both gates are no-ops while no API keys are configured.
+
+See [Agency quickstart](/guide/agency-quickstart) for what the logo upload accepts.
 
 ## Static File Serving
 

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -1,6 +1,6 @@
 ---
 title: HTTP API Reference
-description: REST endpoints served by `voicegw serve`. Covers health, status, models, costs, billing, projects, providers, logs, metrics, and audit log.
+description: REST endpoints served by `voicegw serve`. Covers health, status, models, costs, billing, projects, providers, logs, metrics, audit log, and API keys.
 ---
 
 The VoiceGateway HTTP API runs via `voicegw serve` (default port 8080). It provides read-only observability endpoints and full CRUD for managing providers, models, and projects.
@@ -713,6 +713,42 @@ Return audit log entries for CRUD operations performed via the API.
 curl "http://localhost:8080/v1/audit-log?entity_type=provider&limit=10"
 curl "http://localhost:8080/v1/audit-log?action=delete"
 ```
+
+## API Keys
+
+Mint, list, and revoke the virtual keys (`vk_...`) that authenticate callers of this API.
+
+**Authentication:** every route under `/v1/api-keys` requires the `admin` scope, declared on the router so no route can miss it. Like Diagnostics, the gate is a **no-op while no API keys are configured** (the self-hosted default: no `auth.api_keys` block and no `VOICEGW_API_KEY`), and it enforces the admin scope as soon as auth is enabled. Pass a static key carrying `admin` or the `*` wildcard scope, or an admin-role `vk_` key: `Authorization: Bearer ...`.
+
+This gate matters because a minted key is issued with the wildcard scope. An ungated mint is a write escalation onto every `/v1` endpoint, so an unauthenticated caller must not reach it. A key minted here defaults to `role: tenant`, which means **a minted key cannot mint another key** (`403`): a leaked key is not self-replicating.
+
+| Response | Meaning |
+|---|---|
+| `401` | Auth is enabled and the request carried no token, or an invalid one. |
+| `403` | Valid token without the `admin` scope, or a `vk_` key whose role is not `admin`. |
+
+### POST /v1/api-keys
+
+Mint a virtual key. Body: `name` (required), `tenant_id` (optional, binds the key to one tenant), `issued_by` (optional audit string). Returns `201` with `plaintext` (**the only time the full key is ever returned**) and the stored `key` row. The bcrypt hash is never exposed.
+
+```bash
+curl -X POST http://localhost:8080/v1/api-keys \
+  -H "Authorization: Bearer $VG_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "prod-bot", "tenant_id": "acme"}'
+```
+
+### GET /v1/api-keys
+
+List every key. `include_revoked` (default `true`) keeps soft-revoked rows in the response. Rows carry `key_prefix`, never the hash or the plaintext.
+
+### GET /v1/api-keys/{key_id}
+
+Fetch one key by id. `404` when missing.
+
+### DELETE /v1/api-keys/{key_id}
+
+Soft-revoke a key. The row stays for audit with `revoked_at` set. Returns `204`.
 
 ## LiveKit Webhooks
 

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -1,6 +1,6 @@
 ---
 title: HTTP API Reference
-description: REST endpoints served by `voicegw serve`. Covers health, status, models, costs, billing, projects, providers, logs, metrics, audit log, and API keys.
+description: REST endpoints served by `voicegw serve`. Covers health, status, models, costs, sessions, billing, projects, providers, logs, metrics, audit log, and API keys.
 ---
 
 The VoiceGateway HTTP API runs via `voicegw serve` (default port 8080). It provides read-only observability endpoints and full CRUD for managing providers, models, and projects.
@@ -158,6 +158,46 @@ Return latency statistics for the given period.
 ```bash
 curl "http://localhost:8080/v1/latency?period=today"
 curl "http://localhost:8080/v1/latency?period=week&project=my-app"
+```
+
+---
+
+## Sessions
+
+One row per voice call: when it started and ended, which modalities and providers it used, and what it cost. These are the public twin of the dashboard's `/api/sessions` reads and return the same rows; the [Dashboard API](/api/dashboard-api) additionally serves the per-session drill-downs (turns, transcript, dead air, replay).
+
+**Authentication:** both routes require the same read authentication as the dashboard reads, declared on the router so no route can miss it. The gate is a **no-op while no API keys are configured** (the self-hosted default: no `auth.api_keys` block and no `VOICEGW_API_KEY`), and it enforces as soon as auth is enabled, when an unauthenticated request gets `401`. A read-scoped key is enough; no admin scope is needed to read rows already on disk.
+
+**Tenant scoping:** the tenant comes from the authenticated key, never from a parameter (these routes publish none). A tenant-scoped key lists only its own sessions and reads only its own session by id. The list filters as well as the detail: a list that returned every tenant's sessions would hand over exactly the ids the detail route refuses. An operator with no credential, a static config key, or an admin key sees every tenant, unchanged.
+
+| Response | Meaning |
+|---|---|
+| `401` | Auth is enabled and the request carried no token, or an invalid one. |
+| `404` | No such session **or** the session belongs to another tenant. The two are deliberately identical, body included: a `403` on the foreign case would confirm the id is real. |
+
+### GET /v1/sessions
+
+Return recent sessions.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `limit` | `integer` | `100` | Number of rows (1-1000). |
+| `project` | `string` | `null` | Filter by project ID. |
+| `order_by` | `string` | `"started_at_desc"` | One of: `started_at_desc`, `started_at_asc`, `cost_desc`, `cost_asc`. |
+
+**Response:** An array of session rows, each containing `id`, `project`, `started_at`, `ended_at`, `modalities`, `request_count`, `total_cost_usd`, and `tenant_id`. Empty array when cost tracking is disabled.
+
+### GET /v1/sessions/{session_id}
+
+Return one session with the per-modality cost breakdown (`by_modality`) and the deduplicated `providers` list computed by joining the requests table.
+
+**Example:**
+
+```bash
+curl "http://localhost:8080/v1/sessions?limit=20&order_by=cost_desc"
+curl "http://localhost:8080/v1/sessions/vg-8f1c"
 ```
 
 ---

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -523,7 +523,7 @@ curl -X POST http://localhost:8080/v1/providers \
 
 ### PATCH /v1/providers/{provider_id}
 
-Update a managed provider's API key, base URL, or type.
+Update a managed provider's API key, base URL, or type. Omitted fields keep their stored value, so a body of `{"api_key":"sk-new-key"}` rotates the key and leaves `base_url` alone.
 
 **Example:**
 
@@ -532,6 +532,26 @@ curl -X PATCH http://localhost:8080/v1/providers/deepgram-staging \
   -H "Content-Type: application/json" \
   -d '{"api_key":"sk-new-key"}'
 ```
+
+**Moving `base_url` to a new host**
+
+A request that changes `base_url` without supplying an `api_key` keeps the stored key, and `POST /v1/providers/{provider_id}/test` then sends that key to the new host. So that one combination requires the new host to be permitted. Permitted are the provider's current host, the vendor's own default host (`api.openai.com` for `openai`, `localhost` for `ollama`, and so on), and any host listed in `serve.provider_base_url_hosts` in [voicegw.yaml](/configuration/voicegw-yaml). An unpermitted host returns `400` naming the config key:
+
+```json
+{
+  "detail": "base_url host 'proxy.internal.example.com' is not permitted for provider 'deepgram-staging'. Moving base_url to a new host while reusing the stored API key would send that key to the new host. Add the host to 'serve.provider_base_url_hosts' in voicegw.yaml, or send a fresh 'api_key' in this request."
+}
+```
+
+Sending the key with the change is always allowed, because the caller already holds a key:
+
+```bash
+curl -X PATCH http://localhost:8080/v1/providers/deepgram-staging \
+  -H "Content-Type: application/json" \
+  -d '{"base_url":"https://proxy.internal.example.com","api_key":"sk-new-key"}'
+```
+
+Requests that keep the same host (port or path edits), clear `base_url`, or leave it untouched are unaffected, as are providers stored with an empty key such as a local `ollama`.
 
 ### DELETE /v1/providers/{provider_id}
 

--- a/docs/configuration/voicegw-yaml.md
+++ b/docs/configuration/voicegw-yaml.md
@@ -40,7 +40,7 @@ All sections are optional. Omitted sections use defaults.
 | `ingest` | Rate limits for the fleet collector ingest endpoint |
 | `retention` | Age-out policy for collector data |
 | `workers` | Background rollup and retention cadence |
-| `serve` | Bind host and port for the daemon |
+| `serve` | Bind host and port for the daemon, and the provider `base_url` host allowlist |
 
 ---
 
@@ -351,10 +351,19 @@ Bind host and port for the daemon. The daemon serves the HTTP API (`/v1/*`), das
 serve:
   host: 0.0.0.0
   port: 8080
+  provider_base_url_hosts:
+    - proxy.internal.example.com
 ```
 
 - `host` (string, default `0.0.0.0`): bind address. Use `127.0.0.1` to restrict to localhost.
 - `port` (int, default `8080`): port number.
+- `provider_base_url_hosts` (list of strings, default empty): hosts a managed provider's `base_url` may be moved to by [`PATCH /v1/providers/{provider_id}`](/api/http-api) when the request does not carry a new `api_key`. Entries are bare hosts (`api.example.com`) or full URLs, whose host is what counts. Values support `${ENV_VAR}` substitution.
+
+### Why `provider_base_url_hosts` exists
+
+A `PATCH` that only changes `base_url` keeps the provider's already-stored API key. `POST /v1/providers/{provider_id}/test` then builds the provider from that row, so the stored key is sent to whatever host the `PATCH` set. Anyone who can reach the write API could point a provider at a host they control and read the key out of the request.
+
+The endpoint therefore constrains the host only for that exact combination: a host change that reuses the stored key. Permitted without any config are the provider's current host and the vendor's own default host (`api.openai.com` for `openai`, `localhost` for `ollama`, and so on), so leaving this list empty changes nothing for an existing deployment. Add a host here to allow a proxy or self-hosted gateway. A `PATCH` that includes its own `api_key` is never constrained: the caller already holds a key, so there is nothing to leak.
 
 ---
 

--- a/docs/guide/agency-quickstart.md
+++ b/docs/guide/agency-quickstart.md
@@ -159,12 +159,21 @@ voicegw brand set \
   --accent "#FF6633" \
   --name AcmeVoice
 # Project acme branding updated:
-#   Logo:         /static/branding/acme.png
+#   Logo:         /static/branding/uploads/acme.png
 #   Accent color: #FF6633
 #   Product name: AcmeVoice
 ```
 
 Set `VOICEGW_API_KEY` when your dashboard requires auth.
+
+### What the logo upload accepts
+
+Uploaded logos are served from the deployment's own origin, so the endpoint is strict about what it stores:
+
+- **Admin scope.** `POST /api/projects/{id}/branding/logo` requires an admin-scoped token once you have configured API keys. A read-scoped token gets `403`. With no API keys configured (the single-operator default) nothing changes.
+- **Uploads land in `/static/branding/uploads/`,** never in the branding root, so an upload cannot replace one of the assets that ship with the dashboard. The filename comes from the project id when the id is plain (letters, digits, `_`, `-`); any other id is replaced by a digest of itself, so the stored path is stable but can never contain a path separator.
+- **SVGs are inspected and refused, not sanitized.** A `<script>` element, an `on*` event-handler attribute, `<foreignObject>`, `<iframe>`, `<embed>`, `<object>`, SMIL `<animate>`/`<set>`, an entity declaration, or a `javascript:` or `data:` URL in any attribute returns `400` with the reason. The file must also parse as well-formed XML with an `<svg>` root. Export the logo as a plain vector (paths, groups, fills) or upload the PNG instead.
+- **Every asset under `/static/branding` is served with `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox` and `X-Content-Type-Options: nosniff`,** so a branding file cannot execute in the dashboard's origin even if it gets past the content check. This does not affect how the logo renders in the dashboard.
 
 ## Step 5: share a branded dashboard link
 

--- a/src/dashboard/frontend/src/pages/Projects.tsx
+++ b/src/dashboard/frontend/src/pages/Projects.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import PageHeader from '../components/PageHeader';
 import SourceBadge from '../components/SourceBadge';
-import { fetchJson } from '../lib/api';
+import { fetchJson, uploadBrandingLogo } from '../lib/api';
 import { DEMO_MODE } from '../lib/demo';
 
 interface ProjectBranding {
@@ -325,17 +325,10 @@ function BrandingModal({
     setError(null);
     try {
       if (logoFile) {
-        const fd = new FormData();
-        fd.append('file', logoFile);
-        const resp = await fetch(
-          `/api/projects/${encodeURIComponent(projectId)}/branding/logo`,
-          { method: 'POST', body: fd },
-        );
-        if (!resp.ok) {
-          const body = await resp.json().catch(() => ({}));
-          throw new Error(body.detail || `HTTP ${resp.status}`);
-        }
-        const data = (await resp.json()) as { logo_url: string };
+        // Via the shared helper, not a bare fetch: the upload is an admin
+        // write now, and the hand-rolled call here sent no Authorization
+        // header at all, so it would 401 on any deployment with auth on.
+        const data = await uploadBrandingLogo(projectId, logoFile);
         setLogoUrl(data.logo_url);
       }
       await fetchJson(`/api/projects/${encodeURIComponent(projectId)}/branding`, {

--- a/src/voicegateway/schemas/config_schema.py
+++ b/src/voicegateway/schemas/config_schema.py
@@ -156,12 +156,24 @@ class DashboardConfig(BaseModel):
 
 
 class ServeConfig(BaseModel):
-    """HTTP API serve config (the daemon-first ``voicegw serve`` target)."""
+    """HTTP API serve config (the daemon-first ``voicegw serve`` target).
+
+    ``provider_base_url_hosts`` is the operator allowlist consulted by
+    ``PATCH /v1/providers/{id}`` when a request moves a managed provider's
+    ``base_url`` to a new host WITHOUT supplying a new ``api_key``: that
+    combination would hand the stored provider key to the new host on the next
+    ``POST /v1/providers/{id}/test``. Entries are hosts (``api.example.com``)
+    or full URLs whose host is used. Left empty (the default) the endpoint
+    still permits the provider's current host and the vendor's own default
+    host, so an existing deployment is unaffected. Values support
+    ``${ENV_VAR}`` substitution like every other string in the config.
+    """
 
     model_config = ConfigDict(extra="allow")
 
     host: str = "0.0.0.0"
     port: int = 8080
+    provider_base_url_hosts: list[str] = Field(default_factory=list)
 
 
 class LiveKitConfig(BaseModel):

--- a/src/voicegateway/server/api/api_keys.py
+++ b/src/voicegateway/server/api/api_keys.py
@@ -1,10 +1,21 @@
-"""FastAPI router for api-key management."""
+"""FastAPI router for api-key management.
+
+Auth is declared ONCE, here, for every route on this router. A minted key
+carries the wildcard scope (``api_keys_repository`` defaults ``scopes='*'``),
+so an ungated mint hands the caller write access to every ``/v1`` endpoint.
+``require_scope(ADMIN_SCOPE)`` is a no-op while no API keys are configured
+(the self-hosted single-operator default: ``core.auth.check_request``
+returns None on an empty key list), and enforces the admin scope once auth
+is enabled. Declaring it on the router rather than per handler means a new
+route cannot forget to opt in.
+"""
 
 from __future__ import annotations
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
+from voicegateway.core.auth import ADMIN_SCOPE
 from voicegateway.core.container import Container
 from voicegateway.core.exceptions import NotFoundError
 from voicegateway.schemas.api.api_key_schema import (
@@ -13,9 +24,14 @@ from voicegateway.schemas.api.api_key_schema import (
     ApiKeyResponse,
     CreatedApiKey,
 )
+from voicegateway.server.api._deps import require_scope
 from voicegateway.services.api_key_service import ApiKeyService
 
-router = APIRouter(prefix="/api-keys", tags=["api-keys"])
+router = APIRouter(
+    prefix="/api-keys",
+    tags=["api-keys"],
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 
 
 @router.post("", response_model=CreatedApiKey, status_code=201)

--- a/src/voicegateway/server/api/dashboard/api_keys.py
+++ b/src/voicegateway/server/api/dashboard/api_keys.py
@@ -4,6 +4,15 @@ Virtual keys expose their plaintext exactly once at creation: the FE
 shows the "save this key" modal and discards it; subsequent list
 responses expose only ``key_prefix``. Revoke is soft (the row stays
 for audit per OQ5).
+
+Auth is declared ONCE, here, for every route on this router. A minted key
+carries the wildcard scope (``api_keys_repository`` defaults ``scopes='*'``),
+so an ungated mint hands the caller write access to every ``/v1`` endpoint.
+``require_scope(ADMIN_SCOPE)`` is a no-op while no API keys are configured
+(the self-hosted single-operator default: ``core.auth.check_request``
+returns None on an empty key list), and enforces the admin scope once auth
+is enabled, exactly like Diagnostics and the Server overview. The dashboard
+frontend already sends its bearer token on these calls.
 """
 
 from __future__ import annotations
@@ -13,15 +22,20 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 
+from voicegateway.core.auth import ADMIN_SCOPE
 from voicegateway.repository import (
     api_keys_repository as api_keys,
 )
-from voicegateway.server.api._deps import get_gateway
+from voicegateway.server.api._deps import get_gateway, require_scope
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
 
-router = APIRouter(prefix="/api_keys", tags=["dashboard"])
+router = APIRouter(
+    prefix="/api_keys",
+    tags=["dashboard"],
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 
 
 @router.get("")

--- a/src/voicegateway/server/api/dashboard/branding.py
+++ b/src/voicegateway/server/api/dashboard/branding.py
@@ -13,6 +13,12 @@ The branding directory itself is mounted at ``/static/branding/*`` by
 uploaded logos resolve at
 ``http://<daemon>/static/branding/uploads/<id>.<ext>``.
 
+Both POSTs are admin writes, gated per ROUTE rather than on the router: the
+GET is called by every dashboard layout mount to apply the brand, and the FE
+treats a 403 exactly like a 401 (it clears the stored token and shows the
+login gate), so a router-level admin dependency would log out a read-scoped
+operator on page load.
+
 Three properties the logo upload has to hold, because the bytes it takes
 are attacker-controlled and are then served same-origin:
 
@@ -304,7 +310,10 @@ async def get_project_branding(
     return {"project_id": project_id, "branding": project.get("branding")}
 
 
-@router.post("/{project_id}/branding")
+@router.post(
+    "/{project_id}/branding",
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 async def update_project_branding(
     project_id: str,
     body: dict[str, Any] = Body(...),
@@ -316,6 +325,17 @@ async def update_project_branding(
     shape (hex regex, 64-char product_name cap, no unknown keys).
     Returns the validated branding plus the project_id so the FE can
     re-apply the CSS variables on the next layout mount.
+
+    **Auth.** Same gate as its sibling :func:`upload_project_logo`, and for
+    the same reason: white-label branding is an operator/agency setting, and
+    this is the route that actually stamps ``logo_url`` onto the project.
+    Gating only the upload left the interesting half open, since ``logo_url``
+    is an arbitrary caller-supplied string here (the upload is just one way
+    to produce one), and ``product_name`` is what every dashboard page then
+    renders as its own name. Declared on the ROUTE and not the router
+    because ``GET /{project_id}/branding`` below must stay reachable by a
+    read-scoped operator. The gate is a no-op while no API keys are
+    configured, so the self-hosted default is unchanged.
     """
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")

--- a/src/voicegateway/server/api/dashboard/branding.py
+++ b/src/voicegateway/server/api/dashboard/branding.py
@@ -10,21 +10,46 @@ Three handlers backing the v0.5.0 white-label branding feature
 The branding directory itself is mounted at ``/static/branding/*`` by
 :func:`mount_static_branding` in this module; the daemon's
 ``ApplicationBuilder`` calls that during ``_configure_routers`` so
-uploaded logos resolve at ``http://<daemon>/static/branding/<id>.<ext>``.
+uploaded logos resolve at
+``http://<daemon>/static/branding/uploads/<id>.<ext>``.
+
+Three properties the logo upload has to hold, because the bytes it takes
+are attacker-controlled and are then served same-origin:
+
+1. **It is an admin write.** See :func:`upload_project_logo`.
+2. **An uploaded SVG must not be able to run script.** An SVG opened as a
+   top-level document is an active document, not an image, so a payload
+   under ``/static/branding`` would run in the dashboard's own origin and
+   read its ``localStorage`` token. Two independent defences:
+   :func:`_reject_unsafe_svg` refuses the content, and
+   :class:`_InertStaticFiles` serves the whole directory under a CSP
+   sandbox so anything that slips past the first defence is still inert.
+3. **The write must stay inside the uploads directory.** Uploads land in
+   the ``uploads/`` SUBDIRECTORY, never in the branding root, so a project
+   id can never name (and overwrite) one of the assets shipped in the repo
+   (``default.svg``, ``logo.svg``, ``favicon.svg``, ...). The filename is
+   derived by :func:`_logo_filename` from a strict allow-list, and
+   :func:`_resolve_logo_target` re-checks containment on the resolved path.
 """
 
 from __future__ import annotations
 
+import hashlib
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from xml.etree import ElementTree
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, UploadFile
 from fastapi.staticfiles import StaticFiles
 
-from voicegateway.server.api._deps import get_gateway
+from voicegateway.core.auth import ADMIN_SCOPE
+from voicegateway.server.api._deps import get_gateway, require_scope
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
+    from starlette.responses import Response
+    from starlette.types import Scope
 
     from voicegateway.core.gateway import Gateway
 
@@ -44,21 +69,222 @@ _MAX_LOGO_BYTES = 256 * 1024
 _MAX_LOGO_DIMENSION = 512
 _ALLOWED_LOGO_FORMATS = ("PNG", "SVG")
 
+# Uploaded logos go one level down, into their own subdirectory. The branding
+# root holds assets that ship in the repo (default.svg, logo.svg, favicon.svg,
+# wordings.png); before this split an upload for the project literally called
+# "default" wrote default.svg and replaced a tracked file on disk.
+_UPLOAD_SUBDIR = "uploads"
+
+# Served with every branding asset. `sandbox` (no tokens) drops the response
+# into an opaque origin and disables script, so a top-level navigation to an
+# uploaded SVG cannot touch the dashboard's origin; `default-src 'none'` blocks
+# script and subresource loads a second time. Neither breaks <img src=...>,
+# which is how the dashboard renders the logo. `style-src 'unsafe-inline'`
+# keeps inline presentation attributes working for an ordinary vector logo.
+_BRANDING_CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+
 router = APIRouter(prefix="/projects", tags=["dashboard"])
+
+
+class _InertStaticFiles(StaticFiles):
+    """StaticFiles that serves branding assets as inert documents.
+
+    The upload directory is the one place on the daemon where a caller can
+    put bytes that are later served from the dashboard's own origin, so the
+    response carries its own defence rather than trusting the content check
+    upstream of it. ``get_response`` is the documented override point and is
+    also on the 404 path, where the headers simply do not apply.
+    """
+
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        response = await super().get_response(path, scope)
+        response.headers.setdefault("Content-Security-Policy", _BRANDING_CSP)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        return response
 
 
 def mount_static_branding(app: FastAPI) -> None:
     """Mount the branding upload directory at ``/static/branding``.
 
     Called by the daemon's ``ApplicationBuilder`` so the uploaded logos
-    resolve at ``http://<daemon>/static/branding/<project_id>.<ext>``.
+    resolve at ``http://<daemon>/static/branding/uploads/<project_id>.<ext>``.
     Idempotent: a second call replaces the existing mount.
     """
     app.mount(
         "/static/branding",
-        StaticFiles(directory=_BRANDING_DIR),
+        _InertStaticFiles(directory=_BRANDING_DIR),
         name="branding",
     )
+
+
+# ---------------------------------------------------------------------------
+# Where an upload is allowed to land
+# ---------------------------------------------------------------------------
+
+# The one shape a project id may contribute to a filename verbatim: ASCII
+# alphanumerics, underscore and dash, starting with an alphanumeric, at most
+# 64 chars. No dot, no slash, no backslash, no NUL, so "..", "../x" and
+# "x/../../y" all fail it and take the digest branch below.
+_SAFE_STEM_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9_-]{0,63}\Z")
+
+
+def _upload_dir() -> Path:
+    """Directory uploaded logos are written to.
+
+    Derived at call time rather than bound at import so a test can redirect
+    ``_BRANDING_DIR`` to a tmp_path and have BOTH the writes and the static
+    mount follow it, instead of writing into the repo's tracked asset tree.
+    """
+    return _BRANDING_DIR / _UPLOAD_SUBDIR
+
+
+def _logo_filename(project_id: str, suffix: str) -> str:
+    """Return the on-disk filename for a project's logo, safe by construction.
+
+    A project id is an arbitrary caller-supplied string (nothing validates it
+    at creation), so it is never interpolated into a path unchecked. An id
+    that matches :data:`_SAFE_STEM_RE` is used as-is, which keeps the URL
+    readable for the ordinary ``acme``-style id; anything else is replaced
+    wholesale by a digest of the id, so the result is still deterministic (a
+    re-upload replaces that project's own logo) but cannot contain a path
+    separator, a traversal segment or a NUL.
+    """
+    stem = project_id if _SAFE_STEM_RE.match(project_id) else None
+    if stem is None:
+        digest = hashlib.sha256(project_id.encode("utf-8")).hexdigest()[:16]
+        stem = f"p-{digest}"
+    return f"{stem}.{suffix}"
+
+
+def _resolve_logo_target(project_id: str, suffix: str) -> Path:
+    """Absolute write path for a logo, re-checked to be inside the uploads dir.
+
+    :func:`_logo_filename` already guarantees this; the check is kept because
+    the cost of being wrong here is an arbitrary file write, and a future edit
+    to the filename rule should fail closed rather than escape.
+    """
+    root = _upload_dir().resolve()
+    filename = _logo_filename(project_id, suffix)
+    target = (root / filename).resolve()
+    if target.parent != root or target.name != filename:
+        raise HTTPException(
+            status_code=400,
+            detail="logo filename resolves outside the branding upload directory",
+        )
+    return target
+
+
+# ---------------------------------------------------------------------------
+# What an uploaded SVG is allowed to contain
+# ---------------------------------------------------------------------------
+
+# Elements that either run script or can retarget an attribute to something
+# that does. A logo needs none of them.
+_SVG_FORBIDDEN_TAGS = frozenset(
+    {
+        "script",
+        "foreignobject",
+        "iframe",
+        "embed",
+        "object",
+        "handler",
+        "audio",
+        "video",
+        "animate",
+        "set",
+    }
+)
+
+# URL schemes refused in any attribute value. `javascript:` executes; `data:`
+# is refused because a data: document inherits nothing to stop it (an operator
+# who needs a raster logo can upload the PNG itself).
+_SVG_FORBIDDEN_SCHEMES = ("javascript:", "data:", "vbscript:")
+
+# Markers refused on the raw bytes as well as on the parsed tree, so they are
+# caught even where they never become a node: entity declarations (billion
+# laughs / smuggled markup) and a script element hidden by malformed markup
+# that expat drops but a browser's lenient parser would still honour.
+_SVG_FORBIDDEN_RAW = ("<script", "<foreignobject", "<!entity", "javascript:")
+
+_WHITESPACE_RE = re.compile(r"[\s\x00-\x1f]+")
+
+
+def _local_name(tag: str) -> str:
+    """Strip the ``{namespace}`` prefix ElementTree puts on qualified names."""
+    return tag.rsplit("}", 1)[-1].lower()
+
+
+def _reject_unsafe_svg(content: bytes) -> None:
+    """Raise 400 unless ``content`` is an SVG that cannot execute anything.
+
+    The pre-hardening check was ``b"<svg" in content[:512]``, which accepts a
+    file whose very next element is ``<script>``. Two passes now:
+
+    - A raw pass over the decoded text, whitespace-stripped so ``< script``
+      and ``java script:`` normalise onto the marker, for the handful of
+      things that must not appear anywhere in the file. Stripping the
+      ``\\x00-\\x1f`` range also collapses UTF-16-encoded ASCII (``<\\x00s``
+      ...) onto the same markers, so a re-encoded payload does not slip the
+      pass.
+    - A parse pass over the element tree, which is encoding-independent (a
+      UTF-16 payload defeats a byte scan but not the parser) and precise:
+      forbidden elements, any ``on*`` event-handler attribute, and any
+      attribute value carrying an executable scheme.
+
+    Refusing rather than rewriting is deliberate: a sanitiser that silently
+    edits the operator's file has to be right about every browser quirk,
+    whereas a refusal is a decision the operator can see and act on.
+    """
+    text = content.decode("utf-8", errors="replace").lower()
+    flat = _WHITESPACE_RE.sub("", text)
+    for marker in _SVG_FORBIDDEN_RAW:
+        if marker in flat:
+            raise HTTPException(
+                status_code=400,
+                detail=f"SVG rejected: contains {marker!r}",
+            )
+
+    # Stdlib ElementTree rather than defusedxml, which is not a dependency of
+    # this package: the two attacks it guards are already closed here. Entity
+    # declarations are refused by the raw pass above (so no billion laughs),
+    # and expat under ElementTree never resolves an external entity - an
+    # undefined reference is a ParseError, i.e. a 400 below, not a fetch.
+    try:
+        root = ElementTree.fromstring(content)
+    except ElementTree.ParseError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"SVG rejected: not well-formed XML ({exc})",
+        ) from exc
+    if _local_name(root.tag) != "svg":
+        raise HTTPException(
+            status_code=400,
+            detail=f"SVG rejected: root element is {_local_name(root.tag)!r}, not 'svg'",
+        )
+
+    for element in root.iter():
+        name = _local_name(str(element.tag))
+        if name in _SVG_FORBIDDEN_TAGS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"SVG rejected: forbidden element <{name}>",
+            )
+        for attr, value in element.attrib.items():
+            attr_name = _local_name(attr)
+            if attr_name.startswith("on"):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"SVG rejected: event-handler attribute {attr_name!r}",
+                )
+            flat_value = _WHITESPACE_RE.sub("", value).lower()
+            for scheme in _SVG_FORBIDDEN_SCHEMES:
+                if scheme in flat_value:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"SVG rejected: {scheme} URL in attribute {attr_name!r}"
+                        ),
+                    )
 
 
 @router.get("/{project_id}/branding")
@@ -119,7 +345,10 @@ async def update_project_branding(
     }
 
 
-@router.post("/{project_id}/branding/logo")
+@router.post(
+    "/{project_id}/branding/logo",
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 async def upload_project_logo(
     project_id: str,
     file: UploadFile = File(...),
@@ -134,10 +363,22 @@ async def upload_project_logo(
       is skipped).
 
     Persists the file under
-    ``dashboard/api/static/branding/{project_id}.{ext}`` and stamps the
+    ``dashboard/api/static/branding/uploads/{stem}.{ext}`` and stamps the
     returned URL onto the project's ``branding.logo_url``. The endpoint
     does NOT update other branding fields; call
     POST /api/projects/{id}/branding for that.
+
+    **Auth.** This route carried no dependency at all: anyone who could
+    reach the port could write bytes into a directory the dashboard serves
+    from its own origin. It takes ``require_scope(ADMIN_SCOPE)``, the same
+    gate the API-key routers take, because white-label branding is an
+    operator/agency setting rather than a read. The dependency is declared
+    on the ROUTE and not on the router (the S1 idiom) for the reason
+    ``dashboard/replay.py`` gives: this router also carries
+    ``GET /{id}/branding``, which every dashboard layout mount calls to
+    apply the brand, and gating that read behind the admin scope would
+    log out a read-scoped operator on page load. The gate is a no-op while
+    no API keys are configured, so the self-hosted default is unchanged.
     """
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
@@ -192,11 +433,12 @@ async def upload_project_logo(
         ".svg"
     ):
         suffix = "svg"
-        # SVG is text/XML; reject obvious binary garbage. Full XML
-        # validation is out of scope for v0.5.0; the operator should
-        # control which agency staff can upload.
+        # An SVG is an active document, not an image, so "looks like SVG" is
+        # not a safety property. _reject_unsafe_svg is what stands between an
+        # upload and script running on the dashboard's origin.
         if b"<svg" not in content[:512].lower():
             raise HTTPException(status_code=400, detail="file does not look like SVG")
+        _reject_unsafe_svg(content)
     else:
         raise HTTPException(
             status_code=400,
@@ -204,9 +446,13 @@ async def upload_project_logo(
             f"content_type={content_type!r})",
         )
 
-    target = _BRANDING_DIR / f"{project_id}.{suffix}"
+    # Never `_BRANDING_DIR / f"{project_id}.{suffix}"`: that interpolates a
+    # caller-supplied id straight into a path, and it put the write in the
+    # same directory as the repo's own default.svg / logo.svg / favicon.svg.
+    target = _resolve_logo_target(project_id, suffix)
+    target.parent.mkdir(parents=True, exist_ok=True)
     target.write_bytes(content)
-    logo_url = f"/static/branding/{project_id}.{suffix}"
+    logo_url = f"/static/branding/{_UPLOAD_SUBDIR}/{target.name}"
 
     # Merge with existing branding so we don't clobber accent_color or
     # product_name.

--- a/src/voicegateway/server/api/dashboard/replay.py
+++ b/src/voicegateway/server/api/dashboard/replay.py
@@ -11,12 +11,26 @@ per-project storage-usage view:
 Same ``/api/*`` prefix as the v0.2.0 metrics endpoints; the main
 server may publish ``/v1/*`` mirrors later if SDK consumers need them.
 
-Auth here is declared per handler, not on the router: this router also
-carries the two write endpoints and the cross-project storage read, and
-gating the replay READ is what was scoped. ``GET /sessions/{id}/replay``
-is the fifth read under a session id, so it takes exactly the dependency
-and the tenant check that the other four take in
-:mod:`voicegateway.server.api.dashboard.sessions`.
+Auth here is declared per handler, not on the router, because the four
+handlers do not want the same gate:
+
+- the two READS take :func:`require_principal`, the dependency the sibling
+  dashboard reads use, plus a tenant check. ``GET /sessions/{id}/replay``
+  is the fifth read under a session id, so it takes exactly the dependency
+  and the check the other four take in
+  :mod:`voicegateway.server.api.dashboard.sessions`; ``GET /replay/storage``
+  aggregates every session row on the deployment, so it scopes its own
+  query.
+- the DELETE and the retention POST take ``require_scope(ADMIN_SCOPE)``,
+  which is what every write on a dashboard router takes (the API-key
+  routers, the diagnostics run, the agent probe, the branding logo
+  upload). One destroys captured payloads outright and the other sets how
+  long any of them survive.
+
+A router-level dependency would have to be the strictest of those, and
+putting the admin scope on the replay reads would refuse a read-scoped
+operator on the Replay page. Every one of these gates is a no-op while no
+API keys are configured, so the self-hosted default is unchanged.
 """
 
 from __future__ import annotations
@@ -27,6 +41,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy import text
 
+from voicegateway.core.auth import ADMIN_SCOPE
 from voicegateway.repository import (
     replay_repository as replay,
 )
@@ -34,6 +49,8 @@ from voicegateway.server.api._deps import (
     Principal,
     get_gateway,
     require_principal,
+    require_scope,
+    resolve_read_tenant,
 )
 from voicegateway.server.api.dashboard.sessions import require_visible_session
 
@@ -76,7 +93,10 @@ async def get_session_replay(
     }
 
 
-@router.delete("/sessions/{session_id}/replay")
+@router.delete(
+    "/sessions/{session_id}/replay",
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 async def delete_session_replay(
     session_id: str, gateway: Gateway = Depends(get_gateway)
 ) -> dict[str, Any]:
@@ -85,6 +105,17 @@ async def delete_session_replay(
     Cascade across all four ``replay_*`` tables in one transaction.
     Returns the total row count deleted (across modalities) so the
     caller can confirm the cleanup landed.
+
+    **Auth.** This route carried no dependency at all while its GET sibling
+    was gated, so the one verb that destroys the captured payloads of a call
+    was the one verb anyone could reach. It takes
+    ``require_scope(ADMIN_SCOPE)``, the scope every write on a dashboard
+    router takes. The gate is a no-op while no API keys are configured, so
+    the self-hosted default is unchanged.
+
+    No tenant check on top of the scope: an admin principal is not narrowed
+    by tenant anywhere in this codebase, and the only key that clears the
+    admin scope is an admin key.
     """
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
@@ -97,6 +128,7 @@ async def delete_session_replay(
 @router.get("/replay/storage")
 async def get_replay_storage(
     gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
 ) -> dict[str, Any]:
     """Return per-project replay storage breakdown.
 
@@ -105,19 +137,42 @@ async def get_replay_storage(
     captured replay (NULL replay_size_bytes) contribute 0 to the sum.
     The Refinery requires the dashboard surface this so "the cost is
     not invisible" to the developer.
+
+    **Auth and tenant scoping.** This read had no dependency: it aggregates
+    every session row on the deployment, so it named other tenants' projects
+    and sized their captured traffic to anyone who could reach the port. It
+    takes :func:`require_principal`, the dependency the sibling dashboard
+    reads take, and the tenant resolved from that principal becomes a
+    predicate on the query. The predicate is the one the repositories use
+    (``session_repository.list_sessions``): ``None`` means every row (the
+    operator/admin case, unchanged), ``""`` means the unattributed bucket,
+    i.e. ``tenant_id IS NULL``. Filtering in SQL rather than post-hoc keeps
+    ``total_replay_size_bytes`` consistent with ``by_project``: a total
+    computed over rows the caller cannot see would leak the size back.
     """
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
+    tenant = resolve_read_tenant(principal, None)
+    conditions = ["replay_size_bytes IS NOT NULL"]
+    params: dict[str, Any] = {}
+    if tenant is not None:
+        if tenant == "":
+            conditions.append("tenant_id IS NULL")
+        else:
+            conditions.append("tenant_id = :tenant")
+            params["tenant"] = tenant
+    where = " AND ".join(conditions)
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
         result = await db.execute(
             text(
                 "SELECT project, COALESCE(SUM(replay_size_bytes), 0) "
                 "FROM sessions "
-                "WHERE replay_size_bytes IS NOT NULL "
+                f"WHERE {where} "
                 "GROUP BY project "
                 "ORDER BY project ASC"
-            )
+            ),
+            params,
         )
         per_project: list[dict[str, Any]] = []
         total = 0
@@ -137,7 +192,10 @@ async def get_replay_storage(
         }
 
 
-@router.post("/projects/{project_id}/replay/retention")
+@router.post(
+    "/projects/{project_id}/replay/retention",
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 async def update_replay_retention(
     project_id: str,
     body: dict[str, Any] = Body(...),
@@ -155,6 +213,15 @@ async def update_replay_retention(
     follow-up that needs config-file-write infrastructure; the in-
     memory mutation matches the runtime contract the retention worker
     reads from.
+
+    **Auth.** This route carried no dependency at all: it edits runtime
+    config, and the config it edits decides how long captured payloads
+    survive, so an anonymous caller could shorten a project's window to a
+    day and let the retention worker do the deleting. It takes
+    ``require_scope(ADMIN_SCOPE)``, the scope every write on a dashboard
+    router takes, declared on the ROUTE and not the router because the two
+    reads on this router must stay reachable by a read-scoped operator. The
+    gate is a no-op while no API keys are configured.
     """
     new_days_raw = body.get("retention_days")
     if not isinstance(new_days_raw, int) or new_days_raw < 1 or new_days_raw > 365:

--- a/src/voicegateway/server/api/dashboard/replay.py
+++ b/src/voicegateway/server/api/dashboard/replay.py
@@ -10,6 +10,13 @@ per-project storage-usage view:
 
 Same ``/api/*`` prefix as the v0.2.0 metrics endpoints; the main
 server may publish ``/v1/*`` mirrors later if SDK consumers need them.
+
+Auth here is declared per handler, not on the router: this router also
+carries the two write endpoints and the cross-project storage read, and
+gating the replay READ is what was scoped. ``GET /sessions/{id}/replay``
+is the fifth read under a session id, so it takes exactly the dependency
+and the tenant check that the other four take in
+:mod:`voicegateway.server.api.dashboard.sessions`.
 """
 
 from __future__ import annotations
@@ -23,7 +30,12 @@ from sqlalchemy import text
 from voicegateway.repository import (
     replay_repository as replay,
 )
-from voicegateway.server.api._deps import get_gateway
+from voicegateway.server.api._deps import (
+    Principal,
+    get_gateway,
+    require_principal,
+)
+from voicegateway.server.api.dashboard.sessions import require_visible_session
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
@@ -33,7 +45,9 @@ router = APIRouter(tags=["dashboard"])
 
 @router.get("/sessions/{session_id}/replay")
 async def get_session_replay(
-    session_id: str, gateway: Gateway = Depends(get_gateway)
+    session_id: str,
+    gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
 ) -> dict[str, Any]:
     """Return the full time-ordered replay for one session.
 
@@ -45,9 +59,14 @@ async def get_session_replay(
     (pre-v0.3.0 sessions or projects with ``replay.enabled: false``);
     the FE renders a PreV030Banner in that case (REQ-VG-REPLAY-001
     AC-3).
+
+    A replay carries the raw STT/LLM/TTS payloads of the call, so a
+    tenant-bound caller reading another tenant's session gets the same 404
+    it would get for a session id that does not exist.
     """
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
+    await require_visible_session(gateway.storage, session_id, principal)
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
         events = await replay.read_full_replay(db, session_id)

--- a/src/voicegateway/server/api/dashboard/sessions.py
+++ b/src/voicegateway/server/api/dashboard/sessions.py
@@ -9,6 +9,23 @@
 The replay endpoints on /api/sessions/{id}/replay live in
 :mod:`voicegateway.server.api.dashboard.replay` to keep the replay-
 related Pydantic shapes and the StaticFiles mount they share local.
+
+Auth is declared ONCE, on the router, for the reason
+``dashboard/calls.py`` gives: a per-handler dependency is a thing a later
+handler can forget, and the list endpoint carried one while the four
+per-session reads did not. :func:`require_principal` is the dependency the
+sibling dashboard *reads* use (``dashboard/costs.py``, ``dashboard/calls.py``);
+``require_scope(ADMIN_SCOPE)`` is reserved for the routers that spend money or
+touch infra, and reading rows already on disk does neither. The list endpoint
+keeps its handler-level parameter as well: FastAPI caches a dependency per
+request, so the key is verified once, not twice, and the scope it requires is
+unchanged.
+
+Tenant scoping is enforced AFTER the fetch, through
+:func:`require_visible_session`, rather than by adding a tenant predicate to
+``session_repository.get_session``: the row already carries ``tenant_id``
+(``row_to_session``), so no query changes and every caller of that repo keeps
+its current behavior.
 """
 
 from __future__ import annotations
@@ -34,8 +51,61 @@ from voicegateway.server.api._deps import (
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
+    from voicegateway.services.storage_service import StorageService
 
-router = APIRouter(prefix="/sessions", tags=["dashboard"])
+router = APIRouter(
+    prefix="/sessions",
+    tags=["dashboard"],
+    dependencies=[Depends(require_principal)],
+)
+
+
+def _visible(row: dict[str, Any], tenant: str | None) -> bool:
+    """Whether a session row is readable by a principal scoped to ``tenant``.
+
+    ``None`` is the operator/admin case: every row. ``""`` is the unattributed
+    bucket, i.e. ``tenant_id IS NULL``, the same convention the repositories use
+    for their SQL tenant predicate (``session_repository.list_sessions``) and the
+    same helper shape ``dashboard/calls.py`` uses for call rows.
+    """
+    if tenant is None:
+        return True
+    stored: str | None = row["tenant_id"]
+    if tenant == "":
+        return stored is None
+    return stored == tenant
+
+
+def _not_found(session_id: str) -> HTTPException:
+    """The single 404 every unreadable session id gets."""
+    return HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+
+
+async def require_visible_session(
+    storage: StorageService, session_id: str, principal: Principal
+) -> None:
+    """Raise 404 unless ``principal`` may read ``session_id``.
+
+    The per-session sub-resources (turns, transcript, dead air, replay) query
+    their own tables by ``session_id`` and never see the session row, so the
+    tenant check needs one lookup of the parent session. It is skipped entirely
+    for the operator/admin principal (``tenant is None``), which keeps the
+    self-hosted default free of an extra query AND preserves the pre-existing
+    contract that an unknown id yields an empty payload rather than a 404.
+
+    For a tenant-bound key, "this session is another tenant's" and "this session
+    does not exist" are deliberately the same 404. A 403 on the foreign case
+    would confirm the id exists, which is the fact being protected.
+
+    Imported by :mod:`voicegateway.server.api.dashboard.replay`, whose /replay
+    read is the fifth endpoint under this session id.
+    """
+    tenant = resolve_read_tenant(principal, None)
+    if tenant is None:
+        return
+    row = await storage.get_session(session_id)
+    if row is None or not _visible(row, tenant):
+        raise _not_found(session_id)
 
 
 @router.get("")
@@ -79,7 +149,9 @@ async def get_sessions(
 
 @router.get("/{session_id}")
 async def get_session_detail(
-    session_id: str, gateway: Gateway = Depends(get_gateway)
+    session_id: str,
+    gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
 ) -> dict[str, Any]:
     """Return one session by id with per-modality breakdown.
 
@@ -87,18 +159,24 @@ async def get_session_detail(
     ``by_modality`` and ``providers`` fields the storage method
     computes via a join on the requests table. 404 when no row
     matches.
+
+    A session belonging to another tenant gets that same 404, checked on the
+    row already fetched here (no second query). See
+    :func:`require_visible_session` for why it is a 404 and not a 403.
     """
     if gateway.storage is None:
-        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+        raise _not_found(session_id)
     row = await gateway.storage.get_session(session_id)
-    if row is None:
-        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+    if row is None or not _visible(row, resolve_read_tenant(principal, None)):
+        raise _not_found(session_id)
     return row
 
 
 @router.get("/{session_id}/turns")
 async def get_session_turns(
-    session_id: str, gateway: Gateway = Depends(get_gateway)
+    session_id: str,
+    gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
 ) -> dict[str, Any]:
     """Return ordered per-turn rows for a session (REQ-VG-METRICS-002).
 
@@ -106,9 +184,12 @@ async def get_session_turns(
     mirrors the ``TurnRow`` dataclass; ``agent_speak_*`` and
     ``response_speed_ms`` are null when the agent never spoke for that
     turn (T02 contract).
+
+    404 for a tenant-bound caller reading another tenant's session.
     """
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
+    await require_visible_session(gateway.storage, session_id, principal)
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
         rows = await turns.list_turns_by_session(db, session_id)
@@ -120,32 +201,44 @@ async def get_session_turns(
 
 @router.get("/{session_id}/transcript")
 async def get_session_transcript(
-    session_id: str, gateway: Gateway = Depends(get_gateway)
+    session_id: str,
+    gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
 ) -> dict[str, Any]:
     """Return the ordered per-turn transcript for a call.
 
     Populated when transcript capture is on (``attach(transcript=True)``, the
     default). Returns an empty list (not a 404) when a call has no captured
     transcript, so the UI can show a clean empty state.
+
+    This is the most sensitive payload on the router (it is what the caller
+    said), so the tenant check is the same one the other per-session reads
+    take: 404 for a tenant-bound caller reading another tenant's session.
     """
     if gateway.storage is None:
         return {"session_id": session_id, "turns": []}
+    await require_visible_session(gateway.storage, session_id, principal)
     turns = await gateway.storage.get_transcript(session_id)
     return {"session_id": session_id, "turns": turns}
 
 
 @router.get("/{session_id}/dead_air")
 async def get_session_dead_air(
-    session_id: str, gateway: Gateway = Depends(get_gateway)
+    session_id: str,
+    gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
 ) -> dict[str, Any]:
     """Return dead-air events for a session (REQ-VG-METRICS-004).
 
     Used by the Metrics page's DeadAirList drill-down (T14). Events
     are ordered by ``started_at_ms`` ASC, matching the chronological
     rendering the FE expects.
+
+    404 for a tenant-bound caller reading another tenant's session.
     """
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
+    await require_visible_session(gateway.storage, session_id, principal)
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
         events = await dead_air.list_events_by_session(db, session_id)

--- a/src/voicegateway/server/api/providers.py
+++ b/src/voicegateway/server/api/providers.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -19,6 +20,91 @@ if TYPE_CHECKING:
 router = APIRouter(prefix="/providers", tags=["providers"])
 write_dep = Depends(require_scope("write"))
 logger = logging.getLogger(__name__)
+
+# The operator allowlist for provider base_url hosts. Declared on ServeConfig in
+# schemas/config_schema.py; read here off the raw ``serve:`` block because that
+# is what GatewayConfig carries at runtime.
+_HOSTS_CONFIG_KEY = "provider_base_url_hosts"
+_HOSTS_CONFIG_PATH = f"serve.{_HOSTS_CONFIG_KEY}"
+
+# The host each provider module already treats as its own endpoint, mirroring
+# the literals in voicegateway/inference/providers/*.py. Keeping these permitted
+# by default is what makes an unset allowlist a no-op for deployments that only
+# ever point a provider at its own vendor.
+_DEFAULT_PROVIDER_HOSTS: dict[str, tuple[str, ...]] = {
+    "openai": ("api.openai.com",),
+    "anthropic": ("api.anthropic.com",),
+    "deepgram": ("api.deepgram.com",),
+    "cartesia": ("api.cartesia.ai",),
+    "elevenlabs": ("api.elevenlabs.io",),
+    "assemblyai": ("api.assemblyai.com",),
+    "groq": ("api.groq.com",),
+    "ollama": ("localhost",),
+}
+
+
+def _url_host(value: Any) -> str | None:
+    """Return the lowercase host of a base URL, or None when there is none."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    candidate = value.strip()
+    if "//" not in candidate:
+        # Bare "api.example.com/v1" parses as a path without this.
+        candidate = "//" + candidate
+    try:
+        host = urlparse(candidate).hostname
+    except ValueError:
+        return None
+    return host.lower() if host else None
+
+
+def _allowlisted_hosts(gateway: Gateway) -> set[str]:
+    """Return the hosts the operator configured under ``serve:``."""
+    serve_cfg: Any = getattr(gateway.config, "serve", None)
+    if isinstance(serve_cfg, dict):
+        raw = serve_cfg.get(_HOSTS_CONFIG_KEY)
+    else:
+        raw = getattr(serve_cfg, _HOSTS_CONFIG_KEY, None)
+    if not isinstance(raw, list):
+        return set()
+    hosts = {_url_host(entry) for entry in raw}
+    return {host for host in hosts if host is not None}
+
+
+def _guard_base_url_host(
+    gateway: Gateway,
+    provider_id: str,
+    provider_type: str,
+    current_base_url: Any,
+    new_base_url: Any,
+) -> None:
+    """Reject repointing a stored key at a host nobody approved.
+
+    Only called when the update keeps the already-stored key: with the key in
+    the same request there is nothing to leak, so the host stays unconstrained.
+    """
+    new_host = _url_host(new_base_url)
+    if new_host is None:
+        # Cleared or absent base_url falls back to the provider's own default.
+        return
+
+    permitted = _allowlisted_hosts(gateway)
+    permitted.update(_DEFAULT_PROVIDER_HOSTS.get(provider_type, ()))
+    current_host = _url_host(current_base_url)
+    if current_host is not None:
+        permitted.add(current_host)
+
+    if new_host in permitted:
+        return
+
+    raise HTTPException(
+        400,
+        f"base_url host '{new_host}' is not permitted for provider "
+        f"'{provider_id}'. Moving base_url to a new host while reusing the "
+        "stored API key would send that key to the new host. Add the host to "
+        f"'{_HOSTS_CONFIG_PATH}' in voicegw.yaml, or send a fresh 'api_key' "
+        "in this request.",
+    )
 
 
 @router.get("")
@@ -114,6 +200,24 @@ async def update_provider(
         raise HTTPException(400, f"Unknown provider_type '{ptype}'")
 
     project = body.get("project", existing.get("project"))
+
+    # The dangerous shape is "new host + stored key": POST /test would then ship
+    # the operator's key to a host the caller picked. A request that carries its
+    # own api_key owns a key already, and an empty stored key is not a secret, so
+    # both stay unconstrained. Default hosts come from the STORED provider_type,
+    # the vendor that issued the stored key, not from a caller-supplied one.
+    supplied_key = body.get("api_key")
+    reuses_stored_key = bool(current_key) and not (
+        isinstance(supplied_key, str) and supplied_key
+    )
+    if reuses_stored_key:
+        _guard_base_url_host(
+            gateway,
+            provider_id,
+            str(existing["provider_type"]),
+            existing.get("base_url"),
+            base_url,
+        )
 
     await gateway.storage.upsert_managed_provider(
         provider_id, ptype, api_key, base_url, project=project

--- a/src/voicegateway/server/api/sessions.py
+++ b/src/voicegateway/server/api/sessions.py
@@ -1,17 +1,52 @@
-"""Session endpoints: GET /v1/sessions, GET /v1/sessions/{id}."""
+"""Session endpoints: GET /v1/sessions, GET /v1/sessions/{id}.
+
+These are the public twin of the dashboard reads under ``/api/sessions``:
+same storage calls, same rows. They took only ``get_gateway``, so everything
+gated and tenant-scoped on ``/api/sessions`` was still served unauthenticated
+and unscoped one prefix over, which makes the gate on the mirror worth
+nothing to anyone who can spell ``/v1``.
+
+Auth is declared ONCE, on the router, the idiom
+``dashboard/sessions.py`` and ``dashboard/calls.py`` give: both routes here
+are reads and a per-handler dependency is a thing a later handler can forget.
+:func:`require_principal` is the dependency the sibling *reads* use;
+``require_scope(ADMIN_SCOPE)`` is reserved for the routers that spend money or
+touch infra, and reading rows already on disk does neither. The gate is a
+no-op while no API keys are configured (the self-hosted single-operator
+default), so nothing changes for an operator who has not enabled auth. The
+handlers keep a ``principal`` parameter as well because they need the identity
+itself; FastAPI caches a dependency per request, so the key is verified once.
+
+Tenant scoping reuses the helpers
+:mod:`voicegateway.server.api.dashboard.sessions` added rather than restating
+them, so the two surfaces cannot drift: the list filters at the query through
+``resolve_read_tenant``, and the detail checks ``_visible`` on the row it has
+already fetched. A foreign session returns the same 404, with the same body,
+as a session id that does not exist.
+"""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 
-from voicegateway.server.api._deps import get_gateway
+from voicegateway.server.api._deps import (
+    Principal,
+    get_gateway,
+    require_principal,
+    resolve_read_tenant,
+)
+from voicegateway.server.api.dashboard.sessions import _not_found, _visible
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
 
-router = APIRouter(prefix="/sessions", tags=["sessions"])
+router = APIRouter(
+    prefix="/sessions",
+    tags=["sessions"],
+    dependencies=[Depends(require_principal)],
+)
 
 
 @router.get("")
@@ -23,12 +58,25 @@ async def list_sessions(
         pattern="^(started_at_desc|started_at_asc|cost_desc|cost_asc)$",
     ),
     gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
 ) -> list[dict]:
-    """Return recent voice sessions, ordered per ``order_by``."""
+    """Return recent voice sessions, ordered per ``order_by``.
+
+    Scoped to the authenticated principal: the tenant comes from the key, not
+    from a caller-supplied parameter (this route publishes none), so a
+    tenant-bound key never sees another tenant's sessions in the list. An
+    operator with no credential, a static config key, or an admin key resolves
+    to ``None`` and keeps listing every tenant, unchanged.
+
+    Filtering here and not only on the detail route matters: a list that
+    returned every tenant's sessions hands over the ids that the detail route
+    is refusing.
+    """
+    tenant = resolve_read_tenant(principal, None)
     if gateway.storage is None:
         return []
     return await gateway.storage.list_sessions(
-        limit=limit, project=project, order_by=order_by
+        limit=limit, project=project, order_by=order_by, tenant=tenant
     )
 
 
@@ -36,11 +84,18 @@ async def list_sessions(
 async def session_detail(
     session_id: str,
     gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
 ) -> dict:
-    """Return one session by id with a per-modality cost breakdown."""
+    """Return one session by id with a per-modality cost breakdown.
+
+    A session belonging to another tenant gets the same 404 as a session id
+    that does not exist, checked on the row already fetched here (no second
+    query). See ``dashboard.sessions.require_visible_session`` for why it is a
+    404 and not a 403: a 403 would confirm the id is real.
+    """
     if gateway.storage is None:
-        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+        raise _not_found(session_id)
     row = await gateway.storage.get_session(session_id)
-    if row is None:
-        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found")
+    if row is None or not _visible(row, resolve_read_tenant(principal, None)):
+        raise _not_found(session_id)
     return row

--- a/src/voicegateway/tests/server/test_api_keys_route.py
+++ b/src/voicegateway/tests/server/test_api_keys_route.py
@@ -102,3 +102,116 @@ async def test_create_validation_rejects_empty_name(client: AsyncClient) -> None
     assert response.status_code == 422
     body = response.json()
     assert body["type"] == "RequestValidationError"
+
+
+# ---------------------------------------------------------------------------
+# Auth: the router is admin-gated once auth is enabled
+# ---------------------------------------------------------------------------
+
+
+async def test_mint_stays_open_when_no_keys_are_configured(gateway) -> None:
+    """The self-hosted default (no keys configured) is unchanged.
+
+    ``core.auth.check_request`` returns None on an empty key list, so
+    ``require_scope(ADMIN_SCOPE)`` is a no-op here and an operator with no
+    auth block still mints a key with no credential. Every other test in
+    this file rides on that path; this one asserts it explicitly.
+    """
+    app = build_app(gateway)
+    assert app.state.api_keys == []
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        created = await c.post("/v1/api-keys", json={"name": "local-operator"})
+        assert created.status_code == 201
+        assert created.json()["plaintext"].startswith("vk_")
+        assert (await c.get("/v1/api-keys")).status_code == 200
+
+
+async def test_router_requires_admin_when_auth_enabled(gateway) -> None:
+    """With static keys configured, an unauthenticated caller cannot mint.
+
+    A minted key carries the wildcard scope, so an ungated POST here is a
+    write escalation onto every /v1 endpoint. The gate covers the reads too:
+    the list exposes every key prefix and tenant.
+    """
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+
+    app = build_app(gateway)
+    # A non-vk_ token takes the static-key path (check_request, which reads
+    # app.state.api_keys). A vk_ token would take the DB storage path instead.
+    app.state.api_keys = [
+        ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,))
+    ]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        blocked = await c.post("/v1/api-keys", json={"name": "stolen"})
+        assert blocked.status_code == 401
+        assert (await c.get("/v1/api-keys")).status_code == 401
+        assert (await c.get("/v1/api-keys/1")).status_code == 401
+        assert (await c.delete("/v1/api-keys/1")).status_code == 401
+
+        # A bad token is rejected too, not just a missing one.
+        assert (
+            await c.post(
+                "/v1/api-keys",
+                json={"name": "stolen"},
+                headers={"Authorization": "Bearer wrong-token"},
+            )
+        ).status_code == 401
+
+        ok = await c.post(
+            "/v1/api-keys",
+            json={"name": "minted-by-admin"},
+            headers={"Authorization": "Bearer admin-secret-token"},
+        )
+        assert ok.status_code == 201
+
+
+async def test_router_rejects_key_without_admin_scope(gateway) -> None:
+    """A valid static key lacking the admin scope is authenticated but 403."""
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+
+    app = build_app(gateway)
+    app.state.api_keys = [
+        ApiKey(token="read-only-token", name="viewer", scopes=("read",)),
+        ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,)),
+    ]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        denied = await c.post(
+            "/v1/api-keys",
+            json={"name": "escalation"},
+            headers={"Authorization": "Bearer read-only-token"},
+        )
+        assert denied.status_code == 403
+        assert (
+            await c.get(
+                "/v1/api-keys", headers={"Authorization": "Bearer read-only-token"}
+            )
+        ).status_code == 403
+
+
+async def test_minted_tenant_key_cannot_mint_another_key(gateway) -> None:
+    """A vk_ key minted here defaults to role='tenant', so it cannot re-mint.
+
+    Without this, a single leaked wildcard key would be self-replicating.
+    """
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+
+    app = build_app(gateway)
+    open_transport = ASGITransport(app=app)
+    async with AsyncClient(transport=open_transport, base_url="http://test") as c:
+        minted = (await c.post("/v1/api-keys", json={"name": "agent"})).json()
+    plaintext = minted["plaintext"]
+
+    app.state.api_keys = [
+        ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,))
+    ]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        denied = await c.post(
+            "/v1/api-keys",
+            json={"name": "self-replication"},
+            headers={"Authorization": f"Bearer {plaintext}"},
+        )
+        assert denied.status_code == 403

--- a/src/voicegateway/tests/server/test_branding_endpoint.py
+++ b/src/voicegateway/tests/server/test_branding_endpoint.py
@@ -3,6 +3,12 @@
 After the dashboard fold-in, these handlers live in
 :mod:`voicegateway.server.api.dashboard.branding` and are reached
 through the daemon's ``build_app(...)``.
+
+The sections after the original v0.5.0 tests cover the three defects the
+security audit found in the logo upload: it had no auth dependency at all, it
+accepted any bytes containing ``<svg`` and served them same-origin, and it
+interpolated the project id straight into a path inside the directory that
+holds the repo's own shipped brand assets.
 """
 
 from __future__ import annotations
@@ -12,8 +18,39 @@ from io import BytesIO
 import pytest
 from fastapi.testclient import TestClient
 
+from voicegateway.core.auth import ApiKey
 from voicegateway.core.gateway import Gateway
+from voicegateway.server.api.dashboard import branding as branding_mod
 from voicegateway.server.main import build_app
+
+# Stand-in for one of the assets that ship in the repo's branding directory
+# (default.svg, logo.svg, favicon.svg, wordings.png). Distinctive so a clobber
+# is visible in the assertion message rather than inferred.
+_SHIPPED_ASSET = b'<svg xmlns="http://www.w3.org/2000/svg"><!-- shipped --></svg>'
+
+_CLEAN_SVG = (
+    b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">'
+    b'<circle cx="5" cy="5" r="4"/></svg>'
+)
+
+
+@pytest.fixture(autouse=True)
+def sandbox_branding_dir(tmp_path, monkeypatch):
+    """Point the branding directory at tmp_path for every test in this module.
+
+    Autouse so it is in place before ``build_app`` mounts StaticFiles on the
+    directory. Without it the upload tests write into
+    ``src/dashboard/api/static/branding/``, which is TRACKED: that is how the
+    repo's own ``default.svg`` came to hold this file's SVG fixture. The
+    sandbox is seeded with a stand-in shipped asset so the no-clobber
+    assertions below have something real to check.
+    """
+    sandbox = tmp_path / "branding"
+    sandbox.mkdir()
+    (sandbox / "default.svg").write_bytes(_SHIPPED_ASSET)
+    (sandbox / "logo.svg").write_bytes(_SHIPPED_ASSET)
+    monkeypatch.setattr(branding_mod, "_BRANDING_DIR", sandbox)
+    return sandbox
 
 
 @pytest.fixture
@@ -147,3 +184,306 @@ def test_logo_upload_png_accepts_valid(client) -> None:
     )
     assert r.status_code == 200
     assert r.json()["format"] == "PNG"
+
+
+def _upload_svg(c, svg: bytes, project: str = "default"):
+    return c.post(
+        f"/api/projects/{project}/branding/logo",
+        files={"file": ("logo.svg", svg, "image/svg+xml")},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth: the upload is an admin write, and carried no dependency at all
+# ---------------------------------------------------------------------------
+
+
+def test_logo_upload_open_when_no_keys_are_configured(client) -> None:
+    """The self-hosted default (no keys configured) is unchanged.
+
+    ``core.auth.check_request`` returns None on an empty key list, so the
+    admin gate costs the single-operator deployment nothing.
+    """
+    _, c = client
+    assert c.app.state.api_keys == []
+    assert _upload_svg(c, _CLEAN_SVG).status_code == 200
+
+
+def test_logo_upload_requires_admin_when_auth_is_enabled(client, sandbox_branding_dir):
+    """With keys configured, only an admin-scoped caller may write bytes.
+
+    Before this, the route had no dependency: any caller who could reach the
+    port could put a file into a directory the dashboard serves from its own
+    origin, on a deployment that otherwise required a token for every read.
+    """
+    _, c = client
+    c.app.state.api_keys = [
+        ApiKey(token="read-token", name="viewer", scopes=("read",)),
+        ApiKey(token="admin-token", name="operator", scopes=("admin",)),
+    ]
+
+    anon = _upload_svg(c, _CLEAN_SVG)
+    assert anon.status_code == 401, anon.text
+
+    wrong = c.post(
+        "/api/projects/default/branding/logo",
+        files={"file": ("logo.svg", _CLEAN_SVG, "image/svg+xml")},
+        headers={"Authorization": "Bearer nope"},
+    )
+    assert wrong.status_code == 401, wrong.text
+
+    reader = c.post(
+        "/api/projects/default/branding/logo",
+        files={"file": ("logo.svg", _CLEAN_SVG, "image/svg+xml")},
+        headers={"Authorization": "Bearer read-token"},
+    )
+    assert reader.status_code == 403, reader.text
+
+    # Nothing landed on disk for any of the three refusals.
+    assert not (sandbox_branding_dir / "uploads").exists()
+
+    admin = c.post(
+        "/api/projects/default/branding/logo",
+        files={"file": ("logo.svg", _CLEAN_SVG, "image/svg+xml")},
+        headers={"Authorization": "Bearer admin-token"},
+    )
+    assert admin.status_code == 200, admin.text
+    assert (sandbox_branding_dir / "uploads" / "default.svg").read_bytes() == _CLEAN_SVG
+
+
+def test_branding_read_is_not_gated_behind_the_admin_scope(client) -> None:
+    """The GET stays a read: the admin gate is on the upload route only.
+
+    Every dashboard layout mount calls this endpoint to apply the brand
+    (``lib/branding.ts``), and the FE treats 403 the same as 401: it clears
+    the stored token and shows the login gate. Putting the admin dependency
+    on the whole router would log out a read-scoped operator on page load.
+    """
+    _, c = client
+    c.app.state.api_keys = [ApiKey(token="read-token", name="viewer", scopes=("read",))]
+    r = c.get(
+        "/api/projects/default/branding",
+        headers={"Authorization": "Bearer read-token"},
+    )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Stored XSS: an uploaded SVG is an active document, not an image
+# ---------------------------------------------------------------------------
+
+# Each payload is a file the pre-hardening check accepted: it starts with
+# "<svg" inside the first 512 bytes, which was the entire validation.
+_MALICIOUS_SVGS = {
+    "script_element": (
+        b'<svg xmlns="http://www.w3.org/2000/svg">'
+        b'<script>fetch("/api/api_keys")</script></svg>'
+    ),
+    "event_handler": (
+        b'<svg xmlns="http://www.w3.org/2000/svg" onload="alert(document.domain)">'
+        b'<circle cx="5" cy="5" r="4"/></svg>'
+    ),
+    "event_handler_on_child": (
+        b'<svg xmlns="http://www.w3.org/2000/svg">'
+        b'<circle cx="5" cy="5" r="4" onclick="alert(1)"/></svg>'
+    ),
+    "foreign_object": (
+        b'<svg xmlns="http://www.w3.org/2000/svg"><foreignObject>'
+        b'<body xmlns="http://www.w3.org/1999/xhtml">hi</body></foreignObject></svg>'
+    ),
+    "javascript_url": (
+        b'<svg xmlns="http://www.w3.org/2000/svg" '
+        b'xmlns:xlink="http://www.w3.org/1999/xlink">'
+        b'<a xlink:href="javascript:alert(1)"><text>x</text></a></svg>'
+    ),
+    "data_url": (
+        b'<svg xmlns="http://www.w3.org/2000/svg">'
+        b'<image href="data:text/html;base64,PHNjcmlwdD4="/></svg>'
+    ),
+    "entity_declaration": (
+        b'<svg xmlns="http://www.w3.org/2000/svg">'
+        b'<!ENTITY xxe SYSTEM "file:///etc/passwd">&xxe;</svg>'
+    ),
+    "animate_retargeting_href": (
+        b'<svg xmlns="http://www.w3.org/2000/svg"><a><animate attributeName="href" '
+        b'values="javascript:alert(1)"/><text>x</text></a></svg>'
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_MALICIOUS_SVGS))
+def test_logo_upload_rejects_executable_svg(client, sandbox_branding_dir, name) -> None:
+    """Every executable SVG shape is refused, and nothing reaches disk.
+
+    These are served same-origin from ``/static/branding``; an SVG opened as a
+    top-level document runs its script in the dashboard's origin, where the
+    dashboard's bearer token lives in localStorage.
+    """
+    _, c = client
+    resp = _upload_svg(c, _MALICIOUS_SVGS[name])
+    assert resp.status_code == 400, f"{name} was accepted: {resp.text}"
+    assert not (sandbox_branding_dir / "uploads").exists(), (
+        f"{name} was refused but still written to disk"
+    )
+
+
+def test_logo_upload_rejects_malformed_xml(client) -> None:
+    """Markup a strict parser rejects but a lenient browser parser may run."""
+    _, c = client
+    resp = _upload_svg(c, b'<svg xmlns="http://www.w3.org/2000/svg"><circle>')
+    assert resp.status_code == 400
+    assert "well-formed" in resp.json()["detail"]
+
+
+def test_logo_upload_still_accepts_an_ordinary_vector_logo(
+    client, sandbox_branding_dir
+) -> None:
+    """The rejection rules do not cost a real logo: paths, groups, styles."""
+    _, c = client
+    svg = (
+        b'<?xml version="1.0" encoding="UTF-8"?>'
+        b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" '
+        b'width="64" height="64"><title>Acme</title>'
+        b'<g fill="none" stroke="#1F96AA" stroke-width="4">'
+        b'<path d="M8 56 L32 8 L56 56 Z" style="stroke-linejoin:round"/>'
+        b'</g><rect x="0" y="0" width="64" height="64" fill="#fff" '
+        b'opacity="0.1"/></svg>'
+    )
+    resp = _upload_svg(c, svg)
+    assert resp.status_code == 200, resp.text
+    assert (sandbox_branding_dir / "uploads" / "default.svg").read_bytes() == svg
+
+
+def test_svg_scan_sees_through_utf16_encoding() -> None:
+    """The raw pass normalises UTF-16 ASCII onto the same markers.
+
+    A byte scan for ``<script`` misses ``<\\x00s\\x00c...``; stripping the
+    control range before matching does not. Asserted on the checker directly
+    because the legacy ``b"<svg" in content[:512]`` sniff refuses a UTF-16
+    file earlier in the handler, which would hide whether this pass works.
+    """
+    from fastapi import HTTPException
+
+    payload = '<svg xmlns="http://www.w3.org/2000/svg"><script>x</script></svg>'
+    with pytest.raises(HTTPException) as excinfo:
+        branding_mod._reject_unsafe_svg(payload.encode("utf-16-le"))
+    assert excinfo.value.status_code == 400
+    assert "<script" in excinfo.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Path confinement: the audit's upload replaced a TRACKED repo asset
+# ---------------------------------------------------------------------------
+
+
+def test_upload_never_overwrites_a_shipped_branding_asset(
+    client, sandbox_branding_dir
+) -> None:
+    """Regression: uploading for project "default" replaced default.svg.
+
+    The branding root holds assets that ship in the repo (default.svg,
+    logo.svg, favicon.svg, wordings.png) and the handler wrote
+    ``<root>/{project_id}.{ext}``, so a project whose id matched an asset stem
+    silently replaced a tracked file with attacker-supplied bytes. Uploads now
+    land one level down, where they cannot name a shipped asset at all.
+    """
+    _, c = client
+    resp = _upload_svg(c, _CLEAN_SVG)
+    assert resp.status_code == 200, resp.text
+
+    assert (sandbox_branding_dir / "default.svg").read_bytes() == _SHIPPED_ASSET
+    assert (sandbox_branding_dir / "logo.svg").read_bytes() == _SHIPPED_ASSET
+    assert (sandbox_branding_dir / "uploads" / "default.svg").read_bytes() == _CLEAN_SVG
+    assert resp.json()["logo_url"] == "/static/branding/uploads/default.svg"
+
+
+@pytest.mark.parametrize(
+    "project_id",
+    [
+        "../../default",
+        "../../../../etc/passwd",
+        "..\\..\\default",
+        "..",
+        ".",
+        "a/b",
+        "/absolute",
+        "with\x00nul",
+        "with space",
+        "unicode-é",
+        "",
+    ],
+)
+def test_hostile_project_id_cannot_escape_the_upload_directory(
+    sandbox_branding_dir, project_id
+) -> None:
+    """The write path is confined for any project id, however hostile.
+
+    Asserted on the resolver rather than over HTTP because Starlette's path
+    converter is ``[^/]+``: an encoded separator never routes (pinned by
+    ``test_encoded_traversal_does_not_route`` below). That is the second line
+    of defence, not the first. A project id is an arbitrary string with no
+    validation at creation, and a proxy that decodes ``%2F`` before forwarding
+    would change what routes without changing this guarantee.
+    """
+    root = (sandbox_branding_dir / "uploads").resolve()
+    target = branding_mod._resolve_logo_target(project_id, "svg")
+
+    assert target.parent == root, f"{project_id!r} escaped to {target}"
+    assert target.name.endswith(".svg")
+    assert "/" not in target.name and "\\" not in target.name
+    assert "\x00" not in target.name
+    # And it can never name one of the shipped assets, which live one level up.
+    assert target != sandbox_branding_dir / "default.svg"
+
+
+def test_safe_project_id_keeps_a_readable_filename(sandbox_branding_dir) -> None:
+    """The ordinary id is still used verbatim, so the URL stays legible."""
+    assert branding_mod._logo_filename("acme", "png") == "acme.png"
+    assert branding_mod._logo_filename("acme_2-eu", "svg") == "acme_2-eu.svg"
+    # Anything outside the allow-list collapses to a digest, deterministically.
+    hostile = branding_mod._logo_filename("../../default", "svg")
+    assert hostile.startswith("p-") and hostile.endswith(".svg")
+    assert branding_mod._logo_filename("../../default", "svg") == hostile
+
+
+def test_encoded_traversal_does_not_route(client, sandbox_branding_dir) -> None:
+    """An encoded separator in the id never reaches the handler.
+
+    Starlette's path converter is ``[^/]+``, so the upload route does not
+    match. 405 rather than 404 because the dashboard's SPA fallback claims the
+    unmatched path for GET; either way no handler runs and nothing is written.
+    """
+    _, c = client
+    resp = c.post(
+        "/api/projects/..%2F..%2Fdefault/branding/logo",
+        files={"file": ("logo.svg", _CLEAN_SVG, "image/svg+xml")},
+    )
+    assert resp.status_code in (404, 405), resp.text
+    assert (sandbox_branding_dir / "default.svg").read_bytes() == _SHIPPED_ASSET
+    assert not (sandbox_branding_dir / "uploads").exists()
+
+
+# ---------------------------------------------------------------------------
+# The served response is inert even if a payload ever gets past the checks
+# ---------------------------------------------------------------------------
+
+
+def test_branding_assets_are_served_with_a_sandbox_csp(client) -> None:
+    """The static mount carries the defence that does not depend on the check.
+
+    Content inspection is a denylist and denylists lose eventually; the CSP
+    is what makes the loss survivable. ``sandbox`` alone puts the response in
+    an opaque origin, so script in a branding asset cannot read the
+    dashboard's localStorage even if it runs.
+    """
+    _, c = client
+    assert _upload_svg(c, _CLEAN_SVG).status_code == 200
+
+    for path in ("/static/branding/uploads/default.svg", "/static/branding/logo.svg"):
+        resp = c.get(path)
+        assert resp.status_code == 200, f"{path}: {resp.status_code}"
+        csp = resp.headers.get("content-security-policy")
+        assert csp is not None, f"{path} served with no CSP"
+        assert "sandbox" in csp
+        assert "default-src 'none'" in csp
+        assert resp.headers.get("x-content-type-options") == "nosniff"

--- a/src/voicegateway/tests/server/test_branding_endpoint.py
+++ b/src/voicegateway/tests/server/test_branding_endpoint.py
@@ -251,6 +251,69 @@ def test_logo_upload_requires_admin_when_auth_is_enabled(client, sandbox_brandin
     assert (sandbox_branding_dir / "uploads" / "default.svg").read_bytes() == _CLEAN_SVG
 
 
+def test_post_branding_open_when_no_keys_are_configured(client) -> None:
+    """The self-hosted default (no keys configured) is unchanged.
+
+    ``core.auth.check_request`` returns None on an empty key list, so the
+    admin gate costs the single-operator deployment nothing here either.
+    """
+    _, c = client
+    assert c.app.state.api_keys == []
+    r = c.post("/api/projects/default/branding", json={"product_name": "LocalVoice"})
+    assert r.status_code == 200, r.text
+    assert r.json()["branding"]["product_name"] == "LocalVoice"
+
+
+def test_post_branding_requires_admin_when_auth_is_enabled(client) -> None:
+    """The branding write takes the same gate its upload sibling took.
+
+    Gating only the upload left the interesting half open: ``logo_url`` is an
+    arbitrary string here (the upload is one way to produce one, not the only
+    way), and ``product_name`` is what every dashboard page then renders as
+    its own name. An anonymous caller gets 401, a read-scoped token 403, and
+    the stored branding is untouched by both.
+    """
+    _, c = client
+    c.app.state.api_keys = [
+        ApiKey(token="read-token", name="viewer", scopes=("read",)),
+        ApiKey(token="admin-token", name="operator", scopes=("admin",)),
+    ]
+    payload = {"product_name": "Impostor", "accent_color": "#FF0000"}
+
+    anon = c.post("/api/projects/default/branding", json=payload)
+    assert anon.status_code == 401, anon.text
+
+    wrong = c.post(
+        "/api/projects/default/branding",
+        json=payload,
+        headers={"Authorization": "Bearer nope"},
+    )
+    assert wrong.status_code == 401, wrong.text
+
+    reader = c.post(
+        "/api/projects/default/branding",
+        json=payload,
+        headers={"Authorization": "Bearer read-token"},
+    )
+    assert reader.status_code == 403, reader.text
+
+    # Nothing landed for any of the three refusals.
+    unchanged = c.get(
+        "/api/projects/default/branding",
+        headers={"Authorization": "Bearer read-token"},
+    )
+    assert unchanged.status_code == 200, unchanged.text
+    assert unchanged.json()["branding"] is None
+
+    admin = c.post(
+        "/api/projects/default/branding",
+        json=payload,
+        headers={"Authorization": "Bearer admin-token"},
+    )
+    assert admin.status_code == 200, admin.text
+    assert admin.json()["branding"]["product_name"] == "Impostor"
+
+
 def test_branding_read_is_not_gated_behind_the_admin_scope(client) -> None:
     """The GET stays a read: the admin gate is on the upload route only.
 

--- a/src/voicegateway/tests/server/test_dashboard_api_keys.py
+++ b/src/voicegateway/tests/server/test_dashboard_api_keys.py
@@ -113,3 +113,113 @@ def test_list_api_keys_filters_revoked_when_include_revoked_false(client) -> Non
 
     assert any(k["id"] == created_id for k in with_revoked)
     assert all(k["id"] != created_id for k in without_revoked)
+
+
+# ---------------------------------------------------------------------------
+# Auth: the router is admin-gated once auth is enabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_under_test(temp_config, tmp_path, monkeypatch):
+    """A built app the auth tests can stamp ``state.api_keys`` onto."""
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "vk-auth.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    gw = Gateway(config_path=temp_config)
+    return build_app(gw, enable_mcp_sse=False, enable_dashboard=False)
+
+
+def test_mint_stays_open_when_no_keys_are_configured(app_under_test) -> None:
+    """The self-hosted default (no keys configured) is unchanged.
+
+    ``core.auth.check_request`` returns None on an empty key list, so
+    ``require_scope(ADMIN_SCOPE)`` is a no-op and the local operator still
+    mints a key with no credential.
+    """
+    assert app_under_test.state.api_keys == []
+    client = TestClient(app_under_test)
+    created = client.post("/api/api_keys", json={"name": "local-operator"})
+    assert created.status_code in (200, 201)
+    assert created.json()["plaintext"].startswith("vk_")
+    assert client.get("/api/api_keys").status_code == 200
+
+
+def test_router_requires_admin_when_auth_enabled(app_under_test) -> None:
+    """With static keys configured, an unauthenticated caller cannot mint.
+
+    A minted key carries the wildcard scope, so an ungated POST here is a
+    write escalation onto every /v1 endpoint. The gate covers the list and
+    the revoke too.
+    """
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+
+    # A non-vk_ token takes the static-key path (check_request, which reads
+    # app.state.api_keys). A vk_ token would take the DB storage path instead.
+    app_under_test.state.api_keys = [
+        ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,))
+    ]
+    client = TestClient(app_under_test)
+
+    assert client.post("/api/api_keys", json={"name": "stolen"}).status_code == 401
+    assert client.get("/api/api_keys").status_code == 401
+    assert client.post("/api/api_keys/1/revoke").status_code == 401
+    assert (
+        client.post(
+            "/api/api_keys",
+            json={"name": "stolen"},
+            headers={"Authorization": "Bearer wrong-token"},
+        ).status_code
+        == 401
+    )
+
+    ok = client.post(
+        "/api/api_keys",
+        json={"name": "minted-by-admin"},
+        headers={"Authorization": "Bearer admin-secret-token"},
+    )
+    assert ok.status_code in (200, 201)
+
+
+def test_router_rejects_key_without_admin_scope(app_under_test) -> None:
+    """A valid static key lacking the admin scope is authenticated but 403."""
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+
+    app_under_test.state.api_keys = [
+        ApiKey(token="read-only-token", name="viewer", scopes=("read",)),
+        ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,)),
+    ]
+    client = TestClient(app_under_test)
+
+    denied = client.post(
+        "/api/api_keys",
+        json={"name": "escalation"},
+        headers={"Authorization": "Bearer read-only-token"},
+    )
+    assert denied.status_code == 403
+    assert (
+        client.get(
+            "/api/api_keys", headers={"Authorization": "Bearer read-only-token"}
+        ).status_code
+        == 403
+    )
+
+
+def test_minted_tenant_key_cannot_mint_another_key(app_under_test) -> None:
+    """A vk_ key minted here defaults to role='tenant', so it cannot re-mint.
+
+    Without this, a single leaked wildcard key would be self-replicating.
+    """
+    from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
+
+    client = TestClient(app_under_test)
+    plaintext = client.post("/api/api_keys", json={"name": "agent"}).json()["plaintext"]
+
+    app_under_test.state.api_keys = [
+        ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,))
+    ]
+    denied = client.post(
+        "/api/api_keys",
+        json={"name": "self-replication"},
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert denied.status_code == 403

--- a/src/voicegateway/tests/server/test_read_tenant_isolation.py
+++ b/src/voicegateway/tests/server/test_read_tenant_isolation.py
@@ -12,6 +12,11 @@ principal, never from the raw caller-supplied ``tenant`` query param:
 - the admin cross-tenant endpoint is gated: a tenant key gets 403 before any
   backend-availability (503) check, an admin key gets 503 when ClickHouse is
   absent (the SQLite self-hoster default).
+
+The last section covers the per-session reads, which take no ``tenant`` param
+at all: the id IS the request. There the check runs on the fetched row, and a
+foreign session must return the same 404 as a session that does not exist, so
+that the response never confirms the id is real.
 """
 
 from __future__ import annotations
@@ -177,3 +182,73 @@ async def test_no_credential_operator_sees_all(harness):
     assert costs.json()["total"] == pytest.approx(1.30)
     ids = {r["id"] for r in sessions.json()}
     assert {"s-acme-1", "s-acme-2", "s-beta-1"}.issubset(ids)
+
+
+# ---------------------------------------------------------------------------
+# Per-session reads: the id is the whole request, so the check is post-fetch
+# ---------------------------------------------------------------------------
+
+# Every read that hangs off /api/sessions/{id}. /replay is served by
+# dashboard/replay.py, the other four by dashboard/sessions.py.
+_SESSION_READ_TEMPLATES = [
+    "/api/sessions/{sid}",
+    "/api/sessions/{sid}/turns",
+    "/api/sessions/{sid}/transcript",
+    "/api/sessions/{sid}/dead_air",
+    "/api/sessions/{sid}/replay",
+]
+
+
+@pytest.mark.parametrize("template", _SESSION_READ_TEMPLATES)
+async def test_foreign_session_read_is_404(harness, template):
+    """An acme key reading beta's session gets 404, never beta's rows.
+
+    404 and not 403: a 403 would tell the caller the id exists, which is the
+    fact being protected. The assertion below pins that a foreign id and a
+    made-up id are the same status.
+    """
+    token = await _make_key(harness.gateway, tenant_id="acme")
+    headers = {"Authorization": f"Bearer {token}"}
+    async with harness.client() as c:
+        foreign = await c.get(template.format(sid="s-beta-1"), headers=headers)
+        missing = await c.get(template.format(sid="no-such-session"), headers=headers)
+
+    assert foreign.status_code == 404, (
+        f"{template} on a foreign session should be 404, got "
+        f"{foreign.status_code}: {foreign.text}"
+    )
+    assert missing.status_code == foreign.status_code
+    # Same body too: nothing but the id the caller already typed comes back.
+    assert foreign.json() == {"detail": "Session 's-beta-1' not found"}
+    assert missing.json() == {"detail": "Session 'no-such-session' not found"}
+
+
+@pytest.mark.parametrize("template", _SESSION_READ_TEMPLATES)
+async def test_own_session_read_still_works(harness, template):
+    """The guard refuses the foreign id only: acme still reads acme."""
+    token = await _make_key(harness.gateway, tenant_id="acme")
+    async with harness.client() as c:
+        resp = await c.get(
+            template.format(sid="s-acme-1"),
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200, f"{template}: {resp.status_code} {resp.text}"
+
+
+@pytest.mark.parametrize("template", _SESSION_READ_TEMPLATES)
+async def test_no_credential_operator_reads_any_session(harness, template):
+    """The self-hosted operator keeps reading every tenant's sessions."""
+    async with harness.client() as c:
+        resp = await c.get(template.format(sid="s-beta-1"))
+    assert resp.status_code == 200, f"{template}: {resp.status_code} {resp.text}"
+
+
+async def test_admin_key_reads_any_session(harness):
+    """An admin vk_ key (tenant_id None) is not narrowed by the guard."""
+    token = await _make_key(harness.gateway, tenant_id=None, role="admin")
+    async with harness.client() as c:
+        resp = await c.get(
+            "/api/sessions/s-beta-1", headers={"Authorization": f"Bearer {token}"}
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["id"] == "s-beta-1"

--- a/src/voicegateway/tests/server/test_read_tenant_isolation.py
+++ b/src/voicegateway/tests/server/test_read_tenant_isolation.py
@@ -252,3 +252,130 @@ async def test_admin_key_reads_any_session(harness):
         )
     assert resp.status_code == 200, resp.text
     assert resp.json()["id"] == "s-beta-1"
+
+
+# ---------------------------------------------------------------------------
+# The public /v1 twin: same rows, so the same scoping
+# ---------------------------------------------------------------------------
+
+
+async def test_v1_foreign_session_read_is_404(harness):
+    """An acme key reading beta's session on /v1 gets the same 404 as /api.
+
+    404 and not 403 for the same reason the mirror gives: a 403 would tell
+    the caller the id exists. Pinned against a made-up id so the two cases
+    stay indistinguishable in status AND body.
+    """
+    token = await _make_key(harness.gateway, tenant_id="acme")
+    headers = {"Authorization": f"Bearer {token}"}
+    async with harness.client() as c:
+        foreign = await c.get("/v1/sessions/s-beta-1", headers=headers)
+        missing = await c.get("/v1/sessions/no-such-session", headers=headers)
+
+    assert foreign.status_code == 404, foreign.text
+    assert missing.status_code == foreign.status_code
+    assert foreign.json() == {"detail": "Session 's-beta-1' not found"}
+    assert missing.json() == {"detail": "Session 'no-such-session' not found"}
+
+
+async def test_v1_own_session_read_still_works(harness):
+    """The guard refuses the foreign id only: acme still reads acme on /v1."""
+    token = await _make_key(harness.gateway, tenant_id="acme")
+    async with harness.client() as c:
+        resp = await c.get(
+            "/v1/sessions/s-acme-1", headers={"Authorization": f"Bearer {token}"}
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["id"] == "s-acme-1"
+
+
+async def test_v1_session_list_scopes_to_own_tenant(harness):
+    """The /v1 list filters too, not just the detail route.
+
+    A list that returned every tenant's sessions would hand over exactly the
+    ids the detail route is refusing.
+    """
+    token = await _make_key(harness.gateway, tenant_id="acme")
+    async with harness.client() as c:
+        resp = await c.get("/v1/sessions", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.text
+    ids = {r["id"] for r in resp.json()}
+    assert ids == {"s-acme-1", "s-acme-2"}
+    assert "s-beta-1" not in resp.text
+
+
+async def test_v1_no_credential_operator_sees_all_sessions(harness):
+    """The self-hosted operator keeps reading every tenant's sessions on /v1."""
+    async with harness.client() as c:
+        listed = await c.get("/v1/sessions")
+        detail = await c.get("/v1/sessions/s-beta-1")
+    assert listed.status_code == 200, listed.text
+    assert {"s-acme-1", "s-acme-2", "s-beta-1"}.issubset(
+        {r["id"] for r in listed.json()}
+    )
+    assert detail.status_code == 200, detail.text
+
+
+# ---------------------------------------------------------------------------
+# GET /api/replay/storage: an aggregate, so the leak is the size not the id
+# ---------------------------------------------------------------------------
+
+
+async def _set_replay_sizes(gateway, sizes: dict[str, int]) -> None:
+    """Stamp ``replay_size_bytes`` onto seeded sessions.
+
+    ``finalize_session_replay`` normally writes this column; the rows the
+    harness seeds have it NULL, and the endpoint sums only non-NULL rows.
+    """
+    from sqlalchemy import text
+
+    async with gateway.storage._conn.session() as db:
+        for session_id, size in sizes.items():
+            await db.execute(
+                text("UPDATE sessions SET replay_size_bytes = :n WHERE id = :id"),
+                {"n": size, "id": session_id},
+            )
+        await db.commit()
+
+
+async def test_replay_storage_totals_are_scoped_to_the_tenant(harness):
+    """An acme key is told acme's replay footprint, never the deployment's.
+
+    There is no id to 404 on here: the endpoint is an aggregate, so the fact
+    being protected is the SIZE of another tenant's captured traffic (and the
+    names of the projects producing it). The predicate therefore runs in the
+    query, which keeps ``total_replay_size_bytes`` consistent with
+    ``by_project``: a total summed over rows excluded from the breakdown
+    would leak the number straight back.
+    """
+    await _set_replay_sizes(
+        harness.gateway, {"s-acme-1": 100, "s-acme-2": 200, "s-beta-1": 4000}
+    )
+    token = await _make_key(harness.gateway, tenant_id="acme")
+    async with harness.client() as c:
+        scoped = await c.get(
+            "/api/replay/storage", headers={"Authorization": f"Bearer {token}"}
+        )
+        operator = await c.get("/api/replay/storage")
+
+    assert scoped.status_code == 200, scoped.text
+    assert scoped.json()["total_replay_size_bytes"] == 300
+    assert [r["replay_size_bytes"] for r in scoped.json()["by_project"]] == [300]
+
+    # The self-hosted operator keeps seeing the whole deployment.
+    assert operator.status_code == 200, operator.text
+    assert operator.json()["total_replay_size_bytes"] == 4300
+
+
+async def test_replay_storage_admin_key_sees_every_tenant(harness):
+    """An admin vk_ key (tenant_id None) is not narrowed by the predicate."""
+    await _set_replay_sizes(
+        harness.gateway, {"s-acme-1": 100, "s-acme-2": 200, "s-beta-1": 4000}
+    )
+    token = await _make_key(harness.gateway, tenant_id=None, role="admin")
+    async with harness.client() as c:
+        resp = await c.get(
+            "/api/replay/storage", headers={"Authorization": f"Bearer {token}"}
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total_replay_size_bytes"] == 4300

--- a/src/voicegateway/tests/server/test_sessions_endpoint.py
+++ b/src/voicegateway/tests/server/test_sessions_endpoint.py
@@ -1,4 +1,8 @@
-"""Tests for /v1/sessions and /v1/sessions/{id} HTTP endpoints."""
+"""Tests for /v1/sessions and /v1/sessions/{id} HTTP endpoints.
+
+The last section covers the dashboard mirrors under /api/sessions/{id}*,
+which are gated by ``require_principal`` on the router.
+"""
 
 from __future__ import annotations
 
@@ -331,3 +335,80 @@ async def test_list_sessions_returns_empty_when_storage_disabled(
         resp = await c.get("/v1/sessions")
         assert resp.status_code == 200
         assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Auth: every per-session dashboard read is gated once auth is enabled
+# ---------------------------------------------------------------------------
+
+# The four reads that hung off a session id without a dependency. The
+# transcript read is the fifth; its auth tests live beside its own
+# behavior tests in test_sessions_transcript_endpoint.py.
+_PER_SESSION_READS = [
+    "/api/sessions/vg-gated",
+    "/api/sessions/vg-gated/turns",
+    "/api/sessions/vg-gated/dead_air",
+    "/api/sessions/vg-gated/replay",
+]
+
+
+@pytest.fixture
+def gated_app(temp_config, tmp_path, monkeypatch):
+    """A built app the auth tests can stamp ``state.api_keys`` onto."""
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "sessions-auth.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    gw = Gateway(config_path=temp_config)
+    return build_app(gw, enable_mcp_sse=False, enable_dashboard=False)
+
+
+async def test_per_session_reads_stay_open_when_no_keys_are_configured(gated_app):
+    """The self-hosted default (no keys configured) is unchanged.
+
+    ``core.auth.check_request`` returns None on an empty key list, so
+    ``require_principal`` resolves the operator principal and the local
+    operator still reads every session with no credential.
+    """
+    assert gated_app.state.api_keys == []
+    await _seed_session(gated_app.state.gateway.storage, "vg-gated")
+
+    transport = ASGITransport(app=gated_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        for path in _PER_SESSION_READS:
+            resp = await c.get(path)
+            assert resp.status_code == 200, f"{path}: {resp.status_code} {resp.text}"
+
+
+async def test_per_session_reads_require_auth_when_enabled(gated_app):
+    """With static keys configured, an unauthenticated caller reads nothing.
+
+    Only the list endpoint carried a dependency before; a session id was
+    enough to read the detail, the turns, the dead air and the replay of any
+    call on the deployment.
+    """
+    from voicegateway.core.auth import ApiKey
+
+    # A non-vk_ token takes the static-key path (check_request, which reads
+    # app.state.api_keys). A vk_ token would take the DB storage path instead.
+    gated_app.state.api_keys = [
+        ApiKey(token="read-token", name="viewer", scopes=("read",))
+    ]
+    await _seed_session(gated_app.state.gateway.storage, "vg-gated")
+
+    transport = ASGITransport(app=gated_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        for path in _PER_SESSION_READS:
+            anon = await c.get(path)
+            assert anon.status_code == 401, f"{path}: {anon.status_code} {anon.text}"
+
+            wrong = await c.get(path, headers={"Authorization": "Bearer nope"})
+            assert wrong.status_code == 401, f"{path}: {wrong.status_code}"
+
+            ok = await c.get(path, headers={"Authorization": "Bearer read-token"})
+            assert ok.status_code == 200, f"{path}: {ok.status_code} {ok.text}"
+
+        # The already-gated list endpoint keeps the scope it required.
+        assert (await c.get("/api/sessions")).status_code == 401
+        listed = await c.get(
+            "/api/sessions", headers={"Authorization": "Bearer read-token"}
+        )
+        assert listed.status_code == 200

--- a/src/voicegateway/tests/server/test_sessions_endpoint.py
+++ b/src/voicegateway/tests/server/test_sessions_endpoint.py
@@ -412,3 +412,170 @@ async def test_per_session_reads_require_auth_when_enabled(gated_app):
             "/api/sessions", headers={"Authorization": "Bearer read-token"}
         )
         assert listed.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Auth: the public /v1 twin serves the same rows as the gated /api mirror
+# ---------------------------------------------------------------------------
+
+_V1_SESSION_READS = [
+    "/v1/sessions",
+    "/v1/sessions/vg-gated",
+]
+
+
+async def test_v1_session_reads_stay_open_when_no_keys_are_configured(gated_app):
+    """The self-hosted default (no keys configured) is unchanged.
+
+    ``core.auth.check_request`` returns None on an empty key list, so
+    ``require_principal`` resolves the operator principal and the local
+    operator still reads every session with no credential. The behavior tests
+    at the top of this file all ride on that path; this one asserts it.
+    """
+    assert gated_app.state.api_keys == []
+    await _seed_session(gated_app.state.gateway.storage, "vg-gated")
+
+    transport = ASGITransport(app=gated_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        for path in _V1_SESSION_READS:
+            resp = await c.get(path)
+            assert resp.status_code == 200, f"{path}: {resp.status_code} {resp.text}"
+
+
+async def test_v1_session_reads_require_auth_when_enabled(gated_app):
+    """With static keys configured, an unauthenticated caller reads nothing.
+
+    These two routes return exactly the rows the /api mirror returns, so
+    leaving them open made the gate on the mirror worth nothing: the same
+    session detail was one prefix away.
+    """
+    from voicegateway.core.auth import ApiKey
+
+    # A non-vk_ token takes the static-key path (check_request, which reads
+    # app.state.api_keys). A vk_ token would take the DB storage path instead.
+    gated_app.state.api_keys = [
+        ApiKey(token="read-token", name="viewer", scopes=("read",))
+    ]
+    await _seed_session(gated_app.state.gateway.storage, "vg-gated")
+
+    transport = ASGITransport(app=gated_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        for path in _V1_SESSION_READS:
+            anon = await c.get(path)
+            assert anon.status_code == 401, f"{path}: {anon.status_code} {anon.text}"
+            assert "vg-gated" not in anon.text
+
+            wrong = await c.get(path, headers={"Authorization": "Bearer nope"})
+            assert wrong.status_code == 401, f"{path}: {wrong.status_code}"
+
+            ok = await c.get(path, headers={"Authorization": "Bearer read-token"})
+            assert ok.status_code == 200, f"{path}: {ok.status_code} {ok.text}"
+
+
+# ---------------------------------------------------------------------------
+# Auth: the three ungated siblings on the replay router
+# ---------------------------------------------------------------------------
+#
+# The replay READ was gated on its own; these three were not. They live here
+# rather than in test_replay_endpoint.py so every gate this change adds is
+# asserted in one place, next to the /api/sessions/{id}/replay read above.
+
+
+async def test_replay_siblings_stay_open_when_no_keys_are_configured(gated_app):
+    """The self-hosted default (no keys configured) is unchanged.
+
+    Both write gates and the storage read are no-ops on an empty key list, so
+    the single-operator deployment still deletes a replay, reads the storage
+    breakdown and sets a retention window with no credential.
+    """
+    assert gated_app.state.api_keys == []
+    await _seed_session(gated_app.state.gateway.storage, "vg-gated")
+
+    transport = ASGITransport(app=gated_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        assert (await c.get("/api/replay/storage")).status_code == 200
+        assert (await c.delete("/api/sessions/vg-gated/replay")).status_code == 200
+        retention = await c.post(
+            "/api/projects/test-project/replay/retention",
+            json={"retention_days": 7},
+        )
+        assert retention.status_code == 200, retention.text
+
+
+async def test_replay_storage_read_requires_auth_when_enabled(gated_app):
+    """The storage breakdown names every project on the deployment.
+
+    It is a read, so it takes the read dependency the other dashboard reads
+    take: a read-scoped token is enough, an anonymous caller is not.
+    """
+    from voicegateway.core.auth import ApiKey
+
+    gated_app.state.api_keys = [
+        ApiKey(token="read-token", name="viewer", scopes=("read",))
+    ]
+    await _seed_session(gated_app.state.gateway.storage, "vg-gated")
+
+    transport = ASGITransport(app=gated_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        assert (await c.get("/api/replay/storage")).status_code == 401
+        wrong = await c.get(
+            "/api/replay/storage", headers={"Authorization": "Bearer nope"}
+        )
+        assert wrong.status_code == 401
+        ok = await c.get(
+            "/api/replay/storage", headers={"Authorization": "Bearer read-token"}
+        )
+        assert ok.status_code == 200, ok.text
+
+
+async def test_replay_writes_require_admin_when_auth_enabled(gated_app):
+    """The delete and the retention write take the dashboard write scope.
+
+    Admin, like every other write on a dashboard router. A read-scoped token
+    is authenticated but refused (403), an anonymous caller gets 401, and
+    neither one destroys the captured payloads or shortens the window that
+    decides how long they survive.
+    """
+    from voicegateway.core.auth import ApiKey
+
+    gated_app.state.api_keys = [
+        ApiKey(token="read-token", name="viewer", scopes=("read",)),
+        ApiKey(token="admin-token", name="operator", scopes=("admin",)),
+    ]
+    await _seed_session(gated_app.state.gateway.storage, "vg-gated")
+    gateway = gated_app.state.gateway
+    before = gateway.config.projects["test-project"].replay.retention_days
+
+    transport = ASGITransport(app=gated_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        assert (await c.delete("/api/sessions/vg-gated/replay")).status_code == 401
+        denied = await c.delete(
+            "/api/sessions/vg-gated/replay",
+            headers={"Authorization": "Bearer read-token"},
+        )
+        assert denied.status_code == 403, denied.text
+
+        retention_path = "/api/projects/test-project/replay/retention"
+        anon = await c.post(retention_path, json={"retention_days": 1})
+        assert anon.status_code == 401
+        reader = await c.post(
+            retention_path,
+            json={"retention_days": 1},
+            headers={"Authorization": "Bearer read-token"},
+        )
+        assert reader.status_code == 403, reader.text
+        # Nothing moved on either refusal.
+        assert gateway.config.projects["test-project"].replay.retention_days == before
+
+        ok_delete = await c.delete(
+            "/api/sessions/vg-gated/replay",
+            headers={"Authorization": "Bearer admin-token"},
+        )
+        assert ok_delete.status_code == 200, ok_delete.text
+        ok_retention = await c.post(
+            retention_path,
+            json={"retention_days": 1},
+            headers={"Authorization": "Bearer admin-token"},
+        )
+        assert ok_retention.status_code == 200, ok_retention.text
+        assert gateway.config.projects["test-project"].replay.retention_days == 1

--- a/src/voicegateway/tests/server/test_sessions_transcript_endpoint.py
+++ b/src/voicegateway/tests/server/test_sessions_transcript_endpoint.py
@@ -42,3 +42,56 @@ async def test_transcript_endpoint_empty_for_unknown_call(tmp_path, monkeypatch)
     async with _client(gw) as c:
         data = (await c.get("/api/sessions/nope/transcript")).json()
     assert data == {"session_id": "nope", "turns": []}
+
+
+# ---------------------------------------------------------------------------
+# Auth: the transcript is the most sensitive payload on the router
+# ---------------------------------------------------------------------------
+
+
+async def test_transcript_stays_open_when_no_keys_are_configured(tmp_path, monkeypatch):
+    """The self-hosted default (no keys configured) is unchanged."""
+    gw = _gateway(tmp_path, monkeypatch)
+    app = build_app(gw)
+    assert app.state.api_keys == []
+    await gw.storage.write_transcript("call-open", [("user", "hi")])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        resp = await c.get("/api/sessions/call-open/transcript")
+    assert resp.status_code == 200
+    assert [t["text"] for t in resp.json()["turns"]] == ["hi"]
+
+
+async def test_transcript_requires_auth_when_enabled(tmp_path, monkeypatch):
+    """With static keys configured, a session id alone does not buy a call.
+
+    This route was ungated: anyone who could reach the port could read what
+    the caller said, on any session, by guessing or scraping one id.
+    """
+    from voicegateway.core.auth import ApiKey
+
+    gw = _gateway(tmp_path, monkeypatch)
+    app = build_app(gw)
+    app.state.api_keys = [ApiKey(token="read-token", name="viewer", scopes=("read",))]
+    await gw.storage.write_transcript("call-secret", [("user", "my card number is")])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        anon = await c.get("/api/sessions/call-secret/transcript")
+        wrong = await c.get(
+            "/api/sessions/call-secret/transcript",
+            headers={"Authorization": "Bearer nope"},
+        )
+        ok = await c.get(
+            "/api/sessions/call-secret/transcript",
+            headers={"Authorization": "Bearer read-token"},
+        )
+
+    assert anon.status_code == 401, anon.text
+    assert "my card number is" not in anon.text
+    assert wrong.status_code == 401
+    assert ok.status_code == 200
+    assert [t["text"] for t in ok.json()["turns"]] == ["my card number is"]

--- a/src/voicegateway/tests/server/test_test_provider_endpoint.py
+++ b/src/voicegateway/tests/server/test_test_provider_endpoint.py
@@ -249,6 +249,173 @@ async def test_stateless_test_timeout_returns_failed(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# PATCH base_url must not repoint the stored key at an unapproved host
+#
+# POST /v1/providers/{id}/test builds the provider from the stored row, so a
+# PATCH that moves base_url to a new host while keeping the stored key is what
+# ships that key to a host the caller chose.
+# ---------------------------------------------------------------------------
+
+
+def _config_with_allowlist(tmp_path, hosts: list[str] | None) -> str:
+    """Write a minimal config, optionally with the serve host allowlist."""
+    serve: dict[str, Any] = {"host": "127.0.0.1", "port": 8080}
+    if hosts is not None:
+        serve["provider_base_url_hosts"] = hosts
+    cfg_path = tmp_path / "voicegw.yaml"
+    cfg_path.write_text(
+        yaml.dump(
+            {
+                "providers": {},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "stacks": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "cost_tracking": {"enabled": True},
+                "observability": {"latency_tracking": True},
+                "serve": serve,
+            }
+        )
+    )
+    return str(cfg_path)
+
+
+@pytest.fixture
+def allowlist_client(tmp_path, monkeypatch):
+    """Build a client whose serve block carries the given host allowlist."""
+
+    def _build(hosts: list[str] | None):
+        monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "allowlist.db"))
+        gw = Gateway(config_path=_config_with_allowlist(tmp_path, hosts))
+        transport = ASGITransport(app=build_app(gw))
+        return gw, AsyncClient(transport=transport, base_url="http://test")
+
+    return _build
+
+
+async def _create_keyed_provider(client, provider_id: str = "openai-managed") -> None:
+    resp = await client.post(
+        "/v1/providers",
+        json={
+            "provider_id": provider_id,
+            "provider_type": "openai",
+            "api_key": "sk-operator-secret",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_patch_to_new_host_with_stored_key_is_rejected(allowlist_client):
+    gw, ctx = allowlist_client(None)
+    async with ctx as client:
+        await _create_keyed_provider(client)
+        resp = await client.patch(
+            "/v1/providers/openai-managed",
+            json={"base_url": "https://attacker.example.com/v1"},
+        )
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert "attacker.example.com" in detail
+        # The error must name the config key the operator has to set.
+        assert "serve.provider_base_url_hosts" in detail
+        # And nothing may have been persisted.
+        row = await gw.storage.get_managed_provider("openai-managed")
+        assert row["base_url"] is None
+
+
+async def test_patch_to_allowlisted_host_with_stored_key_is_permitted(
+    allowlist_client,
+):
+    gw, ctx = allowlist_client(["https://proxy.internal.example.com"])
+    async with ctx as client:
+        await _create_keyed_provider(client)
+        resp = await client.patch(
+            "/v1/providers/openai-managed",
+            json={"base_url": "https://proxy.internal.example.com/v1"},
+        )
+        assert resp.status_code == 200, resp.text
+        row = await gw.storage.get_managed_provider("openai-managed")
+        assert row["base_url"] == "https://proxy.internal.example.com/v1"
+
+
+async def test_patch_to_new_host_with_fresh_key_needs_no_allowlist(allowlist_client):
+    """A caller who supplies the key has nothing to exfiltrate."""
+    gw, ctx = allowlist_client(None)
+    async with ctx as client:
+        await _create_keyed_provider(client)
+        resp = await client.patch(
+            "/v1/providers/openai-managed",
+            json={
+                "base_url": "https://byo.example.com/v1",
+                "api_key": "sk-caller-owned",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        row = await gw.storage.get_managed_provider("openai-managed")
+        assert row["base_url"] == "https://byo.example.com/v1"
+
+
+async def test_patch_same_host_with_stored_key_still_works(allowlist_client):
+    """Port and path edits on the host already stored keep working."""
+    gw, ctx = allowlist_client(None)
+    async with ctx as client:
+        await _create_keyed_provider(client)
+        first = await client.patch(
+            "/v1/providers/openai-managed",
+            json={
+                "base_url": "https://proxy.example.com/v1",
+                "api_key": "sk-operator-secret",
+            },
+        )
+        assert first.status_code == 200, first.text
+
+        resp = await client.patch(
+            "/v1/providers/openai-managed",
+            json={"base_url": "https://proxy.example.com:8443/v2"},
+        )
+        assert resp.status_code == 200, resp.text
+        row = await gw.storage.get_managed_provider("openai-managed")
+        assert row["base_url"] == "https://proxy.example.com:8443/v2"
+
+
+async def test_patch_to_vendor_default_host_needs_no_allowlist(allowlist_client):
+    """The provider's own default host stays reachable with the allowlist unset."""
+    gw, ctx = allowlist_client(None)
+    async with ctx as client:
+        await _create_keyed_provider(client)
+        resp = await client.patch(
+            "/v1/providers/openai-managed",
+            json={"base_url": "https://api.openai.com/v1"},
+        )
+        assert resp.status_code == 200, resp.text
+        row = await gw.storage.get_managed_provider("openai-managed")
+        assert row["base_url"] == "https://api.openai.com/v1"
+
+
+async def test_patch_that_changes_nothing_still_works(allowlist_client):
+    gw, ctx = allowlist_client(None)
+    async with ctx as client:
+        await _create_keyed_provider(client)
+        resp = await client.patch("/v1/providers/openai-managed", json={})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["updated"] is True
+        row = await gw.storage.get_managed_provider("openai-managed")
+        assert row["base_url"] is None
+
+
+async def test_patch_project_only_with_stored_key_still_works(allowlist_client):
+    """A non-base_url field edit must not trip the host guard."""
+    gw, ctx = allowlist_client(None)
+    async with ctx as client:
+        await _create_keyed_provider(client)
+        resp = await client.patch(
+            "/v1/providers/openai-managed", json={"project": "tony-pizza"}
+        )
+        assert resp.status_code == 200, resp.text
+        row = await gw.storage.get_managed_provider("openai-managed")
+        assert row["project"] == "tony-pizza"
+
+
+# ---------------------------------------------------------------------------
 # Suppressed unused-import noise (mocks may move into the file later).
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Five nodes from a grounded audit of `main` @4135e9e. Each defect was confirmed
to exist before any code was written.

| | Defect | Fix |
|---|---|---|
| S1 | Both API-key routers minted a **wildcard-scope** key (`role='tenant'`, `scopes='*'`), so any caller reaching them escalated to write on every `/v1` endpoint | `require_scope(ADMIN_SCOPE)` at the router level on both |
| S2 | Only `GET /api/sessions` was gated. Detail, turns, transcript, dead_air and replay had no dependency **and no tenant predicate**, so any caller could read any tenant's transcript by id | `require_principal` + post-fetch tenant scope |
| S3 | `update_provider` kept the decrypted key while overwriting `base_url` unvalidated; `POST /test` then shipped that key to the new host | Host allowlist behind `serve.provider_base_url_hosts` |
| S4 | Logo upload had **no auth at all**, validated only `b'<svg'` in the first 512 bytes, and wrote raw bytes served same-origin | Admin gate, raw + parsed SVG rejection, confined `uploads/` dir, CSP sandbox |
| S5 | `/v1/sessions` served the same rows S2 gated, unauthenticated. Plus ungated replay delete, replay storage and branding write | Five routes gated and tenant-scoped |

## Two things worth knowing before merging

**These bind only deployments that have enabled auth.** `core/auth.check_request`
returns None when no keys are configured, which is the default self-hosted
install. This PR hardens the keyed path; a stock local box is unchanged. Worth
stating plainly in release notes rather than implying the holes are closed.

**S4's audit finding was worse than reported.** The tracked
`src/dashboard/api/static/branding/default.svg` *was* the test fixture,
byte-identical, so the suite had been rewriting a tracked repo asset on every
run. An autouse sandbox fixture stops that.

## Deliberate non-changes

`GET /api/projects/{id}/branding` stays ungated: every dashboard layout mount
calls it and `fetchJson` treats 403 exactly like 401, so gating it would log out
a read-scoped operator on page load. A test pins this.

S3 guards only the dangerous shape (new host **and** a reused non-empty stored
key). A PATCH carrying its own `api_key` has nothing to exfiltrate and stays
unconstrained, so no documented call pattern breaks.

`+64 tests, zero removed.` One alembic head. No migration.