### PR TITLE
fix(dashboard): connect what was built but never wired

### DIFF
--- a/docs/api/dashboard-api.md
+++ b/docs/api/dashboard-api.md
@@ -213,6 +213,8 @@ Only the `sip.*` participant attributes are persisted and served in `attributes_
 
 Authentication follows the other dashboard reads: with no API keys configured (the self-hosted default) the endpoint is open, and once keys are configured a tenant-scoped key sees only its own calls.
 
+Tenant scoping happens in the query, not on the page after it is read, so `limit` means the same thing for a scoped key as for the operator: a key bound to one tenant asking for 50 gets its own newest 50, not whatever fraction of the newest 50 calls overall happened to belong to it. A key whose `tenant_id` is null reads the unattributed calls (`tenant_id IS NULL`), never every tenant's.
+
 **Example:**
 
 ```bash

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -677,6 +677,16 @@ voicegw_diag_run_timestamp_seconds 1785412800.000
 
 This endpoint exposes VoiceGateway's own numbers so your Prometheus can scrape it. It is the opposite direction from the node scrape, which pulls exposition text *from* livekit-server and node_exporter *into* this database; nothing scraped from another process is served back out here.
 
+**Turning the node scrape on.** That inbound scrape is off unless you name targets. Set `VOICEGW_NODE_SCRAPE_TARGETS` to a comma-separated list of `source:name=url` entries before starting the collector:
+
+```bash
+export VOICEGW_NODE_SCRAPE_TARGETS="livekit-server:sfu-1=http://10.0.0.4:6789/metrics,node-exporter:sfu-1=http://10.0.0.4:9100/metrics"
+```
+
+`source` is one of `livekit-server`, `livekit-sip` or `node-exporter`. `name` is the node the samples are filed under, and using the same `name` for two sources is the point: it puts an SFU's own counters and its host's file descriptors on one time axis. A malformed entry is skipped with a warning instead of failing startup, and the collector logs how many targets it read.
+
+With the variable unset or empty no scrape worker is started and the collector makes no outbound requests, which is the default. Cadence comes from `workers.node_scrape_interval_seconds` in `voicegw.yaml` (default 15 seconds, matching Prometheus' own default); `workers.enabled: false` disables this worker along with the rollups.
+
 **Diagnostics gate series.** `voicegw_diag_gate_status` reports the health gates of the newest stored [diagnostics run](/cli/livekit) that gated anything, aggregated per gate id and status: the probed agent is not a label, so cardinality does not grow with your fleet. Statuses are the one ladder `voicegw livekit check` uses, `PASS < WARN < UNKNOWN < FAIL`, where **`UNKNOWN` means the gate could not be evaluated and is not a pass** (only `PASS` exits 0). `voicegw_diag_run_verdict` is that run's stored verdict, and `voicegw_diag_run_timestamp_seconds` is when it finished, so a clean verdict from three weeks ago is distinguishable from one from a minute ago.
 
 **Unknown values are omitted, never zero.** No diagnostics run, no readable diagnostics table, or a status this build does not recognise means the series is *absent*. A `0` would be a real observation and would be alerted on; absence is the honest reading. Alert on what is there (for example `voicegw_diag_gate_status{status!="PASS"} > 0`) and on `absent(...)` if you require a run to have happened.

--- a/docs/configuration/voicegw-yaml.md
+++ b/docs/configuration/voicegw-yaml.md
@@ -335,11 +335,19 @@ workers:
   enabled: true
   rollup_interval_seconds: 900
   retention_interval_seconds: 3600
+  node_scrape_interval_seconds: 15
 ```
 
 - `enabled` (bool, default `true`): start the background workers.
 - `rollup_interval_seconds` (int, default `900`): how often the latency and agent rollups refresh.
 - `retention_interval_seconds` (int, default `3600`): how often retention runs.
+- `node_scrape_interval_seconds` (int, default `15`): how often the node scrape polls, when it runs at all.
+
+The node scrape is the one worker that is off by default. It is built only when
+`VOICEGW_NODE_SCRAPE_TARGETS` names at least one target, so an install that does
+not set that variable starts no scrape task and makes no outbound requests, and
+this interval has no effect. See `GET /v1/metrics` in the HTTP API reference for
+the target grammar.
 
 ---
 

--- a/src/dashboard/frontend/src/lib/demoFixtures.ts
+++ b/src/dashboard/frontend/src/lib/demoFixtures.ts
@@ -1107,17 +1107,27 @@ const DIAG_CREDS: DiagnosticsCreds = {
 // computed against and the prober's own resource sample, and `latency` carries
 // per-agent stats (seconds) plus the split read back from the agent's own rows.
 //
-// Three deliberate properties, so the demo shows the honest cases and not just
+// Four deliberate properties, so the demo shows the honest cases and not just
 // the happy one:
-//   - The newest run's verdict is PASS while one probed agent answered nothing.
-//     That is what today's `_verdict` really does (it only compares averages
-//     against target_ms), and the Errors tab is what surfaces the no-reply.
-//   - The two older runs each carry one real failure string, so the error-class
+//   - One run died before recording anything: `status: 'failed'`, `results:
+//     null`, `verdict: null`, one error string. That is exactly what the backend
+//     stores on that path. It is deliberately NOT the newest: the tabs only ever
+//     render the first run, and leading the public demo with four "no result"
+//     cards would sell the product short. It sits in the run history, which is
+//     enough to prove the failed path is stored and listed honestly.
+//   - One completed run stores the verdict PASS while one probed agent answered
+//     nothing. That was `_verdict`'s reading, and `_verdict` is gone: `gates`
+//     replaced it and would call the same payload UNKNOWN, because a probe that
+//     measured nothing has not passed. This page renders the STORED verdict and
+//     never recomputes one, so the value here is a display fixture and not a
+//     claim about what today's gates return. The Errors tab surfaces the
+//     no-reply either way.
+//   - The two oldest runs each carry one real failure string, so the error-class
 //     bars have something to group: a per-check timeout and a dispatch that found
 //     no worker.
 //   - The oldest run has `roster: []` (a configured collector reporting nothing)
-//     against the newest run's populated roster: two different answers that must
-//     never collapse into "0 workers".
+//     against the populated roster of the run above it: two different answers
+//     that must never collapse into "0 workers".
 const DIAG_RUNS: DiagnosticRun[] = [
   {
     run_id: 'diag_run_003',
@@ -1277,6 +1287,38 @@ const DIAG_RUNS: DiagnosticRun[] = [
     created_at: iso(BASE_EPOCH - 12 * MIN),
     started_at: iso(BASE_EPOCH - 12 * MIN),
     ended_at: iso(BASE_EPOCH - 12 * MIN + 96),
+  },
+  {
+    // A run that ended without recording anything. `_execute` wraps the whole
+    // run in `asyncio.wait_for(..., 360s)`; when that fires, `run.results` was
+    // never assigned and no verdict was ever computed, so the stored row is
+    // `results: null` + `verdict: null` + the error string verbatim. It is NOT a
+    // run of zeros: a zero would claim a measurement nobody took.
+    //
+    // Deliberately NOT the newest. The tabs and the exportable report only ever
+    // render the first run, and voicegateway.dev/demo is a shop window: leading
+    // with four 'no result' cards would sell the product short. It sits in the
+    // run history instead, where it still proves the failed path is stored and
+    // listed honestly. Make the history rows selectable and this becomes
+    // reachable in the demo without costing the default view.
+    //
+    // `latency` is left out of `checks` so the four per-check tabs cover both
+    // resultless states: three that were asked for and recorded nothing, and one
+    // that was never part of the run at all.
+    run_id: 'diag_run_004',
+    status: 'failed',
+    // A 4-tier ramp held 30s per tier does not fit inside the six-minute cap,
+    // which is why this run hit it.
+    checks: ['agents', 'sfu', 'sfu_load'],
+    config: { target_ms: 1500, ramp: [2, 10, 25, 50], duration: 30, trials: 3 },
+    results: null,
+    verdict: null,
+    // Verbatim from the TimeoutError branch of `_execute`.
+    error: 'run timed out',
+    created_at: iso(BASE_EPOCH - 26 * MIN),
+    started_at: iso(BASE_EPOCH - 26 * MIN),
+    // Started plus the 360s cap: the run was killed, it did not finish early.
+    ended_at: iso(BASE_EPOCH - 20 * MIN),
   },
   {
     run_id: 'diag_run_002',

--- a/src/dashboard/frontend/src/pages/Diagnostics.tsx
+++ b/src/dashboard/frontend/src/pages/Diagnostics.tsx
@@ -15,7 +15,7 @@ import ErrorsTab from './diagnostics/ErrorsTab';
 import LatencyTab from './diagnostics/LatencyTab';
 import LoadTab from './diagnostics/LoadTab';
 import ReportTab from './diagnostics/ReportTab';
-import { Note } from './diagnostics/shared';
+import { Card, Note } from './diagnostics/shared';
 import SfuTab from './diagnostics/SfuTab';
 
 const CHECK_OPTS = [
@@ -91,6 +91,9 @@ export default function Diagnostics() {
   }, [run, runs]);
   const current = run ?? allRuns[0] ?? null;
   const checks = current?.results?.checks;
+  // Still in flight, as opposed to ended without recording anything. The two are
+  // both "no results", and only the second one has a report worth exporting.
+  const pending = current?.status === 'queued' || current?.status === 'running';
 
   const toggleCheck = (key: string) => {
     setSelected((prev) => {
@@ -271,10 +274,10 @@ export default function Diagnostics() {
         <>
           <RunSummary run={current} />
 
-          {current.results === null ? (
+          {current.results === null && (
             <div className="vg-card" style={{ marginBottom: 16 }}>
               <div className="vg-card__label" style={{ marginBottom: 10 }}>Results</div>
-              {current.status === 'queued' || current.status === 'running' ? (
+              {pending ? (
                 <Note>
                   The checks are still running. Results appear per check as the run completes; a run
                   is capped at six minutes.
@@ -285,7 +288,16 @@ export default function Diagnostics() {
                 </Note>
               )}
             </div>
-          ) : (
+          )}
+
+          {/* The tab strip is gated on the run having ENDED, not on it having
+              produced results. A run that failed before recording anything still
+              has a report the server renders for it (its status, its error, the
+              checks it was asked for, and every finding as "no result"), and a
+              failed run is exactly when an operator needs that file. Only a run
+              still in flight has no tabs: there, "nothing yet" is not a finding.
+              The per-check tabs of a resultless run say so themselves below. */}
+          {(current.results !== null || !pending) && (
             <>
               <div className="neo-tabs">
                 {TABS.map((t) => (
@@ -300,12 +312,32 @@ export default function Diagnostics() {
                 ))}
               </div>
 
-              {activeTab === 'Agents' && <AgentsTab check={checks?.agents} />}
+              {activeTab === 'Agents' &&
+                (current.results === null ? (
+                  <NoRunResult label="Agents in rooms" run={current} names={['agents']} />
+                ) : (
+                  <AgentsTab check={checks?.agents} />
+                ))}
               {/* The plain sfu check and the load check both measure a baseline;
                   prefer the dedicated one, fall back to the load run's. */}
-              {activeTab === 'SFU' && <SfuTab check={checks?.sfu ?? checks?.sfu_load} />}
-              {activeTab === 'Load' && <LoadTab check={checks?.sfu_load} />}
-              {activeTab === 'Latency' && <LatencyTab check={checks?.latency} />}
+              {activeTab === 'SFU' &&
+                (current.results === null ? (
+                  <NoRunResult label="SFU baseline" run={current} names={['sfu', 'sfu_load']} />
+                ) : (
+                  <SfuTab check={checks?.sfu ?? checks?.sfu_load} />
+                ))}
+              {activeTab === 'Load' &&
+                (current.results === null ? (
+                  <NoRunResult label="SFU load" run={current} names={['sfu_load']} />
+                ) : (
+                  <LoadTab check={checks?.sfu_load} />
+                ))}
+              {activeTab === 'Latency' &&
+                (current.results === null ? (
+                  <NoRunResult label="Latency (real calls)" run={current} names={['latency']} />
+                ) : (
+                  <LatencyTab check={checks?.latency} />
+                ))}
               {activeTab === 'Errors' && <ErrorsTab runs={allRuns} />}
               {activeTab === 'Report' && <ReportTab run={current} />}
             </>
@@ -348,6 +380,43 @@ export default function Diagnostics() {
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * What one per-check tab shows for a run that ended having recorded no results.
+ *
+ * It does NOT go through `CheckGate`: an absent payload there means "this check
+ * was not part of the run", which is only true when the run recorded results and
+ * this check is missing from them. A run that died before writing anything is the
+ * other case, and the check may well have been requested. The report the server
+ * renders keeps those apart (`not_requested` vs `no_result`), so this does too.
+ * Neither branch renders a number, a chart or a zero: nothing was measured.
+ */
+function NoRunResult({
+  label,
+  run,
+  names,
+}: {
+  label: string;
+  run: DiagnosticRun;
+  names: DiagCheckName[];
+}) {
+  const requested = names.some((name) => run.checks.includes(name));
+  return (
+    <Card label={label} right={<span className="neo-badge neo-badge--black">no result</span>}>
+      {requested ? (
+        <Note tone="bad">
+          This run was asked for this check and ended without recording anything for it:{' '}
+          {run.error ?? 'the reason was not reported'}. Nothing was measured, so nothing is shown.
+        </Note>
+      ) : (
+        <Note>
+          This run did not include the check, and it recorded no results at all, so there is
+          nothing measured to show. The Report tab still exports the run itself.
+        </Note>
+      )}
+    </Card>
   );
 }
 

--- a/src/dashboard/frontend/src/pages/Diagnostics.tsx
+++ b/src/dashboard/frontend/src/pages/Diagnostics.tsx
@@ -15,7 +15,7 @@ import ErrorsTab from './diagnostics/ErrorsTab';
 import LatencyTab from './diagnostics/LatencyTab';
 import LoadTab from './diagnostics/LoadTab';
 import ReportTab from './diagnostics/ReportTab';
-import { Card, Note } from './diagnostics/shared';
+import { Card, Note, verdictBadgeClass } from './diagnostics/shared';
 import SfuTab from './diagnostics/SfuTab';
 
 const CHECK_OPTS = [
@@ -42,13 +42,6 @@ const CHECK_LABEL: Record<DiagCheckName, string> = {
 };
 
 const CHECK_ORDER: DiagCheckName[] = ['agents', 'sfu', 'sfu_load', 'latency'];
-
-function verdictBadgeClass(v: string | null): string {
-  if (v === 'PASS') return 'neo-badge--green';
-  if (v === 'WARN') return 'neo-badge--warning';
-  if (v === 'FAIL') return 'neo-badge--red';
-  return 'neo-badge--black';
-}
 
 export default function Diagnostics() {
   const mountedRef = useRef(true);

--- a/src/dashboard/frontend/src/pages/diagnostics/ReportTab.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/ReportTab.tsx
@@ -19,18 +19,9 @@ import { useState } from 'react';
 import { getToken } from '../../lib/api';
 import { DEMO_MODE } from '../../lib/demo';
 import type { DiagnosticRun } from '../../lib/types';
-import { Card, Note } from './shared';
+import { Card, Note, verdictBadgeClass } from './shared';
 
 type Kind = 'html' | 'json';
-
-/** Badge class for a stored verdict. UNKNOWN is deliberately not green. */
-function verdictBadgeClass(verdict: string | null): string {
-  if (verdict === 'PASS') return 'neo-badge--green';
-  if (verdict === 'WARN') return 'neo-badge--warning';
-  if (verdict === 'FAIL') return 'neo-badge--red';
-  // UNKNOWN, and anything this build does not recognise: neutral, never green.
-  return 'neo-badge--black';
-}
 
 /** Same filename the server puts in Content-Disposition, same sanitising. */
 function fileName(runId: string, kind: Kind): string {

--- a/src/dashboard/frontend/src/pages/diagnostics/shared.tsx
+++ b/src/dashboard/frontend/src/pages/diagnostics/shared.tsx
@@ -131,6 +131,36 @@ export function qualityBadgeClass(quality: string): string {
   return 'neo-badge--black'; // Unknown: the SDK reported nothing usable
 }
 
+/**
+ * Badge class for one stored verdict. Never re-judges: the verdict is whatever
+ * `livekit_diag.gates` recorded when the run executed.
+ *
+ * It lives here, beside `qualityBadgeClass`, because two surfaces render the
+ * same run's verdict: the run-history table and the summary pill on
+ * `Diagnostics`, and the header on `ReportTab`. Those were separate copies, and
+ * they disagreed the moment one of them learned about UNKNOWN.
+ *
+ * UNKNOWN has its own case because it is a real, reachable verdict and not a
+ * missing one: `gates.verdict` returns it when nothing could be evaluated, and
+ * `gates.exit_code` still exits non-zero for it. Every other treatment in this
+ * kit would misreport it. Green and teal read as healthy, and a run that
+ * measured nothing has not passed. Amber is WARN's, a different and strictly
+ * lesser severity. Ink is what this very badge already shows for a run with NO
+ * verdict at all: `RunSummary` renders `verdict ?? status`, so a run that never
+ * produced one puts "failed" / "running" in the same pill, and UNKNOWN sharing
+ * it would collapse "could not tell" into "never got that far". That leaves the
+ * kit's colourless badge, which is the point: it makes no claim, and no claim is
+ * all an unevaluated run has earned.
+ */
+export function verdictBadgeClass(v: string | null): string {
+  if (v === 'PASS') return 'neo-badge--green';
+  if (v === 'WARN') return 'neo-badge--warning';
+  if (v === 'FAIL') return 'neo-badge--red';
+  if (v === 'UNKNOWN') return 'neo-badge--white';
+  // No verdict, or one this build does not recognise. Not a health claim either.
+  return 'neo-badge--black';
+}
+
 export function CheckGate<R>({
   check,
   label,

--- a/src/voicegateway/core/events.py
+++ b/src/voicegateway/core/events.py
@@ -5,6 +5,11 @@ cost tracking is enabled and workers are not disabled, starts the latency and
 agent rollup workers plus the retention worker, stopping them on shutdown. The
 poll intervals come from the ``workers`` config; retention runs only when
 enabled and prunes every project that has data at ``retention.default_days``.
+
+The Prometheus node scrape is the one worker that is not started by default:
+it is the only one that talks to the network, so it is built only when
+``VOICEGW_NODE_SCRAPE_TARGETS`` names at least one target. An install that
+never sets the variable behaves exactly as it did before the worker existed.
 """
 
 from __future__ import annotations
@@ -23,6 +28,11 @@ from voicegateway.middleware.agent_observations_worker_middleware import (
 )
 from voicegateway.middleware.latency_observations_worker_middleware import (
     LatencyObservationsWorker,
+)
+from voicegateway.middleware.node_samples_worker_middleware import (
+    TARGETS_ENV_VAR,
+    NodeSamplesWorker,
+    targets_from_env,
 )
 from voicegateway.services.retention_service import RetentionWorker
 
@@ -68,6 +78,27 @@ def _build_workers(gateway: Gateway) -> list[Any]:
                 default_retention_days=retention_cfg.default_days,
                 poll_interval_seconds=workers_cfg.retention_interval_seconds,
             )
+        )
+
+    # The node scrape is opt-in, and opting in is naming targets: it is the only
+    # worker here that makes outbound HTTP requests, so an install that upgrades
+    # into this code must not start talking to the network on its own. No
+    # targets, no worker at all (rather than a worker idling on empty ticks), so
+    # the default process has exactly the tasks it had before.
+    node_targets = targets_from_env()
+    if node_targets:
+        workers.append(
+            NodeSamplesWorker(
+                storage,
+                poll_interval_seconds=workers_cfg.node_scrape_interval_seconds,
+            )
+        )
+        # Logged because the alternative is silence: an operator who typos the
+        # variable otherwise cannot tell "not read" from "read and empty".
+        logger.info(
+            "Node scrape enabled: %d target(s) from %s",
+            len(node_targets),
+            TARGETS_ENV_VAR,
         )
     return workers
 

--- a/src/voicegateway/repository/calls_repository.py
+++ b/src/voicegateway/repository/calls_repository.py
@@ -847,6 +847,7 @@ async def list_calls(
     limit: int = 100,
     project: str | None = None,
     run_id: str | None = None,
+    tenant: str | None = None,
     is_probe: bool | None = False,
 ) -> list[CallRow]:
     """Newest calls first.
@@ -855,6 +856,27 @@ async def list_calls(
     asked for**, so a caller computing production numbers cannot silently mix
     synthetic load into them. Pass ``True`` for load traffic only, ``None`` for
     every row.
+
+    ``tenant`` is a read SCOPE, not a column value, which is why it is not named
+    ``tenant_id`` like the write path's argument. It carries the same three-way
+    convention every sibling read uses
+    (``session_repository.list_sessions``, ``cost_repository``,
+    ``request_log_repository``, ``latency_repository``):
+
+    * ``None`` -- every tenant. The operator/admin case.
+    * ``""`` -- the unattributed bucket, i.e. ``tenant_id IS NULL``.
+    * anything else -- that tenant's rows only.
+
+    The predicate belongs HERE and not in the caller: filtering a page after it
+    has been read makes ``limit`` a bound on rows *scanned* rather than rows
+    *returned*, so a tenant-scoped reader asking for 50 gets however many of its
+    own calls happened to fall inside the newest 50 overall -- possibly none,
+    while more of its own sit one row past the boundary.
+
+    The ``""`` case is spelled ``IS NULL`` explicitly rather than left to SQL's
+    three-valued logic: ``tenant_id = ''`` matches no NULL row on SQLite or
+    PostgreSQL, so the unattributed reader would silently be served an empty
+    page instead of its own calls.
 
     The explicit ``started_at_ms IS NULL`` sort key puts a start-less row (an
     INVITE that never produced a room) last on SQLite and PostgreSQL alike: the
@@ -866,6 +888,11 @@ async def list_calls(
         stmt = stmt.where(Call.project == project)  # type: ignore[arg-type]
     if run_id is not None:
         stmt = stmt.where(Call.run_id == run_id)  # type: ignore[arg-type]
+    if tenant is not None:
+        if tenant == "":
+            stmt = stmt.where(Call.tenant_id.is_(None))  # type: ignore[union-attr]
+        else:
+            stmt = stmt.where(Call.tenant_id == tenant)  # type: ignore[arg-type]
     if is_probe is not None:
         stmt = stmt.where(Call.is_probe == int(is_probe))  # type: ignore[arg-type]
     stmt = stmt.order_by(

--- a/src/voicegateway/schemas/config_schema.py
+++ b/src/voicegateway/schemas/config_schema.py
@@ -96,11 +96,16 @@ class RetentionConfig(_StrictBase):
 
 
 class WorkersConfig(_StrictBase):
-    """Background-worker cadence for the collector (rollups, retention)."""
+    """Background-worker cadence for the collector (rollups, retention, scrape)."""
 
     enabled: bool = True
     rollup_interval_seconds: int = Field(default=900, ge=1)
     retention_interval_seconds: int = Field(default=3600, ge=1)
+    # Cadence of the Prometheus node scrape. 15 s is Prometheus' own default and
+    # the resolution the node_samples row budget is sized against. Setting it
+    # does NOT turn the scrape on: the worker exists only when
+    # VOICEGW_NODE_SCRAPE_TARGETS names at least one target.
+    node_scrape_interval_seconds: int = Field(default=15, ge=1)
 
 
 class ProjectConfig(_StrictBase):

--- a/src/voicegateway/server/api/dashboard/calls.py
+++ b/src/voicegateway/server/api/dashboard/calls.py
@@ -61,21 +61,6 @@ DEFAULT_LIMIT = 50
 MAX_LIMIT = 200
 
 
-def _visible(row: dict[str, Any], tenant: str | None) -> bool:
-    """Whether a call row is readable by a principal scoped to ``tenant``.
-
-    ``None`` is the operator/admin case: every row. ``""`` is the unattributed
-    bucket, i.e. ``tenant_id IS NULL``, the same convention the repositories use
-    for their SQL tenant predicate (``session_repository.list_sessions``).
-    """
-    if tenant is None:
-        return True
-    stored: str | None = row["tenant_id"]
-    if tenant == "":
-        return stored is None
-    return stored == tenant
-
-
 @router.get("")
 async def get_calls(
     limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
@@ -92,11 +77,16 @@ async def get_calls(
     keeps synthetic calls out of the numbers a reader takes for production, and
     this endpoint does not expose a knob to mix them back in.
 
-    Tenant scoping: a tenant-bound (non-admin) key sees only its own calls. The
-    filter runs here rather than in the query, so such a page can hold fewer than
-    ``limit`` rows -- fewer, never another tenant's. The self-hosted operator
-    default (no credential, or a static config key) is an admin principal and is
-    unaffected.
+    Tenant scoping: a tenant-bound (non-admin) key sees only its own calls, and
+    the predicate is pushed into the query rather than applied to the page after
+    it is read. That is what makes ``limit`` mean the same thing for a scoped
+    reader as for the operator: filtering afterwards bounded the rows SCANNED,
+    so a tenant asking for 50 could be handed 3 while more of its own calls sat
+    one row past the boundary, and a reader had no way to tell a quiet week from
+    a truncated page. ``resolve_read_tenant`` maps the principal onto the
+    repository's convention (``None`` every tenant, ``""`` the unattributed
+    ``tenant_id IS NULL`` bucket). The self-hosted operator default (no
+    credential, or a static config key) is an admin principal and is unaffected.
 
     503 when storage is disabled, rather than an empty list: "no call has been
     recorded" and "this deployment records nothing" are different facts and the
@@ -105,11 +95,9 @@ async def get_calls(
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
     tenant = resolve_read_tenant(principal, None)
-    rows = await gateway.storage.list_calls(limit=limit)
+    rows = await gateway.storage.list_calls(limit=limit, tenant=tenant)
     calls: list[dict[str, Any]] = []
     for row in rows:
-        if not _visible(row, tenant):
-            continue
         legs = await gateway.storage.list_call_legs(row["id"])
         calls.append({**row, "legs": legs})
     return {"calls": calls}

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -509,10 +509,19 @@ class StorageService:
         limit: int = 100,
         project: str | None = None,
         run_id: str | None = None,
+        tenant: str | None = None,
         is_probe: bool | None = False,
     ) -> list[dict[str, Any]]:
         """Newest calls first. ``is_probe=False`` (the default) excludes
         load-test traffic; ``True`` returns only it, ``None`` returns every row.
+
+        ``tenant`` carries the same read-scope convention as the other list
+        passthroughs on this service (``list_sessions``,
+        ``get_recent_requests``): ``None`` is every tenant, ``""`` is the
+        unattributed bucket (``tenant_id IS NULL``), anything else is that
+        tenant. It is applied in SQL, so ``limit`` bounds the rows RETURNED for
+        the scoped caller and not merely the rows scanned before a caller-side
+        filter thins them.
         """
         import dataclasses
 
@@ -521,7 +530,12 @@ class StorageService:
         await self._ensure_initialized()
         async with self._conn.session() as db:
             rows = await calls_repository.list_calls(
-                db, limit=limit, project=project, run_id=run_id, is_probe=is_probe
+                db,
+                limit=limit,
+                project=project,
+                run_id=run_id,
+                tenant=tenant,
+                is_probe=is_probe,
             )
         return [dataclasses.asdict(r) for r in rows]
 

--- a/src/voicegateway/tests/repository/test_calls_repository.py
+++ b/src/voicegateway/tests/repository/test_calls_repository.py
@@ -412,3 +412,164 @@ async def test_answer_latency_columns_default_to_null(db: AsyncSession) -> None:
     assert row is not None
     assert row.answer_latency_ms is None
     assert row.answer_latency_source is None
+
+
+# --- the tenant predicate ---------------------------------------------------
+
+
+async def _seed_tenant_calls(
+    db: AsyncSession,
+    *,
+    tenant_id: str | None,
+    prefix: str,
+    count: int,
+    base_ms: int,
+) -> None:
+    """``count`` calls for one tenant, oldest first, 1s apart."""
+    for i in range(count):
+        await repo.upsert_call(
+            db,
+            origin="webhook",
+            room_sid=f"{prefix}{i}",
+            tenant_id=tenant_id,
+            started_at_ms=base_ms + i * 1000,
+        )
+
+
+async def test_a_tenant_scoped_read_returns_a_full_page(db: AsyncSession) -> None:
+    """THE regression. Filtering after a bounded read makes ``limit`` a bound on
+    rows scanned, not rows returned: every one of the six newest calls belongs to
+    beta, so a caller-side filter hands acme an empty page while six acme calls
+    sit one row past the boundary. In SQL the page is acme's own six."""
+    await _seed_tenant_calls(
+        db, tenant_id="acme", prefix="RM_acme", count=6, base_ms=1_750_000_000_000
+    )
+    await _seed_tenant_calls(
+        db, tenant_id="beta", prefix="RM_beta", count=6, base_ms=1_750_000_100_000
+    )
+
+    rows = await repo.list_calls(db, limit=6, tenant="acme")
+
+    assert len(rows) == 6
+    assert {r.tenant_id for r in rows} == {"acme"}
+    # Newest first, inside the scope.
+    assert [r.room_sid for r in rows] == [f"RM_acme{i}" for i in reversed(range(6))]
+
+
+async def test_a_tenant_scope_beyond_the_page_still_honours_limit(
+    db: AsyncSession,
+) -> None:
+    """The scoped page is bounded by ``limit`` as well as filled by it: a tenant
+    with more rows than the page size gets its newest ``limit``, not all of them."""
+    await _seed_tenant_calls(
+        db, tenant_id="acme", prefix="RM_many", count=8, base_ms=1_750_000_000_000
+    )
+
+    rows = await repo.list_calls(db, limit=3, tenant="acme")
+
+    assert [r.room_sid for r in rows] == ["RM_many7", "RM_many6", "RM_many5"]
+
+
+async def test_no_tenant_is_every_tenant(db: AsyncSession) -> None:
+    """``tenant=None`` is the operator: rows of every tenant, including the
+    unattributed ones, and the unscoped ordering and limit are untouched."""
+    await _seed_tenant_calls(
+        db, tenant_id="acme", prefix="RM_ops_a", count=4, base_ms=1_750_000_000_000
+    )
+    await _seed_tenant_calls(
+        db, tenant_id="beta", prefix="RM_ops_b", count=4, base_ms=1_750_000_100_000
+    )
+    await repo.upsert_call(
+        db, origin="webhook", room_sid="RM_ops_none", started_at_ms=1_750_000_200_000
+    )
+
+    everything = await repo.list_calls(db, limit=100)
+    assert len(everything) == 9
+    assert {r.tenant_id for r in everything} == {"acme", "beta", None}
+
+    # Unscoped, `limit` still cuts by recency and nothing else.
+    newest = await repo.list_calls(db, limit=3)
+    assert [r.room_sid for r in newest] == ["RM_ops_none", "RM_ops_b3", "RM_ops_b2"]
+
+
+async def test_empty_tenant_is_the_unattributed_bucket(db: AsyncSession) -> None:
+    """``tenant=""`` means ``tenant_id IS NULL`` (the sibling convention in
+    ``session_repository.list_sessions``), and a NULL row belongs to nobody
+    else: a named tenant's scope must not pick it up on either engine."""
+    await repo.upsert_call(
+        db, origin="webhook", room_sid="RM_null1", started_at_ms=1_750_000_000_000
+    )
+    await repo.upsert_call(
+        db, origin="webhook", room_sid="RM_null2", started_at_ms=1_750_000_001_000
+    )
+    await repo.upsert_call(
+        db,
+        origin="webhook",
+        room_sid="RM_named",
+        tenant_id="acme",
+        started_at_ms=1_750_000_002_000,
+    )
+
+    unattributed = await repo.list_calls(db, tenant="")
+    assert [r.room_sid for r in unattributed] == ["RM_null2", "RM_null1"]
+    assert all(r.tenant_id is None for r in unattributed)
+
+    named = await repo.list_calls(db, tenant="acme")
+    assert [r.room_sid for r in named] == ["RM_named"]
+
+
+async def test_a_tenant_scope_keeps_the_start_less_row_last(db: AsyncSession) -> None:
+    """The dialect-neutral NULL sort key survives the predicate: a scoped page
+    still puts an INVITE that never produced a room last, not first."""
+    await repo.upsert_call(
+        db,
+        origin="webhook",
+        room_sid="RM_scoped_old",
+        tenant_id="acme",
+        started_at_ms=1000,
+    )
+    await repo.upsert_call(
+        db,
+        origin="webhook",
+        room_sid="RM_scoped_new",
+        tenant_id="acme",
+        started_at_ms=9000,
+    )
+    await repo.upsert_call(
+        db, origin="loadgen", attempt_id="att-scoped-503", tenant_id="acme"
+    )
+
+    rows = await repo.list_calls(db, tenant="acme")
+
+    assert [r.room_sid for r in rows] == ["RM_scoped_new", "RM_scoped_old", None]
+
+
+async def test_the_tenant_predicate_composes_with_the_other_filters(
+    db: AsyncSession,
+) -> None:
+    """Tenant narrows alongside project / run_id / is_probe rather than
+    replacing them, so load traffic stays excluded inside a scope."""
+    await repo.upsert_call(
+        db, origin="webhook", room_sid="RM_mix_real", tenant_id="acme", project="p1"
+    )
+    await repo.upsert_call(
+        db,
+        origin="loadgen",
+        room_sid="RM_mix_probe",
+        tenant_id="acme",
+        project="p1",
+        is_probe=True,
+    )
+    await repo.upsert_call(
+        db, origin="webhook", room_sid="RM_mix_other", tenant_id="acme", project="p2"
+    )
+
+    scoped = await repo.list_calls(db, tenant="acme", project="p1")
+    assert [r.room_sid for r in scoped] == ["RM_mix_real"]
+
+    with_probes = await repo.list_calls(db, tenant="acme", is_probe=None)
+    assert {r.room_sid for r in with_probes} == {
+        "RM_mix_real",
+        "RM_mix_probe",
+        "RM_mix_other",
+    }

--- a/src/voicegateway/tests/server/test_calls_endpoint.py
+++ b/src/voicegateway/tests/server/test_calls_endpoint.py
@@ -409,6 +409,59 @@ async def test_the_operator_default_still_sees_every_call(client, gateway):
     assert {c["room_sid"] for c in body["calls"]} == {"RM_acme2", "RM_none"}
 
 
+async def test_a_tenant_key_gets_a_full_page_not_a_short_one(client, gateway):
+    """``limit`` means the same thing for a scoped reader as for the operator.
+
+    The endpoint used to read ``limit`` rows and drop the other tenants' in
+    Python, so this fixture (the six newest calls all belong to beta) handed acme
+    an EMPTY page while six acme calls sat one row past the read boundary. With
+    the predicate in the query the page is acme's own six, newest first.
+    """
+    for i in range(6):
+        await _answered_call(
+            gateway.storage,
+            room_sid=f"RM_pg_acme{i}",
+            tenant_id="acme",
+            started_at_ms=1_750_000_000_000 + i * 1000,
+        )
+    for i in range(6):
+        await _answered_call(
+            gateway.storage,
+            room_sid=f"RM_pg_beta{i}",
+            tenant_id="beta",
+            started_at_ms=1_750_000_100_000 + i * 1000,
+        )
+    async with gateway.storage._conn.session() as db:
+        created = await api_keys.create_api_key(db, name="acme-page", tenant_id="acme")
+
+    resp = await client.get(
+        f"{_URL}?limit=6", headers={"Authorization": f"Bearer {created.plaintext}"}
+    )
+
+    assert resp.status_code == 200
+    calls = resp.json()["calls"]
+    assert [c["room_sid"] for c in calls] == [
+        f"RM_pg_acme{i}" for i in reversed(range(6))
+    ]
+    assert {c["tenant_id"] for c in calls} == {"acme"}
+
+
+async def test_a_key_with_no_tenant_reads_the_unattributed_bucket(client, gateway):
+    """A non-admin key whose ``tenant_id`` is NULL resolves to ``""``, which the
+    query reads as ``tenant_id IS NULL`` -- never as every tenant."""
+    await _answered_call(gateway.storage, room_sid="RM_unattributed")
+    await _answered_call(gateway.storage, room_sid="RM_owned", tenant_id="acme")
+    async with gateway.storage._conn.session() as db:
+        created = await api_keys.create_api_key(db, name="no-tenant-ui")
+
+    resp = await client.get(
+        _URL, headers={"Authorization": f"Bearer {created.plaintext}"}
+    )
+
+    assert resp.status_code == 200
+    assert [c["room_sid"] for c in resp.json()["calls"]] == ["RM_unattributed"]
+
+
 # --- storage disabled -------------------------------------------------------
 
 

--- a/src/voicegateway/tests/server/test_lifespan_workers.py
+++ b/src/voicegateway/tests/server/test_lifespan_workers.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
 import yaml
 from starlette.testclient import TestClient
@@ -9,6 +12,10 @@ from starlette.testclient import TestClient
 from voicegateway.core import events
 from voicegateway.core.events import lifespan
 from voicegateway.core.gateway import Gateway
+from voicegateway.middleware.node_samples_worker_middleware import (
+    TARGETS_ENV_VAR,
+    NodeSamplesWorker,
+)
 from voicegateway.server import build_app
 
 
@@ -107,3 +114,143 @@ async def test_partial_start_failure_stops_started_workers(
         async with lifespan(app):
             pass
     assert good.started and good.stopped  # the started worker was cleaned up
+
+
+# --- the node scrape worker: opt-in, and off by default ----------------------
+#
+# Every other worker reads the database it is already attached to. This one
+# makes outbound HTTP requests, so "does a default install start it" is the
+# question these tests exist to answer, and the answer has to stay "no".
+
+# Port 9 (discard) is reliably closed on loopback: the scrape fails fast with a
+# refused connection instead of reaching anything real.
+_TARGET = "node-exporter:sfu-1=http://127.0.0.1:9/metrics"
+
+
+def _node_workers(workers) -> list[NodeSamplesWorker]:
+    return [w for w in workers if isinstance(w, NodeSamplesWorker)]
+
+
+async def test_node_scrape_not_started_when_env_unset(tmp_path, monkeypatch) -> None:
+    """The default install: no targets variable, no scrape worker, no traffic."""
+    monkeypatch.delenv(TARGETS_ENV_VAR, raising=False)
+    gw = _gateway(tmp_path, monkeypatch, {"cost_tracking": {"enabled": True}})
+    app = build_app(gw)
+    async with lifespan(app):
+        assert _node_workers(app.state.workers) == []
+        # Unchanged from before this worker was wired in.
+        assert len(app.state.workers) == 3
+
+
+async def test_node_scrape_not_started_when_env_is_blank(tmp_path, monkeypatch) -> None:
+    """A set-but-empty variable is still no targets, so still no worker."""
+    monkeypatch.setenv(TARGETS_ENV_VAR, "  ,  ")
+    gw = _gateway(tmp_path, monkeypatch, {"cost_tracking": {"enabled": True}})
+    app = build_app(gw)
+    async with lifespan(app):
+        assert _node_workers(app.state.workers) == []
+
+
+async def test_node_scrape_not_started_when_workers_disabled(
+    tmp_path, monkeypatch
+) -> None:
+    """``workers.enabled: false`` is a kill switch for this worker too."""
+    monkeypatch.setenv(TARGETS_ENV_VAR, _TARGET)
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {"cost_tracking": {"enabled": True}, "workers": {"enabled": False}},
+    )
+    app = build_app(gw)
+    async with lifespan(app):
+        assert app.state.workers == []
+
+
+async def test_node_scrape_not_started_when_storage_disabled(
+    tmp_path, monkeypatch
+) -> None:
+    """No storage to write samples into means no scrape, targets or not."""
+    monkeypatch.setenv(TARGETS_ENV_VAR, _TARGET)
+    gw = _gateway(
+        tmp_path, monkeypatch, {"cost_tracking": {"enabled": False}}, db=False
+    )
+    app = build_app(gw)
+    async with lifespan(app):
+        assert app.state.workers == []
+
+
+async def test_node_scrape_starts_and_stops_when_targets_configured(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv(TARGETS_ENV_VAR, _TARGET)
+    gw = _gateway(tmp_path, monkeypatch, {"cost_tracking": {"enabled": True}})
+    app = build_app(gw)
+    async with lifespan(app):
+        workers = app.state.workers
+        assert len(workers) == 4  # the usual three plus the scrape
+        node = _node_workers(workers)
+        assert len(node) == 1
+        assert node[0]._poll_interval == 15  # the default cadence
+        task = node[0]._task
+        assert task is not None
+    assert node[0]._task is None  # stopped on shutdown, like its siblings
+    assert task.cancelled()  # cancelled and awaited, so nothing went unretrieved
+    assert not [t for t in asyncio.all_tasks() if t.get_name() == "node-samples-worker"]
+
+
+async def test_node_scrape_interval_is_applied(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv(TARGETS_ENV_VAR, _TARGET)
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {
+            "cost_tracking": {"enabled": True},
+            "workers": {"node_scrape_interval_seconds": 333},
+        },
+    )
+    app = build_app(gw)
+    async with lifespan(app):
+        assert [w._poll_interval for w in _node_workers(app.state.workers)] == [333]
+
+
+async def test_node_scrape_shutdown_is_not_blocked_by_a_hanging_target(
+    tmp_path, monkeypatch
+) -> None:
+    """A target that accepts the connection and never answers must not hold up
+    shutdown: the worker is cancelled mid-scrape, not waited out."""
+    release = asyncio.Event()
+
+    async def _never_answer(_reader, writer) -> None:
+        try:
+            await release.wait()
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(_never_answer, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        monkeypatch.setenv(
+            TARGETS_ENV_VAR, f"node-exporter:hung=http://127.0.0.1:{port}/metrics"
+        )
+        gw = _gateway(tmp_path, monkeypatch, {"cost_tracking": {"enabled": True}})
+        app = build_app(gw)
+        ctx = lifespan(app)
+        await ctx.__aenter__()
+        node = _node_workers(app.state.workers)
+        assert len(node) == 1
+        task = node[0]._task
+        assert task is not None
+        # Let the scrape get in flight and block on the read.
+        await asyncio.sleep(0.05)
+        assert not task.done()
+        started = time.monotonic()
+        await ctx.__aexit__(None, None, None)
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+        server.close()
+        await server.wait_closed()
+    assert task.cancelled()
+    # Well inside the worker's 5 s per-target scrape deadline: shutdown cancels
+    # the in-flight request rather than waiting for it to time out.
+    assert elapsed < 3.0


### PR DESCRIPTION
Four things that existed, were tested, and were unreachable.

**G1: `NodeSamplesWorker` was never started.** Nothing constructed it, so node
sampling collected nothing. It now rides the same `_build_workers` and
start/stop loops as the rollup and retention workers.

Gated at build time on `targets_from_env()`: with `VOICEGW_NODE_SCRAPE_TARGETS`
unset there is no worker, therefore no task, therefore no outbound request. Four
tests pin that, and the unset test also asserts the worker count is still
exactly 3 so the existing three-worker test keeps meaning what it meant.

Shutdown is pinned against a loopback server that **accepts and never answers**:
`__aexit__` completes in under 3s, well inside the worker's 5s per-target
deadline, so a hanging target is cancelled rather than waited out.

**G2: `limit` did not mean what the caller thought.** `GET /api/calls` read up to
`limit` rows then dropped other tenants' rows in Python, so a tenant asking for
50 could get 3 back while more of their own rows sat just past the boundary.
Pagination silently lost data.

The predicate is now in SQL, matching `session_repository.list_sessions` three
ways. The empty-string case compiles to `IS NULL` rather than `= ''`, so the
unattributed reader is not handed an empty page by three-valued logic.

**G3: the Report tab was unreachable exactly when it mattered.** The tab strip
was gated on the run having results, so a failed run showed no tabs, even though
the report endpoints handle that case correctly. Verified in a browser: tabs went
from none to all six.

**G4: UNKNOWN rendered as black.** It is now a real reachable verdict (see #186),
so it gets the colourless badge, which makes no claim. `verdictBadgeClass` also
existed **twice** and the two disagreed the moment one learned about UNKNOWN;
it now lives in `shared.tsx` and both import it.

## One judgement call

G4 added a failed run to `demoFixtures` and placed it first, which is the only
way the demo's tabs can show it. That turned `voicegateway.dev/demo` into four
"no result" cards instead of the SFU ramp and agent roster. It was re-timed to
sit between run_003 and run_002 instead: the demo keeps its best content, and
the failed run appears in the run history. Cost: G3's fix is not demo-visible.

Making run-history rows selectable would give both. Not in this PR.

`+15 tests, zero removed.` One alembic head. No migration.