### PR TITLE
fix(diagnostics): correctness of numbers already published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Changed
 
+- **`voicegw_cost_usd_total` and `voicegw_requests_total` on `GET /v1/metrics`
+  are now `# TYPE ... gauge`, not `counter`.** Both are sums over the `"today"`
+  window, which is `time.time() - 86400`: a **rolling trailing 24 hours**, not a
+  calendar day and not a since-start total. The value falls whenever a request
+  ages out of the trailing edge, so it was never a counter. Declaring it one
+  told Prometheus the series is monotonic, and `rate()` / `increase()` read
+  every one of those decreases as a counter reset and extrapolate spend and
+  traffic that never happened. The HELP text now states the window.
+
+  **The metric names are unchanged**, deliberately. `docs/api/http-api.md` and
+  `docs/reference/faq.md` publish them as things you graph in Grafana, and
+  renaming a scraped series breaks every dashboard, alert and recording rule
+  built on it. So the `_total` suffix survives on a gauge, which is ugly and
+  against Prometheus naming convention. It is a wart we are choosing over a
+  broken contract; a rename would be a separate, announced breaking change.
+
+  **Migration for existing dashboards.** Nothing to change on the scrape side:
+  same endpoint, same names, same labels. Prometheus accepts the new type on the
+  next scrape with no config change and no re-ingest. What you must fix is any
+  query that treats these as counters:
+
+  | Before (silently wrong) | After |
+  |---|---|
+  | `rate(voicegw_cost_usd_total[5m])` | `voicegw_cost_usd_total{period="today"}` |
+  | `increase(voicegw_cost_usd_total[1h])` | `delta(voicegw_cost_usd_total{period="today"}[1h])` |
+  | `rate(voicegw_requests_total[5m])` | `sum(voicegw_requests_total)` |
+  | `increase(voicegw_requests_total[24h])` | `sum(voicegw_requests_total)` (already the last 24h) |
+
+  Historical samples already stored in Prometheus are unaffected: the values
+  were always the rolling-window numbers, only the type metadata was wrong, so
+  fixing the query fixes the whole retained history too. Two further traps worth
+  checking while you are in there: bare `sum(voicegw_cost_usd_total)`
+  triple-counts, because that series is emitted once with `period="today"`, once
+  per `provider` and once per `project`; and there is no monotonic spend counter
+  to migrate to, so if you need a since-start total use
+  `GET /v1/costs?period=all`.
+
+  `voicegw_request_ttfb_seconds` and `voicegw_request_total_latency_seconds` keep
+  `# TYPE ... summary`: summary quantiles are sliding-window statistics, never
+  counters, and no `_sum` / `_count` children are published. Their HELP text now
+  names the same rolling 24-hour window. `voicegw_uptime_seconds`, the
+  `*_configured` series and every `voicegw_diag_*` series were already gauges and
+  are unchanged.
+
 - **BREAKING for CI: `voicegw livekit check` exit codes changed.** This needs a
   MINOR version bump, not a patch. The command had **two** verdict
   implementations that disagreed (`livekit_diag/service.py:_verdict` for the

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -660,9 +660,10 @@ voicegw_uptime_seconds 3621.4
 # HELP voicegw_providers_configured Configured providers
 # TYPE voicegw_providers_configured gauge
 voicegw_providers_configured 5
-# HELP voicegw_cost_usd_total Total cost in USD (today)
-# TYPE voicegw_cost_usd_total counter
+# HELP voicegw_cost_usd_total USD cost summed over a ROLLING trailing 24 hours (now-86400s to now). This is a gauge despite the _total suffix: it DECREASES as requests age out of the window. It is not a since-start total and not a calendar day. Do not use rate() or increase() on it.
+# TYPE voicegw_cost_usd_total gauge
 voicegw_cost_usd_total{period="today"} 1.234500
+# TYPE voicegw_requests_total gauge
 voicegw_requests_total{provider="deepgram"} 42
 voicegw_cost_usd_total{provider="deepgram"} 0.512300
 # HELP voicegw_diag_gate_status Health gates in the newest stored LiveKit diagnostics run, counted by gate id and status.
@@ -676,6 +677,30 @@ voicegw_diag_run_timestamp_seconds 1785412800.000
 ```
 
 This endpoint exposes VoiceGateway's own numbers so your Prometheus can scrape it. It is the opposite direction from the node scrape, which pulls exposition text *from* livekit-server and node_exporter *into* this database; nothing scraped from another process is served back out here.
+
+**`voicegw_cost_usd_total` and `voicegw_requests_total` are gauges over a rolling 24-hour window, not counters.** Both are computed from the `"today"` window, which is `now - 86400` seconds: a rolling trailing 24 hours. It is *not* midnight-to-now and *not* a since-process-start total. The value therefore goes **down** as well as up, every time a request falls off the trailing edge. The `period="today"` label and the `_total` suffix are both misnomers kept for backward compatibility, because renaming a scraped series would break every dashboard already built on it. The `# TYPE` metadata is now `gauge`, which is what your tooling actually reads.
+
+Concretely, this means:
+
+```promql
+# WRONG. rate()/increase() require a counter. Every decrease (a request ageing
+# out of the 24h window) is read as a counter reset, and Prometheus extrapolates
+# spend and traffic that never happened.
+rate(voicegw_cost_usd_total[5m])
+increase(voicegw_requests_total[1h])
+
+# RIGHT. Read the gauge as-is, or aggregate/compare it over time.
+voicegw_cost_usd_total{period="today"}                    # spend in the last 24h
+sum(voicegw_requests_total)                               # requests in the last 24h
+delta(voicegw_cost_usd_total{period="today"}[1h])         # how the 24h window moved
+max_over_time(voicegw_cost_usd_total{period="today"}[7d]) # worst 24h in a week
+```
+
+`sum(voicegw_requests_total)` sums the per-provider series; there is no separate unlabelled total. Do **not** write bare `sum(voicegw_cost_usd_total)`: that series is emitted three times over, once with `period="today"`, once per `provider` and once per `project`, so an unfiltered `sum` counts the same spend about three times. Always select a label set.
+
+For an actual monotonic spend counter (one that supports `rate()` and `increase()`), VoiceGateway does not publish one yet. Use `GET /v1/costs?period=all`, which is a true since-start total, or `period=week` / `period=month` for wider rolling windows.
+
+The latency series (`voicegw_request_ttfb_seconds`, `voicegw_request_total_latency_seconds`) are summary quantiles over the same rolling trailing 24 hours. Summary quantiles were never counters, so their type is unchanged; no `_sum` or `_count` children are published, so there is nothing to `rate()` there either.
 
 **Diagnostics gate series.** `voicegw_diag_gate_status` reports the health gates of the newest stored [diagnostics run](/cli/livekit) that gated anything, aggregated per gate id and status: the probed agent is not a label, so cardinality does not grow with your fleet. Statuses are the one ladder `voicegw livekit check` uses, `PASS < WARN < UNKNOWN < FAIL`, where **`UNKNOWN` means the gate could not be evaluated and is not a pass** (only `PASS` exits 0). `voicegw_diag_run_verdict` is that run's stored verdict, and `voicegw_diag_run_timestamp_seconds` is when it finished, so a clean verdict from three weeks ago is distinguishable from one from a minute ago.
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -107,13 +107,27 @@ voicegw_uptime_seconds 3421.5
 # HELP voicegw_providers_configured Configured providers
 # TYPE voicegw_providers_configured gauge
 voicegw_providers_configured 5
-# HELP voicegw_cost_usd_total Total cost in USD (today)
-# TYPE voicegw_cost_usd_total counter
+# HELP voicegw_cost_usd_total USD cost summed over a ROLLING trailing 24 hours (now-86400s to now). This is a gauge despite the _total suffix: it DECREASES as requests age out of the window. It is not a since-start total and not a calendar day. Do not use rate() or increase() on it.
+# TYPE voicegw_cost_usd_total gauge
 voicegw_cost_usd_total{period="today"} 12.340000
+# TYPE voicegw_requests_total gauge
 voicegw_requests_total{provider="deepgram"} 142
 ```
 
-For Grafana, point it at Prometheus and query `voicegw_cost_usd_total` or `voicegw_requests_total`.
+For Grafana, point it at Prometheus and graph `voicegw_cost_usd_total{period="today"}` or `sum(voicegw_requests_total)` directly.
+
+**They are gauges, so `rate()` and `increase()` do not apply.** Both series are sums over a rolling trailing 24 hours (`now - 86400`), not since-start totals and not a calendar day, so the value falls whenever a request ages out of the window. `rate()` and `increase()` require a monotonic counter and read every one of those decreases as a counter reset, which invents spend and traffic that never happened. The `_total` suffix and the `period="today"` label are misnomers kept so the published series names do not break; the `# TYPE` line is now `gauge`.
+
+```promql
+# Wrong
+rate(voicegw_cost_usd_total[5m])
+
+# Right
+voicegw_cost_usd_total{period="today"}             # spend in the last 24h
+delta(voicegw_cost_usd_total{period="today"}[1h])  # how that 24h figure moved
+```
+
+If you were already graphing these with `rate()` or `increase()`, replace the expression rather than the metric name: the names are unchanged. For a true monotonic total, use `GET /v1/costs?period=all`.
 
 ---
 

--- a/src/voicegateway/livekit_diag/client.py
+++ b/src/voicegateway/livekit_diag/client.py
@@ -27,10 +27,102 @@ from __future__ import annotations
 
 import array
 import asyncio
+import contextlib
+import logging
+import threading
 import wave
 from collections.abc import Iterator
 
 from livekit import rtc
+
+# The livekit rtc SDK logs through logging.getLogger("livekit"): its own task and
+# queue errors (_utils.task_done_logger, _ffi_client "error putting to queue")
+# and, far more numerously, every native Rust/libwebrtc record the FFI layer
+# forwards (_ffi_client.ffi_event_callback -> logger.log(level, ...)). Tearing a
+# room down mid-session makes that native stack report the shutdown as errors:
+# roughly 40 ERROR lines per diagnostics run, on the order of one per synthetic
+# client, none of them a failure. A healthy run reads as broken to anyone looking
+# at the logs, which is the opposite of what a diagnostics tool is for.
+#
+# Same technique as core.database.quiet_embedded_dependency_loggers: reach for the
+# named third-party logger rather than the root, and touch it as little as
+# possible. This has to be narrower still, because swallowing genuine LiveKit
+# errors would defeat the probe, so the suppression is bounded three ways:
+#
+#   1. In time. It is only live while a SyntheticClient teardown is actually in
+#      flight (see SyntheticClient.disconnect). Connect, publish, ping, reply
+#      detection and every measurement window keep logging at ERROR.
+#   2. In scope. A logging.Filter attached to a *logger* only sees records logged
+#      through that exact logger; records from children reach the handlers via
+#      Logger.callHandlers and never pass through it. So "livekit.agents" (an
+#      embedded agent's own logging) is untouched by this, verified in the tests.
+#   3. In severity handling. The record is demoted, never dropped: filter()
+#      always returns True and the record keeps flowing at DEBUG, so a run with
+#      DEBUG handlers still prints every one of those lines, tagged with the
+#      level it was demoted from.
+#
+# Only ERROR is demoted, not >= ERROR: nothing in the SDK logs CRITICAL through
+# this logger, so demoting CRITICAL would buy no quiet and could only ever hide
+# something severe.
+_LIVEKIT_SDK_LOGGER = "livekit"
+
+
+class _TeardownNoiseFilter(logging.Filter):
+    """Demotes SDK ERROR records to DEBUG while a room teardown is in flight.
+
+    The depth counter is guarded by a lock because the noisiest records are
+    emitted from the FFI callback thread, not the asyncio thread that opened the
+    window, and the whole point is to catch those. That thread affinity is also
+    why the window cannot be a ContextVar: the FFI thread does not carry the
+    teardown context.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self._depth = 0
+
+    def open(self) -> None:
+        with self._lock:
+            self._depth += 1
+
+    def close(self) -> None:
+        with self._lock:
+            self._depth -= 1
+
+    def active(self) -> bool:
+        with self._lock:
+            return self._depth > 0
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno == logging.ERROR and self.active():
+            # Keep the original severity readable on the demoted line, so a DEBUG
+            # run can still tell teardown noise from ordinary SDK chatter.
+            record.__dict__["vg_demoted_from"] = record.levelname
+            record.levelno = logging.DEBUG
+            record.levelname = logging.getLevelName(logging.DEBUG)
+        return True
+
+
+_TEARDOWN_NOISE = _TeardownNoiseFilter()
+_INSTALL_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def quiet_livekit_teardown_noise() -> Iterator[None]:
+    """Demote the rtc SDK's shutdown ERROR lines to DEBUG for the duration.
+
+    Installed lazily, on first teardown, so merely importing this module does not
+    reach into a third-party logger. ``Logger.addFilter`` is a no-op when the
+    filter is already attached, so repeated entry adds nothing.
+    """
+    with _INSTALL_LOCK:
+        logging.getLogger(_LIVEKIT_SDK_LOGGER).addFilter(_TEARDOWN_NOISE)
+    _TEARDOWN_NOISE.open()
+    try:
+        yield
+    finally:
+        _TEARDOWN_NOISE.close()
 
 
 class ReplyDetector:
@@ -207,4 +299,8 @@ class SyntheticClient:
     async def disconnect(self) -> None:
         if self._silence_task is not None:
             self._silence_task.cancel()
-        await self._room.disconnect()
+        # The only window in this client where the SDK's ERROR lines are demoted.
+        # Everything the probe actually measures happens before it, so a real
+        # connect/publish/ping failure is still reported at ERROR.
+        with quiet_livekit_teardown_noise():
+            await self._room.disconnect()

--- a/src/voicegateway/livekit_diag/distributed.py
+++ b/src/voicegateway/livekit_diag/distributed.py
@@ -26,10 +26,19 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from voicegateway.livekit_diag.sfu import NOT_MEASURED
+
 # Worst-to-best quality ranking; the aggregate reports the worst any vantage saw
 # at a tier. "Unknown" sits above the healthy states but below the bad ones: it
 # is a missing signal, not evidence of failure.
 _QUALITY_RANK = {"Excellent": 0, "Good": 1, "Unknown": 2, "Poor": 3, "Lost": 4}
+
+# What a combined tier's ``rtt_ms`` is: the worst (max) of the vantage readings
+# that exist, or nothing at all. Named beside the number for the same reason
+# RampStep names its own statistic: an absent reading must not read as a fast
+# one. ``NOT_MEASURED`` is imported rather than restated so the two surfaces
+# cannot drift apart.
+_WORST_OF_N = "worst_of_n"
 
 
 class RegisterBody(BaseModel):
@@ -53,7 +62,7 @@ class VantageReport:
     """One prover's ramp result: per-tier steps in ramp order, plus its label."""
 
     vantage: str
-    steps: list[dict]  # each: {clients, rtt_ms, loss_pct, quality}
+    steps: list[dict]  # each: {clients, rtt_ms, loss_pct, quality, samples}
     baseline: dict | None = None
 
 
@@ -61,6 +70,33 @@ def _worst_quality(qualities: list[str]) -> str:
     if not qualities:
         return "Unknown"
     return max(qualities, key=lambda q: _QUALITY_RANK.get(q, 2))
+
+
+def _rtt_reading(step: dict[str, Any]) -> float | None:
+    """One vantage's tier rtt, or ``None`` when that vantage measured nothing.
+
+    A vantage whose pings all timed out reports ``rtt_ms`` 0.0 with ``samples``
+    0, and folding that 0.0 into the aggregate is how an unmeasured vantage
+    reads as a fast one: with every vantage in that state the combined tier came
+    out at 0.0, inside any budget, and the knee walk called the ramp sustained.
+    A round trip through an SFU is never 0.0 ms and never negative, so a
+    non-positive rtt is the placeholder, not a reading.
+
+    Also the one place that could raise: ``float(None)`` is a TypeError, and a
+    step is free to carry a null rtt.
+    """
+    samples = step.get("samples")
+    if samples is not None:
+        try:
+            if int(samples) <= 0:
+                return None
+        except (TypeError, ValueError):
+            pass
+    try:
+        rtt = float(step["rtt_ms"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return rtt if rtt > 0.0 else None
 
 
 def aggregate_vantages(
@@ -74,18 +110,32 @@ def aggregate_vantages(
     only as healthy as its unhappiest vantage). The combined knee is the last
     tier whose total client count stayed within both thresholds. Vantages that
     reported short (a failed tier) only contribute the tiers they have.
+
+    **An unmeasured vantage contributes nothing, not a zero.** Only vantages
+    with a real reading (see :func:`_rtt_reading`) fold into a tier's rtt, and
+    ``measured_vantages`` says how many that was, so ``4 clients from 2
+    vantages`` can no longer hide that neither of them got a ping back. A tier
+    no vantage measured reports ``rtt_ms`` ``None`` with ``rtt_stat``
+    ``not_measured``: never 0.0, which the knee walk would have read as
+    comfortably inside budget. The knee walk stops at such a tier rather than
+    walking past it, and ``unmeasured_tiers`` lists them, because a ``knee`` of
+    None means "sustained the whole ramp" and nothing else may be allowed to
+    produce it.
     """
     valid = [r for r in reports if r.steps]
     tier_count = min((len(r.steps) for r in valid), default=0)
     combined: list[dict[str, Any]] = []
     for i in range(tier_count):
         row = [r.steps[i] for r in valid]
+        rtts = [rtt for rtt in (_rtt_reading(s) for s in row) if rtt is not None]
         combined.append(
             {
                 "tier": i,
                 "clients": sum(int(s.get("clients", 0)) for s in row),
                 "vantages": len(row),
-                "rtt_ms": max((float(s.get("rtt_ms", 0.0)) for s in row), default=0.0),
+                "measured_vantages": len(rtts),
+                "rtt_ms": max(rtts) if rtts else None,
+                "rtt_stat": _WORST_OF_N if rtts else NOT_MEASURED,
                 "loss_pct": max(
                     (float(s.get("loss_pct", 0.0)) for s in row), default=0.0
                 ),
@@ -99,9 +149,16 @@ def aggregate_vantages(
     # a threshold. Matches single-host find_knee semantics exactly, including None
     # when no tier breaks ("no knee within ramp: sustained the whole ramp"), so
     # the two SFU modes never report contradictory things for an all-healthy run.
+    # A tier nobody measured breaks the walk too: it was not demonstrated
+    # healthy, so the last count that WAS demonstrated is where the evidence
+    # ends. That understates capacity when the tier was fine, which is the safe
+    # direction; unmeasured_tiers says which reading it was.
     knee: int | None = None
     last_ok: int | None = None
     for tier in combined:
+        if tier["rtt_ms"] is None:
+            knee = last_ok
+            break
         if tier["rtt_ms"] > target_rtt_ms or tier["loss_pct"] > max_loss:
             knee = last_ok
             break
@@ -111,6 +168,7 @@ def aggregate_vantages(
         "vantages": [{"vantage": r.vantage, "steps": r.steps} for r in valid],
         "combined": combined,
         "knee": knee,
+        "unmeasured_tiers": [t["tier"] for t in combined if t["rtt_ms"] is None],
         "target_rtt_ms": target_rtt_ms,
         "max_loss": max_loss,
         "dropped": [r.vantage for r in reports if not r.steps],
@@ -367,6 +425,11 @@ async def run_prober(
                     "rtt_ms": s.rtt_ms,
                     "loss_pct": s.loss_pct,
                     "quality": s.quality,
+                    # Sent so the coordinator can tell a vantage that measured a
+                    # fast tier from one that measured nothing: both report an
+                    # rtt_ms, and only one of them is a reading.
+                    "samples": s.samples,
+                    "rtt_stat": s.rtt_stat,
                 }
                 for s in steps
             ],

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -315,6 +315,29 @@ def sfu_quality_gate(baseline: dict[str, Any] | None) -> GateResult:
     ``Poor``/``Lost`` is a FAIL, which is ``check_json``'s reading;
     ``_verdict`` called the same input a WARN. Loss is not consulted: it is a
     hardcoded ``0.0`` (see the module docstring).
+
+    ``quality`` and ``rtt_ms`` are INDEPENDENT readings, and this gate used to
+    consult only the first. ``quality`` is the SDK's own peer-connection metric;
+    ``rtt_ms`` is a mean over ping round trips, which needs a pong back. They
+    disagree exactly when the connection came up and every ping timed out: that
+    baseline reports ``Excellent`` beside an rtt of ``0.0`` over zero samples,
+    and ``Excellent`` is neither falsy, nor :data:`_NO_QUALITY`, nor in
+    :data:`_DEGRADED_QUALITY`, so it fell through to PASS while the detail line
+    printed ``rtt 0.0ms`` as though that were a time. So the gate certified a
+    healthy baseline for a run in which not one round trip completed: the same
+    defect :func:`sfu_capacity_gate` had for the ramp.
+
+    A baseline that measured nothing (:func:`_unmeasured_reason`, the helper the
+    ramp already uses, so the two surfaces cannot drift) is now :data:`UNKNOWN`
+    whatever ``quality`` says. UNKNOWN and not FAIL, for the ramp's reason:
+    nothing was observed, so nothing is claimed, and the pings can die because
+    the PROBER never got its own client connected. It still exits non-zero and
+    still outranks WARN.
+
+    A ``Poor``/``Lost`` baseline that measured no rtt is still a FAIL, also
+    matching the ramp: a degraded quality is a real observation of the SFU,
+    while a missing round trip is only an absence. Its rtt is not a reading
+    either way, so no branch prints one it does not have.
     """
     if not baseline:
         return GateResult(
@@ -324,6 +347,7 @@ def sfu_quality_gate(baseline: dict[str, Any] | None) -> GateResult:
         )
     quality = baseline.get("quality")
     rtt = baseline.get("rtt_ms")
+    unmeasured = _unmeasured_reason(baseline)
     if not quality or quality == _NO_QUALITY:
         return GateResult(
             gate=SFU_QUALITY_GATE,
@@ -334,11 +358,24 @@ def sfu_quality_gate(baseline: dict[str, Any] | None) -> GateResult:
             ),
         )
     if quality in _DEGRADED_QUALITY:
+        observed = (
+            f"no rtt reading: {unmeasured}" if unmeasured is not None else f"rtt {rtt}ms"
+        )
         return GateResult(
             gate=SFU_QUALITY_GATE,
             status=FAIL,
-            detail=f"SFU baseline connection quality is {quality} (rtt {rtt}ms)",
+            detail=f"SFU baseline connection quality is {quality} ({observed})",
             metric="sfu_baseline_quality",
+        )
+    if unmeasured is not None:
+        return GateResult(
+            gate=SFU_QUALITY_GATE,
+            status=UNKNOWN,
+            detail=(
+                f"the SFU baseline measured nothing: {unmeasured}, so its "
+                f"connection quality of {quality} is the only signal and no "
+                "round trip through the SFU was completed at all"
+            ),
         )
     return GateResult(
         gate=SFU_QUALITY_GATE,
@@ -359,11 +396,11 @@ def _breaches(step: dict[str, Any], target_rtt_ms: float) -> bool:
 
 
 def _sample_count(step: dict[str, Any]) -> int | None:
-    """``samples`` off a ramp step, or ``None`` when the step carries no count.
+    """``samples`` off a ramp step or baseline, or ``None`` when it carries none.
 
-    Absent is NOT zero. Ramps stored before ``sfu.RampStep`` grew a sample count
+    Absent is NOT zero. Runs stored before ``sfu.RampStep`` grew a sample count
     have no such key, and reading that absence as "measured nothing" would
-    retroactively turn every archived ramp UNKNOWN, healthy ones included.
+    retroactively turn every archived run UNKNOWN, healthy ones included.
     """
     if "samples" not in step:
         return None
@@ -377,23 +414,30 @@ def _sample_count(step: dict[str, Any]) -> int | None:
 
 
 def _unmeasured_reason(step: dict[str, Any]) -> str | None:
-    """Why a ramp tier is not a measurement, or ``None`` when it is one.
+    """Why a ramp tier or baseline is not a measurement, or ``None`` when it is.
+
+    One helper for both, deliberately: :func:`sfu_capacity_gate` and
+    :func:`sfu_quality_gate` read the same ``{rtt_ms, quality, samples}`` shape
+    off the same probe, so a second copy of this rule is a second place for it
+    to drift.
 
     Keyed on ``samples``, the count of ping round-trips that came back, because
-    a count is a fact while the ``rtt_ms`` of ``0.0`` a tier reports when every
-    ping timed out is an artifact of averaging an empty list. Nothing else here
-    could catch that: ``0.0 > target`` is False, and the quality such a tier
-    reports is :data:`_NO_QUALITY`, which is deliberately not in
-    :data:`_DEGRADED_QUALITY`. So a ramp where every single ping timed out used
-    to satisfy :func:`sfu_capacity_gate` and report PASS -- a monitoring tool
-    telling an operator a dead SFU is fine.
+    a count is a fact while the ``rtt_ms`` of ``0.0`` a reading reports when
+    every ping timed out is an artifact of averaging an empty list. Nothing else
+    here could catch that: ``0.0 > target`` is False, and the quality a tier
+    reports in that state is :data:`_NO_QUALITY`, which is deliberately not in
+    :data:`_DEGRADED_QUALITY` -- while a BASELINE in that state can report a
+    perfectly healthy ``Excellent``, since its quality comes from the SDK's
+    peer-connection metric rather than from the pings. So a run where every
+    single ping timed out used to satisfy both gates and report PASS -- a
+    monitoring tool telling an operator a dead SFU is fine.
 
-    A step with no ``samples`` key at all is NOT assumed unmeasured: ramps
+    A reading with no ``samples`` key at all is NOT assumed unmeasured: runs
     stored before the count existed have no such key, and reading absence as
-    zero would turn every archived ramp UNKNOWN. Those fall back to the number
+    zero would turn every archived run UNKNOWN. Those fall back to the number
     itself, under the rule :func:`_has_measurement` already applies to reply
     latency: a round trip through an SFU cannot take zero milliseconds, so a
-    non-positive (or missing) rtt on a step that carries no count is the
+    non-positive (or missing) rtt on a reading that carries no count is the
     placeholder, and any positive rtt is judged exactly as it was before.
     """
     count = _sample_count(step)

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -358,6 +358,56 @@ def _breaches(step: dict[str, Any], target_rtt_ms: float) -> bool:
         return False
 
 
+def _sample_count(step: dict[str, Any]) -> int | None:
+    """``samples`` off a ramp step, or ``None`` when the step carries no count.
+
+    Absent is NOT zero. Ramps stored before ``sfu.RampStep`` grew a sample count
+    have no such key, and reading that absence as "measured nothing" would
+    retroactively turn every archived ramp UNKNOWN, healthy ones included.
+    """
+    if "samples" not in step:
+        return None
+    raw = step.get("samples")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _unmeasured_reason(step: dict[str, Any]) -> str | None:
+    """Why a ramp tier is not a measurement, or ``None`` when it is one.
+
+    Keyed on ``samples``, the count of ping round-trips that came back, because
+    a count is a fact while the ``rtt_ms`` of ``0.0`` a tier reports when every
+    ping timed out is an artifact of averaging an empty list. Nothing else here
+    could catch that: ``0.0 > target`` is False, and the quality such a tier
+    reports is :data:`_NO_QUALITY`, which is deliberately not in
+    :data:`_DEGRADED_QUALITY`. So a ramp where every single ping timed out used
+    to satisfy :func:`sfu_capacity_gate` and report PASS -- a monitoring tool
+    telling an operator a dead SFU is fine.
+
+    A step with no ``samples`` key at all is NOT assumed unmeasured: ramps
+    stored before the count existed have no such key, and reading absence as
+    zero would turn every archived ramp UNKNOWN. Those fall back to the number
+    itself, under the rule :func:`_has_measurement` already applies to reply
+    latency: a round trip through an SFU cannot take zero milliseconds, so a
+    non-positive (or missing) rtt on a step that carries no count is the
+    placeholder, and any positive rtt is judged exactly as it was before.
+    """
+    count = _sample_count(step)
+    if count is not None:
+        return None if count > 0 else "no ping round-trip came back (samples 0)"
+    rtt = _as_float(step.get("rtt_ms"))
+    if rtt is None or rtt <= 0.0:
+        return (
+            "it carries no sample count (a run stored before they were recorded) "
+            f"and its rtt of {step.get('rtt_ms')} is not a round-trip time"
+        )
+    return None
+
+
 def sfu_capacity_gate(
     ramp: Sequence[dict[str, Any]],
     target_rtt_ms: float | None,
@@ -373,6 +423,11 @@ def sfu_capacity_gate(
 
     Finding a knee at a later tier is NOT a failure -- measuring where capacity
     ends is the entire purpose of running a ramp.
+
+    A smallest tier that measured NOTHING (see :func:`_unmeasured_reason`) is
+    :data:`UNKNOWN`. It used to be a PASS, which is the same class of bug as the
+    ``knee is None`` ambiguity this gate exists to close, in a worse direction:
+    the reading came from a server where every ping timed out.
     """
     if not ramp:
         return GateResult(
@@ -403,6 +458,26 @@ def sfu_capacity_gate(
     unmeasured_prober = resource is not None and resource.get("saturated") is None
     first = ramp[0]
     clients = first.get("clients")
+    unmeasured = _unmeasured_reason(first)
+    degraded = first.get("quality") in _DEGRADED_QUALITY
+    if unmeasured is not None and not degraded:
+        # Nothing came back, and no quality reading indicts the SFU either, so
+        # there is no number to compare and no observed failure to report.
+        # UNKNOWN, not FAIL: FAIL would claim a breach nobody watched, and the
+        # tier may have measured nothing because the PROBER could not connect
+        # its own clients. UNKNOWN still exits non-zero (see exit_code) and
+        # still outranks WARN in the run verdict, so this is not the soft
+        # option: it is the accurate one.
+        return GateResult(
+            gate=SFU_CAPACITY_GATE,
+            status=UNKNOWN,
+            detail=(
+                f"the smallest tier ({clients} clients) measured nothing: "
+                f"{unmeasured}, so there is no rtt to compare against the "
+                f"{target_rtt_ms}ms budget and no capacity was demonstrated"
+            ),
+            threshold=target_rtt_ms,
+        )
     if _breaches(first, target_rtt_ms):
         caveat = (
             "; the prober's own load was not measured, so this host cannot be "
@@ -410,17 +485,24 @@ def sfu_capacity_gate(
             if unmeasured_prober
             else ""
         )
+        # A degraded tier that measured no rtt is still a FAIL -- Poor/Lost is an
+        # observation -- but its rtt of 0.0 is not, so it is neither printed as a
+        # reading nor published as the gate's value.
+        observed = (
+            f"quality {first.get('quality')}, and no rtt reading: {unmeasured}"
+            if unmeasured is not None
+            else f"rtt {first.get('rtt_ms')}ms, quality {first.get('quality')}"
+        )
         return GateResult(
             gate=SFU_CAPACITY_GATE,
             status=FAIL,
             detail=(
                 f"the smallest tier ({clients} clients) was already outside "
-                f"budget (rtt {first.get('rtt_ms')}ms, quality "
-                f"{first.get('quality')}) against a {target_rtt_ms}ms target, so "
+                f"budget ({observed}) against a {target_rtt_ms}ms target, so "
                 f"there is no healthy capacity to report{caveat}"
             ),
-            metric="sfu_ramp_rtt_ms",
-            value=_as_float(first.get("rtt_ms")),
+            metric=None if unmeasured is not None else "sfu_ramp_rtt_ms",
+            value=None if unmeasured is not None else _as_float(first.get("rtt_ms")),
             threshold=target_rtt_ms,
         )
     return GateResult(

--- a/src/voicegateway/livekit_diag/service.py
+++ b/src/voicegateway/livekit_diag/service.py
@@ -248,11 +248,12 @@ class RealProbes:
         not a measurement and must not be rendered as one; ``quality`` is the
         coarse signal that is real.
 
-        Each ramp step carries ``samples`` (how many ping round-trips came back)
-        and ``rtt_stat`` beside its ``rtt_ms``, because a tier whose pings all
-        timed out reports an rtt of 0.0 and only the count says that 0.0 is a
-        placeholder rather than a very fast SFU. ``gates.sfu_capacity_gate``
-        reads it.
+        The baseline and each ramp step carry ``samples`` (how many ping
+        round-trips came back) and ``rtt_stat`` beside their ``rtt_ms``, because
+        a reading whose pings all timed out reports an rtt of 0.0 and only the
+        count says that 0.0 is a placeholder rather than a very fast SFU.
+        ``gates.sfu_capacity_gate`` reads the ramp's; ``gates.sfu_quality_gate``
+        reads the baseline's.
         """
         d = _diag()
         admin = d.LiveKitAdmin(creds)
@@ -280,6 +281,17 @@ class RealProbes:
                 "rtt_ms": base.rtt_ms,
                 "loss_pct": base.loss_pct,
                 "quality": base.quality,
+                # The same two keys the ramp steps carry, for the same reason
+                # and one worse case: ``quality`` and ``rtt_ms`` are INDEPENDENT
+                # readings here. ``quality`` is the SDK's own peer-connection
+                # metric, ``rtt_ms`` is a mean over ping round trips, so a
+                # connection that came up while every ping timed out reports
+                # quality "Excellent" beside an rtt of 0.0 over zero samples.
+                # Without the count, sfu_quality_gate read only the quality and
+                # certified that baseline healthy. int/str, so both survive the
+                # round trip through the stored run JSON.
+                "samples": base.samples,
+                "rtt_stat": base.rtt_stat,
             },
             "ramp": [
                 {

--- a/src/voicegateway/livekit_diag/service.py
+++ b/src/voicegateway/livekit_diag/service.py
@@ -247,6 +247,12 @@ class RealProbes:
         hardcoded 0.0 in ``sfu.py`` (per-connection loss is not exposed). It is
         not a measurement and must not be rendered as one; ``quality`` is the
         coarse signal that is real.
+
+        Each ramp step carries ``samples`` (how many ping round-trips came back)
+        and ``rtt_stat`` beside its ``rtt_ms``, because a tier whose pings all
+        timed out reports an rtt of 0.0 and only the count says that 0.0 is a
+        placeholder rather than a very fast SFU. ``gates.sfu_capacity_gate``
+        reads it.
         """
         d = _diag()
         admin = d.LiveKitAdmin(creds)
@@ -281,6 +287,14 @@ class RealProbes:
                     "rtt_ms": s.rtt_ms,
                     "loss_pct": s.loss_pct,
                     "quality": s.quality,
+                    # What rtt_ms IS. A tier whose pings all timed out reports
+                    # 0.0, and without a count of the round-trips behind it that
+                    # 0.0 is indistinguishable from a very fast SFU: it read as
+                    # comfortably inside budget, so a completely unmeasured ramp
+                    # passed sfu_capacity. Both keys are ints/strings, so they
+                    # survive the round trip through the stored run JSON.
+                    "samples": s.samples,
+                    "rtt_stat": s.rtt_stat,
                 }
                 for s in steps
             ],

--- a/src/voicegateway/livekit_diag/sfu.py
+++ b/src/voicegateway/livekit_diag/sfu.py
@@ -57,11 +57,29 @@ class RampStep:
 def find_knee(
     steps: list[RampStep], target_rtt_ms: float, max_loss: float
 ) -> int | None:
-    """The last healthy client count before the first step that breaks a
-    threshold. None when every step is within budget.
+    """The last healthy client count before the walk stops.
+
+    The walk stops at the first step that breaks a threshold, and also at the
+    first step that measured nothing (``samples`` 0). Capacity cannot be
+    certified past a tier that was never demonstrated: such a tier reports an
+    ``rtt_ms`` of 0.0, which is the mean of an empty list rather than a fast
+    SFU, and ``0.0 > target_rtt_ms`` is False, so walking on credited every tier
+    below it with capacity nobody measured. Stopping there understates capacity
+    when the tier was in fact fine, which is the safe direction, and it matches
+    the multi-vantage walk in :func:`distributed.aggregate_vantages` so the two
+    SFU modes cannot report contradictory things about the same server.
+
+    A step that DID measure is judged exactly as before, against the same
+    ``target_rtt_ms`` and ``max_loss``.
+
+    None when every step was measured and stayed within budget, and ALSO when
+    the very first step stopped the walk. ``gates.sfu_capacity_gate`` exists to
+    tell those apart; None must never be read as health on its own.
     """
     last_ok = None
     for s in steps:
+        if s.samples <= 0:
+            return last_ok
         if s.rtt_ms > target_rtt_ms or s.loss_pct > max_loss:
             return last_ok
         last_ok = s.clients

--- a/src/voicegateway/livekit_diag/sfu.py
+++ b/src/voicegateway/livekit_diag/sfu.py
@@ -1,6 +1,19 @@
 """SFU connection-quality baseline and capacity ramp, using synthetic clients
 talking to each other (no agent). Latency is a clock-sync-free data-channel
 round-trip through the SFU; jitter/loss come from connection stats.
+
+**Cold start is warmed, never measured.** The first message a client sends over
+its data channel pays that session's TLS/ICE/DTLS setup, and a step takes
+exactly ONE sample per client, so with no warm-up every sample is a cold one.
+Measured on a live deployment, that read 129.3ms at 2 clients against 26.1ms at
+10 and 25.7ms at 25: more clients measuring FASTER, which is backwards for a
+capacity probe and only explainable by per-session setup cost landing in the
+number. The steady state was ~26ms, so the two-client tier came out roughly 5x
+high, and that tier is exactly the one ``gates.sfu_capacity_gate`` reads: a
+healthy server failed its own capacity gate on a warm-up artifact. Every client
+now sends one discarded ping before the measured round (see
+:meth:`SfuProbe._warm_up`). The budget is untouched; raising it would have
+hidden this rather than fixed it.
 """
 
 from __future__ import annotations
@@ -8,6 +21,14 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from statistics import mean
+from typing import Any
+
+# What ``rtt_ms`` actually is, named beside the number so a step that measured
+# nothing cannot be read as a fast one. Same vocabulary as the node-correlation
+# summaries (``p95`` / ``max_of_n`` / ``not_measured``): name the statistic, and
+# say ``not_measured`` rather than presenting an absence as a reading.
+MEAN_OF_N = "mean_of_n"
+NOT_MEASURED = "not_measured"
 
 
 @dataclass(frozen=True)
@@ -16,6 +37,21 @@ class RampStep:
     rtt_ms: float
     loss_pct: float
     quality: str
+    # How many ping round-trips ``rtt_ms`` is the mean of. Never counts the
+    # discarded warm-up ping, and never counts a ping that did not come back.
+    # Defaults to 0 so a hand-built step is not credited with evidence it does
+    # not carry; every step this module measures sets it.
+    samples: int = 0
+
+    @property
+    def rtt_stat(self) -> str:
+        """The name of the statistic in ``rtt_ms``.
+
+        ``mean_of_n`` over ``samples`` round-trips, or ``not_measured`` when
+        none came back. A step with ``samples == 0`` measured nothing at all,
+        and its ``rtt_ms`` of 0.0 is a placeholder, not a fast SFU.
+        """
+        return MEAN_OF_N if self.samples else NOT_MEASURED
 
 
 def find_knee(
@@ -38,6 +74,34 @@ class SfuProbe:
         self._make_client = client_factory
         self._monitor = monitor
 
+    async def _warm_up(self, clients: list[Any]) -> None:
+        """One discarded ping per client, before anything is measured.
+
+        The first message over a client's data channel pays that session's
+        TLS/ICE/DTLS setup, and :meth:`_measure` takes exactly ONE sample per
+        client, so without this pass every sample carries setup cost.
+
+        Warming, rather than dropping the first measured sample, is what this
+        shape of measurement needs. Dropping one sample would leave the
+        two-client baseline with a single reading (and a one-client tier with
+        none) while STILL leaving every remaining client's own first-message
+        cost inside the number, because each client only ever pings once.
+
+        It runs before the soak, not immediately before the measured round, so
+        that a pong still in flight from this pass has drained by the time the
+        measurement starts: a stray pong completes the next ping early and would
+        under-report the rtt, which is the one error worse than over-reporting
+        it.
+        """
+        for c in clients:
+            try:
+                await c.ping()
+            except Exception:  # noqa: BLE001 - a warm-up produces no number
+                # so it must not be what ends a probe that can still measure. A
+                # client that is genuinely broken fails its measured ping too,
+                # and that failure is the honest one to report.
+                pass
+
     async def _measure(
         self, room: str, n: int, seconds: float, *, cleanup: bool = True
     ) -> RampStep:
@@ -50,13 +114,18 @@ class SfuProbe:
                 )
                 await c.connect()
                 clients.append(c)
+            await self._warm_up(clients)
             await asyncio.sleep(seconds)
-            pings = [p for c in clients for p in [await c.ping()] if p is not None]
+            pings: list[float] = []
+            for c in clients:
+                rtt = await c.ping()
+                if rtt is not None:
+                    pings.append(rtt)
             rtt_ms = (mean(pings) * 1000) if pings else 0.0
             quality = clients[0].quality() if clients else "Unknown"
             # Loss is read from stats where available; default 0.0 when the SDK does
             # not expose it. quality carries the coarse signal regardless.
-            return RampStep(n, round(rtt_ms, 1), 0.0, quality)
+            return RampStep(n, round(rtt_ms, 1), 0.0, quality, len(pings))
         finally:
             for c in clients:
                 await c.disconnect()

--- a/src/voicegateway/models/agent_probe_result_model.py
+++ b/src/voicegateway/models/agent_probe_result_model.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from sqlalchemy import Text
 from sqlmodel import Field, SQLModel
 
 
@@ -20,6 +21,11 @@ class AgentProbeResult(SQLModel, table=True):
     # One cached result per agent (single-tenant OSS). A new probe overwrites it.
     agent_id: str = Field(primary_key=True)
     # The probe response dict, JSON-serialized (e2e, components, cost, models...).
-    result_json: str
+    # Text, not VARCHAR: this holds a serialized document of no fixed length (a
+    # whole probe payload), and migration d2f6b8a1c3e5 declares it that way --
+    # nothing in this repo runs autogenerate, so the model has to agree with the
+    # DDL by hand. SQLite treats the two alike; PostgreSQL does not, so a fresh
+    # create_all install and an upgraded install would otherwise differ.
+    result_json: str = Field(sa_type=Text)
     # Epoch seconds the probe ran, so the UI can show "measured Ns ago".
     created_at: float

--- a/src/voicegateway/models/request_model.py
+++ b/src/voicegateway/models/request_model.py
@@ -94,7 +94,20 @@ class Request(SQLModel, table=True):
     rated_price_usd: float | None = Field(
         default=0.0, sa_column_kwargs={"server_default": "0"}
     )
-    rate_rule: str = Field(default="", sa_column_kwargs={"server_default": ""})
+    # Text and nullable, because migration c7d2a9f1e6b4 declares
+    # ``sa.Text(), nullable=True`` and the migration is deployed truth: a plain
+    # ``str`` here maps to VARCHAR NOT NULL, so an upgraded install and a fresh
+    # ``create_all`` install would disagree on both halves. Nothing in this repo
+    # runs autogenerate, so the model has to agree with the DDL by hand. SQLite
+    # hides the VARCHAR/Text half; PostgreSQL does not, and it enforces the NOT
+    # NULL half for real. Nothing reads this column back except as an opaque
+    # audit token, so NULL is as harmless as the "" the server default writes.
+    # (ClickHouse declares it a third way, LowCardinality(String) DEFAULT ''
+    # and non-nullable, in clickhouse/migrations/0004_requests_rated_price.sql;
+    # that store is separate and is not what this line unifies.)
+    rate_rule: str | None = Field(
+        default="", sa_type=Text, sa_column_kwargs={"server_default": ""}
+    )
     ttfb_ms: float | None = None
     total_latency_ms: float | None = None
     status: str | None = Field(default="success")

--- a/src/voicegateway/server/api/metrics.py
+++ b/src/voicegateway/server/api/metrics.py
@@ -12,6 +12,19 @@ another process's numbers to this one.
 known. In Prometheus a ``0`` is an observation: it is graphed, alerted on and
 believed. An absent series says "nothing was measured"; a zero says "measured,
 and it was none", and only one of those is true when no diagnostics run exists.
+
+**No fabricated counters.** ``voicegw_cost_usd_total`` and
+``voicegw_requests_total`` are sums over the ``"today"`` window, which
+``cost_repository.period_since`` defines as ``time.time() - 86400``: a ROLLING
+trailing 24 hours, not a calendar day and not a since-start total. Their values
+fall whenever a request ages out of that window, so they are gauges. They were
+published as ``# TYPE ... counter``, which promises Prometheus the value never
+decreases; ``rate()`` and ``increase()`` read every one of those decreases as a
+counter reset and silently invent traffic that did not happen. The ``_total``
+suffix is kept only because the names are published (docs/api/http-api.md,
+docs/reference/faq.md) and renaming a scraped series breaks every dashboard
+built on it; the suffix is wrong and the type metadata is what operators'
+tooling actually reads.
 """
 
 from __future__ import annotations
@@ -75,11 +88,21 @@ async def prometheus_metrics(
     if gateway.storage is not None:
         today = await gateway.storage.get_cost_summary("today")
         lines += [
-            "# HELP voicegw_cost_usd_total Total cost in USD (today)",
-            "# TYPE voicegw_cost_usd_total counter",
+            # gauge, not counter: see the module docstring. The window is a
+            # rolling one, so the value goes down as well as up.
+            "# HELP voicegw_cost_usd_total USD cost summed over a ROLLING "
+            "trailing 24 hours (now-86400s to now). This is a gauge despite the "
+            "_total suffix: it DECREASES as requests age out of the window. It "
+            "is not a since-start total and not a calendar day. Do not use "
+            "rate() or increase() on it.",
+            "# TYPE voicegw_cost_usd_total gauge",
             f'voicegw_cost_usd_total{{period="today"}} {today["total"]:.6f}',
-            "# HELP voicegw_requests_total Total requests (today)",
-            "# TYPE voicegw_requests_total counter",
+            "# HELP voicegw_requests_total Requests counted over a ROLLING "
+            "trailing 24 hours (now-86400s to now). This is a gauge despite the "
+            "_total suffix: it DECREASES as requests age out of the window. It "
+            "is not a since-start total and not a calendar day. Do not use "
+            "rate() or increase() on it.",
+            "# TYPE voicegw_requests_total gauge",
         ]
         for provider, data in today.get("by_provider", {}).items():
             lines.append(
@@ -98,12 +121,20 @@ async def prometheus_metrics(
         pcts = gateway.config.latency.get("percentiles") or [50.0, 95.0, 99.0]
         latency = await gateway.storage.get_latency_stats("today", percentiles=pcts)
         if latency:
+            # summary is the right type here: the quantile children of a
+            # summary are already sliding-window statistics, not counters, so
+            # nothing promises Prometheus they only rise. The window is stated
+            # anyway, because "p95 of what span?" is not answerable from the
+            # series alone. No _sum / _count children are emitted, so there is
+            # no counter here to rate() either.
             lines += [
-                "# HELP voicegw_request_ttfb_seconds "
-                "Per-model time to first byte (seconds, summary)",
+                "# HELP voicegw_request_ttfb_seconds Per-model time to first "
+                "byte (seconds), quantiles over a ROLLING trailing 24 hours "
+                "(now-86400s to now). Not since-start, not a calendar day.",
                 "# TYPE voicegw_request_ttfb_seconds summary",
-                "# HELP voicegw_request_total_latency_seconds "
-                "Per-model total latency (seconds, summary)",
+                "# HELP voicegw_request_total_latency_seconds Per-model total "
+                "latency (seconds), quantiles over a ROLLING trailing 24 hours "
+                "(now-86400s to now). Not since-start, not a calendar day.",
                 "# TYPE voicegw_request_total_latency_seconds summary",
             ]
             for model, s in latency.items():

--- a/src/voicegateway/services/retention_service.py
+++ b/src/voicegateway/services/retention_service.py
@@ -182,6 +182,14 @@ class RetentionWorker:
         requests independently
         by timestamp. Each chunk commits so a large backlog never holds one long
         write lock.
+
+        A request is NOT a child of a session (it prunes on the request clock
+        and routinely outlives the session it names), so it is not deleted with
+        the session pass; its ``session_id`` pointer is nulled instead, in the
+        same chunk transaction as the delete. That keeps the invariant at the
+        source, which is the only guard this pointer has: no read joins
+        ``requests`` to ``sessions``, so unlike ``sessions.call_id`` there is no
+        read-time LEFT JOIN that would filter a dangling one out.
         """
         deleted = 0
 
@@ -206,6 +214,21 @@ class RetentionWorker:
                     {"ids": ids},
                 )
                 deleted += _rowcount(res)
+            # A request is NOT a child of a session (it prunes on its own
+            # ``timestamp`` clock and routinely outlives the session it names),
+            # so it is not deleted here; its ``session_id`` pointer is dropped
+            # before the row it points at, inside this chunk's transaction, so
+            # a crash mid-sweep can never commit the delete without the
+            # null-out. Deliberately not scoped by project: a pointer from
+            # anywhere at a session that is going away is dangling either way.
+            # Not added to ``deleted`` either, which counts deleted rows and
+            # would otherwise over-report.
+            await db.execute(
+                text(
+                    "UPDATE requests SET session_id = NULL WHERE session_id IN :ids"
+                ).bindparams(bindparam("ids", expanding=True)),
+                {"ids": ids},
+            )
             res = await db.execute(
                 text("DELETE FROM sessions WHERE id IN :ids").bindparams(
                     bindparam("ids", expanding=True)

--- a/src/voicegateway/services/retention_service.py
+++ b/src/voicegateway/services/retention_service.py
@@ -256,6 +256,13 @@ class RetentionWorker:
 
         The cutoff arrives in epoch seconds and this table stores epoch
         milliseconds, hence the conversion here.
+
+        A session is NOT a child of a call (it prunes on the session clock and
+        routinely outlives the call it names), so it is not deleted here; its
+        ``call_id`` pointer is nulled instead, in the same chunk transaction as
+        the delete. That keeps the invariant at the source. The read side keeps
+        its own LEFT JOIN guard against dangling pointers regardless: this is
+        defence in depth, not a replacement for it.
         """
         deleted = 0
         cutoff_ms = int(cutoff_ts * 1000)
@@ -279,6 +286,18 @@ class RetentionWorker:
                     {"ids": ids},
                 )
                 deleted += _rowcount(res)
+            # Drop the pointers before the rows they point at, inside this
+            # chunk's transaction, so a crash mid-sweep can never commit the
+            # delete without the null-out. Deliberately not scoped by project:
+            # a pointer from anywhere at a call that is going away is dangling
+            # either way. Not added to ``deleted`` either, which counts deleted
+            # rows and would otherwise over-report.
+            await db.execute(
+                text(
+                    "UPDATE sessions SET call_id = NULL WHERE call_id IN :ids"
+                ).bindparams(bindparam("ids", expanding=True)),
+                {"ids": ids},
+            )
             res = await db.execute(
                 text("DELETE FROM calls WHERE id IN :ids").bindparams(
                     bindparam("ids", expanding=True)

--- a/src/voicegateway/tests/livekit_diag/test_distributed.py
+++ b/src/voicegateway/tests/livekit_diag/test_distributed.py
@@ -62,6 +62,82 @@ def test_aggregate_worst_quality_wins():
     assert out["combined"][0]["quality"] == "Poor"
 
 
+def _unmeasured_steps(*, clients=(2,), quality="Unknown"):
+    """What a vantage reports for a tier where not one ping came back."""
+    return [
+        {
+            "clients": c,
+            "rtt_ms": 0.0,
+            "loss_pct": 0.0,
+            "quality": quality,
+            "samples": 0,
+            "rtt_stat": "not_measured",
+        }
+        for c in clients
+    ]
+
+
+def test_a_tier_no_vantage_measured_is_null_not_a_fast_zero():
+    """0.0 is inside every budget, so it made a dead ramp look sustained."""
+    reports = [
+        VantageReport("iad", _unmeasured_steps()),
+        VantageReport("sjc", _unmeasured_steps()),
+    ]
+    out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
+    tier = out["combined"][0]
+    assert tier["rtt_ms"] is None  # never 0.0
+    assert tier["rtt_stat"] == "not_measured"
+    assert tier["vantages"] == 2 and tier["measured_vantages"] == 0
+    # knee None reads as "sustained the whole ramp", so it cannot be the only
+    # signal: this says the walk never had anything to walk.
+    assert out["unmeasured_tiers"] == [0]
+
+
+def test_an_unmeasured_vantage_does_not_dilute_a_measured_tier():
+    reports = [
+        VantageReport("iad", _steps([40.0], clients=(2,))),
+        VantageReport("sjc", _unmeasured_steps()),
+    ]
+    out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
+    tier = out["combined"][0]
+    assert tier["rtt_ms"] == 40.0  # the reading that exists
+    assert tier["rtt_stat"] == "worst_of_n"
+    assert tier["measured_vantages"] == 1  # of 2 vantages, so the gap is visible
+    assert out["unmeasured_tiers"] == []
+
+
+def test_aggregate_does_not_crash_on_a_null_or_missing_rtt():
+    """``float(None)`` is a TypeError, and a step may carry a null rtt."""
+    reports = [
+        VantageReport("iad", [{"clients": 2, "rtt_ms": None, "loss_pct": 0.0}]),
+        VantageReport("sjc", [{"clients": 2, "loss_pct": 0.0}]),
+    ]
+    out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
+    assert out["combined"][0]["rtt_ms"] is None
+    assert out["combined"][0]["measured_vantages"] == 0
+
+
+def test_the_knee_walk_stops_at_a_tier_nobody_measured():
+    """Capacity past an unmeasured tier was not demonstrated, so it is not claimed."""
+    reports = [
+        VantageReport(
+            "iad",
+            _steps([10.0], clients=(2,))
+            + _unmeasured_steps(clients=(5,))
+            + _steps([12.0], clients=(9,)),
+        ),
+        VantageReport(
+            "sjc",
+            _steps([11.0], clients=(2,))
+            + _unmeasured_steps(clients=(5,))
+            + _steps([13.0], clients=(9,)),
+        ),
+    ]
+    out = aggregate_vantages(reports, target_rtt_ms=50.0, max_loss=1.0)
+    assert out["knee"] == 4  # the last tier that WAS measured healthy (2+2)
+    assert out["unmeasured_tiers"] == [1]
+
+
 def test_aggregate_ragged_reports_use_common_tier_count_and_flag_empty():
     reports = [
         VantageReport("iad", _steps([10.0, 20.0])),  # 2 tiers
@@ -249,3 +325,40 @@ async def test_run_prober_barrier_times_out_instead_of_hanging():
             poll_interval=1.0,
             barrier_timeout=3.0,  # -> at most 3 polls, then raise
         )
+
+
+class _HalfMeasuringProbe:
+    """One tier measured, one where every ping timed out."""
+
+    async def ramp(self, room, counts, duration, target, max_loss, *, cleanup):
+        return [
+            RampStep(counts[0], 11.0, 0.0, "Good", 2),
+            RampStep(counts[1], 0.0, 0.0, "Unknown", 0),
+        ], None
+
+
+async def test_run_prober_reports_the_sample_count_behind_each_rtt():
+    """The coordinator cannot aggregate honestly on numbers alone."""
+    http = _FakeHttp(ready_after=1)
+
+    async def _sleep(_d):
+        pass
+
+    payload = await run_prober(
+        "http://coord",
+        _HalfMeasuringProbe(),
+        vantage="iad",
+        http=http,
+        sleep=_sleep,
+        clock=lambda: 100.0,
+        poll_interval=0.5,
+    )
+    assert [s["samples"] for s in payload["steps"]] == [2, 0]
+    assert [s["rtt_stat"] for s in payload["steps"]] == ["mean_of_n", "not_measured"]
+
+    # And the tier that measured nothing does not read as a fast one on arrival.
+    out = aggregate_vantages(
+        [VantageReport("iad", payload["steps"])], target_rtt_ms=50.0, max_loss=1.0
+    )
+    assert [t["rtt_ms"] for t in out["combined"]] == [11.0, None]
+    assert out["unmeasured_tiers"] == [1]

--- a/src/voicegateway/tests/livekit_diag/test_gates.py
+++ b/src/voicegateway/tests/livekit_diag/test_gates.py
@@ -483,3 +483,135 @@ def test_the_run_verdict_is_the_worst_gate():
     results = gates.evaluate_checks(checks, 1500.0)
     assert [g.status for g in results] == [gates.PASS, gates.FAIL, gates.PASS]
     assert gates.verdict(results) == gates.FAIL
+
+
+# ---------------------------------------------------------------------------
+# A baseline that measured nothing: quality and rtt are INDEPENDENT readings
+#
+# quality is the SDK's own peer-connection metric; rtt_ms is a mean over ping
+# round trips. A connection that came up while every ping timed out reports
+# "Excellent" beside 0.0ms over 0 samples, and "Excellent" is not falsy, not
+# _NO_QUALITY and not degraded, so the gate fell through to PASS.
+# ---------------------------------------------------------------------------
+
+
+def _baseline(rtt: float, samples: int, quality: str = "Excellent") -> dict:
+    """A baseline as ``service.sfu`` publishes it, with its sample count."""
+    return {
+        "rtt_ms": rtt,
+        "loss_pct": 0.0,
+        "quality": quality,
+        "samples": samples,
+        "rtt_stat": "mean_of_n" if samples else "not_measured",
+    }
+
+
+def test_an_excellent_baseline_where_every_ping_timed_out_does_not_pass():
+    """The bug F6 removed from the ramp, still live in the baseline gate."""
+    gate = gates.sfu_quality_gate(_baseline(0.0, 0))
+    assert gate.status == gates.UNKNOWN
+    assert gate.status != gates.PASS
+    assert "measured nothing" in gate.detail
+    assert "samples 0" in gate.detail
+    # The 0.0 is the mean of an empty list, so it is never printed as a time.
+    assert "rtt 0.0ms" not in gate.detail
+    # Nothing decided it, so no metric is claimed.
+    assert gate.metric is None and gate.value is None
+    # UNKNOWN is not the soft option: the run still exits non-zero.
+    assert gates.exit_code(gates.verdict([gate])) == 1
+
+
+def test_a_measured_baseline_passes_exactly_as_before():
+    gate = gates.sfu_quality_gate(_baseline(11.0, 2))
+    assert gate.status == gates.PASS
+    assert gate.detail == "SFU baseline connection quality is Excellent (rtt 11.0ms)"
+    assert gate.metric == "sfu_baseline_quality"
+    # A single round trip is still a round trip.
+    assert gates.sfu_quality_gate(_baseline(11.0, 1)).status == gates.PASS
+
+
+def test_a_degraded_baseline_that_measured_no_rtt_is_still_a_failure():
+    """Matches the ramp: Poor/Lost is an observation, an absent rtt is not.
+
+    ``sfu_capacity_gate`` FAILs an unmeasured tier that reported Poor rather
+    than calling it UNKNOWN, and the two gates read the same probe, so they
+    answer the same way. Its 0.0ms is not a reading either way, so it is not
+    printed as one.
+    """
+    for quality in ("Poor", "Lost"):
+        gate = gates.sfu_quality_gate(_baseline(0.0, 0, quality))
+        assert gate.status == gates.FAIL, quality
+        assert f"quality is {quality}" in gate.detail
+        assert "no rtt reading" in gate.detail
+        assert "rtt 0.0ms" not in gate.detail
+    # And a degraded baseline that DID measure still prints its rtt.
+    assert "rtt 90.0ms" in gates.sfu_quality_gate(_baseline(90.0, 2, "Poor")).detail
+
+
+def test_a_baseline_from_an_older_run_without_a_sample_count_is_not_mislabelled():
+    """Absent is not zero: archived runs must not all turn UNKNOWN."""
+    legacy = {"rtt_ms": 11.0, "loss_pct": 0.0, "quality": "Excellent"}
+    assert "samples" not in legacy
+    assert gates.sfu_quality_gate(legacy).status == gates.PASS
+
+    degraded = {"rtt_ms": 90.0, "loss_pct": 0.0, "quality": "Poor"}
+    assert gates.sfu_quality_gate(degraded).status == gates.FAIL
+
+    # With no count to key on, the number itself decides, under the same rule
+    # _has_measurement applies to reply latency: an rtt of 0.0 through an SFU is
+    # not a time, so a legacy total failure must not read as a fast one either.
+    dead = {"rtt_ms": 0.0, "loss_pct": 0.0, "quality": "Excellent"}
+    gate = gates.sfu_quality_gate(dead)
+    assert gate.status == gates.UNKNOWN
+    assert "no sample count" in gate.detail
+    assert gate.value is None
+
+    # A legacy baseline with no rtt key at all is not a 0.0 either.
+    assert gates.sfu_quality_gate({"quality": "Excellent"}).status == gates.UNKNOWN
+    # ... and a null rtt does not raise on the way there.
+    assert (
+        gates.sfu_quality_gate({"quality": "Excellent", "rtt_ms": None}).status
+        == gates.UNKNOWN
+    )
+
+
+def test_an_unusable_baseline_sample_count_falls_back_instead_of_crashing():
+    """A null or junk ``samples`` is no count at all, not a count of zero."""
+    for junk in (None, "", "abc", [], {}):
+        alive = {"rtt_ms": 11.0, "quality": "Excellent", "samples": junk}
+        assert gates.sfu_quality_gate(alive).status == gates.PASS  # 11.0 is a reading
+
+        dead = {"rtt_ms": 0.0, "quality": "Excellent", "samples": junk}
+        assert gates.sfu_quality_gate(dead).status == gates.UNKNOWN
+
+    # A count that is a string of digits is still a count.
+    counted = {"rtt_ms": 11.0, "quality": "Excellent", "samples": "3"}
+    assert gates.sfu_quality_gate(counted).status == gates.PASS
+
+
+def test_an_unmeasured_baseline_is_unknown_through_the_whole_run():
+    checks = {
+        "sfu_load": {
+            "ok": True,
+            "result": {
+                # The connection was fine; not one ping came back.
+                "baseline": _baseline(0.0, 0),
+                "ramp": [_measured(2, 11.0, 3)],
+                "target_rtt_ms": 50.0,
+                "resource": None,
+            },
+        }
+    }
+    results = gates.evaluate_checks(checks, 1500.0)
+    quality = [g for g in results if g.gate == gates.SFU_QUALITY_GATE]
+    assert [g.status for g in quality] == [gates.UNKNOWN]
+    # The ramp still measured something, so this is the baseline's verdict alone.
+    assert [g.status for g in results if g.gate == gates.SFU_CAPACITY_GATE] == [
+        gates.PASS
+    ]
+    assert gates.verdict(results) != gates.PASS
+
+    import json
+
+    for gate in results:
+        json.loads(json.dumps(gate.as_dict()))

--- a/src/voicegateway/tests/livekit_diag/test_gates.py
+++ b/src/voicegateway/tests/livekit_diag/test_gates.py
@@ -271,7 +271,13 @@ def test_a_ramp_that_broke_at_the_first_tier_fails():
 def test_a_ramp_that_never_broke_passes():
     from voicegateway.livekit_diag.sfu import RampStep, find_knee
 
-    steps = [RampStep(2, 11.0, 0.0, "Excellent"), RampStep(10, 14.0, 0.0, "Excellent")]
+    # The sample counts keep this None meaning "every tier was measured and
+    # stayed in budget". Drop them and the walk stops at tier one for lack of
+    # evidence, which is the same None for the opposite reason.
+    steps = [
+        RampStep(2, 11.0, 0.0, "Excellent", 2),
+        RampStep(10, 14.0, 0.0, "Excellent", 10),
+    ]
     assert find_knee(steps, 50.0, 1.0) is None  # same None, opposite outcome
 
     gate = gates.sfu_capacity_gate([_step(2, 11.0), _step(10, 14.0)], 50.0, None)

--- a/src/voicegateway/tests/livekit_diag/test_gates.py
+++ b/src/voicegateway/tests/livekit_diag/test_gates.py
@@ -307,6 +307,145 @@ def test_a_ramp_with_no_steps_or_no_threshold_is_unknown():
 
 
 # ---------------------------------------------------------------------------
+# A ramp that measured nothing: 0.0ms is under every budget
+# ---------------------------------------------------------------------------
+
+
+def _measured(
+    clients: int, rtt: float, samples: int, quality: str = "Excellent"
+) -> dict:
+    """A step as ``service.sfu`` publishes it, with its sample count."""
+    return {
+        "clients": clients,
+        "rtt_ms": rtt,
+        "loss_pct": 0.0,
+        "quality": quality,
+        "samples": samples,
+        "rtt_stat": "mean_of_n" if samples else "not_measured",
+    }
+
+
+def _timed_out(clients: int, quality: str = "Unknown") -> dict:
+    """The step a tier reports when not one ping came back."""
+    return _measured(clients, 0.0, 0, quality)
+
+
+def test_a_ramp_where_every_ping_timed_out_does_not_pass():
+    """The mirror image of a healthy server reading FAIL, and worse.
+
+    ``0.0 > target`` is False and ``Unknown`` is not in _DEGRADED_QUALITY, so
+    this ramp used to satisfy the gate and report PASS: a monitoring tool
+    telling an operator that a server it could not reach at all is fine.
+    """
+    ramp = [_timed_out(2), _timed_out(10)]
+    gate = gates.sfu_capacity_gate(ramp, 50.0, None)
+    assert gate.status == gates.UNKNOWN
+    assert gate.status != gates.PASS
+    assert "measured nothing" in gate.detail
+    assert "samples 0" in gate.detail
+    # Nothing decided it, so no number is published: a value of 0.0 here is the
+    # placeholder that caused the bug, not a reading.
+    assert gate.metric is None and gate.value is None
+    assert gate.threshold == 50.0
+    # UNKNOWN is not the soft option: the run still exits non-zero.
+    assert gates.exit_code(gates.verdict([gate])) == 1
+
+
+def test_an_unmeasured_ramp_is_unknown_through_the_whole_run():
+    checks = {
+        "sfu_load": {
+            "ok": True,
+            "result": {
+                "baseline": {"rtt_ms": 0.0, "loss_pct": 0.0, "quality": "Unknown"},
+                "ramp": [_timed_out(2), _timed_out(10)],
+                "target_rtt_ms": 50.0,
+                "resource": None,
+            },
+        }
+    }
+    results = gates.evaluate_checks(checks, 1500.0)
+    capacity = [g for g in results if g.gate == gates.SFU_CAPACITY_GATE]
+    assert [g.status for g in capacity] == [gates.UNKNOWN]
+    assert gates.verdict(results) != gates.PASS
+
+    import json
+
+    for gate in results:
+        json.loads(json.dumps(gate.as_dict()))
+
+
+def test_a_partially_measured_tier_is_judged_on_what_it_measured():
+    """Some pongs back is a measurement; the budget for it is unchanged."""
+    healthy = gates.sfu_capacity_gate([_measured(10, 11.0, 3)], 50.0, None)
+    assert healthy.status == gates.PASS
+    assert healthy.value == 11.0
+
+    slow = gates.sfu_capacity_gate([_measured(10, 90.0, 3)], 50.0, None)
+    assert slow.status == gates.FAIL
+    assert slow.value == 90.0
+
+
+def test_a_degraded_tier_that_measured_no_rtt_is_still_a_failure():
+    """Poor is an observation. Its companion 0.0ms is not, so it is not shown."""
+    gate = gates.sfu_capacity_gate([_timed_out(2, "Poor")], 50.0, None)
+    assert gate.status == gates.FAIL
+    assert "quality Poor" in gate.detail
+    assert "no rtt reading" in gate.detail
+    assert "rtt 0.0ms" not in gate.detail
+    assert gate.value is None
+
+
+def test_a_step_from_an_older_run_without_a_sample_count_is_not_mislabelled():
+    """Absent is not zero: archived ramps must not all turn UNKNOWN.
+
+    ``_step`` is the pre-``samples`` shape, which is what every stored run made
+    before the count existed looks like.
+    """
+    assert "samples" not in _step(2, 11.0)
+    healthy = gates.sfu_capacity_gate([_step(2, 11.0), _step(10, 14.0)], 50.0, None)
+    assert healthy.status == gates.PASS
+    assert healthy.value == 11.0
+
+    breached = gates.sfu_capacity_gate([_step(2, 90.0, "Poor")], 50.0, None)
+    assert breached.status == gates.FAIL
+
+    # With no count to key on, the number itself decides, under the same rule
+    # _has_measurement applies to reply latency: an rtt of 0.0 through an SFU is
+    # not a time. A legacy total failure must not read as a fast one either.
+    dead = gates.sfu_capacity_gate([_step(2, 0.0, "Unknown")], 50.0, None)
+    assert dead.status == gates.UNKNOWN
+    assert "no sample count" in dead.detail
+
+    # ... including when the connection quality read fine and only the pings
+    # never came back.
+    quiet = gates.sfu_capacity_gate([_step(2, 0.0, "Excellent")], 50.0, None)
+    assert quiet.status == gates.UNKNOWN
+    assert quiet.value is None
+
+    # A legacy step with no rtt key at all is not a 0.0 either.
+    no_rtt = gates.sfu_capacity_gate([{"clients": 2, "quality": "Excellent"}], 50.0, None)
+    assert no_rtt.status == gates.UNKNOWN
+
+
+def test_an_unusable_sample_count_falls_back_instead_of_crashing():
+    """A null or junk ``samples`` is no count at all, not a count of zero."""
+    for junk in (None, "", "abc", [], {}):
+        step = dict(_step(2, 11.0))
+        step["samples"] = junk
+        gate = gates.sfu_capacity_gate([step], 50.0, None)
+        assert gate.status == gates.PASS  # rtt 11.0 is still a reading
+
+        dead = dict(_step(2, 0.0, "Unknown"))
+        dead["samples"] = junk
+        assert gates.sfu_capacity_gate([dead], 50.0, None).status == gates.UNKNOWN
+
+    # A count that is a string of digits is still a count.
+    counted = dict(_step(2, 11.0))
+    counted["samples"] = "3"
+    assert gates.sfu_capacity_gate([counted], 50.0, None).status == gates.PASS
+
+
+# ---------------------------------------------------------------------------
 # The whole-run shape
 # ---------------------------------------------------------------------------
 

--- a/src/voicegateway/tests/livekit_diag/test_service.py
+++ b/src/voicegateway/tests/livekit_diag/test_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+from voicegateway.livekit_diag import gates
 from voicegateway.livekit_diag import service as probes
 from voicegateway.livekit_diag.config import LiveKitCreds
 from voicegateway.livekit_diag.resources import ResourceReport
@@ -294,3 +295,81 @@ def test_resource_json_reports_unsampled_metrics_as_none():
 
 def test_resource_json_is_none_without_a_report():
     assert probes._resource_json(None) is None
+
+
+# ---------------------------------------------------------------------------
+# What rtt_ms IS travels with it: a tier that measured nothing says so
+# ---------------------------------------------------------------------------
+
+
+class _MixedSfuProbe:
+    """A ramp with one measured tier and one where every ping timed out."""
+
+    def __init__(self, admin, client_factory, monitor) -> None:
+        pass
+
+    async def baseline(self, room, seconds: float = 10.0):
+        return RampStep(2, 11.4, 0.0, "Excellent", 2)
+
+    async def ramp(self, room, steps, duration, target_rtt_ms, max_loss, **kwargs):
+        return (
+            [
+                RampStep(2, 12.0, 0.0, "Excellent", 2),
+                # 10 clients, not one pong back: rtt_ms 0.0 is the placeholder
+                # mean of an empty list, and quality has nothing to read.
+                RampStep(10, 0.0, 0.0, "Unknown", 0),
+            ],
+            None,
+        )
+
+
+class _AllTimedOutSfuProbe:
+    """Every tier timed out: the ramp that used to report a clean PASS."""
+
+    def __init__(self, admin, client_factory, monitor) -> None:
+        pass
+
+    async def baseline(self, room, seconds: float = 10.0):
+        return RampStep(2, 0.0, 0.0, "Unknown", 0)
+
+    async def ramp(self, room, steps, duration, target_rtt_ms, max_loss, **kwargs):
+        return (
+            [RampStep(2, 0.0, 0.0, "Unknown", 0), RampStep(10, 0.0, 0.0, "Unknown", 0)],
+            None,
+        )
+
+
+async def test_ramp_steps_publish_the_sample_count_behind_rtt(monkeypatch):
+    """0.0ms and 12.0ms are both floats; only ``samples`` says which is a reading."""
+    import json
+
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(SfuProbe=_MixedSfuProbe))
+    out = await probes.RealProbes().sfu(_CREDS, True, probes.clamp_config({}))
+
+    assert [s["samples"] for s in out["ramp"]] == [2, 0]
+    assert [s["rtt_stat"] for s in out["ramp"]] == ["mean_of_n", "not_measured"]
+    # Runs are persisted and re-read, so the honesty has to survive the JSON.
+    assert json.loads(json.dumps(out))["ramp"] == out["ramp"]
+
+
+async def test_a_measured_smallest_tier_still_passes_through_the_payload(monkeypatch):
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(SfuProbe=_MixedSfuProbe))
+    out = await probes.RealProbes().sfu(_CREDS, True, probes.clamp_config({}))
+
+    gate = gates.sfu_capacity_gate(
+        out["ramp"], out["target_rtt_ms"], out["resource"]
+    )
+    assert gate.status == gates.PASS  # 12.0ms of 2 real round-trips, budget 50ms
+
+
+async def test_a_ramp_that_measured_nothing_does_not_pass_the_capacity_gate(monkeypatch):
+    """End to end: the probe's own payload, fed to the gate that reads it."""
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(SfuProbe=_AllTimedOutSfuProbe))
+    out = await probes.RealProbes().sfu(_CREDS, True, probes.clamp_config({}))
+
+    assert [s["rtt_stat"] for s in out["ramp"]] == ["not_measured", "not_measured"]
+    gate = gates.sfu_capacity_gate(
+        out["ramp"], out["target_rtt_ms"], out["resource"]
+    )
+    assert gate.status == gates.UNKNOWN
+    assert gates.exit_code(gates.verdict([gate])) == 1

--- a/src/voicegateway/tests/livekit_diag/test_service.py
+++ b/src/voicegateway/tests/livekit_diag/test_service.py
@@ -164,8 +164,8 @@ class _FakeSfuProbe:
     async def ramp(self, room, steps, duration, target_rtt_ms, max_loss, **kwargs):
         return (
             [
-                RampStep(2, 12.0, 0.0, "Excellent"),
-                RampStep(10, 61.0, 0.0, "Poor"),
+                RampStep(2, 12.0, 0.0, "Excellent", 2),
+                RampStep(10, 61.0, 0.0, "Poor", 10),
             ],
             ResourceReport(
                 cpu_peak=91.2,
@@ -262,7 +262,17 @@ async def test_sfu_baseline_only_has_no_ramp_and_no_resource(monkeypatch):
     assert out["ramp"] == []
     assert out["knee"] is None
     assert out["resource"] is None
-    assert out["baseline"] == {"rtt_ms": 11.4, "loss_pct": 0.0, "quality": "Excellent"}
+    # _FakeSfuProbe builds its baseline RampStep without a sample count, so the
+    # dataclass default of 0 travels: a hand-built step is not credited with
+    # evidence it does not carry, and rtt_stat says so rather than implying the
+    # 11.4 came from somewhere.
+    assert out["baseline"] == {
+        "rtt_ms": 11.4,
+        "loss_pct": 0.0,
+        "quality": "Excellent",
+        "samples": 0,
+        "rtt_stat": "not_measured",
+    }
 
 
 def test_resource_json_reports_unsampled_metrics_as_none():
@@ -372,4 +382,65 @@ async def test_a_ramp_that_measured_nothing_does_not_pass_the_capacity_gate(monk
         out["ramp"], out["target_rtt_ms"], out["resource"]
     )
     assert gate.status == gates.UNKNOWN
+    assert gates.exit_code(gates.verdict([gate])) == 1
+
+
+# ---------------------------------------------------------------------------
+# The same, for the BASELINE: its quality and its rtt are separate readings
+# ---------------------------------------------------------------------------
+
+
+class _SilentPingSfuProbe:
+    """The connection came up; not one ping came back.
+
+    ``quality`` is the SDK's own peer-connection metric, so it reads
+    ``Excellent``; ``rtt_ms`` is a mean over round trips, so it is the 0.0 of an
+    empty list. This is the pair that used to satisfy ``sfu_quality_gate``.
+    """
+
+    def __init__(self, admin, client_factory, monitor) -> None:
+        pass
+
+    async def baseline(self, room, seconds: float = 10.0):
+        return RampStep(2, 0.0, 0.0, "Excellent", 0)
+
+    async def ramp(self, room, steps, duration, target_rtt_ms, max_loss, **kwargs):
+        return [], None
+
+
+async def test_the_baseline_publishes_the_sample_count_behind_its_rtt(monkeypatch):
+    """Without it, 'Excellent, rtt 0.0ms' is indistinguishable from a fast SFU."""
+    import json
+
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(SfuProbe=_MixedSfuProbe))
+    out = await probes.RealProbes().sfu(_CREDS, False, probes.clamp_config({}))
+
+    assert out["baseline"]["samples"] == 2
+    assert out["baseline"]["rtt_stat"] == "mean_of_n"
+    # Runs are persisted and re-read, so the honesty has to survive the JSON.
+    assert json.loads(json.dumps(out))["baseline"] == out["baseline"]
+
+
+async def test_a_measured_baseline_still_passes_the_quality_gate(monkeypatch):
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(SfuProbe=_MixedSfuProbe))
+    out = await probes.RealProbes().sfu(_CREDS, False, probes.clamp_config({}))
+
+    gate = gates.sfu_quality_gate(out["baseline"])
+    assert gate.status == gates.PASS  # Excellent over 2 real round-trips
+    assert "rtt 11.4ms" in gate.detail
+
+
+async def test_an_excellent_baseline_that_measured_nothing_does_not_pass(monkeypatch):
+    """End to end: the probe's own payload, fed to the gate that reads it."""
+    monkeypatch.setattr(
+        probes, "_diag_cache", _fake_diag(SfuProbe=_SilentPingSfuProbe)
+    )
+    out = await probes.RealProbes().sfu(_CREDS, False, probes.clamp_config({}))
+
+    assert out["baseline"]["quality"] == "Excellent"  # the SDK really said this
+    assert out["baseline"]["rtt_stat"] == "not_measured"
+    gate = gates.sfu_quality_gate(out["baseline"])
+    assert gate.status == gates.UNKNOWN
+    assert gate.status != gates.PASS
+    assert "rtt 0.0ms" not in gate.detail
     assert gates.exit_code(gates.verdict([gate])) == 1

--- a/src/voicegateway/tests/livekit_diag/test_sfu.py
+++ b/src/voicegateway/tests/livekit_diag/test_sfu.py
@@ -25,9 +25,9 @@ WARM_MS = 26.0
 
 def test_find_knee_at_first_threshold_break():
     steps = [
-        RampStep(10, 5.0, 0.0, "Excellent"),
-        RampStep(25, 9.0, 0.1, "Good"),
-        RampStep(50, 22.0, 1.4, "Poor"),
+        RampStep(10, 5.0, 0.0, "Excellent", 10),
+        RampStep(25, 9.0, 0.1, "Good", 25),
+        RampStep(50, 22.0, 1.4, "Poor", 50),
     ]
     assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) == 25  # last good before break
 
@@ -35,6 +35,77 @@ def test_find_knee_at_first_threshold_break():
 def test_find_knee_none_when_all_healthy():
     steps = [RampStep(10, 4.0, 0.0, "Excellent"), RampStep(25, 6.0, 0.0, "Good")]
     assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) is None
+
+
+# --- the knee walk stops where the evidence stops ---------------------------
+#
+# A tier that measured nothing reports rtt_ms 0.0 (the mean of an empty list),
+# and 0.0 is inside every budget, so the walk used to sail straight through it.
+# This is the single-host twin of the multi-vantage walk in
+# distributed.aggregate_vantages, which stops at an unmeasured tier for the same
+# reason; the two SFU modes must not disagree about the same server.
+
+
+def test_find_knee_stops_at_a_step_that_measured_nothing():
+    """Measured up to 25 clients, then not one ping came back at 50.
+
+    The old walk read the 50-client tier's placeholder 0.0 as comfortably inside
+    budget, ran off the end of the ramp and returned None, which is the value
+    that means "sustained the whole ramp". Capacity now ends at the last tier
+    that actually demonstrated it.
+    """
+    steps = [
+        RampStep(10, 5.0, 0.0, "Excellent", 10),
+        RampStep(25, 9.0, 0.1, "Good", 25),
+        RampStep(50, 0.0, 0.0, "Unknown", 0),
+    ]
+    assert steps[2].rtt_stat == NOT_MEASURED
+    assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) == 25
+
+
+def test_an_all_unmeasured_ramp_is_not_reported_as_sustaining_the_ramp():
+    """A completely dead SFU: every ping of every tier timed out.
+
+    ``knee`` is a published ``int | None`` that callers and stored runs read, so
+    it cannot grow a third value meaning "I measured nothing" and this stays
+    None. What changed is underneath it: the walk stops at the first tier
+    instead of crediting each placeholder 0.0 as sustained on its way to that
+    None, so no tier of a dead ramp is ever the answer (see the mixed-ramp test
+    above, where the difference is visible in the return value).
+
+    ``rtt_stat`` is the evidence that tells this None from a clean ramp's None.
+    It travels with the steps into the published payload, and
+    ``gates.sfu_capacity_gate`` is what reads it: None alone is never health.
+    """
+    steps = [RampStep(n, 0.0, 0.0, "Unknown", 0) for n in (2, 10, 25)]
+
+    assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) is None
+    assert [s.rtt_stat for s in steps] == [NOT_MEASURED] * 3
+
+
+def test_a_fully_measured_healthy_ramp_returns_none_exactly_as_before():
+    """Regression: a real clean ramp is unaffected by the unmeasured guard."""
+    steps = [
+        RampStep(10, 4.0, 0.0, "Excellent", 10),
+        RampStep(25, 6.0, 0.0, "Good", 25),
+    ]
+    assert [s.rtt_stat for s in steps] == [MEAN_OF_N, MEAN_OF_N]
+    assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) is None
+
+
+def test_a_measured_breach_still_returns_the_last_healthy_count():
+    """Regression: a step that DID measure is judged against the same budget.
+
+    Same ramp, same thresholds and same answer as
+    ``test_find_knee_at_first_threshold_break``; only the loss threshold breaks
+    here, to pin that ``max_loss`` was not disturbed either.
+    """
+    steps = [
+        RampStep(10, 5.0, 0.0, "Excellent", 10),
+        RampStep(25, 9.0, 0.1, "Good", 25),
+        RampStep(50, 9.5, 1.4, "Good", 50),
+    ]
+    assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) == 25
 
 
 class _FakeAdmin:

--- a/src/voicegateway/tests/livekit_diag/test_sfu.py
+++ b/src/voicegateway/tests/livekit_diag/test_sfu.py
@@ -1,5 +1,12 @@
+import contextlib
+import logging
+from collections.abc import Iterator
 from typing import Any
 
+from voicegateway.livekit_diag.client import (
+    SyntheticClient,
+    quiet_livekit_teardown_noise,
+)
 from voicegateway.livekit_diag.sfu import (
     MEAN_OF_N,
     NOT_MEASURED,
@@ -189,3 +196,123 @@ async def test_ramp_tiers_are_not_dominated_by_setup_cost():
     assert rtts[0] < unwarmed_smallest_tier / 2
     # Every client of every tier was warmed exactly once and measured once.
     assert {c.pings for c in made} == {2}
+
+
+# --- teardown log noise -----------------------------------------------------
+#
+# A probe run tears down ~40 synthetic clients, and the rtc SDK reports each
+# shutdown through logging.getLogger("livekit") at ERROR. Those lines make a
+# healthy run look broken. They are demoted to DEBUG, and only while a teardown
+# is in flight; see client.quiet_livekit_teardown_noise.
+
+
+class _CapturingHandler(logging.Handler):
+    """Records what a handler at a given level would actually emit."""
+
+    def __init__(self, level: int) -> None:
+        super().__init__(level=level)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@contextlib.contextmanager
+def _capture(level: int) -> Iterator[_CapturingHandler]:
+    handler = _CapturingHandler(level)
+    root = logging.getLogger()
+    previous = root.level
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)  # let the record reach the handler's own level
+    try:
+        yield handler
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(previous)
+
+
+def test_teardown_noise_is_demoted_not_shown_at_error():
+    sdk = logging.getLogger("livekit")
+    with _capture(logging.WARNING) as handler:
+        with quiet_livekit_teardown_noise():
+            sdk.error("livekit::room:412:rtc_engine - failed to close data channel")
+
+    # A default (WARNING) handler sees nothing: the run stops looking broken.
+    assert handler.records == []
+
+
+def test_demoted_teardown_noise_is_still_visible_at_debug():
+    sdk = logging.getLogger("livekit")
+    with _capture(logging.DEBUG) as handler:
+        with quiet_livekit_teardown_noise():
+            sdk.error("livekit::room:412:rtc_engine - failed to close data channel")
+
+    # Demoted, never discarded, and it still says what it was demoted from.
+    assert [r.getMessage() for r in handler.records] == [
+        "livekit::room:412:rtc_engine - failed to close data channel"
+    ]
+    assert handler.records[0].levelno == logging.DEBUG
+    assert handler.records[0].__dict__["vg_demoted_from"] == "ERROR"
+
+
+def test_livekit_error_outside_teardown_is_still_an_error():
+    """The suppression is a window, not a mute. This is the whole safety margin:
+    a genuine connect/ping/measurement failure is what the probe exists to show.
+    """
+    sdk = logging.getLogger("livekit")
+    with _capture(logging.ERROR) as handler:
+        with quiet_livekit_teardown_noise():
+            pass  # window opened and closed
+        sdk.error("livekit::rtc_engine:88:signal_client - connection refused")
+
+    assert [r.levelno for r in handler.records] == [logging.ERROR]
+    assert "connection refused" in handler.records[0].getMessage()
+
+
+def test_child_logger_errors_are_untouched_during_teardown():
+    """An embedded agent logs to ``livekit.agents``. A filter on a logger only
+    sees records logged through that exact logger, so the child never passes
+    through this one even while the window is open.
+    """
+    agent_log = logging.getLogger("livekit.agents")
+    with _capture(logging.ERROR) as handler:
+        with quiet_livekit_teardown_noise():
+            agent_log.error("agent failed to start")
+
+    assert [r.levelno for r in handler.records] == [logging.ERROR]
+
+
+def test_non_error_levels_are_left_alone_during_teardown():
+    sdk = logging.getLogger("livekit")
+    with _capture(logging.WARNING) as handler:
+        with quiet_livekit_teardown_noise():
+            sdk.warning("livekit::room:412 - reconnecting")
+            sdk.critical("livekit::ffi:1 - unrecoverable")
+
+    assert [r.levelno for r in handler.records] == [logging.WARNING, logging.CRITICAL]
+
+
+async def test_disconnect_opens_the_quiet_window():
+    """Pins the wiring, not just the filter: it is ``SyntheticClient.disconnect``
+    that opens the window, so the SDK's teardown ERROR lands inside it.
+    """
+
+    class _NoisyRoom:
+        def __init__(self) -> None:
+            self.disconnected = False
+
+        async def disconnect(self) -> None:
+            logging.getLogger("livekit").error(
+                "livekit::room:412:rtc_engine - peer connection closed"
+            )
+            self.disconnected = True
+
+    client = SyntheticClient.__new__(SyntheticClient)
+    client._silence_task = None
+    client._room = _NoisyRoom()  # type: ignore[assignment]
+
+    with _capture(logging.WARNING) as handler:
+        await client.disconnect()
+
+    assert client._room.disconnected  # type: ignore[attr-defined]
+    assert handler.records == []

--- a/src/voicegateway/tests/livekit_diag/test_sfu.py
+++ b/src/voicegateway/tests/livekit_diag/test_sfu.py
@@ -33,7 +33,13 @@ def test_find_knee_at_first_threshold_break():
 
 
 def test_find_knee_none_when_all_healthy():
-    steps = [RampStep(10, 4.0, 0.0, "Excellent"), RampStep(25, 6.0, 0.0, "Good")]
+    # Sample counts are load-bearing: without them these steps default to
+    # samples 0, the walk stops at the first tier for lack of evidence, and the
+    # None below arrives for the opposite reason to the one this test names.
+    steps = [
+        RampStep(10, 4.0, 0.0, "Excellent", 10),
+        RampStep(25, 6.0, 0.0, "Good", 25),
+    ]
     assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) is None
 
 

