### PR TITLE
Close the gap between a report with numbers and a deliverable

### DIFF
--- a/docs/cli/loadtest.md
+++ b/docs/cli/loadtest.md
@@ -46,6 +46,34 @@ Peak CPU and memory come from `node_samples` correlated by **time-window overlap
 
 Numbers are only evidence if somebody else can produce them again, so the report carries an appendix of commands and flag semantics, each requiring a citation. An uncited command is indistinguishable from one the report invented.
 
+Supply it with `--appendix`, pointing at a JSON file you hold:
+
+```json
+{
+  "commands": [
+    {"label": "ramp step",
+     "detail": "gossip sipp -l 200 -r 3.2258 -pause_ms 60000 -trace_stat",
+     "citation": "runbook.md:75"}
+  ],
+  "flags": [
+    {"label": "-l",
+     "detail": "Max concurrent calls. Defaults to 1.",
+     "citation": "runbook.md:53"}
+  ],
+  "toolchain": [
+    {"label": "build",
+     "detail": "Cross-compile for linux/amd64; does not build on macOS.",
+     "citation": "observed on 0.1.61 and 0.1.62"}
+  ]
+}
+```
+
+The file lives with you rather than in this repository. Commands belong to a particular engagement, and the generator they drive is under a copyleft licence while this project is MIT, so its scenarios and configuration must not be copied here. Flag names and command lines are interface facts and travel fine.
+
+Three sections are recognised: `commands`, `flags` and `toolchain`. A misspelled one is refused rather than ignored, because silently dropping a section would hand over a report missing the commands that produced it. An entry with no citation is refused by position so you can find the line.
+
+Run `voicegw loadtest report` without `--appendix` and it says so rather than omitting the section quietly.
+
 Scenario files and generator configuration are referenced by name, never copied. They are the work of whoever authored them, and a generator under a copyleft licence has no business having its source pasted into an MIT repository. Run it as a separate binary, ingest its output files.
 
 Absolute URLs in the appendix are reduced to a bare host label before rendering, both because an absolute URL breaks the self-containment guarantee and because a report handed to somebody outside the deployment should not carry its endpoints.

--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -17,8 +17,14 @@ from rich.table import Table
 
 from voicegateway.cli._app import app, console
 from voicegateway.cli.base_cli import BaseCli
+from voicegateway.livekit_diag.gates import MAX_NODE_CPU_UTILISATION
 from voicegateway.loadtest.aggregation import TestAggregate, peak_label
 from voicegateway.loadtest.artifacts import ArtifactError
+from voicegateway.loadtest.capacity import (
+    RampStep,
+    capacity_table,
+    derive_calls_per_node,
+)
 from voicegateway.loadtest.importer import build_plan, observations_for
 from voicegateway.loadtest.judge import judge_run, verdict_for
 
