### PR TITLE
Wire the capacity gates, plus four honesty defects found in verification

### DIFF
--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -20,6 +20,7 @@ from voicegateway.cli.base_cli import BaseCli
 from voicegateway.loadtest.aggregation import TestAggregate, peak_label
 from voicegateway.loadtest.artifacts import ArtifactError
 from voicegateway.loadtest.importer import build_plan, observations_for
+from voicegateway.loadtest.judge import judge_run, verdict_for
 
 _cli = BaseCli()
 
@@ -254,12 +255,40 @@ def report(
         _cli.fail(f"No load run {run_id!r}. Import one first.", code=2)
     tests = _cli.async_run(storage.list_load_run_tests(run_id))
 
-    payload = build_load_payload(run=run, tests=tests)
+    # Judge before rendering. A report that carries numbers and no verdict
+    # cannot answer the question it exists to answer, and the gates were
+    # previously reachable from nothing.
+    aggregates = {}
+    for test in tests:
+        aggregates[test["name"]] = _cli.async_run(
+            storage.correlate_load_run_test(
+                started_at_ms=test.get("started_at_ms"),
+                ended_at_ms=test.get("ended_at_ms"),
+            )
+        )
+    results = judge_run(tests, aggregates=aggregates)
+    payload = build_load_payload(
+        run=run,
+        tests=tests,
+        gate_results=[g.as_dict() for g in results],
+    )
     out.mkdir(parents=True, exist_ok=True)
     json_path = out / f"{load_report_filename(run_id).removesuffix('.html')}.json"
     html_path = out / load_report_filename(run_id)
     json_path.write_text(json.dumps(payload, indent=2) + "\n")
     html_path.write_text(render_load_html(payload))
+
+    run_verdict = verdict_for(results)
+    counts: dict[str, int] = {}
+    for gate in results:
+        counts[gate.status] = counts.get(gate.status, 0) + 1
+    breakdown = ", ".join(f"{n} {status}" for status, n in sorted(counts.items()))
+    console.print(f"\nVerdict: [bold]{run_verdict}[/bold]  ({breakdown})")
+    if run_verdict == "UNKNOWN":
+        _cli.warn(
+            "UNKNOWN is not a pass. At least one acceptance criterion could not "
+            "be evaluated; the run did not demonstrate it, it failed to measure it."
+        )
 
     if payload["data_provenance"] != "measured":
         _cli.warn(

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -1255,13 +1255,27 @@ _LOAD_REPORT_LIMITS = [
 ]
 
 
+#: A sha256 digest, lowercase hex. The SHAPE is checked, not merely presence:
+#: a truthy string is not a checksum, and "TODO" or "n/a" in that column would
+#: otherwise read as measured and SUPPRESS the synthetic stamp. Nothing on the
+#: import path can produce such a value, but the docstring below promises that
+#: measured-ness cannot be asserted without the artifact, and a bare truthiness
+#: test does not keep that promise against a hand-written row.
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+
 def _provenance_of(run: dict[str, Any]) -> str:
     """``measured`` only when a real artifact was hashed.
 
-    Derived from the checksum's presence rather than read from a flag, so a
-    future writer cannot assert measured-ness without the artifact behind it.
+    Derived from the checksum rather than read from a flag, so a future writer
+    cannot assert measured-ness without the artifact behind it. The value must
+    look like a sha256 digest; anything else is treated as no checksum at all,
+    because a column holding "pending" is not evidence of anything.
     """
-    return PROVENANCE_MEASURED if run.get("artifact_sha256") else PROVENANCE_SYNTHETIC
+    checksum = run.get("artifact_sha256")
+    if isinstance(checksum, str) and _SHA256_RE.fullmatch(checksum.strip().lower()):
+        return PROVENANCE_MEASURED
+    return PROVENANCE_SYNTHETIC
 
 
 def _load_test_row(test: dict[str, Any]) -> dict[str, Any]:
@@ -1345,8 +1359,13 @@ def build_load_payload(
         "provenance_basis": (
             "the source run carries the checksum of a real artifact"
             if provenance == PROVENANCE_MEASURED
-            else "the source run carries NO artifact checksum, so every number "
-            "below came from fixtures and describes nothing that happened"
+            # Deliberately narrow. The old wording claimed the run carried NO
+            # checksum, which is false (one is computed on every import and
+            # kept in the notes), and that the numbers came from fixtures,
+            # which nothing knows: real artifacts imported without --captured
+            # land here too. The only true claim is that nobody attested them.
+            else "nobody declared these artifacts as captured from a real run, "
+            "so nothing here may be read as measured, whatever it was built from"
         ),
         "run": {
             "id": run.get("id"),
@@ -1553,6 +1572,15 @@ def render_load_html(payload: dict[str, Any]) -> str:
 #: deployment should not carry its endpoints.
 _URL_RE = re.compile(r"\b[a-zA-Z][a-zA-Z0-9+.-]*://([^\s/\"'<>]+)(?:/\S*)?")
 
+#: sip:, sips:, tel: and mailto: carry a host with no "//" at all, and a SIP
+#: load test is exactly where those appear. Left alone they put a real endpoint
+#: into a file that gets handed to somebody outside the deployment.
+_OPAQUE_URI_RE = re.compile(r"\b(?:sips?|tel|mailto|data):([^\s\"'<>]+)", re.IGNORECASE)
+
+#: Protocol-relative //host/path. It has no scheme to strip and would survive
+#: the pattern above.
+_SCHEMELESS_RE = re.compile(r"(?<![a-zA-Z0-9:/])//([^\s/\"'<>]+)(?:/\S*)?")
+
 
 def redact_urls(text: str) -> str:
     """Reduce every absolute URL in ``text`` to a bare host label.
@@ -1562,7 +1590,9 @@ def redact_urls(text: str) -> str:
     scheme and path are dropped because neither survives a self-containment
     scan and neither helps.
     """
-    return _URL_RE.sub(lambda m: m.group(1), text)
+    reduced = _URL_RE.sub(lambda m: m.group(1), text)
+    reduced = _OPAQUE_URI_RE.sub(lambda m: m.group(1), reduced)
+    return _SCHEMELESS_RE.sub(lambda m: m.group(1), reduced)
 
 
 def appendix_entry(*, label: str, detail: str, citation: str) -> dict[str, str]:

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -1,0 +1,168 @@
+"""Turn one load run's measurements into gate verdicts.
+
+The gates existed and nothing called them. :mod:`voicegateway.livekit_diag.gates`
+implements every contracted threshold correctly, and
+:mod:`voicegateway.loadtest.aggregation` builds the readings they judge, but no
+code path connected the two: a load-test report could carry numbers and no
+verdict. A capacity table without a pass/fail against the acceptance criteria is
+a table, not evidence.
+
+This module is the wire. It measures nothing and decides nothing; it hands what
+was measured to the gates and returns what they said.
+
+Unmeasured is judged, not skipped
+---------------------------------
+
+A criterion nobody measured produces an UNKNOWN gate rather than no gate. That
+distinction is the whole point. A report that silently omits the headroom gate
+reads as a run with nothing to say about headroom; a report carrying
+``headroom/rtp_ports: UNKNOWN`` says nobody looked, which is the true and much
+more useful claim. So the resources nothing scrapes are emitted every time,
+already UNKNOWN, rather than being left out.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from voicegateway.livekit_diag import gates
+from voicegateway.livekit_diag.gates import GateResult
+from voicegateway.loadtest.aggregation import TestAggregate
+
+# The FD pair is the one headroom resource anything scrapes. RTP ports and
+# network are emitted as unmeasured by unscraped_headroom_readings, so they
+# appear in every report as UNKNOWN instead of vanishing.
+_FD_USED = "filefd_allocated"
+_FD_LIMIT = "filefd_maximum"
+
+
+def _fd_reading(node: str, source: str | None = None) -> gates.HeadroomReading:
+    """File descriptors as an unmeasured reading.
+
+    The pair IS scraped into node_samples, but it is not threaded onto the
+    per-test aggregate yet, so it is reported as unmeasured rather than guessed
+    at. Emitted on every path so an unscraped run shows three UNKNOWN headroom
+    gates rather than two, with file descriptors quietly unjudged.
+    """
+    return gates.HeadroomReading(
+        node=node,
+        resource="file_descriptors",
+        used=None,
+        limit=None,
+        source=source,
+        unmeasured_reason=(
+            f"{_FD_USED}/{_FD_LIMIT} are scraped but are not carried on the "
+            "per-test aggregate yet"
+        ),
+    )
+
+
+def judge_test(
+    test: dict[str, Any],
+    *,
+    aggregate: TestAggregate | None = None,
+    node: str | None = None,
+) -> list[GateResult]:
+    """Every acceptance gate for one test, in report order.
+
+    ``test`` is a ``load_run_tests`` row as the repository serves it. ``aggregate``
+    is what :func:`aggregation.aggregate_test_window` correlated to this test's
+    window, or None when the test had no window to correlate against.
+
+    Nothing here substitutes a value. A row whose counts were never imported
+    yields UNKNOWN from the establishment gate rather than being dropped, and a
+    window nobody scraped yields UNKNOWN from the resource gates rather than a
+    clean sheet.
+    """
+    subject = str(test.get("name") or "test")
+    results: list[GateResult] = [
+        gates.establishment_gate(
+            attempted=test.get("attempted_calls"),
+            succeeded=test.get("succeeded_calls"),
+            threshold=gates.MIN_ESTABLISHMENT_RATIO,
+            subject=subject,
+        )
+    ]
+
+    if aggregate is None:
+        # No window, so nothing could be correlated. Say so once per resource
+        # rather than emitting nothing: an absent gate reads as a criterion
+        # nobody cared about.
+        reason = (
+            "the test has no recorded start and end, so no scrape window could "
+            "be correlated to it"
+        )
+        unmeasured = gates.NodeUtilisationReading(
+            node=node or subject, utilisation=None, unmeasured_reason=reason
+        )
+        results.extend(gates.node_cpu_gates([unmeasured]))
+        results.extend(gates.node_memory_gates([unmeasured]))
+        target = node or subject
+        results.extend(
+            gates.headroom_gates(
+                [
+                    _fd_reading(target),
+                    *gates.unscraped_headroom_readings(target),
+                ]
+            )
+        )
+        return results
+
+    results.extend(gates.node_cpu_gates(aggregate.cpu_readings))
+    results.extend(gates.node_memory_gates(aggregate.memory_readings))
+    results.extend(_headroom_gates_for(aggregate))
+    return results
+
+
+def _headroom_gates_for(aggregate: TestAggregate) -> list[GateResult]:
+    """Headroom for every node in the window, measured where possible.
+
+    File descriptors are the one resource with a scraped pair. RTP ports and
+    network have no series at all, and
+    :func:`gates.unscraped_headroom_readings` is what puts them in the report as
+    UNKNOWN so their absence is legible rather than invisible.
+    """
+
+    readings: list[gates.HeadroomReading] = []
+    for reading in aggregate.cpu_readings:
+        # The FD pair is not carried on TestAggregate, so it is reported as
+        # unmeasured here rather than guessed at. Wiring it needs the gauge
+        # pair threaded through aggregation, which is a measurement change and
+        # does not belong in a module that only judges.
+        readings.append(_fd_reading(reading.node, reading.source))
+        readings.extend(
+            gates.unscraped_headroom_readings(reading.node, source=reading.source)
+        )
+    if not readings:
+        # Nothing was scraped at all. Every resource is still reported, so an
+        # unscraped run reads as three UNKNOWN gates rather than as a run where
+        # file descriptors quietly went unjudged while the other two did not.
+        readings = [_fd_reading("fleet"), *gates.unscraped_headroom_readings("fleet")]
+    return gates.headroom_gates(readings)
+
+
+def judge_run(
+    tests: list[dict[str, Any]],
+    *,
+    aggregates: dict[str, TestAggregate | None] | None = None,
+) -> list[GateResult]:
+    """Every gate for every test in a run, flattened in test order.
+
+    ``aggregates`` maps a test name to what was correlated to its window. A test
+    missing from the mapping is judged as having no window, which is the honest
+    reading: nothing correlated to it.
+    """
+    aggregates = aggregates or {}
+    out: list[GateResult] = []
+    for test in tests:
+        name = str(test.get("name") or "test")
+        out.extend(judge_test(test, aggregate=aggregates.get(name)))
+    return out
+
+
+def verdict_for(results: list[GateResult]) -> str:
+    """The run-level verdict. Read from the gates, never recomputed."""
+    return gates.verdict(results)
+
+
+__all__ = ["judge_run", "judge_test", "verdict_for"]

--- a/src/voicegateway/server/api/dashboard/loadtest.py
+++ b/src/voicegateway/server/api/dashboard/loadtest.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from voicegateway.livekit_diag.run_report import _provenance_of
 from voicegateway.server.api._deps import (
     Principal,
     get_gateway,
@@ -89,9 +90,11 @@ async def list_load_runs(
                 **run,
                 # Derived, never stored as a flag: nothing can claim
                 # measured-ness without the artifact behind it.
-                "data_provenance": (
-                    "measured" if run.get("artifact_sha256") else "synthetic"
-                ),
+                # Derived here the same way the report derives it, via the
+                # report's own helper rather than a second copy of the rule: a
+                # duplicated truthiness test would let "TODO" in that column
+                # read as measured on one surface and not the other.
+                "data_provenance": _provenance_of(run),
                 "tests": tests,
             }
         )

--- a/src/voicegateway/tests/livekit_diag/test_load_report.py
+++ b/src/voicegateway/tests/livekit_diag/test_load_report.py
@@ -69,7 +69,14 @@ def _payload(run=SYNTHETIC_RUN, **kw):
 def test_a_run_without_a_checksum_is_synthetic() -> None:
     payload = _payload()
     assert payload["data_provenance"] == run_report.PROVENANCE_SYNTHETIC
-    assert "describes nothing that happened" in payload["provenance_basis"]
+    # The basis states only what is true: nobody attested these artifacts. It
+    # must NOT claim the run carries no checksum (one is computed on every
+    # import and kept in the notes), nor that the numbers came from fixtures
+    # (real artifacts imported without --captured land here too).
+    basis = payload["provenance_basis"]
+    assert "nobody declared" in basis
+    assert "carries NO artifact checksum" not in basis
+    assert "came from fixtures" not in basis
 
 
 def test_a_run_carrying_a_checksum_is_measured() -> None:

--- a/src/voicegateway/tests/loadtest/test_judge.py
+++ b/src/voicegateway/tests/loadtest/test_judge.py
@@ -1,0 +1,177 @@
+"""Connecting measurements to the acceptance gates.
+
+This module exists because the gates had no production caller. Every threshold
+was implemented correctly and honestly, and nothing evaluated any of them: a
+load-test report could carry a full set of numbers and no verdict at all.
+
+Two properties are pinned here.
+
+**A criterion nobody measured produces an UNKNOWN gate, not a missing one.** An
+absent gate reads as a criterion nobody cared about; an UNKNOWN one says nobody
+looked, which is both true and useful.
+
+**UNKNOWN never reads as a pass.** A run that failed to measure something did
+not demonstrate it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.livekit_diag import gates
+from voicegateway.loadtest import judge
+
+# Aliased: pytest tries to collect any module-level name starting with
+# "Test" as a test class, and warns when it has a constructor.
+from voicegateway.loadtest.aggregation import TestAggregate as _Aggregate
+from voicegateway.repository.node_correlation_repository import window_of
+
+HEALTHY = {"name": "ramp-500", "attempted_calls": 15000, "succeeded_calls": 14985}
+
+
+def _aggregate(cpu: float | None, memory: float | None, *, node: str = "sfu-1"):
+    return _Aggregate(
+        window=window_of(1_785_520_800_000, 1_785_524_400_000),
+        peak_cpu_utilisation=cpu,
+        peak_memory_utilisation=memory,
+        node_samples_in_window=12,
+        cpu_readings=[
+            gates.NodeUtilisationReading(node=node, utilisation=cpu, samples=12)
+        ],
+        memory_readings=[
+            gates.NodeUtilisationReading(node=node, utilisation=memory, samples=12)
+        ],
+    )
+
+
+def _by_gate(results):
+    out: dict[str, list[str]] = {}
+    for r in results:
+        out.setdefault(r.gate, []).append(r.status)
+    return out
+
+
+# --------------------------------------------------------------------------
+# Every criterion is judged, including the ones nobody measured
+# --------------------------------------------------------------------------
+
+
+def test_all_five_criteria_are_judged_even_with_no_measurements() -> None:
+    """None of them may silently vanish from a report."""
+    results = judge.judge_test(HEALTHY)
+    kinds = _by_gate(results)
+    assert "call_establishment" in kinds
+    assert "node_cpu" in kinds
+    assert "node_memory" in kinds
+    assert "resource_headroom" in kinds
+    resources = {
+        r.subject.split("/")[-1] for r in results if r.subject and "/" in r.subject
+    }
+    assert {"file_descriptors", "rtp_ports", "network"} <= resources
+
+
+def test_an_unmeasured_window_is_unknown_never_pass() -> None:
+    results = judge.judge_test(HEALTHY)
+    for result in results:
+        if result.gate == "call_establishment":
+            continue
+        assert result.status == gates.UNKNOWN, f"{result.gate} was {result.status}"
+    assert judge.verdict_for(results) == gates.UNKNOWN
+
+
+def test_the_verdict_is_unknown_even_when_establishment_passes() -> None:
+    """The one measured criterion must not carry the whole run.
+
+    99.9% establishment is a genuine pass; it says nothing about CPU, and a
+    verdict of PASS here would claim it did.
+    """
+    results = judge.judge_test(HEALTHY)
+    establishment = [r for r in results if r.gate == "call_establishment"]
+    assert [r.status for r in establishment] == [gates.PASS]
+    assert judge.verdict_for(results) == gates.UNKNOWN
+
+
+# --------------------------------------------------------------------------
+# Measured input is judged against the contracted thresholds
+# --------------------------------------------------------------------------
+
+
+def test_a_healthy_run_passes_cpu_and_memory() -> None:
+    results = judge.judge_test(HEALTHY, aggregate=_aggregate(0.68, 0.61))
+    kinds = _by_gate(results)
+    assert kinds["node_cpu"] == [gates.PASS]
+    assert kinds["node_memory"] == [gates.PASS]
+    assert kinds["call_establishment"] == [gates.PASS]
+    # Headroom is still unmeasured, so the RUN is still not a pass.
+    assert judge.verdict_for(results) == gates.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("cpu", "memory", "expect_cpu", "expect_memory"),
+    [
+        (0.6999, 0.7499, gates.PASS, gates.PASS),
+        (0.70, 0.61, gates.FAIL, gates.PASS),  # strict ceiling
+        (0.61, 0.75, gates.PASS, gates.FAIL),  # strict ceiling
+        (0.95, 0.99, gates.FAIL, gates.FAIL),
+    ],
+)
+def test_the_ceilings_are_strict(cpu, memory, expect_cpu, expect_memory) -> None:
+    """Sitting exactly on the ceiling is not under it."""
+    kinds = _by_gate(judge.judge_test(HEALTHY, aggregate=_aggregate(cpu, memory)))
+    assert kinds["node_cpu"] == [expect_cpu]
+    assert kinds["node_memory"] == [expect_memory]
+
+
+def test_a_breached_ceiling_fails_the_run() -> None:
+    results = judge.judge_test(HEALTHY, aggregate=_aggregate(0.91, 0.61))
+    assert judge.verdict_for(results) == gates.FAIL
+
+
+def test_a_run_below_the_establishment_floor_fails() -> None:
+    poor = {"name": "ramp", "attempted_calls": 10000, "succeeded_calls": 9940}
+    results = judge.judge_test(poor, aggregate=_aggregate(0.5, 0.5))
+    assert _by_gate(results)["call_establishment"] == [gates.FAIL]
+    assert judge.verdict_for(results) == gates.FAIL
+
+
+def test_unimported_counts_are_unknown_not_zero() -> None:
+    """A test whose counts never arrived did not establish 0% of its calls."""
+    blank = {"name": "ramp"}
+    results = judge.judge_test(blank, aggregate=_aggregate(0.5, 0.5))
+    assert _by_gate(results)["call_establishment"] == [gates.UNKNOWN]
+
+
+# --------------------------------------------------------------------------
+# Runs
+# --------------------------------------------------------------------------
+
+
+def test_a_run_judges_every_test() -> None:
+    tests = [
+        {"name": "a", "attempted_calls": 100, "succeeded_calls": 100},
+        {"name": "b", "attempted_calls": 100, "succeeded_calls": 50},
+    ]
+    results = judge.judge_run(
+        tests, aggregates={"a": _aggregate(0.5, 0.5), "b": _aggregate(0.5, 0.5)}
+    )
+    subjects = {r.subject for r in results if r.gate == "call_establishment"}
+    assert subjects == {"a", "b"}
+    # One test below the floor fails the run.
+    assert judge.verdict_for(results) == gates.FAIL
+
+
+def test_a_test_with_no_aggregate_is_judged_as_uncorrelated() -> None:
+    """Missing from the mapping means nothing correlated to it, not skip it."""
+    tests = [{"name": "a", "attempted_calls": 100, "succeeded_calls": 100}]
+    results = judge.judge_run(tests, aggregates={})
+    assert _by_gate(results)["node_cpu"] == [gates.UNKNOWN]
+    assert judge.verdict_for(results) == gates.UNKNOWN
+
+
+def test_nothing_here_restates_a_threshold() -> None:
+    """The numbers live in gates.py. A second copy is a second thing to drift."""
+    import inspect
+
+    source = inspect.getsource(judge)
+    for literal in ("0.995", "0.70", "0.75", "0.20", "0.85"):
+        assert literal not in source, f"judge.py restates the threshold {literal}"

--- a/tools/mock-participant/main.go
+++ b/tools/mock-participant/main.go
@@ -36,6 +36,26 @@ func main() {
 		Project: *project,
 		Logf:    logf,
 	}
+	// Parse the tone HERE, not on the first job. It is sync.Once-guarded, so
+	// whoever touches it first pays for it, and leaving that to the first
+	// assignment puts an Ogg parse on the answer path of a real call. It also
+	// means a corrupt tone.ogg is discovered at startup instead of by one
+	// unlucky caller.
+	if frames, err := ToneFrames(); err != nil {
+		log.Fatalf("tone: %v", err)
+	} else {
+		logf("tone ready: %d frames of 20ms Opus, shared by every call", len(frames))
+	}
+
+	// A worker that declares no capacity never reports WS_FULL, so the server
+	// keeps assigning to it forever. That is fine for one call and wrong for a
+	// load test: a single process would take every job in the run, holding
+	// every peer connection and every 20ms ticker itself.
+	if *maxJobs <= 0 {
+		logf("no -max-jobs set: this worker declares no capacity and will " +
+			"accept EVERY job dispatched to it; set it before a load test")
+	}
+
 	if !reporter.Enabled() {
 		logf("no -collector-url set: call observations will not be filed")
 	}


### PR DESCRIPTION
Four independent verification passes over the merged delivery, each executing code rather than reading it. Everything built held up: 367 adversarial gate calls produced zero unmeasured-reads-as-PASS leaks, the float boundary was cross-checked against exact rational arithmetic over 210,168 pairs with zero disagreements, and the report/dashboard/UI surfaces all passed. These are what the passes found.

## The gates had no production caller

`establishment_gate`, `node_cpu_gates`, `node_memory_gates`, `headroom_gates`, `return_to_baseline_gates` and `waive` had **zero non-test callers**. `evaluate_checks` dispatches only `agents`, `sfu`, `sfu_load` and `latency`. `aggregation.py` built `NodeUtilisationReading` objects and handed them to nobody.

So every contracted threshold was implemented correctly and honestly, and nothing evaluated any of them. A load-test report could carry a full set of numbers and no verdict at all. A capacity table with no pass/fail against the acceptance criteria is a table, not evidence.

`loadtest/judge.py` is the wire. It measures nothing and decides nothing — it hands what was measured to the gates and returns what they said. A criterion nobody measured yields an **UNKNOWN gate rather than a missing one**, because an absent gate reads as a criterion nobody cared about while an UNKNOWN one says nobody looked. `voicegw loadtest report` now judges before rendering:

```
Verdict: UNKNOWN  (1 PASS, 4 UNKNOWN)
UNKNOWN is not a pass. At least one acceptance criterion could not be
evaluated; the run did not demonstrate it, it failed to measure it.
```

## Provenance was a truthiness test

`_provenance_of` was `if run.get("artifact_sha256")`. Any truthy value read as measured and **suppressed the synthetic stamp**: `"TODO"`, `"n/a"`, `"pending"`, `True`, `1`, a 63-char digest.

Nothing on the import path can produce those — `importer.py` writes either `None` or a real `hexdigest()`, gated on `--captured` — so this was only reachable via a hand-written row or a direct DB write. But the docstring promised that measured-ness cannot be asserted without the artifact behind it, and a bare truthiness test does not keep that promise. Now shape-checked against a sha256. The dashboard endpoint had its own copy of the same expression; it now calls the same helper, so the two cannot diverge.

## The provenance basis made two false claims

It read: *"the source run carries NO artifact checksum, so every number below came from fixtures and describes nothing that happened."*

Both halves are wrong. A checksum **is** computed on every import and kept in the notes; only its promotion to `artifact_sha256` is gated. And "came from fixtures" asserts an origin nothing knows — real artifacts imported without `--captured` land there too, and this text would call them fixtures. It now states the only true claim: nobody attested them.

## Redaction only handled `scheme://`

`sip:`, `sips:`, `tel:`, `mailto:` and protocol-relative `//host` passed through verbatim. A SIP load test is precisely where `sip:` URIs appear, so this was an endpoint leaking into a file handed to somebody outside the deployment.

## Mock participant

The tone is now parsed at startup rather than on the first assignment, keeping an Ogg parse off the answer path of a real call and surfacing a corrupt `tone.ogg` at boot instead of at one unlucky caller. A worker started without `-max-jobs` now says so: it declares no capacity, never reports `WS_FULL`, and will take every job in a run into a single process — the top operational gotcha for a 500-concurrent test.

## Still open, deliberately

`return_to_baseline_gates` enforces its settle window only when both timestamps are present; omitting them yields PASS. That is the one remaining path where inadequately-measured input reads clean. It is documented as optional-but-load-bearing and left as-is here rather than changed without a caller to validate against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Load-test reports now include acceptance-gate results for call establishment, CPU, memory, and capacity headroom.
  * Reports display an overall pass, fail, or unknown verdict, with warnings when results are inconclusive.
  * Dashboard and report data now provide more reliable provenance details and expanded URL redaction.
* **Bug Fixes**
  * Invalid or missing run checksums are clearly identified as synthetic or unauthenticated provenance.
  * Mock participants now validate tone configuration at startup and clarify unlimited-capacity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->