--- a/src/voicegateway/tests/livekit_diag/test_sfu.py
+++ b/src/voicegateway/tests/livekit_diag/test_sfu.py
@@ -1,4 +1,19 @@
-from voicegateway.livekit_diag.sfu import RampStep, find_knee
+from typing import Any
+
+from voicegateway.livekit_diag.sfu import (
+    MEAN_OF_N,
+    NOT_MEASURED,
+    RampStep,
+    SfuProbe,
+    find_knee,
+)
+
+# The CLI's default --target-rtt-ms, i.e. the budget the live run failed against.
+TARGET_RTT_MS = 50.0
+# Shaped like the live Hetzner run: the first data-channel message of a session
+# costs ~129ms (TLS/ICE/DTLS setup), every one after it ~26ms.
+COLD_MS = 129.3
+WARM_MS = 26.0
 
 
 def test_find_knee_at_first_threshold_break():
@@ -13,3 +28,164 @@ def test_find_knee_at_first_threshold_break():
 def test_find_knee_none_when_all_healthy():
     steps = [RampStep(10, 4.0, 0.0, "Excellent"), RampStep(25, 6.0, 0.0, "Good")]
     assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) is None
+
+
+class _FakeAdmin:
+    url = "ws://fake"
+
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+
+    def join_token(self, room: str, identity: str) -> str:
+        return f"{room}/{identity}"
+
+    async def delete_room(self, room: str) -> None:
+        self.deleted.append(room)
+
+
+class _FakeMonitor:
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    def report_for(self, clients: int) -> dict[str, int]:
+        return {"peak_clients": clients}
+
+
+class _ColdStartClient:
+    """A client whose FIRST ping pays the session's connection setup."""
+
+    def __init__(self, *, cold_ms: float = COLD_MS, warm_ms: float = WARM_MS) -> None:
+        self._cold_ms = cold_ms
+        self._warm_ms = warm_ms
+        self.pings = 0
+        self.connected = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def ping(self) -> float | None:
+        self.pings += 1
+        ms = self._cold_ms if self.pings == 1 else self._warm_ms
+        return ms / 1000.0
+
+    def quality(self) -> str:
+        return "Excellent"
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+
+class _SilentClient(_ColdStartClient):
+    """Connects, but no pong ever comes back: every ping times out."""
+
+    async def ping(self) -> float | None:
+        self.pings += 1
+        return None
+
+
+class _OneAnswersClient(_ColdStartClient):
+    """Only the client named ``c0`` answers; the rest time out."""
+
+    def __init__(self, identity: str) -> None:
+        super().__init__()
+        self._identity = identity
+
+    async def ping(self) -> float | None:
+        self.pings += 1
+        if self._identity != "c0":
+            return None
+        return WARM_MS / 1000.0
+
+
+def _probe(made: list[Any], factory=None) -> SfuProbe:
+    def default_factory(url: str, token: str) -> Any:
+        c = _ColdStartClient()
+        made.append(c)
+        return c
+
+    return SfuProbe(_FakeAdmin(), factory or default_factory, _FakeMonitor())
+
+
+async def test_baseline_excludes_the_cold_first_sample():
+    """The measured rtt is the steady state, not the setup-inflated first ping.
+
+    Before the warm-up, the two-client baseline averaged one cold ping with one
+    warm one and reported ~77.6ms against a 50ms budget on a ~26ms server.
+    """
+    made: list[Any] = []
+    step = await _probe(made).baseline("vg-t-baseline", seconds=0.0)
+
+    assert step.rtt_ms == WARM_MS
+    assert step.rtt_ms <= TARGET_RTT_MS
+    # One discarded warm-up ping plus one measured ping, per client.
+    assert [c.pings for c in made] == [2, 2]
+
+
+async def test_step_says_how_many_samples_it_averaged():
+    made: list[Any] = []
+    step = await _probe(made).baseline("vg-t-samples", seconds=0.0)
+
+    # The warm-up ping is discarded, so it is not counted as evidence.
+    assert step.samples == 2
+    assert step.rtt_stat == MEAN_OF_N
+
+
+async def test_step_with_no_returned_ping_is_not_measured():
+    """Nothing came back, so the step says so instead of naming a statistic.
+
+    ``rtt_ms`` cannot carry None without changing the field type that
+    gates/report/distributed read, so ``rtt_stat`` is what disambiguates a
+    placeholder from a reading.
+    """
+
+    def factory(url: str, token: str) -> Any:
+        return _SilentClient()
+
+    step = await _probe([], factory).baseline("vg-t-silent", seconds=0.0)
+
+    assert step.samples == 0
+    assert step.rtt_stat == NOT_MEASURED
+
+
+async def test_partially_answered_step_counts_only_the_pings_that_returned():
+    def factory(url: str, token: str) -> Any:
+        return _OneAnswersClient(token.rsplit("/", 1)[-1])
+
+    steps, _resource = await _probe([], factory).ramp(
+        "vg-t-partial", [4], 0.0, TARGET_RTT_MS, 1.0
+    )
+
+    # Three of the four clients never answered: the step is the mean of the one
+    # that did, and it says one, rather than passing a lone reading off as the
+    # tier's converged latency.
+    assert steps[0].samples == 1
+    assert steps[0].rtt_stat == MEAN_OF_N
+    assert steps[0].rtt_ms == WARM_MS
+
+
+async def test_ramp_tiers_are_not_dominated_by_setup_cost():
+    """The live run's tell: 129.3ms at 2 clients against 26.1/25.7 at 10/25.
+
+    More clients measuring faster is backwards for a capacity probe. With the
+    cold sample out of the measurement the tiers sit flat, and the smallest tier
+    (the only one sfu_capacity_gate reads) is inside the same budget it failed.
+    """
+    made: list[Any] = []
+    steps, _resource = await _probe(made).ramp(
+        "vg-t-ramp", [2, 10, 25], 0.0, TARGET_RTT_MS, 1.0
+    )
+
+    rtts = [s.rtt_ms for s in steps]
+    assert [s.clients for s in steps] == [2, 10, 25]
+    assert [s.samples for s in steps] == [2, 10, 25]
+    assert max(rtts) <= 1.2 * min(rtts)  # flat across tiers, not 5x at the smallest
+    assert all(rtt <= TARGET_RTT_MS for rtt in rtts)
+    # Control: the un-warmed two-client tier is what breached the budget.
+    unwarmed_smallest_tier = (COLD_MS + WARM_MS) / 2
+    assert unwarmed_smallest_tier > TARGET_RTT_MS
+    assert rtts[0] < unwarmed_smallest_tier / 2
+    # Every client of every tier was warmed exactly once and measured once.
+    assert {c.pings for c in made} == {2}