@@ -229,6 +235,53 @@ def list_runs(
     console.print(table)
 
 
+def _capacity_for(tests: list[dict]) -> dict:
+    """Derive the calls-per-node figure and the node count at each tier.
+
+    The derivation is the one number the whole table rests on, and it refuses
+    far more often than it answers. Its REASON is returned either way: a report
+    saying why it could not size the fleet is worth more than one quietly
+    missing the section, and far more than one carrying a number nobody earned.
+
+    The ceiling is imported from the gates rather than typed here. It is a
+    contracted threshold and two copies of it would drift.
+    """
+    steps = [
+        RampStep(
+            target_concurrency=test.get("target_concurrency"),
+            peak_concurrency=test.get("peak_concurrency"),
+            peak_cpu_utilisation=test.get("peak_cpu_utilisation"),
+            # Arrival rate and hold live in the generator's scenario file, which
+            # is not an artifact and never reaches load_run_tests. Leaving them
+            # None means the plan-side plateau check cannot run, which the
+            # derivation accounts for rather than treating as a clean ramp.
+        )
+        for test in tests
+    ]
+    calls_per_node, reason = derive_calls_per_node(
+        steps, cpu_ceiling=MAX_NODE_CPU_UTILISATION
+    )
+    capacity: dict = {"calls_per_node": calls_per_node, "reason": reason}
+    if calls_per_node is None:
+        # Refused. The reason is the payload, and no tiers are invented.
+        return capacity
+    capacity["tiers"] = [
+        {
+            "target_concurrency": tier.target_concurrency,
+            "calls_per_node": tier.calls_per_node,
+            "usable_per_node": tier.usable_per_node,
+            "nodes_for_load": tier.nodes_for_load,
+            "spare_nodes": tier.spare_nodes,
+            "nodes": tier.nodes,
+        }
+        for tier in capacity_table(calls_per_node)
+    ]
+    # instance_type is deliberately absent. Nothing here can derive a machine
+    # type, and InstanceType requires a citation for exactly that reason, so it
+    # is supplied by whoever holds the source rather than guessed at here.
+    return capacity
+
+
 @loadtest_app.command("report")
 def report(
     run_id: str = typer.Argument(..., help="Run id to report on"),
@@ -267,10 +320,12 @@ def report(
             )
         )
     results = judge_run(tests, aggregates=aggregates)
+    capacity = _capacity_for(tests)
     payload = build_load_payload(
         run=run,
         tests=tests,
         gate_results=[g.as_dict() for g in results],
+        capacity=capacity,
     )
     out.mkdir(parents=True, exist_ok=True)
     json_path = out / f"{load_report_filename(run_id).removesuffix('.html')}.json"
@@ -288,6 +343,17 @@ def report(
         _cli.warn(
             "UNKNOWN is not a pass. At least one acceptance criterion could not "
             "be evaluated; the run did not demonstrate it, it failed to measure it."
+        )
+
+    if capacity.get("calls_per_node") is None:
+        _cli.warn(f"No capacity table: {capacity['reason']}")
+    else:
+        console.print(
+            f"Sized from {capacity['calls_per_node']} calls per node: "
+            + ", ".join(
+                f"{t['target_concurrency']}->{t['nodes']} nodes"
+                for t in capacity["tiers"]
+            )
         )
 
     if payload["data_provenance"] != "measured":

--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -17,7 +17,7 @@ from rich.table import Table
 
 from voicegateway.cli._app import app, console
 from voicegateway.cli.base_cli import BaseCli
-from voicegateway.livekit_diag.gates import MAX_NODE_CPU_UTILISATION
+from voicegateway.livekit_diag.gates import MAX_NODE_CPU_UTILISATION, exit_code
 from voicegateway.livekit_diag.run_report import appendix_entry
 from voicegateway.loadtest.aggregation import TestAggregate, peak_label
 from voicegateway.loadtest.artifacts import ArtifactError
@@ -458,3 +458,18 @@ def report(
             "artifacts and re-import with --captured before handing it over."
         )
     _cli.success(f"Wrote {json_path} and {html_path}")
+
+    # Exit AFTER both files are written. A failing run is exactly the run whose
+    # evidence somebody needs, so exiting before writing it would destroy the
+    # only record of why it failed.
+    #
+    # The code comes from gates.exit_code rather than a second convention here:
+    # 0 only for PASS. WAIVED is not clean (a waived gate is one nobody held the
+    # run to, and a pipeline that goes green on a waiver has dropped the
+    # requirement rather than recorded it) and UNKNOWN is not clean either (the
+    # run failed to measure something, which is not the same as demonstrating
+    # it). One non-zero code on purpose, so an existing `if [ $? -eq 1 ]` keeps
+    # catching every kind of failure.
+    code = exit_code(run_verdict)
+    if code != 0:
+        raise typer.Exit(code)

--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -27,7 +27,7 @@ from voicegateway.loadtest.capacity import (
     derive_calls_per_node,
 )
 from voicegateway.loadtest.importer import build_plan, observations_for
-from voicegateway.loadtest.judge import judge_run, verdict_for
+from voicegateway.loadtest.judge import judge_run
 
 _cli = BaseCli()
 
@@ -416,7 +416,10 @@ def report(
     json_path.write_text(json.dumps(payload, indent=2) + "\n")
     html_path.write_text(render_load_html(payload))
 
-    run_verdict = verdict_for(results)
+    # Read from the payload rather than recomputed, so the console, the exit
+    # code, the JSON and the HTML are one derivation rather than four that
+    # happen to agree today.
+    run_verdict = str(payload["verdict"]["status"])
     counts: dict[str, int] = {}
     for gate in results:
         counts[gate.status] = counts.get(gate.status, 0) + 1

--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -18,6 +18,7 @@ from rich.table import Table
 from voicegateway.cli._app import app, console
 from voicegateway.cli.base_cli import BaseCli
 from voicegateway.livekit_diag.gates import MAX_NODE_CPU_UTILISATION
+from voicegateway.livekit_diag.run_report import appendix_entry
 from voicegateway.loadtest.aggregation import TestAggregate, peak_label
 from voicegateway.loadtest.artifacts import ArtifactError
 from voicegateway.loadtest.capacity import (
@@ -282,6 +283,78 @@ def _capacity_for(tests: list[dict]) -> dict:
     return capacity
 
 
+#: The sections _render_appendix renders, in the order it renders them. A file
+#: naming anything else is refused rather than partially read: a typo would
+#: otherwise drop a whole section silently, and the operator would hand over a
+#: report missing the commands that produced it.
+_APPENDIX_SECTIONS = ("commands", "flags", "toolchain")
+
+
+def _appendix_from_file(path: Path) -> dict[str, list[dict[str, str]]]:
+    """Read an operator-supplied appendix, refusing anything uncited.
+
+    The entries live in a file the operator holds rather than in this
+    repository, for two reasons. The commands belong to a particular engagement
+    and have no business being compiled into a general tool. And the generator
+    they drive is AGPL-3.0 while this repository is MIT, so its scenarios and
+    configuration must not be copied here; flag names and command lines are
+    interface facts and travel fine.
+
+    Every entry goes through :func:`appendix_entry`, which requires a citation
+    and reduces any absolute URL to a bare host. An uncited command is
+    indistinguishable from one this report invented, so it is refused by label
+    rather than dropped quietly.
+
+    Shape::
+
+        {"commands": [{"label": ..., "detail": ..., "citation": ...}, ...],
+         "flags":    [...],
+         "toolchain": [...]}
+    """
+    try:
+        raw = json.loads(path.read_text())
+    except OSError as exc:
+        raise typer.BadParameter(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise typer.BadParameter(f"{path}: expected an object of sections")
+
+    unknown = sorted(set(raw) - set(_APPENDIX_SECTIONS))
+    if unknown:
+        raise typer.BadParameter(
+            f"{path}: unknown section(s) {unknown}. Known sections are "
+            f"{list(_APPENDIX_SECTIONS)}; a misspelled one would silently drop "
+            "every entry under it."
+        )
+
+    out: dict[str, list[dict[str, str]]] = {}
+    for section in _APPENDIX_SECTIONS:
+        entries = raw.get(section) or []
+        if not isinstance(entries, list):
+            raise typer.BadParameter(f"{path}: {section} must be a list")
+        built: list[dict[str, str]] = []
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                raise typer.BadParameter(
+                    f"{path}: {section}[{index}] must be an object"
+                )
+            try:
+                built.append(
+                    appendix_entry(
+                        label=str(entry.get("label", "")),
+                        detail=str(entry.get("detail", "")),
+                        citation=str(entry.get("citation", "")),
+                    )
+                )
+            except ValueError as exc:
+                # Refused by label so the operator can find the offending line.
+                raise typer.BadParameter(f"{path}: {section}[{index}]: {exc}") from exc
+        if built:
+            out[section] = built
+    return out
+
+
 @loadtest_app.command("report")
 def report(
     run_id: str = typer.Argument(..., help="Run id to report on"),
@@ -291,6 +364,14 @@ def report(
         "--out",
         "-o",
         help="Directory to write the report into",
+    ),
+    appendix: Path = typer.Option(
+        None,
+        "--appendix",
+        help=(
+            "JSON file of reproducible-test assets. Sections: commands, flags, "
+            "toolchain. Every entry needs label, detail and a citation."
+        ),
     ),
 ) -> None:
     """Write one run's report as JSON plus a self-contained HTML file."""
@@ -321,11 +402,13 @@ def report(
         )
     results = judge_run(tests, aggregates=aggregates)
     capacity = _capacity_for(tests)
+    assets = _appendix_from_file(appendix) if appendix is not None else None
     payload = build_load_payload(
         run=run,
         tests=tests,
         gate_results=[g.as_dict() for g in results],
         capacity=capacity,
+        appendix=assets,
     )
     out.mkdir(parents=True, exist_ok=True)
     json_path = out / f"{load_report_filename(run_id).removesuffix('.html')}.json"
@@ -354,6 +437,18 @@ def report(
                 f"{t['target_concurrency']}->{t['nodes']} nodes"
                 for t in capacity["tiers"]
             )
+        )
+
+    if assets is None:
+        _cli.warn(
+            "No reproducible-test assets recorded. Without the commands and "
+            "flag semantics behind them these numbers cannot be reproduced by "
+            "anybody else, which is most of what makes them evidence. Supply "
+            "them with --appendix."
+        )
+    else:
+        console.print(
+            "Appendix: " + ", ".join(f"{len(v)} {k}" for k, v in sorted(assets.items()))
         )
 
     if payload["data_provenance"] != "measured":

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -1329,6 +1329,38 @@ def _load_test_row(test: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _load_verdict(gate_results: list[dict[str, Any]] | None) -> dict[str, Any]:
+    """The run verdict, derived from the gates this payload already carries.
+
+    Derived rather than passed in, so the verdict and the gate table can never
+    disagree: they are the same list read twice.
+
+    ``None`` gates means nothing was gated at all, which renders as NO VERDICT.
+    An EMPTY list is different and is deliberately not a pass: it means gating
+    ran and produced nothing, which is a run that evaluated nothing. That is the
+    same rule :func:`gates.verdict` applies, and it matters because
+    ``worst_status([])`` returns PASS on its own.
+    """
+    if gate_results is None:
+        return {
+            "status": None,
+            "recorded": False,
+            "meaning": None,
+            "decided_by": "voicegateway.livekit_diag.gates",
+        }
+    status = (
+        gates.worst_status(str(g.get("status")) for g in gate_results)
+        if gate_results
+        else gates.UNKNOWN
+    )
+    return {
+        "status": status,
+        "recorded": True,
+        "meaning": _VERDICT_MEANING.get(status),
+        "decided_by": "voicegateway.livekit_diag.gates",
+    }
+
+
 def build_load_payload(
     *,
     run: dict[str, Any],
@@ -1379,6 +1411,8 @@ def build_load_payload(
             "ended_at_ms": run.get("ended_at_ms"),
         },
         "tests": [_load_test_row(t) for t in tests],
+        # Derived from the gates below, so the two exports cannot disagree.
+        "verdict": _load_verdict(gate_results),
         "gates_recorded": gate_results is not None,
         "gates": list(gate_results) if gate_results is not None else None,
         "capacity": capacity,
@@ -1528,11 +1562,17 @@ def render_load_html(payload: dict[str, Any]) -> str:
     run_id = _esc(payload["run"]["id"])
     body = "".join(
         [
+            # The stamp stays the FIRST element in the body. Its whole design
+            # is that a reader who scrolls to the numbers passes it on the way,
+            # and a verdict above it would be the first thing read on a file
+            # built from fixtures.
             _render_stamp(payload),
             "<h1>Load-test run report</h1>",
             f'<p class="sub">VoiceGateway &middot; run '
             f'<span class="mono">{run_id}</span> &middot; provenance '
             f"<strong>{_esc(payload['data_provenance'])}</strong></p>",
+            # Above the gate table it summarises, and below the stamp.
+            _render_verdict(payload),
             _render_gates(payload),
             _render_load_tests(payload),
             _render_capacity(payload),

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -1451,15 +1451,23 @@ def _render_capacity(payload: dict[str, Any]) -> str:
     """The node count per tier, or the reason there is none."""
     capacity = payload.get("capacity")
     if not capacity:
+        # NOTHING RAN THE DERIVATION. Distinct from a derivation that ran and
+        # refused, which is the branch below and carries a reason. Saying "not
+        # derivable from this run" here would claim an attempt was made and
+        # blame the data for a gap in the caller.
         return (
-            "<h2>Capacity</h2><p>No capacity table: the calls-per-node figure "
-            "was not derivable from this run, so sizing it would mean inventing "
-            "the one number the whole table rests on.</p>"
+            "<h2>Capacity</h2><p>No capacity table, and none was attempted: "
+            "whoever built this payload supplied no capacity block, so nothing "
+            "here is a statement about the run. Sizing without a derivation "
+            "would mean inventing the one number the whole table rests on.</p>"
         )
     if capacity.get("calls_per_node") is None:
+        # The derivation RAN and refused. The reason is the whole value of this
+        # branch, so it is never summarised away.
         return (
-            "<h2>Capacity</h2><p>No capacity table. "
-            f"{_esc(capacity.get('reason') or 'the figure was not derivable')}</p>"
+            "<h2>Capacity</h2><p>No capacity table. The calls-per-node figure "
+            "was not derivable, so sizing would mean inventing the one number "
+            f"the whole table rests on. {_esc(capacity.get('reason') or '')}</p>"
         )
     rows = "".join(
         "<tr>"

--- a/src/voicegateway/loadtest/capacity.py
+++ b/src/voicegateway/loadtest/capacity.py
@@ -88,7 +88,11 @@ class InstanceType:
 class RampStep:
     """One step of a ramp: what was asked for, and what was reached."""
 
-    target_concurrency: int
+    # Optional because an imported row never carries it: the target lives in
+    # the generator's scenario file, which is not an artifact. A step with no
+    # target cannot be said to have asked for more, which is what the plateau
+    # scan needs and why it skips them.
+    target_concurrency: int | None
     peak_concurrency: int | None = None
     peak_cpu_utilisation: float | None = None
     # The generator's arrival rate and hold, when known. Used to predict a
@@ -172,18 +176,22 @@ def unreachable_steps(
     """
     out: list[tuple[RampStep, float, float]] = []
     for step in steps:
-        if step.rate_per_second is None or step.hold_seconds is None:
+        # All three are needed to say a step asks for more than its own plan
+        # can produce. A step missing any of them is not evidence either way,
+        # so it is skipped rather than assumed reachable.
+        target = step.target_concurrency
+        if target is None or step.rate_per_second is None or step.hold_seconds is None:
             continue
         ceiling = sustainable_concurrency(
             step.rate_per_second, step.hold_seconds, setup_overhead_s=setup_overhead_s
         )
-        if step.target_concurrency > ceiling:
+        if target > ceiling:
             out.append(
                 (
                     step,
                     ceiling,
                     required_rate(
-                        step.target_concurrency,
+                        target,
                         step.hold_seconds,
                         setup_overhead_s=setup_overhead_s,
                     ),
@@ -213,7 +221,13 @@ def detect_plateau(
     predicted = unreachable_steps(steps, setup_overhead_s=setup_overhead_s)
     if predicted:
         worst = min(ceiling for _, ceiling, _ in predicted)
-        targets = [step.target_concurrency for step, _, _ in predicted]
+        # Every entry in `predicted` carries a known target: unreachable_steps
+        # skips the ones that do not, so this is list[int] by construction.
+        targets = [
+            step.target_concurrency
+            for step, _, _ in predicted
+            if step.target_concurrency is not None
+        ]
         fixes = ", ".join(
             f"{step.target_concurrency} needs r >= {rate:.2f}/s"
             for step, _, rate in predicted
@@ -229,10 +243,14 @@ def detect_plateau(
             ),
         )
 
+    # A step with no recorded target cannot be said to have asked for more, so
+    # it cannot contribute to a plateau finding. Imported rows routinely have
+    # none: the target lives in the generator's scenario file, which is not an
+    # artifact, so this is the common case rather than the exceptional one.
     reached = [
         (s.target_concurrency, s.peak_concurrency)
         for s in steps
-        if s.peak_concurrency is not None
+        if s.peak_concurrency is not None and s.target_concurrency is not None
     ]
     for (prev_target, prev_peak), (target, peak) in zip(
         reached, reached[1:], strict=False
@@ -266,7 +284,7 @@ def derive_calls_per_node(
     """The calls-per-node figure, or None with the reason it is not derivable.
 
     Returns the highest concurrency actually REACHED while the node stayed at or
-    under ``cpu_ceiling``. Refuses in three cases, each of which would otherwise
+    under ``cpu_ceiling``. Refuses in four cases, each of which would otherwise
     yield a plausible number:
 
     * The ramp plateaued. The ceiling belongs to whatever stopped scaling, and a
@@ -275,10 +293,32 @@ def derive_calls_per_node(
       largest concurrency observed is a floor on its capacity, not a measure of
       it, and sizing from it would UNDER-provision.
     * Nothing measured CPU at all. An unscraped ramp demonstrates nothing.
+    * No step declared what it asked for, so a plateau could not be ruled out.
+      "No plateau detected" from a ramp that recorded neither targets nor rates
+      means the check never ran, which is not the same as a ramp that climbed.
     """
     plateau = detect_plateau(steps, setup_overhead_s=setup_overhead_s)
     if plateau.plateaued:
         return None, plateau.detail
+
+    # A plateau can only be RULED OUT when the steps say what they asked for.
+    # With no targets and no declared rates, "no plateau detected" means the
+    # check could not run, not that the ramp kept climbing, and a false ceiling
+    # sized as a real one buys the wrong fleet. Refusing is the conservative
+    # reading and the only honest one.
+    declared = [
+        s
+        for s in steps
+        if s.target_concurrency is not None
+        or (s.rate_per_second is not None and s.hold_seconds is not None)
+    ]
+    if len(steps) > 1 and not declared:
+        return None, (
+            f"no step recorded a target concurrency or an arrival rate, so a "
+            f"plateau could not be ruled out across {len(steps)} steps. The "
+            "highest concurrency reached may be the load generator's ceiling "
+            "rather than the node's, and sizing from it would be a guess"
+        )
 
     # Narrowed into concrete pairs rather than filtered in place: a step is only
     # evidence when it carries BOTH halves, and pulling them out here means

--- a/src/voicegateway/tests/cli/test_loadtest_appendix.py
+++ b/src/voicegateway/tests/cli/test_loadtest_appendix.py
@@ -1,0 +1,194 @@
+"""Reproducible-test assets reaching the report.
+
+`appendix_entry` existed and `build_load_payload` accepted an `appendix=`
+argument that nothing supplied, so every report shipped saying no assets were
+recorded. Numbers nobody else can reproduce are not evidence, which is most of
+why that section is contractual.
+
+The entries live in a file the operator holds rather than in this repository.
+Commands belong to a particular engagement and have no business compiled into a
+general tool, and the generator they drive is AGPL-3.0 while this repository is
+MIT, so its scenarios and configuration must never be copied here. Flag names
+and command lines are interface facts and travel fine.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+
+from voicegateway.cli.loadtest_cli import _APPENDIX_SECTIONS, _appendix_from_file
+
+GOOD = {
+    "commands": [
+        {
+            "label": "ramp step",
+            "detail": "gossipper sipp -l 200 -r 3.2258 -pause_ms 60000 -trace_stat",
+            "citation": "execution-runbook.md:75",
+        }
+    ],
+    "flags": [
+        {
+            "label": "-l",
+            "detail": "Max concurrent calls. Defaults to 1.",
+            "citation": "execution-runbook.md:53",
+        }
+    ],
+    "toolchain": [
+        {
+            "label": "build",
+            "detail": "Cross-compile for linux/amd64.",
+            "citation": "fixtures README",
+        }
+    ],
+}
+
+
+def _write(tmp_path: Path, payload: object) -> Path:
+    path = tmp_path / "appendix.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+# --------------------------------------------------------------------------
+# Reading
+# --------------------------------------------------------------------------
+
+
+def test_a_well_formed_file_yields_every_section(tmp_path: Path) -> None:
+    assets = _appendix_from_file(_write(tmp_path, GOOD))
+    assert sorted(assets) == ["commands", "flags", "toolchain"]
+    assert assets["flags"][0]["citation"] == "execution-runbook.md:53"
+
+
+def test_an_empty_section_is_omitted_rather_than_carried_empty(
+    tmp_path: Path,
+) -> None:
+    assets = _appendix_from_file(_write(tmp_path, {"commands": GOOD["commands"]}))
+    assert list(assets) == ["commands"]
+
+
+def test_the_sections_match_what_the_renderer_reads() -> None:
+    """A section this file accepts but the report never renders is a silent hole."""
+    from voicegateway.livekit_diag import run_report
+
+    source = run_report._render_appendix.__doc__ or ""
+    assert source  # the renderer is documented
+    for section in _APPENDIX_SECTIONS:
+        assert section in ("commands", "flags", "toolchain")
+
+
+# --------------------------------------------------------------------------
+# Refusals
+# --------------------------------------------------------------------------
+
+
+def test_an_uncited_entry_is_refused_by_position(tmp_path: Path) -> None:
+    """An uncited command is indistinguishable from one the report invented.
+
+    Refused rather than dropped, and located, so the operator can find the line.
+    """
+    bad = {"commands": [{"label": "ramp", "detail": "gossipper sipp", "citation": ""}]}
+    with pytest.raises(typer.BadParameter) as excinfo:
+        _appendix_from_file(_write(tmp_path, bad))
+    assert "commands[0]" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("citation", ["", "   ", "\t\n"])
+def test_whitespace_is_not_a_citation(tmp_path: Path, citation: str) -> None:
+    bad = {"commands": [{"label": "x", "detail": "y", "citation": citation}]}
+    with pytest.raises(typer.BadParameter):
+        _appendix_from_file(_write(tmp_path, bad))
+
+
+def test_an_unknown_section_is_refused_not_ignored(tmp_path: Path) -> None:
+    """A misspelled section would silently drop every entry under it.
+
+    The operator would then hand over a report missing the commands that
+    produced it, with nothing anywhere saying so.
+    """
+    with pytest.raises(typer.BadParameter) as excinfo:
+        _appendix_from_file(_write(tmp_path, {"commmands": GOOD["commands"]}))
+    assert "commmands" in str(excinfo.value)
+    assert "commands" in str(excinfo.value)
+
+
+def test_a_missing_file_is_refused_clearly(tmp_path: Path) -> None:
+    with pytest.raises(typer.BadParameter):
+        _appendix_from_file(tmp_path / "nope.json")
+
+
+def test_malformed_json_is_refused_clearly(tmp_path: Path) -> None:
+    path = tmp_path / "appendix.json"
+    path.write_text("{not json")
+    with pytest.raises(typer.BadParameter) as excinfo:
+        _appendix_from_file(path)
+    assert "not valid JSON" in str(excinfo.value)
+
+
+def test_a_section_that_is_not_a_list_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(typer.BadParameter):
+        _appendix_from_file(_write(tmp_path, {"commands": {"label": "x"}}))
+
+
+# --------------------------------------------------------------------------
+# Redaction survives the file boundary
+# --------------------------------------------------------------------------
+
+
+def test_a_sip_uri_in_a_command_is_reduced_to_its_host(tmp_path: Path) -> None:
+    """The scheme a SIP load test actually contains.
+
+    A report is handed to somebody outside the deployment, so an endpoint in it
+    is a leak. The host survives because reproducing a run needs to know which.
+    """
+    payload = {
+        "commands": [
+            {
+                "label": "ramp",
+                "detail": "gossipper sipp -rsa sip:pbx.example.net:5060 -l 200",
+                "citation": "runbook.md:75",
+            }
+        ]
+    }
+    detail = _appendix_from_file(_write(tmp_path, payload))["commands"][0]["detail"]
+    assert "sip:" not in detail
+    assert "pbx.example.net:5060" in detail
+
+
+def test_an_absolute_url_is_reduced_too(tmp_path: Path) -> None:
+    payload = {
+        "commands": [
+            {
+                "label": "join",
+                "detail": "connect wss://media.example.com/rtc now",
+                "citation": "runbook.md:80",
+            }
+        ]
+    }
+    detail = _appendix_from_file(_write(tmp_path, payload))["commands"][0]["detail"]
+    assert "wss://" not in detail
+    assert "media.example.com" in detail
+
+
+# --------------------------------------------------------------------------
+# The licence boundary
+# --------------------------------------------------------------------------
+
+
+def test_no_generator_scenario_or_config_lives_in_this_repo() -> None:
+    """AGPL-3.0 upstream, MIT here. Interface facts travel; expression does not.
+
+    Command lines and flag names are fine. A scenario XML or a generator config
+    is somebody else's authored work and must be referenced by name only.
+    """
+    root = Path(__file__).resolve().parents[4]
+    offenders = [
+        p
+        for p in root.rglob("*uac*.xml")
+        if ".venv" not in p.parts and "node_modules" not in p.parts
+    ]
+    assert not offenders, f"generator scenario files in the repo: {offenders}"

--- a/src/voicegateway/tests/cli/test_loadtest_capacity_wiring.py
+++ b/src/voicegateway/tests/cli/test_loadtest_capacity_wiring.py
@@ -1,0 +1,172 @@
+"""The capacity table reaching the report.
+
+`derive_calls_per_node` and `capacity_table` were written, tested and never
+called. `build_load_payload` accepted a `capacity=` argument that nothing
+passed, so the report rendered its empty state no matter how good the data was.
+The per-node table is a contractual deliverable, so a correct derivation nobody
+invokes is worth exactly nothing.
+
+Two properties are pinned here.
+
+**A refusal travels as its reason, never as a number.** The derivation declines
+far more often than it answers, and the reason is the useful half: a report
+saying why it could not size the fleet beats one quietly missing the section,
+and beats one carrying a figure nobody earned by a much wider margin.
+
+**The ceiling is imported, never restated.** 70% is contractual. A second copy
+of it in the CLI would drift from the gates that judge against it.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from voicegateway.cli.loadtest_cli import _capacity_for
+from voicegateway.livekit_diag import run_report
+from voicegateway.livekit_diag.gates import MAX_NODE_CPU_UTILISATION
+
+
+def _rows(*triples):
+    return [
+        {
+            "name": f"step-{i}",
+            "target_concurrency": t,
+            "peak_concurrency": p,
+            "peak_cpu_utilisation": c,
+        }
+        for i, (t, p, c) in enumerate(triples)
+    ]
+
+
+SATURATING = _rows(
+    (100, 100, 0.31), (150, 150, 0.48), (200, 200, 0.66), (250, 250, 0.79)
+)
+
+
+# --------------------------------------------------------------------------
+# The figure and the table
+# --------------------------------------------------------------------------
+
+
+def test_a_saturating_ramp_yields_a_figure_and_every_tier() -> None:
+    capacity = _capacity_for(SATURATING)
+    # 200 was sustained at 66%; the 250 step breached the ceiling at 79%.
+    assert capacity["calls_per_node"] == 200
+    assert [t["target_concurrency"] for t in capacity["tiers"]] == [100, 150, 300, 500]
+
+
+def test_the_spare_node_is_present_at_every_tier() -> None:
+    """A tier sized without it has no node it can afford to lose."""
+    for tier in _capacity_for(SATURATING)["tiers"]:
+        assert tier["spare_nodes"] == 1
+        assert tier["nodes"] == tier["nodes_for_load"] + 1
+
+
+def test_the_headline_tier_matches_the_formula_by_hand() -> None:
+    """500 at C=200: ceil(500 / (0.85 x 200)) + 1 = ceil(2.94) + 1 = 4."""
+    tiers = {t["target_concurrency"]: t for t in _capacity_for(SATURATING)["tiers"]}
+    assert tiers[500]["usable_per_node"] == 170.0
+    assert tiers[500]["nodes_for_load"] == 3
+    assert tiers[500]["nodes"] == 4
+
+
+# --------------------------------------------------------------------------
+# Refusals carry their reason and invent nothing
+# --------------------------------------------------------------------------
+
+
+def test_a_refusal_carries_the_reason_and_no_tiers() -> None:
+    """The reason is the payload. A refusal must never become a number."""
+    plateaued = _rows((100, 100, 0.48), (150, 124, 0.58), (200, 124, 0.58))
+    capacity = _capacity_for(plateaued)
+    assert capacity["calls_per_node"] is None
+    assert capacity["reason"]
+    assert "tiers" not in capacity, "tiers were invented for a refused derivation"
+
+
+def test_the_plateau_value_is_never_returned_as_the_figure() -> None:
+    plateaued = _rows((100, 100, 0.48), (150, 124, 0.58), (200, 124, 0.58))
+    capacity = _capacity_for(plateaued)
+    assert capacity["calls_per_node"] != 124
+    assert capacity["calls_per_node"] is None
+
+
+def test_rows_with_no_cpu_reading_are_refused() -> None:
+    """An unscraped ramp shows nothing about a node, whatever it reached."""
+    capacity = _capacity_for(_rows((100, 100, None), (200, 200, None)))
+    assert capacity["calls_per_node"] is None
+    assert "tiers" not in capacity
+
+
+def test_imported_rows_with_null_targets_do_not_crash() -> None:
+    """The real shape. target_concurrency is never imported, so this is the
+    common path and it used to raise TypeError."""
+    capacity = _capacity_for(_rows((None, 100, 0.31), (None, 150, 0.48)))
+    assert capacity["calls_per_node"] is None
+    assert "could not be ruled out" in capacity["reason"]
+
+
+def test_no_instance_type_is_invented() -> None:
+    """Nothing here can derive a machine type, so none is supplied."""
+    assert "instance_type" not in _capacity_for(SATURATING)
+
+
+# --------------------------------------------------------------------------
+# The threshold is imported, not restated
+# --------------------------------------------------------------------------
+
+
+def test_the_cpu_ceiling_is_the_gate_constant() -> None:
+    source = inspect.getsource(_capacity_for)
+    assert "MAX_NODE_CPU_UTILISATION" in source
+    for literal in ("0.70", "0.7,", "70%"):
+        assert literal not in source, f"the CLI restates the ceiling as {literal}"
+
+
+def test_the_derivation_actually_uses_that_ceiling() -> None:
+    """Behavioural, not textual: a step just under it counts, just over does not."""
+    under = _capacity_for(_rows((100, 100, MAX_NODE_CPU_UTILISATION - 0.01)))
+    over = _capacity_for(_rows((100, 100, MAX_NODE_CPU_UTILISATION + 0.01)))
+    # Under the ceiling on every step means the node was never saturated, so it
+    # is a floor rather than a measure; over it on every step means nothing was
+    # sustained within it. Different refusals, which is the point.
+    assert under["reason"] != over["reason"]
+
+
+# --------------------------------------------------------------------------
+# The two empty states say different things
+# --------------------------------------------------------------------------
+
+
+def test_no_capacity_block_is_not_blamed_on_the_run() -> None:
+    """Nothing called the derivation. That is a gap in the caller, not the data."""
+    html = run_report.render_load_html(
+        run_report.build_load_payload(run={"id": "r"}, tests=[])
+    )
+    assert "none was attempted" in html
+    # The gap is in the caller, so the text must not characterise the run's
+    # data. Asserted as "says nothing about the run" rather than by quoting the
+    # sentence, so a rewording does not fail a test about meaning.
+    assert "statement about the run" in html
+    assert "not derivable" not in html
+
+
+def test_a_refused_derivation_reads_differently_and_shows_why() -> None:
+    payload = run_report.build_load_payload(
+        run={"id": "r"},
+        tests=[],
+        capacity={"calls_per_node": None, "reason": "the ramp plateaued at 124"},
+    )
+    html = run_report.render_load_html(payload)
+    assert "was not derivable" in html
+    assert "the ramp plateaued at 124" in html
+    assert "none was attempted" not in html
+
+
+def test_a_derived_table_renders_its_tiers() -> None:
+    payload = run_report.build_load_payload(
+        run={"id": "r"}, tests=[], capacity=_capacity_for(SATURATING)
+    )
+    html = run_report.render_load_html(payload)
+    assert "Sized from 200 calls per node" in html
+    assert "was not derivable" not in html

--- a/src/voicegateway/tests/cli/test_loadtest_end_to_end.py
+++ b/src/voicegateway/tests/cli/test_loadtest_end_to_end.py
@@ -1,0 +1,274 @@
+"""The whole path, driven through the CLI and read back off disk.
+
+Every other test in this area exercises one seam. This one runs the commands an
+operator runs, against a throwaway database, and then OPENS the two files that
+get handed over. A seam that works in isolation and a report that carries the
+result are different claims, and only the second one is the deliverable.
+
+What it pins:
+
+* the payload carries a capacity block and an appendix, both of which were
+  accepted arguments that nothing passed until recently;
+* the file states a verdict, rather than the verdict living only in the
+  operator's terminal scrollback;
+* a FAILING gate exits non-zero AND still leaves the evidence on disk;
+* provenance stays synthetic and the not-a-deliverable stamp stays first, which
+  is what stops a fixture-built file being mistaken for a measurement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from voicegateway.cli._app import app
+
+runner = CliRunner()
+
+# The fixture run's own window, from summary.json: 2026-07-31T18:00Z to 19:00Z.
+WINDOW_START_MS = 1_785_520_800_000
+
+APPENDIX = {
+    "commands": [
+        {
+            "label": "ramp step",
+            "detail": "gossip sipp -l 200 -r 3.2258 -pause_ms 60000 -trace_stat",
+            "citation": "runbook.md:75",
+        }
+    ],
+    "flags": [
+        {
+            "label": "-l",
+            "detail": "Max concurrent calls. Defaults to 1.",
+            "citation": "runbook.md:53",
+        }
+    ],
+}
+
+
+@pytest.fixture
+def run(tmp_path: Path, monkeypatch) -> dict:
+    """Import the fixtures into a throwaway database under tmp_path.
+
+    Never the repository's voicegw.db: VOICEGW_DB_PATH is cleared so a leaked
+    environment variable cannot redirect the write, and db_path is explicit.
+    """
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    fixtures = Path(__file__).resolve().parents[4] / ".agents" / "fixtures"
+    if not (fixtures / "summary.json").is_file():
+        pytest.skip("fixtures are not present in this checkout")
+
+    run_dir = tmp_path / "ramp-500"
+    run_dir.mkdir()
+    for name in ("summary.json", "gossipper_stats.csv"):
+        (run_dir / name).write_bytes((fixtures / name).read_bytes())
+
+    db = tmp_path / "throwaway.db"
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.dump({"cost_tracking": {"enabled": True, "db_path": str(db)}})
+    )
+    appendix = tmp_path / "appendix.json"
+    appendix.write_text(json.dumps(APPENDIX))
+
+    result = runner.invoke(
+        app, ["loadtest", "import", str(run_dir), "--config", str(config)]
+    )
+    assert result.exit_code == 0, result.output
+    return {
+        "config": str(config),
+        "appendix": str(appendix),
+        "out": tmp_path / "out",
+        "db": db,
+    }
+
+
+def _report(run: dict, *extra: str):
+    return runner.invoke(
+        app,
+        [
+            "loadtest",
+            "report",
+            "ramp-500",
+            "--config",
+            run["config"],
+            "--out",
+            str(run["out"]),
+            "--appendix",
+            run["appendix"],
+            *extra,
+        ],
+    )
+
+
+def _artifacts(run: dict) -> tuple[dict, str]:
+    """Read the two files back off disk, as a recipient would."""
+    written = list(run["out"].iterdir())
+    payload = json.loads(next(p for p in written if p.suffix == ".json").read_text())
+    html = next(p for p in written if p.suffix == ".html").read_text()
+    return payload, html
+
+
+# --------------------------------------------------------------------------
+# The artifacts carry what the report is owed
+# --------------------------------------------------------------------------
+
+
+def test_the_payload_carries_capacity_and_appendix(run: dict) -> None:
+    """Both were accepted arguments that nothing supplied."""
+    _report(run)
+    payload, _ = _artifacts(run)
+
+    assert payload["capacity"] is not None
+    # The fixtures cannot yield a figure, and the block says why rather than
+    # being absent. A missing section reads as one nobody needed.
+    assert payload["capacity"]["reason"]
+    assert payload["appendix"] is not None
+    assert payload["appendix"]["flags"][0]["citation"] == "runbook.md:53"
+
+
+def test_the_file_states_a_verdict(run: dict) -> None:
+    """It used to reach the terminal and never the artifact."""
+    _report(run)
+    payload, html = _artifacts(run)
+    assert payload["verdict"]["status"]
+    assert 'class="verdict' in html
+    assert payload["verdict"]["status"] in html
+
+
+def test_the_gates_travel_with_the_numbers(run: dict) -> None:
+    _report(run)
+    payload, _ = _artifacts(run)
+    assert payload["gates_recorded"] is True
+    assert {g["gate"] for g in payload["gates"]} >= {
+        "call_establishment",
+        "node_cpu",
+        "node_memory",
+        "resource_headroom",
+    }
+
+
+# --------------------------------------------------------------------------
+# Provenance, which is what stops any of this being mistaken for measurement
+# --------------------------------------------------------------------------
+
+
+def test_provenance_stays_synthetic_and_the_stamp_stays_first(run: dict) -> None:
+    _report(run)
+    payload, html = _artifacts(run)
+    assert payload["data_provenance"] == "synthetic"
+    body = html[html.index("<body>") + len("<body>") :]
+    assert body.lstrip().startswith('<div class="stamp">')
+    assert "SYNTHETIC DATA: NOT A DELIVERABLE" in html
+    # And the stamp precedes the verdict, so a reader meets it first.
+    assert body.index("stamp") < body.index('class="verdict')
+
+
+def test_the_delivered_file_reaches_for_nothing(run: dict) -> None:
+    _report(run)
+    _, html = _artifacts(run)
+    lowered = html.lower()
+    for marker in (
+        "<script",
+        "<link",
+        "<img",
+        "<iframe",
+        "<object",
+        "<embed",
+        "<svg",
+        "@import",
+        "url(",
+        "src=",
+        "srcset",
+        "integrity=",
+        "crossorigin",
+        "//cdn",
+        "fonts.googleapis",
+        "http://",
+        "https://",
+    ):
+        assert marker not in lowered, f"the report reaches for {marker!r}"
+
+
+# --------------------------------------------------------------------------
+# A failing gate
+# --------------------------------------------------------------------------
+
+
+def _seed_breaching_cpu(db: Path) -> None:
+    """Scrape samples inside the fixture's window showing 80% CPU.
+
+    cpu_seconds_total accrues at the core count and the idle counter at what is
+    left, so 4.0/s total against 0.8/s idle is 80% busy: over the 70% ceiling
+    and therefore a FAIL rather than an UNKNOWN.
+    """
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+    from voicegateway.repository.node_samples_repository import (
+        NodeSampleInput,
+        insert_samples,
+    )
+
+    async def _write() -> None:
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db}")
+        total, idle = 1000.0, 800.0
+        rows = []
+        for i in range(6):
+            rows.append(
+                NodeSampleInput(
+                    node="sfu-1",
+                    source="node_exporter",
+                    at_ms=WINDOW_START_MS + i * 600_000,
+                    outcome="ok",
+                    values={
+                        "cpu_seconds_total": total,
+                        "cpu_idle_seconds_total": idle,
+                        "memory_total_bytes": 16_000_000_000,
+                        "memory_available_bytes": 8_000_000_000,
+                    },
+                )
+            )
+            total += 4.0 * 600.0
+            idle += 0.8 * 600.0
+        async with AsyncSession(engine) as session:
+            await insert_samples(session, rows)
+            await session.commit()
+        await engine.dispose()
+
+    asyncio.run(_write())
+
+
+def test_a_breaching_gate_exits_non_zero_and_still_writes_the_evidence(
+    run: dict,
+) -> None:
+    """The property that matters most on a bad run.
+
+    A failing run is exactly the one whose report somebody needs, so the exit
+    code must be non-zero AND both files must be on disk explaining why.
+    """
+    _seed_breaching_cpu(run["db"])
+    # Re-import so the correlation runs against the samples just seeded.
+    fixtures_dir = Path(run["config"]).parent / "ramp-500"
+    assert (
+        runner.invoke(
+            app, ["loadtest", "import", str(fixtures_dir), "--config", run["config"]]
+        ).exit_code
+        == 0
+    )
+
+    result = _report(run)
+    payload, html = _artifacts(run)
+
+    assert payload["verdict"]["status"] == "FAIL"
+    assert result.exit_code != 0
+    # The evidence survived the failure.
+    assert payload["gates"]
+    assert "FAIL" in html
+    cpu = [g for g in payload["gates"] if g["gate"] == "node_cpu"]
+    assert [g["status"] for g in cpu] == ["FAIL"]
+    assert payload["tests"][0]["peak_cpu_utilisation"] == pytest.approx(0.80)

--- a/src/voicegateway/tests/cli/test_loadtest_exit_code.py
+++ b/src/voicegateway/tests/cli/test_loadtest_exit_code.py
@@ -1,0 +1,156 @@
+"""`voicegw loadtest report` exiting on what the gates decided.
+
+The command computed a verdict, printed it, and returned 0 regardless. A run
+that FAILed every acceptance criterion exited exactly as cleanly as one that
+passed, so any pipeline checking the status code was checking nothing.
+
+Two properties are pinned.
+
+**Only PASS is clean.** WAIVED is a gate nobody held the run to, and a pipeline
+going green on a waiver has dropped the requirement rather than recorded it.
+UNKNOWN means the run failed to measure something, which is not the same as
+demonstrating it.
+
+**The evidence is written before the exit.** A failing run is precisely the one
+whose report somebody needs; exiting first would destroy the record of why.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from voicegateway.cli._app import app
+from voicegateway.livekit_diag import gates
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch) -> dict:
+    """A throwaway database and an imported run, never the repo's voicegw.db."""
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    fixtures = Path(__file__).resolve().parents[4] / ".agents" / "fixtures"
+    if not (fixtures / "summary.json").is_file():
+        pytest.skip("fixtures are not present in this checkout")
+
+    run_dir = tmp_path / "ramp-500"
+    run_dir.mkdir()
+    for name in ("summary.json", "gossipper_stats.csv"):
+        (run_dir / name).write_bytes((fixtures / name).read_bytes())
+
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.dump(
+            {"cost_tracking": {"enabled": True, "db_path": str(tmp_path / "t.db")}}
+        )
+    )
+    imported = runner.invoke(
+        app, ["loadtest", "import", str(run_dir), "--config", str(config)]
+    )
+    assert imported.exit_code == 0, imported.output
+    return {"config": str(config), "out": tmp_path / "out", "tmp": tmp_path}
+
+
+def _report(workspace: dict, *extra: str):
+    return runner.invoke(
+        app,
+        [
+            "loadtest",
+            "report",
+            "ramp-500",
+            "--config",
+            workspace["config"],
+            "--out",
+            str(workspace["out"]),
+            *extra,
+        ],
+    )
+
+
+# --------------------------------------------------------------------------
+# The exit code follows the verdict
+# --------------------------------------------------------------------------
+
+
+def test_an_unknown_verdict_exits_non_zero(workspace: dict) -> None:
+    """The fixtures have no node samples, so four criteria are UNKNOWN.
+
+    UNKNOWN is not a pass: the run failed to measure something rather than
+    demonstrating it, and a pipeline must not go green on that.
+    """
+    result = _report(workspace)
+    assert "UNKNOWN" in result.output
+    assert result.exit_code == 1
+
+
+def test_the_report_is_written_before_the_process_exits(workspace: dict) -> None:
+    """The single most important property here.
+
+    A failing run is exactly the run whose evidence somebody needs. Exiting
+    before writing it would leave nothing to explain the failure.
+    """
+    result = _report(workspace)
+    assert result.exit_code == 1
+    written = sorted(p.name for p in workspace["out"].iterdir())
+    assert any(n.endswith(".json") for n in written), written
+    assert any(n.endswith(".html") for n in written), written
+    # And the file actually carries the gates, not just an empty shell.
+    payload = json.loads(
+        next(p for p in workspace["out"].iterdir() if p.suffix == ".json").read_text()
+    )
+    assert payload["gates_recorded"] is True
+    assert payload["gates"]
+
+
+def test_only_pass_is_clean() -> None:
+    """Pinned against the gates' own convention, not restated here."""
+    assert gates.exit_code(gates.PASS) == 0
+    for status in (gates.WAIVED, gates.WARN, gates.UNKNOWN, gates.FAIL):
+        assert gates.exit_code(status) == 1, status
+
+
+def test_a_waiver_does_not_buy_a_clean_exit() -> None:
+    """A waived gate is one nobody held the run to.
+
+    Called out separately from the loop above because it is the one people
+    expect to be clean, and a pipeline that goes green on it has silently
+    dropped the requirement rather than recording that it was set aside.
+    """
+    assert gates.exit_code(gates.WAIVED) != 0
+
+
+def test_the_cli_uses_the_gates_convention_rather_than_its_own() -> None:
+    import inspect
+
+    from voicegateway.cli import loadtest_cli
+
+    source = inspect.getsource(loadtest_cli)
+    assert "exit_code(run_verdict)" in source
+    # The gates deliberately use ONE non-zero code so an existing
+    # `if [ $? -eq 1 ]` keeps catching every kind of failure. A second
+    # convention here that split WARN and FAIL across 2 and 3 would silently
+    # stop such a pipeline noticing two thirds of them.
+    for status in (gates.WARN, gates.UNKNOWN, gates.FAIL, gates.WAIVED):
+        assert gates.exit_code(status) == 1
+
+
+def test_a_dry_run_import_still_exits_zero(workspace: dict) -> None:
+    """Non-vacuous: the exit is driven by the verdict, not unconditional."""
+    fixtures_dir = workspace["tmp"] / "ramp-500"
+    result = runner.invoke(
+        app,
+        [
+            "loadtest",
+            "import",
+            str(fixtures_dir),
+            "--config",
+            workspace["config"],
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output

--- a/src/voicegateway/tests/livekit_diag/test_load_report.py
+++ b/src/voicegateway/tests/livekit_diag/test_load_report.py
@@ -400,3 +400,103 @@ def test_the_appendix_travels_in_the_payload_not_only_the_html() -> None:
     payload = _payload(appendix=_appendix())
     assert payload["appendix"]["commands"][0]["citation"]
     json.loads(json.dumps(payload))
+
+
+# --------------------------------------------------------------------------
+# The verdict reaches the file, not just the operator's console
+# --------------------------------------------------------------------------
+
+
+def _gated(*statuses: str):
+    return _payload(
+        gate_results=[
+            {"gate": f"g{i}", "status": s, "detail": "d"}
+            for i, s in enumerate(statuses)
+        ]
+    )
+
+
+def test_the_verdict_is_carried_in_the_payload() -> None:
+    payload = _gated("PASS", "UNKNOWN")
+    assert payload["verdict"]["status"] == "UNKNOWN"
+    assert payload["verdict"]["recorded"] is True
+    assert payload["verdict"]["decided_by"] == "voicegateway.livekit_diag.gates"
+
+
+def test_the_verdict_is_derived_from_the_gates_it_ships_with() -> None:
+    """Derived, not passed in, so the two cannot disagree in one file."""
+    payload = _gated("PASS", "FAIL")
+    assert payload["verdict"]["status"] == "FAIL"
+    assert {g["status"] for g in payload["gates"]} == {"PASS", "FAIL"}
+
+
+def test_the_verdict_reaches_the_rendered_file() -> None:
+    """It used to be printed to a console nobody keeps."""
+    document = run_report.render_load_html(_gated("PASS", "UNKNOWN"))
+    assert 'class="verdict' in document
+    assert "UNKNOWN" in document
+
+
+def test_the_stamp_still_comes_before_the_verdict() -> None:
+    """The stamp's whole design is being the first thing a reader passes.
+
+    A verdict above it would be the first thing read on a file built from
+    fixtures, which is the one ordering that must never happen.
+    """
+    document = run_report.render_load_html(_gated("PASS"))
+    body = document[document.index("<body>") + len("<body>") :]
+    assert body.lstrip().startswith('<div class="stamp">')
+    assert body.index("stamp") < body.index('class="verdict')
+
+
+def test_the_verdict_sits_above_the_gate_table_it_summarises() -> None:
+    document = run_report.render_load_html(_gated("PASS", "FAIL"))
+    body = document[document.index("<body>") + len("<body>") :]
+    assert body.index('class="verdict') < body.index("Gates")
+
+
+def test_no_gates_recorded_renders_no_verdict_rather_than_a_pass() -> None:
+    payload = _payload()
+    assert payload["verdict"]["status"] is None
+    assert payload["verdict"]["recorded"] is False
+    assert "NO VERDICT" in run_report.render_load_html(payload)
+
+
+def test_an_empty_gate_list_is_unknown_and_never_a_pass() -> None:
+    """The sharp edge. worst_status([]) returns PASS on its own.
+
+    Gating that ran and produced nothing is a run that evaluated nothing, so it
+    must not read as clean just because there was no failing gate to find.
+    """
+    payload = _payload(gate_results=[])
+    assert payload["verdict"]["status"] == "UNKNOWN"
+    assert payload["verdict"]["recorded"] is True
+
+
+def test_a_waiver_shows_as_the_verdict_and_not_as_a_pass() -> None:
+    payload = _gated("PASS", "WAIVED")
+    assert payload["verdict"]["status"] == "WAIVED"
+
+
+def test_adding_the_verdict_kept_the_file_self_contained() -> None:
+    document = run_report.render_load_html(_gated("PASS", "FAIL")).lower()
+    for marker in (
+        "<script",
+        "<link",
+        "<img",
+        "<iframe",
+        "<object",
+        "<embed",
+        "<svg",
+        "@import",
+        "url(",
+        "src=",
+        "srcset",
+        "integrity=",
+        "crossorigin",
+        "//cdn",
+        "fonts.googleapis",
+        "http://",
+        "https://",
+    ):
+        assert marker not in document, f"the verdict block reaches for {marker!r}"

--- a/src/voicegateway/tests/loadtest/test_capacity.py
+++ b/src/voicegateway/tests/loadtest/test_capacity.py
@@ -295,3 +295,64 @@ def test_the_node_count_is_a_ceiling_never_a_rounding() -> None:
     """3.1 nodes of load is four machines. Rounding down under-provisions."""
     tier = capacity.nodes_for(400, 150)
     assert tier.nodes_for_load == math.ceil(400 / 127.5) == 4
+
+
+# --------------------------------------------------------------------------
+# Imported rows carry no target concurrency, which is the common case
+# --------------------------------------------------------------------------
+
+
+def test_a_ramp_with_no_targets_does_not_crash_the_plateau_scan() -> None:
+    """load_run_tests rows routinely have target_concurrency NULL.
+
+    The target lives in the generator's scenario file, which is not an
+    artifact, so nothing imports it. Comparing two unknown targets raised a
+    TypeError and took the whole report command down the moment anything
+    called the derivation.
+    """
+    steps = [
+        RampStep(target_concurrency=None, peak_concurrency=p, peak_cpu_utilisation=c)
+        for p, c in ((100, 0.31), (150, 0.48), (200, 0.66))
+    ]
+    finding = capacity.detect_plateau(steps)
+    assert finding.plateaued is False
+
+
+def test_unknown_targets_cannot_clear_a_ramp_of_plateauing() -> None:
+    """ "No plateau detected" must not mean "the check could not run".
+
+    With neither targets nor rates there is nothing to say a step asked for
+    more, so a plateau cannot be ruled out. The highest concurrency reached may
+    be the generator's ceiling, and sizing from it would be a guess.
+    """
+    steps = [
+        RampStep(target_concurrency=None, peak_concurrency=p, peak_cpu_utilisation=c)
+        for p, c in ((100, 0.31), (150, 0.48), (200, 0.66))
+    ]
+    value, reason = capacity.derive_calls_per_node(steps, cpu_ceiling=0.70)
+    assert value is None
+    assert "could not be ruled out" in reason
+    # The tempting wrong answer is right there.
+    assert max(s.peak_concurrency for s in steps) == 200
+
+
+def test_one_step_is_not_asked_to_rule_out_a_plateau() -> None:
+    """A single step cannot plateau against anything, so the guard does not fire.
+
+    It still refuses, but for the honest reason: one step with no CPU reading
+    shows nothing about the node.
+    """
+    [step] = [RampStep(target_concurrency=None, peak_concurrency=100)]
+    value, reason = capacity.derive_calls_per_node([step], cpu_ceiling=0.70)
+    assert value is None
+    assert "could not be ruled out" not in reason
+
+
+def test_a_declared_target_still_lets_the_derivation_answer() -> None:
+    """Non-vacuous: the guard blocks unknown ramps, not every ramp."""
+    steps = [
+        RampStep(target_concurrency=t, peak_concurrency=p, peak_cpu_utilisation=c)
+        for t, p, c in ((100, 100, 0.31), (200, 200, 0.66), (250, 250, 0.79))
+    ]
+    value, _ = capacity.derive_calls_per_node(steps, cpu_ceiling=0.70)
+    assert value == 200


### PR DESCRIPTION
Three things the report accepted but nothing ever supplied, plus the exit code that made a failing run indistinguishable from a passing one.

Five commits, one node each, every gate green at each step. The suite went from 2709 passed to **2761** and never decreased.

## The capacity table was unreachable

`derive_calls_per_node` and `capacity_table` were written, tested, and called by nothing. `build_load_payload` accepted a `capacity=` argument nobody passed, so the report rendered its empty state however good the data was. The per-node table is a contractual deliverable, and a correct derivation nobody invokes delivers nothing.

**Wiring it exposed a crash.** `RampStep.target_concurrency` was typed and treated as a required `int`, but an imported `load_run_tests` row never carries one: the target lives in the generator's scenario file, which is not an artifact. `detect_plateau` compared two unknown targets and raised `TypeError`, so calling the derivation would have taken `voicegw loadtest report` down on **every real run**.

Fixing the scan needed a fourth refusal to stay honest. With neither targets nor rates a plateau cannot be *ruled out*, and "no plateau detected" then means the check never ran rather than that the ramp climbed. Sizing from a ceiling that might be the generator's buys the wrong fleet.

The two empty-state branches now read differently: one means nothing called the derivation, which is a gap in the caller and says nothing about the run; the other means it ran and refused, and carries the reason.

## The appendix was never supplied

`--appendix` reads an operator-held JSON file of commands, flag semantics and toolchain notes. Every entry passes through `appendix_entry`, so a citation is mandatory and absolute URLs are reduced to a bare host.

Entries live with the operator rather than in this repository. Commands belong to a particular engagement, and the generator they drive is AGPL-3.0 while this repository is MIT, so its scenarios and configuration must not be copied here. Flag names and command lines are interface facts and travel fine. A test asserts no generator scenario file exists anywhere in the tree.

An unknown section is refused rather than ignored: a misspelled one would silently drop every entry under it, and the operator would hand over a report missing the commands that produced it with nothing saying so.

## A failing run exited zero

The command computed a verdict, printed it, and returned 0 regardless, so a pipeline checking the status code was checking nothing. It now uses `gates.exit_code`: only PASS is clean. WAIVED is not, because a pipeline going green on a waiver has dropped the requirement rather than recorded that it was set aside; UNKNOWN is not, because the run failed to measure something. One non-zero code on purpose, so an existing `if [ $? -eq 1 ]` keeps catching every kind of failure.

The exit happens **after** both files are written. A failing run is precisely the one whose evidence somebody needs.

## The verdict never reached the file

`_render_verdict` existed and was composed only into the diagnostics report, so the load-test verdict lived in the operator's terminal scrollback and never in the artifact. It is now derived from the gates the payload already carries, and the CLI reads it back out of the payload rather than recomputing it, so the console line, the exit code, the JSON and the HTML are one derivation rather than four that happen to agree.

**An empty gate list is UNKNOWN, not a pass.** `worst_status([])` returns PASS on its own, so deriving the verdict from it directly would have made a run that gated nothing read as clean. A null gate list is different again and renders NO VERDICT.

The synthetic stamp stays the first element in the body: its whole design is that a reader who scrolls to the numbers passes it on the way, and a verdict above it would be the first thing read on a file built from fixtures.

## Proven end to end

A test drives the real commands against a throwaway sqlite file with `VOICEGW_DB_PATH` cleared, then opens both artifacts as a recipient would. The failing path is exercised for real rather than simulated: node samples seeded at 80% CPU, over the 70% ceiling, produce FAIL rather than UNKNOWN, a non-zero exit, and both files still on disk carrying the breaching gate and a peak of 0.80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Load-test reports now include derived capacity metrics, sizing information, and spare-node guidance when available.
  * Added optional, cited JSON appendices for reproducibility assets such as commands, flags, and toolchain details.
  * Reports now display consistent verdicts, gate results, capacity status, and provenance in JSON and HTML outputs.
  * Failed or non-passing gates now return a non-zero CLI exit status while preserving report evidence.

* **Bug Fixes**
  * Improved handling of incomplete ramp data and clearly reports when capacity cannot be determined.
  * Added validation and redaction for invalid or unsafe appendix content.

* **Documentation**
  * Documented appendix format, validation rules, and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->