### PR TITLE
mock-participant: two join-path bugs found by a real call

### DIFF
--- a/.github/workflows/go-tools.yml
+++ b/.github/workflows/go-tools.yml
@@ -1,0 +1,63 @@
+name: Go tools
+
+# The Go under tools/ was gated by nothing. ci.yml triggers on
+# src/voicegateway/**, src/dashboard/api/** and pyproject.toml, and pytest's
+# testpaths is src/voicegateway/tests, so a change to the mock participant ran
+# no test, no vet and no build anywhere in CI.
+#
+# That matters more than the usual "add a job for the new language" case. Two
+# bugs shipped in this package that unit tests could not catch, because both
+# only appear when Join talks to a real LiveKit: WithTrack without
+# WithSinglePeerConnection, and Opus declared as 48000/1. The guards written
+# against them live here as Go tests, and a guard nothing runs is a guard that
+# stops working the moment somebody edits around it.
+
+on:
+  pull_request:
+    paths:
+      - 'tools/**'
+      - '.github/workflows/go-tools.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'tools/**'
+      - '.github/workflows/go-tools.yml'
+
+jobs:
+  mock-participant:
+    name: mock-participant
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/mock-participant
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: tools/mock-participant/go.mod
+          cache-dependency-path: tools/mock-participant/go.sum
+
+      - name: Formatting
+        # gofmt -l prints unformatted files and still exits 0, so the output is
+        # what has to be checked, not the status.
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "gofmt would rewrite:" >&2
+            echo "$unformatted" >&2
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      # -race because the worker, the tone streamer and one drain goroutine per
+      # subscribed track all touch the same counters, and those counters are the
+      # bidirectional-media evidence.
+      - name: Test
+        run: go test ./... -race
+
+      - name: Build
+        run: go build -o /dev/null .

--- a/tools/mock-participant/room.go
+++ b/tools/mock-participant/room.go
@@ -10,12 +10,22 @@ import (
 	"github.com/pion/webrtc/v4/pkg/media"
 )
 
-// opusCapability is the codec every published track advertises. 48kHz mono is
-// what tone.ogg was encoded at, and what livekit-sip expects to subscribe to.
+// opusCapability is the codec every published track advertises. It must match
+// what the remote registered or the answer is rejected with "codec is not
+// supported by remote", which surfaces as a join that times out several
+// seconds later rather than as a codec error.
+//
+// CHANNELS IS 2 EVEN THOUGH THE TONE IS MONO. That is not a mismatch: RFC 7587
+// specifies the Opus RTP payload format as always declaring two channels, and
+// mono content is signalled inside the stream (Opus packets are self-describing
+// about channel count) rather than by changing the rtpmap. Declaring 1 here
+// produces an rtpmap no WebRTC endpoint offers. The fmtp line matches pion's
+// own default registration so the two compare equal.
 var opusCapability = webrtc.RTPCodecCapability{
-	MimeType:  webrtc.MimeTypeOpus,
-	ClockRate: 48000,
-	Channels:  1,
+	MimeType:    webrtc.MimeTypeOpus,
+	ClockRate:   48000,
+	Channels:    2,
+	SDPFmtpLine: "minptime=10;useinbandfec=1",
 }
 
 // JoinAndPublish joins the assigned room with an audio track ALREADY ATTACHED

--- a/tools/mock-participant/room.go
+++ b/tools/mock-participant/room.go
@@ -56,8 +56,14 @@ func JoinAndPublish(
 		go drainRTP(track, stats)
 	}
 
+	// WithSinglePeerConnection is a PRECONDITION of WithTrack, not a tuning
+	// option: queuing a track for the join request without it is rejected at
+	// join time with ErrPublishRequiresSinglePC. The two travel together, and
+	// dropping either one silently turns this back into a publish that costs a
+	// second round trip on every call's answer path.
 	room, err := lksdk.ConnectToRoomWithToken(
 		a.URL, a.Token, callback,
+		lksdk.WithSinglePeerConnection(),
 		lksdk.WithTrack(track, &lksdk.TrackPublicationOptions{Name: "mock-audio"}),
 	)
 	if err != nil {

--- a/tools/mock-participant/room_test.go
+++ b/tools/mock-participant/room_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestWithTrackIsPairedWithSinglePeerConnection guards a precondition that no
+// unit test can exercise, because it is only enforced when Join talks to a real
+// server: queuing a track via WithTrack without WithSinglePeerConnection is
+// rejected at join time with ErrPublishRequiresSinglePC.
+//
+// This package shipped without the pairing and compiled, vetted and unit-tested
+// clean. It failed on the first real call, at the join, after the worker
+// handshake and job assignment had both succeeded. A source-level check is a
+// blunt instrument, but it is the only one that fires without a live LiveKit,
+// and dropping the option is a one-line edit that otherwise looks harmless.
+func TestWithTrackIsPairedWithSinglePeerConnection(t *testing.T) {
+	source, err := os.ReadFile("room.go")
+	if err != nil {
+		t.Fatalf("read room.go: %v", err)
+	}
+	text := string(source)
+	if !strings.Contains(text, "lksdk.WithTrack(") {
+		t.Fatal("room.go no longer calls WithTrack; this guard needs rewriting")
+	}
+	if !strings.Contains(text, "lksdk.WithSinglePeerConnection()") {
+		t.Error(
+			"room.go queues a track with WithTrack but never enables " +
+				"WithSinglePeerConnection; the join is rejected with " +
+				"ErrPublishRequiresSinglePC against a real server",
+		)
+	}
+}

--- a/tools/mock-participant/room_test.go
+++ b/tools/mock-participant/room_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/pion/webrtc/v4"
 )
 
 // TestWithTrackIsPairedWithSinglePeerConnection guards a precondition that no
@@ -32,4 +35,87 @@ func TestWithTrackIsPairedWithSinglePeerConnection(t *testing.T) {
 				"ErrPublishRequiresSinglePC against a real server",
 		)
 	}
+}
+
+// TestOpusCapabilityNegotiatesWithAWebRTCPeer runs a full offer/answer against
+// a second peer connection and asserts the published capability survives it.
+//
+// This reproduces the production failure exactly. Declaring one channel yields
+// "unable to start track, codec is not supported by remote" from
+// SetRemoteDescription, which is the same string a real SFU returned. Nothing
+// cheaper catches it: NewTrackLocalStaticSample accepts the bad capability,
+// AddTrack accepts it, and the generated OFFER still advertises opus/48000/2
+// because the offer lists the media engine's registered codecs rather than the
+// track's. The mismatch only appears when the ANSWER is applied.
+//
+// The visible symptom on a real server is not a codec error either: the peer
+// connection never completes and the join fails seconds later with "could not
+// connect after timeout", which points at the network instead of the codec.
+func TestOpusCapabilityNegotiatesWithAWebRTCPeer(t *testing.T) {
+	if err := negotiateWith(opusCapability); err != nil {
+		t.Fatalf("a standard WebRTC peer rejected opusCapability: %v", err)
+	}
+}
+
+// TestMonoOpusCapabilityIsRejected proves the test above is not vacuous.
+//
+// RFC 7587 declares the Opus RTP payload format with two channels whatever the
+// content is; mono is signalled inside the stream. Reading the channel count
+// off the tone (which IS mono) is what produced the bug, so the wrong value is
+// pinned here as rejected rather than merely described in a comment.
+func TestMonoOpusCapabilityIsRejected(t *testing.T) {
+	mono := opusCapability
+	mono.Channels = 1
+	err := negotiateWith(mono)
+	if err == nil {
+		t.Fatal("opus/48000/1 negotiated cleanly; this guard no longer discriminates")
+	}
+	if !strings.Contains(err.Error(), "codec is not supported by remote") {
+		t.Errorf("rejected for the wrong reason: %v", err)
+	}
+}
+
+// negotiateWith runs a complete offer/answer between two peer connections with
+// a track built from cap, returning the error the exchange produced.
+func negotiateWith(capability webrtc.RTPCodecCapability) error {
+	offerer, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		return err
+	}
+	defer offerer.Close()
+	answerer, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		return err
+	}
+	defer answerer.Close()
+
+	track, err := webrtc.NewTrackLocalStaticSample(capability, "audio", "mock")
+	if err != nil {
+		return fmt.Errorf("new track: %w", err)
+	}
+	if _, err = offerer.AddTrack(track); err != nil {
+		return fmt.Errorf("add track: %w", err)
+	}
+	offer, err := offerer.CreateOffer(nil)
+	if err != nil {
+		return err
+	}
+	if err = offerer.SetLocalDescription(offer); err != nil {
+		return err
+	}
+	if err = answerer.SetRemoteDescription(offer); err != nil {
+		return fmt.Errorf("answerer SetRemoteDescription: %w", err)
+	}
+	answer, err := answerer.CreateAnswer(nil)
+	if err != nil {
+		return err
+	}
+	if err = answerer.SetLocalDescription(answer); err != nil {
+		return err
+	}
+	// Where "codec is not supported by remote" fires.
+	if err = offerer.SetRemoteDescription(answer); err != nil {
+		return fmt.Errorf("offerer SetRemoteDescription: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Two bugs that no unit test could reach, both found on the first real call against a live LiveKit. The package compiled, vetted and passed 45 tests under `-race` with both present; each only manifests when `Join` talks to a real server.

## 1. WithTrack requires WithSinglePeerConnection

Rejected at join with `ErrPublishRequiresSinglePC`. The SDK documents this on `WithTrack` itself ("Requires WithSinglePeerConnection") and ships an integration test named for it. I read the part about `WithTrack` publishing as part of the join request, which is true and is the reason to use it, and missed the precondition attached to the same docstring.

## 2. Opus declared as 48000/1 instead of 48000/2

Failed while applying the answer with `unable to start track, codec is not supported by remote`. The capability declared one channel because the tone is mono, and the old comment said so out loud: *"48kHz mono is what tone.ogg was encoded at."* That was the wrong thing to read the channel count from. RFC 7587 declares the Opus RTP payload format with two channels whatever the content is; mono is signalled inside the stream. pion registers `{Opus, 48000, 2, "minptime=10;useinbandfec=1"}`, which the capability now matches exactly.

**This one does not surface as a codec error.** Setting the remote description fails, ICE never gets usable candidates, and the join dies seconds later with `could not connect after timeout` — pointing squarely at the network.

## Guards

The codec test runs a full offer/answer between two peer connections and reproduces the production error string locally. Nothing cheaper works: `NewTrackLocalStaticSample` accepts the bad capability, `AddTrack` accepts it, and the generated offer still advertises `opus/48000/2` because an offer lists the media engine's codecs rather than the track's. The mismatch only appears when the answer is applied.

A first attempt at that test asserted the offer SDP and **passed with the bug present**. It was replaced rather than kept. The mono case is now pinned as rejected so the guard cannot go vacuous, and the single-PC guard was likewise verified to fail with the option removed.

## Verified end to end

Two mock participants dispatched into one room, each publishing a tone and auto-subscribing to the other:

```
mock-a ended: 6824 rtp packets, 503498 bytes, 1 tracks
mock-b ended: 6831 rtp packets, 504167 bytes, 1 tracks
```

Cross-checked against theory rather than accepted for being non-zero: 137s and 138s at 50 packets/sec (20 ms Opus framing) predicts 6850 and 6900. Observed 99.6% and 99.0%, 73.8 bytes/packet on both sides, 0.10% delta between directions. That also independently validates the Ogg segment-table parser, since treating a page as a frame would have made the rate roughly 17x wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Opus audio negotiation by advertising stereo RTP with compatible packetization and forward error correction parameters.
  * Updated room connections to use a single peer connection when publishing tracks.
  * Added validation to reject mono-signaled Opus configurations and prevent incompatible WebRTC negotiations.

* **Tests**
  * Added regression coverage for Opus negotiation and room connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->