--- a/src/voicegateway/tests/server/test_metrics_endpoint.py
+++ b/src/voicegateway/tests/server/test_metrics_endpoint.py
@@ -134,3 +134,60 @@ async def test_metrics_summary_rejects_out_of_range_days(client) -> None:
     assert resp.status_code == 422
     resp = await client.get("/api/metrics?days=1000")
     assert resp.status_code == 422
+
+
+# --------------------------------------------------------------------
+# Prometheus exposition types on GET /v1/metrics
+# --------------------------------------------------------------------
+
+
+def _types(text: str) -> dict[str, str]:
+    """``{series: type}`` from the ``# TYPE`` lines of an exposition body."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        if line.startswith("# TYPE "):
+            _, _, name, kind = line.split(" ", 3)
+            out[name] = kind
+    return out
+
+
+def _help(text: str, series: str) -> str:
+    """The HELP text published for ``series``."""
+    prefix = f"# HELP {series} "
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :]
+    raise AssertionError(f"no HELP line for {series}")
+
+
+async def test_rolling_window_series_are_gauges_not_counters(client) -> None:
+    """A trailing-24h sum is a gauge, and must not be typed as a counter.
+
+    Both series come from the ``"today"`` window, which
+    ``cost_repository.period_since`` defines as ``time.time() - 86400``. That
+    window rolls, so the value falls whenever a request ages off the trailing
+    edge. Typing it ``counter`` promises Prometheus the opposite, and
+    ``rate()`` / ``increase()`` then read every decrease as a counter reset and
+    invent traffic that never happened.
+    """
+    resp = await client.get("/v1/metrics")
+    assert resp.status_code == 200
+    types = _types(resp.text)
+
+    assert types["voicegw_cost_usd_total"] == "gauge"
+    assert types["voicegw_requests_total"] == "gauge"
+    # The names are published in docs/api/http-api.md and docs/reference/faq.md
+    # as things operators graph. Renaming them is a breaking contract change, so
+    # the (wrong) _total suffix stays and only the type metadata is corrected.
+    assert "voicegw_cost_usd_total" in resp.text
+    assert "voicegw_requests_total" in resp.text
+
+
+async def test_rolling_window_help_text_names_the_window(client) -> None:
+    """HELP must say trailing 24h: "today" reads as a calendar day otherwise."""
+    resp = await client.get("/v1/metrics")
+    for series in ("voicegw_cost_usd_total", "voicegw_requests_total"):
+        help_text = _help(resp.text, series)
+        assert "ROLLING" in help_text
+        assert "24 hours" in help_text
+        assert "not a calendar day" in help_text

--- a/src/voicegateway/tests/services/test_retention_calls.py
+++ b/src/voicegateway/tests/services/test_retention_calls.py
@@ -330,3 +330,189 @@ async def test_null_out_and_delete_commit_together(storage) -> None:
     assert await _count(storage, "calls", "id = :i", {"i": doomed}) == 1
     assert await _count(storage, "call_legs", "call_id = :i", {"i": doomed}) == 1
     assert await _session_call_id(storage, "sess-atomic") == doomed
+
+
+# ---- requests.session_id must not outlive the session it names -------------
+#
+# The same defect one level down, which is why it is pinned next to the section
+# above rather than with the request-clock tests: a request prunes on its own
+# ``timestamp`` while a session prunes on ``ended_at``, so the session pass
+# would otherwise leave the pointer aimed at a deleted row. Unlike
+# ``sessions.call_id`` this pointer has NO read-time guard, because no read
+# joins ``requests`` to ``sessions`` at all: nulling at the source is the whole
+# defence, not the belt half of belt-and-braces.
+
+
+_INSERT_REQUEST = text(
+    "INSERT INTO requests "
+    "(id, timestamp, project, modality, model_id, provider, cost_usd, "
+    " session_id, tenant_id) "
+    "VALUES (:id, :ts, :project, 'llm', 'openai/gpt-4o-mini', 'openai', 0.0, "
+    "        :session_id, :tenant)"
+)
+
+
+async def _seed_request(
+    storage,
+    request_id: str,
+    project: str,
+    session_id: str | None,
+    tenant: str | None = None,
+    days_ago: float = 1.0,
+) -> None:
+    """Insert a request that survives the requests pass but names a session.
+
+    ``days_ago`` defaults inside every retention window used here, so the
+    request itself is never the thing being pruned: the session is. Inserted
+    raw rather than through ``log_request`` because that path upserts a
+    ``sessions`` row for the id it is handed, which would fabricate the very
+    row these tests need to control the age of.
+    """
+    ts = (datetime.now(UTC) - timedelta(days=days_ago)).timestamp()
+    async with storage._conn.session() as db:
+        await db.execute(
+            _INSERT_REQUEST,
+            {
+                "id": request_id,
+                "ts": ts,
+                "project": project,
+                "session_id": session_id,
+                "tenant": tenant,
+            },
+        )
+        await db.commit()
+
+
+async def _request_session_id(storage, request_id: str) -> str | None:
+    """The stored pointer. Asserts the row still exists, so a nulled pointer is
+    never confused with a deleted request."""
+    async with storage._conn.session() as db:
+        row = (
+            await db.execute(
+                text("SELECT session_id FROM requests WHERE id = :i"), {"i": request_id}
+            )
+        ).fetchone()
+    assert row is not None, f"request {request_id} was deleted, not repointed"
+    return row[0]
+
+
+async def test_pruned_session_nulls_the_request_pointer(storage) -> None:
+    await _seed_session(storage, "s-req-doomed", "acme", call_id=None, ended_days_ago=10)
+    await _seed_request(storage, "r-keeps", "acme", session_id="s-req-doomed")
+
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+
+    assert await _count(storage, "sessions", "id = :i", {"i": "s-req-doomed"}) == 0
+    assert await _request_session_id(storage, "r-keeps") is None
+
+
+async def test_surviving_session_keeps_the_request_pointer(storage) -> None:
+    """Only pointers at deleted sessions get nulled. A live link is not collateral."""
+    await _seed_session(storage, "s-req-young", "acme", call_id=None, ended_days_ago=1)
+    await _seed_request(storage, "r-linked", "acme", session_id="s-req-young")
+
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+
+    assert await _count(storage, "sessions", "id = :i", {"i": "s-req-young"}) == 1
+    assert await _request_session_id(storage, "r-linked") == "s-req-young"
+
+
+async def test_other_sessions_projects_and_tenants_keep_their_pointers(storage) -> None:
+    """The null-out follows the deleted ids, not the project or the tenant."""
+    await _seed_session(storage, "s-doomed", "acme", call_id=None, ended_days_ago=10)
+    await _seed_session(storage, "s-alive", "acme", call_id=None, ended_days_ago=1)
+    # Aged, but its project is not in this tick's provider, so it stays.
+    await _seed_session(storage, "s-foreign", "other", call_id=None, ended_days_ago=10)
+
+    await _seed_request(storage, "r-doomed", "acme", session_id="s-doomed", tenant="t1")
+    await _seed_request(storage, "r-alive", "acme", session_id="s-alive", tenant="t2")
+    await _seed_request(storage, "r-foreign", "other", session_id="s-foreign", tenant="t3")
+    await _seed_request(storage, "r-none", "acme", session_id=None, tenant="t2")
+    # A request in another project (and another tenant) pointing at the doomed
+    # session: the row itself is out of this tick's scope and must survive, but
+    # its pointer is dangling all the same and goes.
+    await _seed_request(storage, "r-cross", "other", session_id="s-doomed", tenant="t9")
+
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+
+    assert await _request_session_id(storage, "r-doomed") is None
+    assert await _request_session_id(storage, "r-alive") == "s-alive"
+    assert await _request_session_id(storage, "r-foreign") == "s-foreign"
+    assert await _request_session_id(storage, "r-none") is None
+    assert await _request_session_id(storage, "r-cross") is None
+    assert await _count(storage, "sessions", "id = :i", {"i": "s-foreign"}) == 1
+
+
+class _CommitAtSessionDeleteFails:
+    """AsyncSession stand-in that forwards statements but refuses one commit.
+
+    Stands in for a crash at the chunk boundary. The session pass commits more
+    than once per chunk (``replay.delete_replay`` commits per session id, before
+    the chunk's own statements run), so failing on the first commit would prove
+    nothing about the null-out. This forwards every commit taken while the
+    target session row is still present and fails on the one taken after it has
+    gone, which is by construction the chunk commit. Before raising it snapshots
+    the state on its OWN connection, where both the null-out and the delete are
+    already pending: that snapshot is what proves they share a transaction
+    rather than merely both happening at some point.
+    """
+
+    def __init__(self, db, session_id: str, request_id: str) -> None:
+        self._db = db
+        self._session_id = session_id
+        self._request_id = request_id
+        self.forwarded = 0
+        self.pending: tuple[int, str | None] | None = None
+
+    async def execute(self, *args, **kwargs):
+        return await self._db.execute(*args, **kwargs)
+
+    async def commit(self) -> None:
+        sessions_left = int(
+            (
+                await self._db.execute(
+                    text("SELECT COUNT(*) FROM sessions WHERE id = :i"),
+                    {"i": self._session_id},
+                )
+            ).scalar()
+            or 0
+        )
+        if sessions_left:
+            self.forwarded += 1
+            await self._db.commit()
+            return
+        pointer = (
+            await self._db.execute(
+                text("SELECT session_id FROM requests WHERE id = :i"),
+                {"i": self._request_id},
+            )
+        ).scalar()
+        self.pending = (sessions_left, pointer)
+        raise RuntimeError("commit boom")
+
+
+async def test_session_null_out_and_delete_commit_together(storage) -> None:
+    """Neither half lands on its own: the pointer and the row share one commit."""
+    await _seed_session(storage, "s-atomic", "acme", call_id=None, ended_days_ago=10)
+    await _seed_request(storage, "r-atomic", "acme", session_id="s-atomic")
+
+    worker = RetentionWorker(storage, retention_provider=_provider("acme", 5))
+    cutoff = datetime.now(UTC) - timedelta(days=5)
+    # The context manager rolls back on the way out, which is exactly what the
+    # worker's own tick does when a pass raises.
+    failing: _CommitAtSessionDeleteFails | None = None
+    with pytest.raises(RuntimeError, match="commit boom"):
+        async with storage._conn.session() as db:
+            failing = _CommitAtSessionDeleteFails(
+                db, session_id="s-atomic", request_id="r-atomic"
+            )
+            await worker._prune_project(
+                failing, "acme", cutoff.isoformat(), cutoff.timestamp()
+            )
+
+    # Uncommitted, both halves were staged together...
+    assert failing is not None
+    assert failing.pending == (0, None)
+    # ...and the rollback took both back.
+    assert await _count(storage, "sessions", "id = :i", {"i": "s-atomic"}) == 1
+    assert await _request_session_id(storage, "r-atomic") == "s-atomic"

--- a/src/voicegateway/tests/services/test_retention_calls.py
+++ b/src/voicegateway/tests/services/test_retention_calls.py
@@ -46,6 +46,56 @@ async def _count(storage, table: str, where: str, params: dict) -> int:
         return int(result.scalar() or 0)
 
 
+_INSERT_SESSION = text(
+    "INSERT INTO sessions "
+    "(id, project, started_at, ended_at, total_cost_usd, request_count, "
+    " tenant_id, room_name, call_id) "
+    "VALUES (:id, :project, :at, :at, 0.0, 0, :tenant, :room, :call_id)"
+)
+
+
+async def _seed_session(
+    storage,
+    session_id: str,
+    project: str,
+    call_id: str | None,
+    tenant: str | None = None,
+    ended_days_ago: float = 1.0,
+) -> None:
+    """Insert a session that survives the session pass but names a call.
+
+    ``ended_days_ago`` defaults inside every retention window used here, so the
+    session itself is never the thing being pruned: the call is.
+    """
+    at = (datetime.now(UTC) - timedelta(days=ended_days_ago)).isoformat()
+    async with storage._conn.session() as db:
+        await db.execute(
+            _INSERT_SESSION,
+            {
+                "id": session_id,
+                "project": project,
+                "at": at,
+                "tenant": tenant,
+                "room": f"room-{session_id}",
+                "call_id": call_id,
+            },
+        )
+        await db.commit()
+
+
+async def _session_call_id(storage, session_id: str) -> str | None:
+    """The stored pointer. Asserts the row still exists, so a nulled pointer is
+    never confused with a deleted session."""
+    async with storage._conn.session() as db:
+        row = (
+            await db.execute(
+                text("SELECT call_id FROM sessions WHERE id = :i"), {"i": session_id}
+            )
+        ).fetchone()
+    assert row is not None, f"session {session_id} was deleted, not repointed"
+    return row[0]
+
+
 def test_call_legs_is_a_call_child_table() -> None:
     assert "call_legs" in _CALL_CHILD_TABLES
 
@@ -135,3 +185,148 @@ async def test_call_prune_is_idempotent_and_batched(storage) -> None:
     assert second["acme"] == 0
     assert await _count(storage, "calls", "project = :p", {"p": "acme"}) == 0
     assert await _count(storage, "call_legs", "1 = :one", {"one": 1}) == 0
+
+
+# ---- sessions.call_id must not outlive the call it names -------------------
+#
+# A session prunes on its own clock and routinely outlives the call, so the
+# prune above would otherwise leave the pointer aimed at a deleted row. The
+# read side (session_repository.read_correlation_rate) also guards this with a
+# LEFT JOIN and keeps doing so; these tests pin the source-side half.
+
+
+async def test_pruned_call_nulls_the_session_pointer(storage) -> None:
+    old = await storage.upsert_call(
+        origin="webhook",
+        room_sid="RM_ptr_old",
+        project="acme",
+        started_at_ms=_ms_days_ago(11),
+        ended_at_ms=_ms_days_ago(10),
+    )
+    await _seed_session(storage, "sess-old", "acme", call_id=old)
+
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+
+    assert await _count(storage, "calls", "id = :i", {"i": old}) == 0
+    assert await _session_call_id(storage, "sess-old") is None
+
+
+async def test_surviving_call_keeps_the_session_pointer(storage) -> None:
+    """Only pointers at deleted calls get nulled. A live join is not collateral."""
+    young = await storage.upsert_call(
+        origin="webhook",
+        room_sid="RM_ptr_young",
+        project="acme",
+        started_at_ms=_ms_days_ago(1),
+        ended_at_ms=_ms_days_ago(1),
+    )
+    await _seed_session(storage, "sess-young", "acme", call_id=young)
+
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+
+    assert await _count(storage, "calls", "id = :i", {"i": young}) == 1
+    assert await _session_call_id(storage, "sess-young") == young
+
+
+async def test_other_calls_projects_and_tenants_are_unaffected(storage) -> None:
+    """The null-out follows the deleted ids, not the project or the tenant."""
+    doomed = await storage.upsert_call(
+        origin="webhook",
+        room_sid="RM_doomed",
+        project="acme",
+        ended_at_ms=_ms_days_ago(10),
+    )
+    survivor = await storage.upsert_call(
+        origin="webhook",
+        room_sid="RM_survivor",
+        project="acme",
+        ended_at_ms=_ms_days_ago(1),
+    )
+    # Aged, but its project is not in this tick's provider, so it stays.
+    foreign = await storage.upsert_call(
+        origin="webhook",
+        room_sid="RM_foreign",
+        project="other",
+        ended_at_ms=_ms_days_ago(10),
+    )
+    await _seed_session(storage, "s-doomed", "acme", call_id=doomed, tenant="t1")
+    await _seed_session(storage, "s-survivor", "acme", call_id=survivor, tenant="t2")
+    await _seed_session(storage, "s-foreign", "other", call_id=foreign, tenant="t3")
+    await _seed_session(storage, "s-none", "acme", call_id=None, tenant="t2")
+
+    await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
+
+    assert await _session_call_id(storage, "s-doomed") is None
+    assert await _session_call_id(storage, "s-survivor") == survivor
+    assert await _session_call_id(storage, "s-foreign") == foreign
+    assert await _session_call_id(storage, "s-none") is None
+    assert await _count(storage, "calls", "id = :i", {"i": foreign}) == 1
+
+
+class _CommitFails:
+    """AsyncSession stand-in that forwards statements but refuses to commit.
+
+    Stands in for a crash at the chunk boundary. Before raising it snapshots the
+    state on its OWN connection, where both the null-out and the delete are
+    already pending: that snapshot is what proves they share a transaction
+    rather than merely both happening at some point.
+    """
+
+    def __init__(self, db, call_id: str, session_id: str) -> None:
+        self._db = db
+        self._call_id = call_id
+        self._session_id = session_id
+        self.pending: tuple[int, str | None] | None = None
+
+    async def execute(self, *args, **kwargs):
+        return await self._db.execute(*args, **kwargs)
+
+    async def commit(self) -> None:
+        calls_left = int(
+            (
+                await self._db.execute(
+                    text("SELECT COUNT(*) FROM calls WHERE id = :i"),
+                    {"i": self._call_id},
+                )
+            ).scalar()
+            or 0
+        )
+        pointer = (
+            await self._db.execute(
+                text("SELECT call_id FROM sessions WHERE id = :i"),
+                {"i": self._session_id},
+            )
+        ).scalar()
+        self.pending = (calls_left, pointer)
+        raise RuntimeError("commit boom")
+
+
+async def test_null_out_and_delete_commit_together(storage) -> None:
+    """Neither half lands on its own: the pointer and the row share one commit."""
+    doomed = await storage.upsert_call(
+        origin="webhook",
+        room_sid="RM_atomic",
+        project="acme",
+        started_at_ms=_ms_days_ago(11),
+        ended_at_ms=_ms_days_ago(10),
+    )
+    await storage.upsert_call_leg(call_id=doomed, participant_sid="PA_atomic")
+    await _seed_session(storage, "sess-atomic", "acme", call_id=doomed)
+
+    worker = RetentionWorker(storage, retention_provider=_provider("acme", 5))
+    cutoff_ts = (datetime.now(UTC) - timedelta(days=5)).timestamp()
+    # The context manager rolls back on the way out, which is exactly what the
+    # worker's own tick does when a pass raises.
+    failing: _CommitFails | None = None
+    with pytest.raises(RuntimeError, match="commit boom"):
+        async with storage._conn.session() as db:
+            failing = _CommitFails(db, call_id=doomed, session_id="sess-atomic")
+            await worker._prune_calls(failing, "acme", cutoff_ts)
+
+    # Uncommitted, both halves were staged together...
+    assert failing is not None
+    assert failing.pending == (0, None)
+    # ...and the rollback took both back.
+    assert await _count(storage, "calls", "id = :i", {"i": doomed}) == 1
+    assert await _count(storage, "call_legs", "call_id = :i", {"i": doomed}) == 1
+    assert await _session_call_id(storage, "sess-atomic") == doomed

--- a/src/voicegateway/tests/storage/test_migration_agent_probe_results.py
+++ b/src/voicegateway/tests/storage/test_migration_agent_probe_results.py
@@ -1,0 +1,90 @@
+"""Alembic migration d2f6b8a1c3e5: agent_probe_results.
+
+Runs ``alembic upgrade head`` against a throwaway SQLite file (never a configured
+database) and checks the DDL the migration actually produces, including that it
+has not drifted from the SQLModel definition -- nothing in this repo runs
+autogenerate, so the migration and the model can disagree silently. This table
+shipped with exactly that disagreement: the migration declared ``result_json``
+as ``sa.Text()`` while the model declared a plain ``str`` (VARCHAR), which SQLite
+hides and PostgreSQL does not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine, text
+from sqlmodel import SQLModel
+
+from voicegateway.core.config import GatewayConfig
+from voicegateway.core.database import Database
+from voicegateway.models.agent_probe_result_model import (  # noqa: F401 - registers table
+    AgentProbeResult,
+)
+
+
+async def _migrated_engine(tmp_path: Path) -> tuple[Database, sa.Engine]:
+    db = Database(GatewayConfig(cost_tracking={"db_path": str(tmp_path / "probe.db")}))
+    await db.run_migrations()
+    return db, create_engine(f"sqlite:///{db.db_file_path}")
+
+
+def _columns(engine: sa.Engine, table: str) -> dict[str, tuple[str, int]]:
+    """``{column: (declared_type, notnull)}`` as SQLite reports it."""
+    with engine.connect() as conn:
+        rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    return {row[1]: (str(row[2]).upper(), int(row[3])) for row in rows}
+
+
+async def test_migration_creates_agent_probe_results(tmp_path: Path) -> None:
+    db, engine = await _migrated_engine(tmp_path)
+    try:
+        with engine.connect() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type = 'table'")
+                )
+            }
+        assert "agent_probe_results" in tables
+
+        cols = _columns(engine, "agent_probe_results")
+        # The cached probe payload is an opaque serialized document of no fixed
+        # length, so it is TEXT and not VARCHAR(n).
+        assert cols["result_json"][0] == "TEXT", (
+            f"agent_probe_results.result_json is {cols['result_json'][0]}; the "
+            "migration declares sa.Text() and the model must agree"
+        )
+        assert cols["result_json"][1] == 1, "a cached row without a payload is not a cache hit"
+        # Epoch seconds the probe ran, so the UI can say "measured Ns ago". A row
+        # with no timestamp could not be aged, so it is NOT NULL.
+        assert cols["created_at"][0] == "FLOAT"
+        assert cols["created_at"][1] == 1
+    finally:
+        engine.dispose()
+        await db.dispose()
+
+
+async def test_migration_matches_the_model(tmp_path: Path) -> None:
+    """The handwritten migration must produce what ``create_all`` would.
+
+    Nothing here runs alembic autogenerate, so a column added to the model and
+    forgotten in the migration (or vice versa) is invisible until a fresh install
+    diverges from an upgraded one. This is the assertion that catches the
+    VARCHAR-vs-Text drift, because it compares compiled DDL rather than trusting
+    either side's declaration.
+    """
+    db, migrated = await _migrated_engine(tmp_path)
+    declared = create_engine(f"sqlite:///{tmp_path / 'declared.db'}")
+    try:
+        SQLModel.metadata.create_all(
+            declared, tables=[SQLModel.metadata.tables["agent_probe_results"]]
+        )
+        assert _columns(migrated, "agent_probe_results") == _columns(
+            declared, "agent_probe_results"
+        )
+    finally:
+        declared.dispose()
+        migrated.dispose()
+        await db.dispose()

--- a/src/voicegateway/tests/storage/test_migration_requests.py
+++ b/src/voicegateway/tests/storage/test_migration_requests.py
@@ -1,0 +1,106 @@
+"""Alembic migrations for ``requests``: the DDL must match the SQLModel.
+
+Runs ``alembic upgrade head`` against a throwaway SQLite file (never a configured
+database) and checks the DDL the migrations actually produce, including that it
+has not drifted from the SQLModel definition -- nothing in this repo runs
+autogenerate, so the migration and the model can disagree silently. ``requests``
+shipped with exactly that disagreement: migration c7d2a9f1e6b4 added
+``rate_rule`` as ``sa.Text(), nullable=True`` while the model declared a plain
+``str``, which maps to VARCHAR NOT NULL. SQLite hides the VARCHAR/Text half and
+PostgreSQL does not; the NOT NULL half is enforced everywhere, so an upgraded
+install and a fresh ``create_all`` install disagreed on what a valid row is.
+
+The table is assembled by four migrations (f1ae43d7fa98 creates it,
+a7c2e91f8d34 adds ``cached_input_units``, c7d2a9f1e6b4 adds the two billing
+columns, b2e7c4a9f1d3 adds ``agent_id``), so the comparison below is against the
+whole upgrade chain rather than any single revision.
+
+Out of scope: the ClickHouse schema is a third declaration of this table
+(``clickhouse/migrations/0004_requests_rated_price.sql`` makes ``rate_rule`` a
+non-nullable ``LowCardinality(String)``). It is a separate store with its own
+migration runner and is not what these tests unify.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine, text
+from sqlmodel import SQLModel
+
+from voicegateway.core.config import GatewayConfig
+from voicegateway.core.database import Database
+from voicegateway.models.request_model import Request  # noqa: F401 - registers table
+
+
+async def _migrated_engine(tmp_path: Path) -> tuple[Database, sa.Engine]:
+    db = Database(GatewayConfig(cost_tracking={"db_path": str(tmp_path / "req.db")}))
+    await db.run_migrations()
+    return db, create_engine(f"sqlite:///{db.db_file_path}")
+
+
+def _columns(engine: sa.Engine, table: str) -> dict[str, tuple[str, int]]:
+    """``{column: (declared_type, notnull)}`` as SQLite reports it."""
+    with engine.connect() as conn:
+        rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    return {row[1]: (str(row[2]).upper(), int(row[3])) for row in rows}
+
+
+async def test_migration_creates_requests(tmp_path: Path) -> None:
+    db, engine = await _migrated_engine(tmp_path)
+    try:
+        with engine.connect() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type = 'table'")
+                )
+            }
+        assert "requests" in tables
+
+        cols = _columns(engine, "requests")
+        # The audit token for the rule that produced the rated price. Nullable
+        # and TEXT, because that is what c7d2a9f1e6b4 deployed: every install
+        # that upgraded has a nullable column, so declaring NOT NULL would only
+        # mean fresh installs reject rows the older ones accept.
+        assert cols["rate_rule"] == ("TEXT", 0), (
+            f"requests.rate_rule is {cols['rate_rule']}; migration c7d2a9f1e6b4 "
+            "declares sa.Text(), nullable=True and the model must agree"
+        )
+        # Its companion column was already nullable on both sides; pinned here
+        # so the pair cannot drift apart later.
+        assert cols["rated_price_usd"] == ("FLOAT", 0)
+        # The identity of a row, and the clock the retention pass prunes on.
+        # Neither can be absent.
+        assert cols["id"][1] == 1
+        assert cols["timestamp"][1] == 1
+        # A request may have no session at all (direct gateway use, no attach),
+        # and the retention pass nulls this pointer when the session it names is
+        # pruned, so it has to stay nullable.
+        assert cols["session_id"][1] == 0
+    finally:
+        engine.dispose()
+        await db.dispose()
+
+
+async def test_migration_matches_the_model(tmp_path: Path) -> None:
+    """The handwritten migrations must produce what ``create_all`` would.
+
+    Nothing here runs alembic autogenerate, so a column added to the model and
+    forgotten in the migration (or vice versa) is invisible until a fresh install
+    diverges from an upgraded one. This is the assertion that catches the
+    VARCHAR-NOT-NULL-vs-Text-nullable drift on ``rate_rule``, because it compares
+    the DDL both sides actually emit rather than trusting either declaration.
+    """
+    db, migrated = await _migrated_engine(tmp_path)
+    declared = create_engine(f"sqlite:///{tmp_path / 'declared.db'}")
+    try:
+        SQLModel.metadata.create_all(
+            declared, tables=[SQLModel.metadata.tables["requests"]]
+        )
+        assert _columns(migrated, "requests") == _columns(declared, "requests")
+    finally:
+        declared.dispose()
+        migrated.dispose()
+        await db.dispose()


### PR DESCRIPTION
Nine commits. Every number in here was already being shown to operators and was
wrong in a way that pointed at a confident conclusion.

## The two that matter most are mirror images

**F1: a healthy server read FAIL.** Measured on a live Hetzner deployment, the
ramp returned 129.3 / 26.1 / 25.7 ms at 2 / 10 / 25 clients. More clients
measuring *faster* is backwards, and the tell that per-session TLS/ICE/DTLS
setup was landing in the sample. The baseline read 113-129 ms against a true
~26 ms, so `sfu_capacity` failed a healthy server.

`_measure` takes exactly one sample per client, so *every* sample is that
client's first data-channel message. Discarding "the first sample" would have
fixed one cold sample out of N. Every client is warmed instead, before the soak,
so a broadcast warm-up pong cannot satisfy a measured ping early.

**F6/F6b/F7: a dead server read PASS.** A tier whose pings all timed out
reported `rtt_ms=0.0`, and `0.0 > target` is False, while the quality check
tested `{Poor, Lost}` which excludes `Unknown`. So a ramp that measured nothing
passed. `find_knee` had the same hole, returning None, documented as "every step
was within budget".

Now UNKNOWN, not FAIL: a tier can measure nothing because the *prober* failed to
connect, which is not an SFU indictment.

## The rest

- **F2** `voicegw_cost_usd_total` and `voicegw_requests_total` are rolling 24h sums typed as Prometheus **counters**, so `rate()` read every window slide as a counter reset. Both are gauges now. Names unchanged; CHANGELOG has replacement expressions.
- **F3** ~40 SDK teardown ERROR lines per probe run made a healthy run look broken. Demoted to DEBUG, bounded to `room.disconnect()` and to the exact `livekit` logger, never dropped.
- **F4/F8** Model/migration drift. `requests.rate_rule` was the bad one: migrated nullable, modelled NOT NULL, so an upgraded install and a fresh `create_all` install had **different schemas**.
- **F5/F8** Retention pruned rows and left pointers dangling. Nulled in the same transaction. Note `requests.session_id` had **no read-time guard**, unlike `sessions.call_id`, so that null-out is the only defence.

## Behaviour change to announce

A deployment reading PASS today can start reading **UNKNOWN** after this merges.
Nothing broke: a probe that measured nothing stops claiming success.

`+53 tests, zero removed.` One alembic head. No migration.