### PR TITLE
Wire the node metrics a live deployment proved we need, and fix five defects it exposed

### DIFF
--- a/alembic/versions/d1f4b8c93a27_node_samples_live_verified.py
+++ b/alembic/versions/d1f4b8c93a27_node_samples_live_verified.py
@@ -1,0 +1,102 @@
+"""node_samples: the columns a live LiveKit deployment proved we need
+
+Revision ID: d1f4b8c93a27
+Revises: c5a91e37f2b8
+Create Date: 2026-08-01 14:20:00.000000
+
+Every name behind these columns was read off a real livekit-server 1.10.1 plus
+livekit-sip plus node_exporter, with an inbound SIP call placed so every counter
+was populated. Nothing here is inferred from documentation.
+
+ONE revision for all of them, and for the drop, on purpose. Two revisions
+landing in the same branch is how the chain forks, and a forked chain fails only
+at ``alembic upgrade head`` on a real deployment.
+
+ANSWER LATENCY is the group that earns the rest. livekit-sip does not send
+200 OK until it has subscribed to an audio track, so the answering
+participant's join time IS the caller-visible answer latency, and
+``livekit_sip_dur_join_sec`` is the only server-side series that measures it.
+Stored as ``_sum`` and ``_count`` rather than buckets: buckets are cumulative,
+so summing them counts one observation once per bucket, which on the captured
+exposition reads 11 against a true count of 1. Two explicit bucket counts sit
+alongside so a proportion under a bound is answerable without a percentile.
+
+FILE DESCRIPTORS are stored as the PER-PROCESS rlimit, not the host maximum.
+The host ``fs.file-max`` on the observed box is effectively unbounded and does
+not fit a 64-bit column, while ``process_max_fds`` is a real ceiling the service
+actually hits. ``filefd_maximum_unbounded`` records the difference between "the
+limit cannot be reached" and "nobody measured it", which the model's own
+doctrine forbids collapsing. It is an integer carrying three states (1
+unbounded, 0 bounded, NULL unmeasured) rather than a boolean, so it travels the
+same coercion path as every other column instead of needing a parallel one.
+
+``nacks_total`` is DROPPED. ``livekit_nack_total`` does not exist on 1.10.1:
+there are zero occurrences of "nack" anywhere in the exposition under any name.
+A column nothing can ever populate is worse than no column, because it is
+reachable by a chart that will read NULL forever. No substitute is put in its
+place: the obvious candidate is declared a gauge while behaving cumulatively.
+
+Every value column is nullable and NULL means "not measured", never zero.
+Millisecond and byte columns are BigInteger because INT4 overflows.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d1f4b8c93a27"
+down_revision = "c5a91e37f2b8"
+branch_labels = None
+depends_on = None
+
+
+# (name, type) for every column added. Kept as data so the upgrade and the
+# downgrade cannot drift from one another.
+_COLUMNS: tuple[tuple[str, sa.types.TypeEngine], ...] = (
+    # Answer latency.
+    ("sip_join_sec_sum", sa.Float()),
+    ("sip_join_sec_count", sa.BigInteger()),
+    ("sip_join_le1_count", sa.BigInteger()),
+    ("sip_join_le5_count", sa.BigInteger()),
+    ("sip_check_sec_sum", sa.Float()),
+    ("sip_check_sec_count", sa.BigInteger()),
+    ("session_start_time_ms_sum", sa.BigInteger()),
+    ("session_start_time_ms_count", sa.BigInteger()),
+    # File descriptors.
+    ("process_open_fds", sa.BigInteger()),
+    ("process_max_fds", sa.BigInteger()),
+    # Admission and media.
+    ("sip_available", sa.Integer()),
+    ("sip_node_cpu_load", sa.Float()),
+    ("sip_rtp_packets_recv", sa.BigInteger()),
+    ("sip_rtp_packets_send", sa.BigInteger()),
+    # Restart and attribution.
+    ("process_start_time_seconds", sa.Float()),
+    ("process_cpu_seconds_total", sa.Float()),
+    ("process_resident_memory_bytes", sa.BigInteger()),
+    # Port headroom.
+    ("sockstat_udp_inuse", sa.BigInteger()),
+    ("udp_no_ports_total", sa.BigInteger()),
+    # Stale state.
+    ("track_published_total", sa.BigInteger()),
+    ("track_subscribed_total", sa.BigInteger()),
+    ("psrpc_stream_count", sa.BigInteger()),
+    # Derived marker, not a scraped series.
+    ("filefd_maximum_unbounded", sa.Integer()),
+)
+
+
+def upgrade() -> None:
+    for name, type_ in _COLUMNS:
+        op.add_column("node_samples", sa.Column(name, type_, nullable=True))
+    # livekit_nack_total does not exist on livekit-server 1.10.1.
+    op.drop_column("node_samples", "nacks_total")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "node_samples", sa.Column("nacks_total", sa.BigInteger(), nullable=True)
+    )
+    for name, _ in reversed(_COLUMNS):
+        op.drop_column("node_samples", name)

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -746,6 +746,14 @@ export VOICEGW_NODE_SCRAPE_TARGETS="livekit-server:sfu-1=http://10.0.0.4:6789/me
 
 `source` is one of `livekit-server`, `livekit-sip` or `node-exporter`. `name` is the node the samples are filed under, and using the same `name` for two sources is the point: it puts an SFU's own counters and its host's file descriptors on one time axis. A malformed entry is skipped with a warning instead of failing startup, and the collector logs how many targets it read.
 
+**An endpoint behind basic auth** takes the credential in the URL, the usual way:
+
+```bash
+export VOICEGW_NODE_SCRAPE_TARGETS="livekit-server:sfu-1=http://user:secret@10.0.0.4:6789/metrics"
+```
+
+The credential is split off the URL when the variable is parsed and sent as an `Authorization` header instead. That matters because the HTTP client logs its request line at INFO: left in the URL, the password would be written to the log on every tick, four times a minute, for as long as the collector runs. Nothing logs it now, including the warning about a malformed entry, which prints the host with the credential replaced by `***`. Percent-encode a password containing `@`, `:` or `/`.
+
 With the variable unset or empty no scrape worker is started and the collector makes no outbound requests, which is the default. Cadence comes from `workers.node_scrape_interval_seconds` in `voicegw.yaml` (default 15 seconds, matching Prometheus' own default); `workers.enabled: false` disables this worker along with the rollups.
 
 **`voicegw_cost_usd_total` and `voicegw_requests_total` are gauges over a rolling 24-hour window, not counters.** Both are computed from the `"today"` window, which is `now - 86400` seconds: a rolling trailing 24 hours. It is *not* midnight-to-now and *not* a since-process-start total. The value therefore goes **down** as well as up, every time a request falls off the trailing edge. The `period="today"` label and the `_total` suffix are both misnomers kept for backward compatibility, because renaming a scraped series would break every dashboard already built on it. The `# TYPE` metadata is now `gauge`, which is what your tooling actually reads.

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -946,7 +946,15 @@ def unscraped_headroom_readings(
 
 
 def _headroom_gate(reading: HeadroomReading, threshold: float) -> GateResult:
-    subject = f"{reading.node}/{reading.resource}"
+    # The source belongs in the subject whenever there is one, exactly as in
+    # _resource_gate. One node is commonly scraped by several exporters, and
+    # dropping it produced several gates with IDENTICAL subjects: an observed
+    # run emitted "live-1/file_descriptors" three times reading PASS, UNKNOWN
+    # and UNKNOWN, with nothing in the report saying which exporter passed. A
+    # reading with no source keeps the shorter form, so a caller that has only
+    # a node name is unaffected.
+    where = f"{reading.node}/{reading.source}" if reading.source else reading.node
+    subject = f"{where}/{reading.resource}"
     if reading.used is None or reading.limit is None:
         why = reading.unmeasured_reason or "the window produced no usable reading"
         return GateResult(
@@ -954,7 +962,7 @@ def _headroom_gate(reading: HeadroomReading, threshold: float) -> GateResult:
             status=UNKNOWN,
             subject=subject,
             detail=(
-                f"{reading.resource} headroom on {reading.node} was not "
+                f"{reading.resource} headroom on {where} was not "
                 f"measured: {why}. Absent headroom evidence is not spare "
                 "capacity"
             ),
@@ -966,7 +974,7 @@ def _headroom_gate(reading: HeadroomReading, threshold: float) -> GateResult:
             status=UNKNOWN,
             subject=subject,
             detail=(
-                f"the {reading.resource} counts on {reading.node} do not "
+                f"the {reading.resource} counts on {where} do not "
                 f"describe a limit ({reading.used:.0f} of {reading.limit:.0f}), "
                 "so the headroom they imply is not a measurement"
             ),
@@ -989,7 +997,7 @@ def _headroom_gate(reading: HeadroomReading, threshold: float) -> GateResult:
         status=status,
         subject=subject,
         detail=(
-            f"{reading.resource} on {reading.node} had "
+            f"{reading.resource} on {where} had "
             f"{headroom * 100:.1f}% headroom ({reading.used:.0f} of "
             f"{reading.limit:.0f} used), {relation} the "
             f"{threshold * 100:.0f}% floor"

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -52,6 +52,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from voicegateway.livekit_diag.gates import (
     MIN_PERCENTILE_SAMPLES,
+    HeadroomReading,
     NodeUtilisationReading,
 )
 from voicegateway.repository.node_correlation_repository import (
@@ -76,6 +77,15 @@ CPU_IDLE_COLUMN = "cpu_idle_seconds_total"
 MEMORY_AVAILABLE_COLUMN = "memory_available_bytes"
 MEMORY_TOTAL_COLUMN = "memory_total_bytes"
 
+# The file-descriptor pair headroom is judged against. These are the PER-PROCESS
+# rlimit, not the host filefd pair, and the difference is not cosmetic: the host
+# maximum on an observed box reads 9.223372036854776e18, which is effectively
+# unbounded and does not fit a 64-bit column, while this pair reads a real
+# 524287. The limit a service actually hits is its own, and the host figure
+# cannot produce a ratio at all.
+FD_USED_COLUMN = "process_open_fds"
+FD_LIMIT_COLUMN = "process_max_fds"
+
 
 @dataclass(frozen=True)
 class TestAggregate:
@@ -96,6 +106,10 @@ class TestAggregate:
     node_samples_in_window: int
     cpu_readings: list[NodeUtilisationReading] = field(default_factory=list)
     memory_readings: list[NodeUtilisationReading] = field(default_factory=list)
+    # File-descriptor headroom per node, already in the shape the gate judges.
+    # Carried here rather than rebuilt in the judge so the measurement lives in
+    # one place and the judge stays a thing that only decides.
+    fd_readings: list[HeadroomReading] = field(default_factory=list)
 
     @property
     def nodes_seen(self) -> int:
@@ -222,6 +236,58 @@ async def _memory_reading(
     )
 
 
+async def _fd_reading(
+    db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
+) -> HeadroomReading:
+    """One node's WORST file-descriptor headroom over the window.
+
+    Worst, not last: headroom is a floor, and a run that touched 95% for one
+    scrape and settled back has still demonstrated it can get there. The pair is
+    read off the SAME ROW so both halves describe one instant, exactly as memory
+    is, because an open count from one scrape against a limit from another
+    describes a state that never existed.
+
+    A row missing either half contributes nothing rather than a zero. When no
+    row carries both, the reading is unmeasured WITH a reason, and the gate
+    turns that into UNKNOWN rather than a pass.
+    """
+    rows = await list_samples(
+        db,
+        node=node,
+        source=source,
+        since_ms=window.start_ms,
+        until_ms=window.end_ms,
+        limit=limit,
+    )
+    worst: tuple[float, float] | None = None
+    for row in rows:
+        used = getattr(row, FD_USED_COLUMN)
+        ceiling = getattr(row, FD_LIMIT_COLUMN)
+        if used is None or ceiling is None or ceiling <= 0:
+            continue
+        if worst is None or (used / ceiling) > (worst[0] / worst[1]):
+            worst = (float(used), float(ceiling))
+    if worst is None:
+        return HeadroomReading(
+            node=node,
+            resource="file_descriptors",
+            used=None,
+            limit=None,
+            source=source,
+            unmeasured_reason=(
+                f"no row in the window carried both {FD_USED_COLUMN} and "
+                f"{FD_LIMIT_COLUMN} ({len(rows)} rows read)"
+            ),
+        )
+    return HeadroomReading(
+        node=node,
+        resource="file_descriptors",
+        used=worst[0],
+        limit=worst[1],
+        source=source,
+    )
+
+
 async def aggregate_test_window(
     db: AsyncSession,
     *,
@@ -249,6 +315,7 @@ async def aggregate_test_window(
 
     cpu: list[NodeUtilisationReading] = []
     memory: list[NodeUtilisationReading] = []
+    fds: list[HeadroomReading] = []
     for target in targets:
         cpu.append(
             await _cpu_reading(
@@ -257,6 +324,11 @@ async def aggregate_test_window(
         )
         memory.append(
             await _memory_reading(
+                db, node=target.node, source=target.source, window=window, limit=limit
+            )
+        )
+        fds.append(
+            await _fd_reading(
                 db, node=target.node, source=target.source, window=window, limit=limit
             )
         )
@@ -270,12 +342,15 @@ async def aggregate_test_window(
         node_samples_in_window=sum(t.samples for t in targets),
         cpu_readings=cpu,
         memory_readings=memory,
+        fd_readings=fds,
     )
 
 
 __all__ = [
     "CPU_CAPACITY_COLUMN",
     "CPU_IDLE_COLUMN",
+    "FD_LIMIT_COLUMN",
+    "FD_USED_COLUMN",
     "MEMORY_AVAILABLE_COLUMN",
     "MEMORY_TOTAL_COLUMN",
     "TestAggregate",

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -27,22 +27,41 @@ from typing import Any
 
 from voicegateway.livekit_diag import gates
 from voicegateway.livekit_diag.gates import GateResult
-from voicegateway.loadtest.aggregation import TestAggregate
+from voicegateway.loadtest.aggregation import (
+    FD_LIMIT_COLUMN,
+    FD_USED_COLUMN,
+    TestAggregate,
+)
 
 # The FD pair is the one headroom resource anything scrapes. RTP ports and
 # network are emitted as unmeasured by unscraped_headroom_readings, so they
 # appear in every report as UNKNOWN instead of vanishing.
-_FD_USED = "filefd_allocated"
-_FD_LIMIT = "filefd_maximum"
+# The PER-PROCESS rlimit pair, not the host filefd pair. The host maximum is
+# commonly unbounded and yields no ratio at all; the limit a service actually
+# hits is its own.
+_FD_USED = FD_USED_COLUMN
+_FD_LIMIT = FD_LIMIT_COLUMN
 
 
-def _fd_reading(node: str, source: str | None = None) -> gates.HeadroomReading:
-    """File descriptors as an unmeasured reading.
+_NO_WINDOW = (
+    "the test has no window, so no scrape carrying "
+    f"{_FD_USED}/{_FD_LIMIT} could be correlated to it"
+)
+_NOT_ON_AGGREGATE = (
+    f"the correlated window carried no {_FD_USED}/{_FD_LIMIT} reading for this node"
+)
 
-    The pair IS scraped into node_samples, but it is not threaded onto the
-    per-test aggregate yet, so it is reported as unmeasured rather than guessed
-    at. Emitted on every path so an unscraped run shows three UNKNOWN headroom
-    gates rather than two, with file descriptors quietly unjudged.
+
+def _fd_reading(
+    node: str, source: str | None = None, *, reason: str = _NO_WINDOW
+) -> gates.HeadroomReading:
+    """File descriptors as an unmeasured reading, with the reason it is one.
+
+    A test that correlated a window carries REAL readings on its aggregate,
+    built where the measurement happens rather than rebuilt here: this module
+    decides and does not measure. This is the fallback for the two ways a node
+    can arrive with nothing to judge, and it exists so those cases produce an
+    UNKNOWN gate rather than no gate at all.
     """
     return gates.HeadroomReading(
         node=node,
@@ -50,10 +69,7 @@ def _fd_reading(node: str, source: str | None = None) -> gates.HeadroomReading:
         used=None,
         limit=None,
         source=source,
-        unmeasured_reason=(
-            f"{_FD_USED}/{_FD_LIMIT} are scraped but are not carried on the "
-            "per-test aggregate yet"
-        ),
+        unmeasured_reason=reason,
     )
 
 
@@ -124,12 +140,22 @@ def _headroom_gates_for(aggregate: TestAggregate) -> list[GateResult]:
     """
 
     readings: list[gates.HeadroomReading] = []
+    # Real file-descriptor readings, measured during correlation. A node whose
+    # window carried no usable pair arrives here already unmeasured WITH its
+    # reason, which the gate turns into UNKNOWN rather than a pass.
+    readings.extend(aggregate.fd_readings)
+    measured = {(r.node, r.source) for r in aggregate.fd_readings}
     for reading in aggregate.cpu_readings:
-        # The FD pair is not carried on TestAggregate, so it is reported as
-        # unmeasured here rather than guessed at. Wiring it needs the gauge
-        # pair threaded through aggregation, which is a measurement change and
-        # does not belong in a module that only judges.
-        readings.append(_fd_reading(reading.node, reading.source))
+        # A node the aggregate judged for CPU but carries no FD reading for
+        # would otherwise lose the file-descriptor gate while keeping the other
+        # two, which reads as a resource nobody had to satisfy rather than one
+        # nobody measured.
+        if (reading.node, reading.source) not in measured:
+            readings.append(
+                _fd_reading(
+                    reading.node, reading.source, reason=_NOT_ON_AGGREGATE
+                )
+            )
         readings.extend(
             gates.unscraped_headroom_readings(reading.node, source=reading.source)
         )

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -266,6 +266,44 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
 }
 
 
+# The host file-descriptor maximum a kernel reports when nothing constrains it.
+# VERIFIED LIVE: node_filefd_maximum reads 9.223372036854776e+18, and
+# int(float(...)) of that is 9223372036854775808, exactly ONE past the 64-bit
+# ceiling. That is a float64 round-trip artifact of a number that is already
+# 2**63 - 1, not a machine with more descriptors than a signed 64-bit integer
+# can count. So the column is left NULL and the fact is recorded separately.
+#
+# The threshold is short of 2**63 rather than equal to it because the round trip
+# is lossy in both directions: any value this close to the ceiling is the
+# kernel's "no limit", and the last 1024 counts are not a distinction anything
+# can act on.
+FILEFD_UNBOUNDED_THRESHOLD: Final[float] = float(2**63 - 1024)
+_FILEFD_MAXIMUM_COLUMN: Final[str] = "filefd_maximum"
+_FILEFD_UNBOUNDED_COLUMN: Final[str] = "filefd_maximum_unbounded"
+
+
+def _mark_unbounded_filefd(values: dict[str, float | None]) -> None:
+    """Record whether the host descriptor ceiling is reachable at all.
+
+    THREE states, and keeping them apart is the whole point. 1 says the maximum
+    parsed as effectively unbounded, so headroom on it cannot run out. 0 says it
+    parsed as a real bound. Leaving the key out entirely stores NULL, which says
+    nobody measured it.
+
+    Without this, an unbounded ceiling and an unscraped one are the same empty
+    column, and "this limit cannot be hit" reads identically to "we never
+    looked". They support opposite conclusions about a fleet.
+    """
+    maximum = values.get(_FILEFD_MAXIMUM_COLUMN)
+    if maximum is None:
+        # Absent or unparseable. NOT 0: an absent series says nothing about
+        # whether the limit is reachable.
+        return
+    values[_FILEFD_UNBOUNDED_COLUMN] = (
+        1.0 if maximum >= FILEFD_UNBOUNDED_THRESHOLD else 0.0
+    )
+
+
 def validate_series_map(series_map: Mapping[str, tuple[_Series, ...]]) -> None:
     """Refuse a metric map that cannot produce meaningful numbers.
 
@@ -541,12 +579,17 @@ class NodeSamplesWorker(AsyncWorker):
                 continue
             values[series.column] = value
             found += 1
+        _mark_unbounded_filefd(values)
         return node_samples.NodeSampleInput(
             node=target.node,
             source=target.source,
             at_ms=at_ms,
             outcome=outcome,
             project=target.project,
+            # A count of what MATCHED, which is not yet a count of what stored:
+            # a value the repository refuses at coercion is dropped after this
+            # point. insert_samples recomputes from what actually landed, and
+            # this is the input to that.
             series_found=found,
             values=values,
         )

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -151,14 +151,34 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         # kind of detail that drifts between releases.
         _Series("livekit_packet_total", "packets_total"),
         _Series("livekit_packet_bytes", "packet_bytes_total"),
-        # Go runtime, from the standard prometheus/client_golang collectors that
-        # both binaries register by default. These are the return-to-baseline
-        # pair, NOT RSS: Go hands freed heap back to the OS lazily, so a drained
-        # process can hold its resident size long after the heap emptied.
-        # Unverified against a live target, like every name in this map; an
-        # unmatched one stores NULL and is counted by series_found.
+        # Go runtime and process collectors, from the standard
+        # prometheus/client_golang set both binaries register by default. The
+        # heap and goroutine pair is the return-to-baseline signal, NOT RSS: Go
+        # hands freed heap back to the OS lazily, so a drained process can hold
+        # its resident size long after the heap emptied.
+        #
+        # process_max_fds is the PER-PROCESS rlimit and is the ceiling a service
+        # actually hits, unlike the host fs.file-max which is commonly
+        # unbounded. process_start_time_seconds is what makes a mid-run restart
+        # visible rather than an unexplained discontinuity in every counter rate
+        # across it.
         _Series("go_memstats_heap_inuse_bytes", "heap_inuse_bytes"),
         _Series("go_goroutines", "go_goroutines"),
+        _Series("process_open_fds", "process_open_fds"),
+        _Series("process_max_fds", "process_max_fds"),
+        _Series("process_start_time_seconds", "process_start_time_seconds"),
+        _Series("process_cpu_seconds_total", "process_cpu_seconds_total"),
+        _Series("process_resident_memory_bytes", "process_resident_memory_bytes"),
+        # NOT here: livekit_node_cpu_load, which exists on livekit-sip only and
+        # appears in none of the livekit_* families the server exports.
+        #
+        # ALSO NOT here, and their columns therefore store NULL:
+        # livekit_session_start_time_ms_sum/_count, livekit_track_published_total,
+        # livekit_track_subscribed_total and psrpc_stream_count. They are
+        # server-side names that could not be read off a live server, and a
+        # guessed name stores NULL for the life of a deployment while
+        # series_found still reads high because its siblings matched. An
+        # unwired column is honest; a wrong one is invisible.
     ),
     SOURCE_LIVEKIT_SIP: (
         # Fleet aggregates only. livekit-sip is blind to anything per-call, so
@@ -170,14 +190,58 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         # Summed across the `status` label: the per-status split is a different
         # (and wider) table than this one.
         _Series("livekit_sip_calls_terminated", "sip_calls_terminated_total"),
-        # Go runtime, from the standard prometheus/client_golang collectors that
-        # both binaries register by default. These are the return-to-baseline
-        # pair, NOT RSS: Go hands freed heap back to the OS lazily, so a drained
-        # process can hold its resident size long after the heap emptied.
-        # Unverified against a live target, like every name in this map; an
-        # unmatched one stores NULL and is counted by series_found.
+        # Go runtime and process collectors, from the standard
+        # prometheus/client_golang set both binaries register by default. The
+        # heap and goroutine pair is the return-to-baseline signal, NOT RSS: Go
+        # hands freed heap back to the OS lazily, so a drained process can hold
+        # its resident size long after the heap emptied.
+        #
+        # process_max_fds is the PER-PROCESS rlimit and is the ceiling a service
+        # actually hits, unlike the host fs.file-max which is commonly
+        # unbounded. process_start_time_seconds is what makes a mid-run restart
+        # visible rather than an unexplained discontinuity in every counter rate
+        # across it.
         _Series("go_memstats_heap_inuse_bytes", "heap_inuse_bytes"),
         _Series("go_goroutines", "go_goroutines"),
+        _Series("process_open_fds", "process_open_fds"),
+        _Series("process_max_fds", "process_max_fds"),
+        _Series("process_start_time_seconds", "process_start_time_seconds"),
+        _Series("process_cpu_seconds_total", "process_cpu_seconds_total"),
+        _Series("process_resident_memory_bytes", "process_resident_memory_bytes"),
+        # ---- answer latency ------------------------------------------------
+        # The engagement's headline risk: livekit-sip withholds 200 OK until it
+        # has subscribed to an audio track, so this histogram IS caller-visible
+        # answer latency. Stored as _sum and _count; the buckets are cumulative
+        # and summing them counts one observation once per bucket.
+        _Series("livekit_sip_dur_join_sec_sum", "sip_join_sec_sum"),
+        _Series("livekit_sip_dur_join_sec_count", "sip_join_sec_count"),
+        # Two explicit buckets, each selected by an le naming ONE bound, so a
+        # proportion under it is answerable without inventing a percentile.
+        _Series(
+            "livekit_sip_dur_join_sec_bucket", "sip_join_le1_count", where={"le": "1"}
+        ),
+        _Series(
+            "livekit_sip_dur_join_sec_bucket", "sip_join_le5_count", where={"le": "5"}
+        ),
+        _Series("livekit_sip_dur_check_sec_sum", "sip_check_sec_sum"),
+        _Series("livekit_sip_dur_check_sec_count", "sip_check_sec_count"),
+        # ---- admission -----------------------------------------------------
+        # "Whether node can accept new requests". Flips to 0 when the node stops
+        # taking INVITEs, which serves both the health clause and the drain test.
+        _Series("livekit_sip_available", "sip_available"),
+        # livekit-sip ONLY. Absent from every livekit_* family on the server.
+        _Series("livekit_node_cpu_load", "sip_node_cpu_load"),
+        # ---- media ---------------------------------------------------------
+        # SPLIT BY DIRECTION, never summed: a call that sent 337 and received
+        # 330 sums to 667 and one-way audio disappears into that one number.
+        # Not also filtered on payload: the send leg carries the literal string
+        # "audio" rather than a codec name, so a payload filter would empty it.
+        _Series(
+            "livekit_sip_packets_rtp", "sip_rtp_packets_recv", where={"op": "recv"}
+        ),
+        _Series(
+            "livekit_sip_packets_rtp", "sip_rtp_packets_send", where={"op": "send"}
+        ),
     ),
     SOURCE_NODE_EXPORTER: (
         # The M4 headline pair.
@@ -192,6 +256,12 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         ),
         _Series("node_memory_MemAvailable_bytes", "memory_available_bytes"),
         _Series("node_memory_MemTotal_bytes", "memory_total_bytes"),
+        # ---- port headroom -------------------------------------------------
+        # UDP sockets in use, and ports that could not be allocated. The second
+        # is the one that matters: a rising rate means the box ran out of ports,
+        # which at 500 concurrent is a likelier wall than CPU.
+        _Series("node_sockstat_UDP_inuse", "sockstat_udp_inuse"),
+        _Series("node_netstat_Udp_NoPorts", "udp_no_ports_total"),
     ),
 }
 

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -151,7 +151,6 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         # kind of detail that drifts between releases.
         _Series("livekit_packet_total", "packets_total"),
         _Series("livekit_packet_bytes", "packet_bytes_total"),
-        _Series("livekit_nack_total", "nacks_total"),
         # Go runtime, from the standard prometheus/client_golang collectors that
         # both binaries register by default. These are the return-to-baseline
         # pair, NOT RSS: Go hands freed heap back to the OS lazily, so a drained

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -56,9 +56,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import time
+import urllib.parse
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Final
 
 import httpx
@@ -120,12 +122,26 @@ TARGETS_ENV_VAR: Final[str] = "VOICEGW_NODE_SCRAPE_TARGETS"
 
 @dataclass(frozen=True)
 class ScrapeTarget:
-    """One exposition endpoint, and the node name its samples are filed under."""
+    """One exposition endpoint, and the node name its samples are filed under.
+
+    ``url`` NEVER carries userinfo. A metrics endpoint behind basic auth is
+    configured as ``http://user:secret@host/metrics``, and httpx would happily
+    authenticate from that: it also logs the request line at INFO, so the
+    password would be written to the log on every tick, four times a minute, for
+    as long as the process runs. :func:`targets_from_env` splits the credential
+    off into :attr:`auth` so the URL that gets logged, retried and reported is
+    the URL without it.
+
+    ``auth`` is ``repr=False`` because a dataclass repr is the other way a
+    secret escapes: any log line, exception or debugger that renders a target
+    would print it.
+    """
 
     node: str
     url: str
     source: str
     project: str = node_samples.DEFAULT_PROJECT
+    auth: tuple[str, str] | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True)
@@ -363,22 +379,67 @@ def targets_from_env(
             continue
         head, sep, url = item.partition("=")
         source, colon, node = head.partition(":")
+        # Redacted before it reaches a log line. A skipped entry is the case
+        # where a credential is MOST likely present and least likely to have
+        # been parsed out yet, so the warning about it is a leak of its own.
+        shown = redact_url(item)
         if not sep or not colon or not url.strip() or not node.strip():
             logger.warning(
-                "%s: ignoring %r; expected 'source:name=url'", TARGETS_ENV_VAR, item
+                "%s: ignoring %r; expected 'source:name=url'", TARGETS_ENV_VAR, shown
             )
             continue
         if source not in SOURCES:
             logger.warning(
                 "%s: ignoring %r; unknown source %r (known: %s)",
                 TARGETS_ENV_VAR,
-                item,
+                shown,
                 source,
                 ", ".join(SOURCES),
             )
             continue
-        targets.append(ScrapeTarget(node=node.strip(), url=url.strip(), source=source))
+        clean, auth = split_userinfo(url.strip())
+        targets.append(
+            ScrapeTarget(node=node.strip(), url=clean, source=source, auth=auth)
+        )
     return targets
+
+
+# Anything between "://" and the "@" that ends an authority. Used to redact a
+# URL before it is logged, so a credential cannot ride into the log on a path
+# that never went through targets_from_env: a directly constructed target, or a
+# malformed env entry that is skipped before it is ever parsed.
+_USERINFO = re.compile(r"(?<=://)[^@/\s]+@")
+_REDACTED = "***@"
+
+
+def redact_url(text: str) -> str:
+    """``text`` with any URL userinfo replaced by ``***``.
+
+    Applied at every point that logs a URL rather than only at the parse site,
+    because the parse site is not the only way a target is built and a secret
+    written to a log file cannot be unwritten.
+    """
+    return _USERINFO.sub(_REDACTED, text)
+
+
+def split_userinfo(url: str) -> tuple[str, tuple[str, str] | None]:
+    """``(url_without_userinfo, auth_or_None)``.
+
+    httpx authenticates from userinfo on its own, so leaving it in the URL
+    WORKS -- and logs the password at INFO on every request. Splitting it here
+    keeps the behaviour and drops the leak.
+
+    The credential is percent-decoded, because that is how it travels in a URL
+    and how httpx expects it in an auth tuple: a password containing ``@`` or
+    ``/`` is only expressible encoded.
+    """
+    parts = urllib.parse.urlsplit(url)
+    userinfo, sep, host = parts.netloc.rpartition("@")
+    if not sep:
+        return url, None
+    username, _, password = userinfo.partition(":")
+    auth = (urllib.parse.unquote(username), urllib.parse.unquote(password))
+    return urllib.parse.urlunsplit(parts._replace(netloc=host)), auth
 
 
 async def _default_target_provider() -> list[ScrapeTarget]:
@@ -524,7 +585,8 @@ class NodeSamplesWorker(AsyncWorker):
         """Scrape one target. Never raises: a failure becomes a row that says so."""
         try:
             body, outcome = await asyncio.wait_for(
-                self._fetch(client, target.url), timeout=self._scrape_timeout
+                self._fetch(client, target.url, target.auth),
+                timeout=self._scrape_timeout,
             )
         except (TimeoutError, httpx.TimeoutException):
             # The outer wait_for is not redundant with httpx's timeouts: httpx
@@ -540,7 +602,7 @@ class NodeSamplesWorker(AsyncWorker):
             # would propagate it and lose every other target's sample).
             logger.exception(
                 "NodeSamplesWorker: unexpected error scraping %s (%s)",
-                target.url,
+                redact_url(target.url),
                 target.node,
             )
             outcome, body = OUTCOME_UNREACHABLE, None
@@ -595,15 +657,23 @@ class NodeSamplesWorker(AsyncWorker):
         )
 
     async def _fetch(
-        self, client: httpx.AsyncClient, url: str
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        auth: tuple[str, str] | None = None,
     ) -> tuple[str | None, str]:
         """GET one exposition body, capped. ``(body_or_None, outcome)``.
 
         Streamed rather than buffered so the byte cap is enforced while the
         response arrives: a misconfigured target pointed at a log endpoint must
         not be able to allocate its way through this process's memory.
+
+        ``auth`` becomes an Authorization header rather than part of the URL,
+        which is the difference between a credential httpx sends and one it also
+        logs. ``None`` is httpx's "no auth" and is what an unauthenticated
+        target passes.
         """
-        async with client.stream("GET", url) as response:
+        async with client.stream("GET", url, auth=auth) as response:
             if response.status_code != 200:
                 # Body deliberately unread: an error page is not an exposition.
                 return None, OUTCOME_HTTP_ERROR
@@ -614,7 +684,7 @@ class NodeSamplesWorker(AsyncWorker):
                 if total > self._max_response_bytes:
                     logger.warning(
                         "NodeSamplesWorker: %s exceeded %d bytes; dropping the scrape",
-                        url,
+                        redact_url(url),
                         self._max_response_bytes,
                     )
                     return None, OUTCOME_TOO_LARGE
@@ -638,5 +708,7 @@ __all__ = [
     "NodeSamplesWorker",
     "ScrapeTarget",
     "TargetProvider",
+    "redact_url",
+    "split_userinfo",
     "targets_from_env",
 ]

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -64,7 +64,11 @@ from typing import TYPE_CHECKING, Final
 import httpx
 
 from voicegateway.middleware.base_middleware import AsyncWorker
-from voicegateway.middleware.prometheus_exposition import parse_exposition, sum_series
+from voicegateway.middleware.prometheus_exposition import (
+    BUCKET_SUFFIX,
+    parse_exposition,
+    sum_series,
+)
 from voicegateway.repository import node_samples_repository as node_samples
 
 if TYPE_CHECKING:
@@ -191,6 +195,45 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         _Series("node_memory_MemTotal_bytes", "memory_total_bytes"),
     ),
 }
+
+
+def validate_series_map(series_map: Mapping[str, tuple[_Series, ...]]) -> None:
+    """Refuse a metric map that cannot produce meaningful numbers.
+
+    Called at import, so a bad entry is a startup failure rather than a column
+    that quietly stores the wrong thing for the life of a deployment. Both
+    checks exist because both failure modes were observed against a real
+    exposition, and neither announces itself at runtime.
+
+    A ``_bucket`` entry without an ``le`` selector would sum cumulative buckets
+    and count each observation once per bucket. On a real capture that reads
+    11.0 for a histogram whose true count is 1.
+
+    A base histogram name (``livekit_sip_dur_join_sec`` rather than its ``_sum``
+    or ``_count``) matches no sample and stores NULL forever, while
+    ``series_found`` still reads high because the sibling entries matched. That
+    one cannot be caught without an exposition to compare against, so it is
+    checked by a test against a captured fixture rather than here.
+    """
+    problems: list[str] = []
+    for source, entries in series_map.items():
+        for entry in entries:
+            if entry.metric.endswith(BUCKET_SUFFIX) and not (
+                entry.where and "le" in entry.where
+            ):
+                problems.append(
+                    f"{source}: {entry.metric!r} -> {entry.column!r} is a "
+                    "cumulative bucket with no le selector; summing it counts "
+                    "each observation once per bucket"
+                )
+    if problems:
+        raise ValueError(
+            "the node_samples metric map has entries that cannot produce a "
+            "meaningful number:\n  " + "\n  ".join(problems)
+        )
+
+
+validate_series_map(SERIES)
 
 
 TargetProvider = Callable[[], Awaitable[Sequence[ScrapeTarget]]]

--- a/src/voicegateway/middleware/prometheus_exposition.py
+++ b/src/voicegateway/middleware/prometheus_exposition.py
@@ -181,6 +181,41 @@ def parse_exposition(body: str) -> list[Sample]:
     return samples
 
 
+#: The suffix Prometheus gives a histogram's cumulative bucket series.
+BUCKET_SUFFIX = "_bucket"
+
+#: Suffixes that only ever exist on a histogram or summary, never alone. A map
+#: entry naming the BASE of one of these matches no sample at all.
+_AGGREGATE_SUFFIXES = ("_bucket", "_sum", "_count")
+
+
+class HistogramMisuse(ValueError):
+    """A series was requested in a way that cannot produce a meaningful number.
+
+    Raised rather than returning None, because both cases this covers are
+    programming errors in the metric map, not absences in the data, and a None
+    would be indistinguishable from "this deployment does not export it".
+    """
+
+
+def histogram_bases(samples: Iterable[Sample]) -> set[str]:
+    """Names that exist ONLY as ``_bucket``/``_sum``/``_count``.
+
+    A map entry naming one of these matches nothing and stores NULL for the
+    life of the deployment, while ``series_found`` still reads high because the
+    other entries matched. That is invisible without this check.
+    """
+    present = {sample.name for sample in samples}
+    bases: set[str] = set()
+    for name in present:
+        for suffix in _AGGREGATE_SUFFIXES:
+            if name.endswith(suffix):
+                base = name[: -len(suffix)]
+                if base and base not in present:
+                    bases.add(base)
+    return bases
+
+
 def sum_series(
     samples: Iterable[Sample],
     name: str,
@@ -201,7 +236,21 @@ def sum_series(
     a release spelled it differently. ``where`` is used only where the value is
     part of the definition (``mode="idle"``), never to reconstruct a split this
     schema does not store.
+
+    Summing across BUCKETS is a different operation and is refused. Prometheus
+    buckets are cumulative, so ``le=0.1`` is contained in ``le=0.5`` and so on
+    up to ``+Inf``: adding them counts the same observation once per bucket. On
+    a real capture this returns 11.0 for a histogram whose true ``_count`` is 1,
+    and at load that charts as a smooth believable curve nobody questions. A
+    bucket therefore requires an explicit ``le``, which selects ONE bucket and
+    makes the result "observations at or under this bound".
     """
+    if name.endswith(BUCKET_SUFFIX) and not (where and "le" in where):
+        raise HistogramMisuse(
+            f"{name!r} is a cumulative histogram bucket and summing across "
+            "buckets counts each observation once per bucket. Pass an explicit "
+            'le selector, e.g. where={"le": "1"}, to select a single bucket.'
+        )
     total: float | None = None
     for sample in samples:
         if sample.name != name:
@@ -213,7 +262,10 @@ def sum_series(
 
 
 __all__ = [
+    "BUCKET_SUFFIX",
+    "HistogramMisuse",
     "Sample",
+    "histogram_bases",
     "parse_exposition",
     "sum_series",
 ]

--- a/src/voicegateway/models/node_sample_model.py
+++ b/src/voicegateway/models/node_sample_model.py
@@ -100,7 +100,6 @@ class NodeSample(SQLModel, table=True):
     packets_total: int | None = Field(default=None, sa_type=BigInteger)
     # BigInteger is load-bearing here (see the module docstring).
     packet_bytes_total: int | None = Field(default=None, sa_type=BigInteger)
-    nacks_total: int | None = Field(default=None, sa_type=BigInteger)
 
     # ---- livekit-sip ------------------------------------------------------
     # Fleet aggregates only. livekit-sip is blind to anything per-call, so
@@ -143,3 +142,79 @@ class NodeSample(SQLModel, table=True):
     # this table carries its unit in the name.
     heap_inuse_bytes: int | None = Field(default=None, sa_type=BigInteger)
     go_goroutines: int | None = None
+
+    # ---- answer latency ---------------------------------------------------
+    # The engagement's single biggest risk: livekit-sip withholds 200 OK until
+    # it has subscribed to an audio track, so the answering participant's join
+    # time IS the caller-visible answer latency. These are the only server-side
+    # series that measure it.
+    #
+    # A histogram is stored as its _sum and _count rather than its buckets,
+    # because buckets are cumulative and summing them counts one observation
+    # once per bucket. Two explicit bucket counts are kept alongside so a
+    # proportion under a bound is answerable without a percentile: le=1 and
+    # le=5 are the two the acceptance conversation actually turns on.
+    sip_join_sec_sum: float | None = None
+    sip_join_sec_count: int | None = Field(default=None, sa_type=BigInteger)
+    sip_join_le1_count: int | None = Field(default=None, sa_type=BigInteger)
+    sip_join_le5_count: int | None = Field(default=None, sa_type=BigInteger)
+    sip_check_sec_sum: float | None = None
+    sip_check_sec_count: int | None = Field(default=None, sa_type=BigInteger)
+    session_start_time_ms_sum: int | None = Field(default=None, sa_type=BigInteger)
+    session_start_time_ms_count: int | None = Field(default=None, sa_type=BigInteger)
+
+    # ---- file descriptors, the limit that actually binds -------------------
+    # The PER-PROCESS rlimit, not the host fs.file-max. The host figure is
+    # commonly unbounded and unstorable, and the limit a service actually hits
+    # is its own LimitNOFILE, which node_exporter structurally cannot see.
+    process_open_fds: int | None = Field(default=None, sa_type=BigInteger)
+    process_max_fds: int | None = Field(default=None, sa_type=BigInteger)
+
+    # ---- admission and media ----------------------------------------------
+    # sip_available is "whether this node can accept new requests" and flips to
+    # 0 when it stops taking INVITEs, which is both the health signal and the
+    # node-drain test.
+    sip_available: int | None = None
+    # Present on livekit-sip ONLY. Absent from every livekit_* family on the
+    # server, so it is never wired there.
+    sip_node_cpu_load: float | None = None
+    # Split by direction and never summed. A call that sent 337 and received
+    # 330 sums to 667, and one-way audio disappears into that single number.
+    sip_rtp_packets_recv: int | None = Field(default=None, sa_type=BigInteger)
+    sip_rtp_packets_send: int | None = Field(default=None, sa_type=BigInteger)
+
+    # ---- restart and attribution ------------------------------------------
+    # A process that restarted mid-run invalidates every counter rate across
+    # the restart. start_time is what makes that visible rather than a mystery
+    # discontinuity.
+    process_start_time_seconds: float | None = None
+    process_cpu_seconds_total: float | None = None
+    process_resident_memory_bytes: int | None = Field(default=None, sa_type=BigInteger)
+
+    # ---- port headroom ----------------------------------------------------
+    # UDP sockets in use against ports that could not be allocated. The second
+    # is the one that matters: a non-zero rate means the box ran out of ports,
+    # which at 500 concurrent is a far more likely wall than CPU.
+    sockstat_udp_inuse: int | None = Field(default=None, sa_type=BigInteger)
+    udp_no_ports_total: int | None = Field(default=None, sa_type=BigInteger)
+
+    # ---- stale state ------------------------------------------------------
+    # Read for what does NOT come down after teardown. Named _total by the
+    # exporter but behaving as gauges: they are current counts, not cumulative,
+    # so they are never diffed.
+    track_published_total: int | None = Field(default=None, sa_type=BigInteger)
+    track_subscribed_total: int | None = Field(default=None, sa_type=BigInteger)
+    psrpc_stream_count: int | None = Field(default=None, sa_type=BigInteger)
+
+    # ---- unbounded marker -------------------------------------------------
+    # THREE states, and the distinction between them is the entire point.
+    # 1 means the host file-descriptor maximum parsed as effectively unbounded,
+    # so headroom on it cannot run out. 0 means it parsed as a real bound. NULL
+    # means nobody measured it. "Cannot run out" and "nobody looked" are
+    # different claims and this table's doctrine forbids collapsing them.
+    #
+    # Integer rather than Boolean so it travels the same coercion path as every
+    # other scraped column instead of needing a parallel one. It is derived
+    # from node_filefd_maximum rather than scraped directly, but it is still an
+    # observation about one scrape, which is what a value column is.
+    filefd_maximum_unbounded: int | None = None

--- a/src/voicegateway/models/node_sample_model.py
+++ b/src/voicegateway/models/node_sample_model.py
@@ -7,7 +7,7 @@ scraped twice per tick -- once as ``livekit-server`` and once as
 
 **No foreign key to ``calls``, and no ``call_id`` column.** Layer 7 is
 correlated by ``(node, time window)`` only. livekit-server's
-``livekit_packet_*`` / ``livekit_nack_total`` and livekit-sip's
+``livekit_packet_*`` and livekit-sip's
 ``invite_*`` / ``calls_*`` are NODE counters: attributing one of them to a call
 would invent a per-call measurement that does not exist server-side (the same
 reason ``call_legs`` has no loss / jitter / MOS column).

--- a/src/voicegateway/repository/node_correlation_repository.py
+++ b/src/voicegateway/repository/node_correlation_repository.py
@@ -2,8 +2,8 @@
 
 **This module owns no table and writes nothing.** It is the read side of layer 7,
 and it exists because layer 7 has no per-call identity to join on:
-``livekit_packet_*``, ``livekit_nack_total`` and the ``livekit-sip``
-``invite_*``/``calls_*`` families are NODE counters, and ``node_samples`` has no
+``livekit_packet_*`` and the ``livekit-sip`` ``invite_*``/``calls_*``
+families are NODE counters, and ``node_samples`` has no
 ``call_id`` column by design (see the model docstring). There is no ``node_id``
 awareness anywhere in this tree, and this module does not add any.
 

--- a/src/voicegateway/repository/node_samples_repository.py
+++ b/src/voicegateway/repository/node_samples_repository.py
@@ -64,13 +64,26 @@ COUNTER_COLUMNS: frozenset[str] = frozenset(
     {
         "packets_total",
         "packet_bytes_total",
-        "nacks_total",
         "sip_invite_requests_raw_total",
         "sip_invite_requests_total",
         "sip_invite_accepted_total",
         "sip_calls_terminated_total",
         "cpu_seconds_total",
         "cpu_idle_seconds_total",
+        # Histogram _sum and _count are both cumulative, so a rate over them is
+        # the only meaningful read. The two bucket counts are cumulative too.
+        "sip_join_sec_sum",
+        "sip_join_sec_count",
+        "sip_join_le1_count",
+        "sip_join_le5_count",
+        "sip_check_sec_sum",
+        "sip_check_sec_count",
+        "session_start_time_ms_sum",
+        "session_start_time_ms_count",
+        "sip_rtp_packets_recv",
+        "sip_rtp_packets_send",
+        "process_cpu_seconds_total",
+        "udp_no_ports_total",
     }
 )
 
@@ -88,6 +101,25 @@ GAUGE_COLUMNS: frozenset[str] = frozenset(
         # Go runtime. Gauges: what the process holds right now, never diffed.
         "heap_inuse_bytes",
         "go_goroutines",
+        # Per-process rlimit pair, the ceiling a service actually hits.
+        "process_open_fds",
+        "process_max_fds",
+        "sip_available",
+        "sip_node_cpu_load",
+        # A constant per process life, not cumulative: it is the instant the
+        # process started, and it changes only across a restart.
+        "process_start_time_seconds",
+        "process_resident_memory_bytes",
+        "sockstat_udp_inuse",
+        # Named _total by the exporter but behaving as gauges: current counts,
+        # not cumulative. Putting them in COUNTER_COLUMNS would have
+        # read_counter_rate diff a value that already is the answer.
+        "track_published_total",
+        "track_subscribed_total",
+        "psrpc_stream_count",
+        # Derived from node_filefd_maximum rather than scraped, but still an
+        # observation about one scrape. 1 unbounded, 0 bounded, NULL unmeasured.
+        "filefd_maximum_unbounded",
     }
 )
 
@@ -102,7 +134,6 @@ _INT_COLUMNS: frozenset[str] = frozenset(
         "participants",
         "packets_total",
         "packet_bytes_total",
-        "nacks_total",
         "sip_calls_active",
         "sip_invite_requests_raw_total",
         "sip_invite_requests_total",
@@ -114,6 +145,29 @@ _INT_COLUMNS: frozenset[str] = frozenset(
         "memory_total_bytes",
         "heap_inuse_bytes",
         "go_goroutines",
+        # Integer columns. Anything omitted here is stored as a float, and
+        # anything named here that is genuinely fractional would be truncated,
+        # so sip_join_sec_sum / sip_check_sec_sum / sip_node_cpu_load /
+        # process_start_time_seconds / process_cpu_seconds_total are all
+        # deliberately ABSENT: they are seconds and load averages.
+        "sip_join_sec_count",
+        "sip_join_le1_count",
+        "sip_join_le5_count",
+        "sip_check_sec_count",
+        "session_start_time_ms_sum",
+        "session_start_time_ms_count",
+        "process_open_fds",
+        "process_max_fds",
+        "sip_available",
+        "sip_rtp_packets_recv",
+        "sip_rtp_packets_send",
+        "process_resident_memory_bytes",
+        "sockstat_udp_inuse",
+        "udp_no_ports_total",
+        "track_published_total",
+        "track_subscribed_total",
+        "psrpc_stream_count",
+        "filefd_maximum_unbounded",
     }
 )
 
@@ -159,7 +213,6 @@ class NodeSampleRow:
     participants: int | None
     packets_total: int | None
     packet_bytes_total: int | None
-    nacks_total: int | None
     sip_calls_active: int | None
     sip_invite_requests_raw_total: int | None
     sip_invite_requests_total: int | None
@@ -174,6 +227,29 @@ class NodeSampleRow:
     memory_total_bytes: int | None
     heap_inuse_bytes: int | None
     go_goroutines: int | None
+    sip_join_sec_sum: float | None
+    sip_join_sec_count: int | None
+    sip_join_le1_count: int | None
+    sip_join_le5_count: int | None
+    sip_check_sec_sum: float | None
+    sip_check_sec_count: int | None
+    session_start_time_ms_sum: int | None
+    session_start_time_ms_count: int | None
+    process_open_fds: int | None
+    process_max_fds: int | None
+    sip_available: int | None
+    sip_node_cpu_load: float | None
+    sip_rtp_packets_recv: int | None
+    sip_rtp_packets_send: int | None
+    process_start_time_seconds: float | None
+    process_cpu_seconds_total: float | None
+    process_resident_memory_bytes: int | None
+    sockstat_udp_inuse: int | None
+    udp_no_ports_total: int | None
+    track_published_total: int | None
+    track_subscribed_total: int | None
+    psrpc_stream_count: int | None
+    filefd_maximum_unbounded: int | None
 
 
 @dataclass(frozen=True)
@@ -222,7 +298,6 @@ def _row(sample: NodeSample) -> NodeSampleRow:
         participants=sample.participants,
         packets_total=sample.packets_total,
         packet_bytes_total=sample.packet_bytes_total,
-        nacks_total=sample.nacks_total,
         sip_calls_active=sample.sip_calls_active,
         sip_invite_requests_raw_total=sample.sip_invite_requests_raw_total,
         sip_invite_requests_total=sample.sip_invite_requests_total,
@@ -237,6 +312,29 @@ def _row(sample: NodeSample) -> NodeSampleRow:
         memory_total_bytes=sample.memory_total_bytes,
         heap_inuse_bytes=sample.heap_inuse_bytes,
         go_goroutines=sample.go_goroutines,
+        sip_join_sec_sum=sample.sip_join_sec_sum,
+        sip_join_sec_count=sample.sip_join_sec_count,
+        sip_join_le1_count=sample.sip_join_le1_count,
+        sip_join_le5_count=sample.sip_join_le5_count,
+        sip_check_sec_sum=sample.sip_check_sec_sum,
+        sip_check_sec_count=sample.sip_check_sec_count,
+        session_start_time_ms_sum=sample.session_start_time_ms_sum,
+        session_start_time_ms_count=sample.session_start_time_ms_count,
+        process_open_fds=sample.process_open_fds,
+        process_max_fds=sample.process_max_fds,
+        sip_available=sample.sip_available,
+        sip_node_cpu_load=sample.sip_node_cpu_load,
+        sip_rtp_packets_recv=sample.sip_rtp_packets_recv,
+        sip_rtp_packets_send=sample.sip_rtp_packets_send,
+        process_start_time_seconds=sample.process_start_time_seconds,
+        process_cpu_seconds_total=sample.process_cpu_seconds_total,
+        process_resident_memory_bytes=sample.process_resident_memory_bytes,
+        sockstat_udp_inuse=sample.sockstat_udp_inuse,
+        udp_no_ports_total=sample.udp_no_ports_total,
+        track_published_total=sample.track_published_total,
+        track_subscribed_total=sample.track_subscribed_total,
+        psrpc_stream_count=sample.psrpc_stream_count,
+        filefd_maximum_unbounded=sample.filefd_maximum_unbounded,
     )
 
 

--- a/src/voicegateway/repository/node_samples_repository.py
+++ b/src/voicegateway/repository/node_samples_repository.py
@@ -125,6 +125,13 @@ GAUGE_COLUMNS: frozenset[str] = frozenset(
 
 VALUE_COLUMNS: frozenset[str] = COUNTER_COLUMNS | GAUGE_COLUMNS
 
+# Value columns computed FROM a scrape rather than read off one. They are real
+# observations and belong in VALUE_COLUMNS, but they are not series, so they are
+# counted out of ``series_found``: that number answers "how many of the series
+# expected for this source did the target actually expose", and a derived
+# marker would inflate it into a claim about the target.
+DERIVED_COLUMNS: frozenset[str] = frozenset({"filefd_maximum_unbounded"})
+
 # Columns stored as integers. Everything else in VALUE_COLUMNS is a float.
 # Prometheus exposition is float-typed on the wire, so an integer column is
 # truncated on the way in (see :func:`_coerce`).
@@ -387,16 +394,49 @@ async def insert_samples(db: AsyncSession, samples: Sequence[NodeSampleInput]) -
             outcome=sample.outcome,
             series_found=sample.series_found,
         )
+        stored = 0
         for column, value in sample.values.items():
             if column not in VALUE_COLUMNS:
                 raise ValueError(
                     f"unknown node_samples value column {column!r}; known columns "
                     f"are {sorted(VALUE_COLUMNS)}"
                 )
-            setattr(row, column, _coerce(column, value))
+            coerced = _coerce(column, value)
+            setattr(row, column, coerced)
+            if coerced is not None and column not in DERIVED_COLUMNS:
+                stored += 1
+        if sample.series_found is not None:
+            row.series_found = _reconciled_series_found(sample, stored)
         db.add(row)
     await db.commit()
     return len(samples)
+
+
+def _reconciled_series_found(sample: NodeSampleInput, stored: int) -> int:
+    """What ``series_found`` must say once coercion has had its turn.
+
+    The caller counts a series when it MATCHES the exposition, which is before
+    this module gets to refuse it. A value that is non-finite, or that does not
+    survive the trip through a 64-bit column, is dropped here and the caller's
+    count never hears about it: the row then claims one more measurement than it
+    holds, and it is the columns nobody can read that go missing, so the
+    overstatement is invisible in exactly the case it matters.
+
+    A derived marker is excluded because it is not a series. Counting it would
+    make the number say a target exposed something it never did.
+    """
+    claimed = sample.series_found
+    if claimed is not None and claimed != stored:
+        _logger.debug(
+            "node_samples series_found for %s/%s corrected %d -> %d: %d value(s) "
+            "were refused at coercion",
+            sample.node,
+            sample.source,
+            claimed,
+            stored,
+            claimed - stored,
+        )
+    return stored
 
 
 async def list_samples(

--- a/src/voicegateway/tests/fixtures/livekit_sip_exposition.txt
+++ b/src/voicegateway/tests/fixtures/livekit_sip_exposition.txt
@@ -1,0 +1,615 @@
+# HELP go_cgo_go_to_c_calls_calls_total Count of calls made from Go to C by the current process. Sourced from /cgo/go-to-c-calls:calls.
+# TYPE go_cgo_go_to_c_calls_calls_total counter
+go_cgo_go_to_c_calls_calls_total 1221
+# HELP go_cpu_classes_gc_mark_assist_cpu_seconds_total Estimated total CPU time goroutines spent performing GC tasks to assist the GC and prevent it from falling behind the application. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sourced from /cpu/classes/gc/mark/assist:cpu-seconds.
+# TYPE go_cpu_classes_gc_mark_assist_cpu_seconds_total counter
+go_cpu_classes_gc_mark_assist_cpu_seconds_total 0.004909418
+# HELP go_cpu_classes_gc_mark_dedicated_cpu_seconds_total Estimated total CPU time spent performing GC tasks on processors (as defined by GOMAXPROCS) dedicated to those tasks. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sourced from /cpu/classes/gc/mark/dedicated:cpu-seconds.
+# TYPE go_cpu_classes_gc_mark_dedicated_cpu_seconds_total counter
+go_cpu_classes_gc_mark_dedicated_cpu_seconds_total 0.489470377
+# HELP go_cpu_classes_gc_mark_idle_cpu_seconds_total Estimated total CPU time spent performing GC tasks on spare CPU resources that the Go scheduler could not otherwise find a use for. This should be subtracted from the total GC CPU time to obtain a measure of compulsory GC CPU time. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sourced from /cpu/classes/gc/mark/idle:cpu-seconds.
+# TYPE go_cpu_classes_gc_mark_idle_cpu_seconds_total counter
+go_cpu_classes_gc_mark_idle_cpu_seconds_total 1.470157574
+# HELP go_cpu_classes_gc_pause_cpu_seconds_total Estimated total CPU time spent with the application paused by the GC. Even if only one thread is running during the pause, this is computed as GOMAXPROCS times the pause latency because nothing else can be executing. This is the exact sum of samples in /sched/pauses/total/gc:seconds if each sample is multiplied by GOMAXPROCS at the time it is taken. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sourced from /cpu/classes/gc/pause:cpu-seconds.
+# TYPE go_cpu_classes_gc_pause_cpu_seconds_total counter
+go_cpu_classes_gc_pause_cpu_seconds_total 0.062164
+# HELP go_cpu_classes_gc_total_cpu_seconds_total Estimated total CPU time spent performing GC tasks. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sum of all metrics in /cpu/classes/gc. Sourced from /cpu/classes/gc/total:cpu-seconds.
+# TYPE go_cpu_classes_gc_total_cpu_seconds_total counter
+go_cpu_classes_gc_total_cpu_seconds_total 2.026701369
+# HELP go_cpu_classes_idle_cpu_seconds_total Estimated total available CPU time not spent executing any Go or Go runtime code. In other words, the part of /cpu/classes/total:cpu-seconds that was unused. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sourced from /cpu/classes/idle:cpu-seconds.
+# TYPE go_cpu_classes_idle_cpu_seconds_total counter
+go_cpu_classes_idle_cpu_seconds_total 130742.540613084
+# HELP go_cpu_classes_scavenge_assist_cpu_seconds_total Estimated total CPU time spent returning unused memory to the underlying platform in response eagerly in response to memory pressure. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sourced from /cpu/classes/scavenge/assist:cpu-seconds.
+# TYPE go_cpu_classes_scavenge_assist_cpu_seconds_total counter
+go_cpu_classes_scavenge_assist_cpu_seconds_total 1.81e-07
+# HELP go_cpu_classes_scavenge_background_cpu_seconds_total Estimated total CPU time spent performing background tasks to return unused memory to the underlying platform. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sourced from /cpu/classes/scavenge/background:cpu-seconds.
+# TYPE go_cpu_classes_scavenge_background_cpu_seconds_total counter
+go_cpu_classes_scavenge_background_cpu_seconds_total 0.001583637
+# HELP go_cpu_classes_scavenge_total_cpu_seconds_total Estimated total CPU time spent performing tasks that return unused memory to the underlying platform. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sum of all metrics in /cpu/classes/scavenge. Sourced from /cpu/classes/scavenge/total:cpu-seconds.
+# TYPE go_cpu_classes_scavenge_total_cpu_seconds_total counter
+go_cpu_classes_scavenge_total_cpu_seconds_total 0.001583818
+# HELP go_cpu_classes_total_cpu_seconds_total Estimated total available CPU time for user Go code or the Go runtime, as defined by GOMAXPROCS. In other words, GOMAXPROCS integrated over the wall-clock duration this process has been executing for. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sum of all metrics in /cpu/classes. Sourced from /cpu/classes/total:cpu-seconds.
+# TYPE go_cpu_classes_total_cpu_seconds_total counter
+go_cpu_classes_total_cpu_seconds_total 130766.663822516
+# HELP go_cpu_classes_user_cpu_seconds_total Estimated total CPU time spent running user Go code. This may also include some small amount of time spent in the Go runtime. This metric is an overestimate, and not directly comparable to system CPU time measurements. Compare only with other /cpu/classes metrics. Sourced from /cpu/classes/user:cpu-seconds.
+# TYPE go_cpu_classes_user_cpu_seconds_total counter
+go_cpu_classes_user_cpu_seconds_total 22.094924245
+# HELP go_gc_cycles_automatic_gc_cycles_total Count of completed GC cycles generated by the Go runtime. Sourced from /gc/cycles/automatic:gc-cycles.
+# TYPE go_gc_cycles_automatic_gc_cycles_total counter
+go_gc_cycles_automatic_gc_cycles_total 549
+# HELP go_gc_cycles_forced_gc_cycles_total Count of completed GC cycles forced by the application. Sourced from /gc/cycles/forced:gc-cycles.
+# TYPE go_gc_cycles_forced_gc_cycles_total counter
+go_gc_cycles_forced_gc_cycles_total 0
+# HELP go_gc_cycles_total_gc_cycles_total Count of all completed GC cycles. Sourced from /gc/cycles/total:gc-cycles.
+# TYPE go_gc_cycles_total_gc_cycles_total counter
+go_gc_cycles_total_gc_cycles_total 549
+# HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 2.8895e-05
+go_gc_duration_seconds{quantile="0.25"} 3.4465e-05
+go_gc_duration_seconds{quantile="0.5"} 5.4614e-05
+go_gc_duration_seconds{quantile="0.75"} 8.4649e-05
+go_gc_duration_seconds{quantile="1"} 0.000933163
+go_gc_duration_seconds_sum 0.038240737
+go_gc_duration_seconds_count 549
+# HELP go_gc_gogc_percent Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent.
+# TYPE go_gc_gogc_percent gauge
+go_gc_gogc_percent 100
+# HELP go_gc_gomemlimit_bytes Go runtime memory limit configured by the user, otherwise math.MaxInt64. This value is set by the GOMEMLIMIT environment variable, and the runtime/debug.SetMemoryLimit function. Sourced from /gc/gomemlimit:bytes.
+# TYPE go_gc_gomemlimit_bytes gauge
+go_gc_gomemlimit_bytes 9.223372036854776e+18
+# HELP go_gc_heap_allocs_by_size_bytes Distribution of heap allocations by approximate size. Bucket counts increase monotonically. Note that this does not include tiny objects as defined by /gc/heap/tiny/allocs:objects, only tiny blocks. Sourced from /gc/heap/allocs-by-size:bytes.
+# TYPE go_gc_heap_allocs_by_size_bytes histogram
+go_gc_heap_allocs_by_size_bytes_bucket{le="8.999999999999998"} 134550
+go_gc_heap_allocs_by_size_bytes_bucket{le="24.999999999999996"} 497930
+go_gc_heap_allocs_by_size_bytes_bucket{le="64.99999999999999"} 716004
+go_gc_heap_allocs_by_size_bytes_bucket{le="144.99999999999997"} 970711
+go_gc_heap_allocs_by_size_bytes_bucket{le="320.99999999999994"} 1.05208e+06
+go_gc_heap_allocs_by_size_bytes_bucket{le="704.9999999999999"} 1.122206e+06
+go_gc_heap_allocs_by_size_bytes_bucket{le="1536.9999999999998"} 1.127083e+06
+go_gc_heap_allocs_by_size_bytes_bucket{le="3200.9999999999995"} 1.129797e+06
+go_gc_heap_allocs_by_size_bytes_bucket{le="6528.999999999999"} 1.132097e+06
+go_gc_heap_allocs_by_size_bytes_bucket{le="13568.999999999998"} 1.132689e+06
+go_gc_heap_allocs_by_size_bytes_bucket{le="27264.999999999996"} 1.133176e+06
+go_gc_heap_allocs_by_size_bytes_bucket{le="+Inf"} 1.133273e+06
+go_gc_heap_allocs_by_size_bytes_sum 1.43308928e+08
+go_gc_heap_allocs_by_size_bytes_count 1.133273e+06
+# HELP go_gc_heap_allocs_bytes_total Cumulative sum of memory allocated to the heap by the application. Sourced from /gc/heap/allocs:bytes.
+# TYPE go_gc_heap_allocs_bytes_total counter
+go_gc_heap_allocs_bytes_total 1.43308928e+08
+# HELP go_gc_heap_allocs_objects_total Cumulative count of heap allocations triggered by the application. Note that this does not include tiny objects as defined by /gc/heap/tiny/allocs:objects, only tiny blocks. Sourced from /gc/heap/allocs:objects.
+# TYPE go_gc_heap_allocs_objects_total counter
+go_gc_heap_allocs_objects_total 1.133273e+06
+# HELP go_gc_heap_frees_by_size_bytes Distribution of freed heap allocations by approximate size. Bucket counts increase monotonically. Note that this does not include tiny objects as defined by /gc/heap/tiny/allocs:objects, only tiny blocks. Sourced from /gc/heap/frees-by-size:bytes.
+# TYPE go_gc_heap_frees_by_size_bytes histogram
+go_gc_heap_frees_by_size_bytes_bucket{le="8.999999999999998"} 133882
+go_gc_heap_frees_by_size_bytes_bucket{le="24.999999999999996"} 471103
+go_gc_heap_frees_by_size_bytes_bucket{le="64.99999999999999"} 676420
+go_gc_heap_frees_by_size_bytes_bucket{le="144.99999999999997"} 919239
+go_gc_heap_frees_by_size_bytes_bucket{le="320.99999999999994"} 998414
+go_gc_heap_frees_by_size_bytes_bucket{le="704.9999999999999"} 1.066966e+06
+go_gc_heap_frees_by_size_bytes_bucket{le="1536.9999999999998"} 1.071382e+06
+go_gc_heap_frees_by_size_bytes_bucket{le="3200.9999999999995"} 1.073909e+06
+go_gc_heap_frees_by_size_bytes_bucket{le="6528.999999999999"} 1.076099e+06
+go_gc_heap_frees_by_size_bytes_bucket{le="13568.999999999998"} 1.076645e+06
+go_gc_heap_frees_by_size_bytes_bucket{le="27264.999999999996"} 1.077115e+06
+go_gc_heap_frees_by_size_bytes_bucket{le="+Inf"} 1.077192e+06
+go_gc_heap_frees_by_size_bytes_sum 1.34742912e+08
+go_gc_heap_frees_by_size_bytes_count 1.077192e+06
+# HELP go_gc_heap_frees_bytes_total Cumulative sum of heap memory freed by the garbage collector. Sourced from /gc/heap/frees:bytes.
+# TYPE go_gc_heap_frees_bytes_total counter
+go_gc_heap_frees_bytes_total 1.34742912e+08
+# HELP go_gc_heap_frees_objects_total Cumulative count of heap allocations whose storage was freed by the garbage collector. Note that this does not include tiny objects as defined by /gc/heap/tiny/allocs:objects, only tiny blocks. Sourced from /gc/heap/frees:objects.
+# TYPE go_gc_heap_frees_objects_total counter
+go_gc_heap_frees_objects_total 1.077192e+06
+# HELP go_gc_heap_goal_bytes Heap size target for the end of the GC cycle. Sourced from /gc/heap/goal:bytes.
+# TYPE go_gc_heap_goal_bytes gauge
+go_gc_heap_goal_bytes 1.6288538e+07
+# HELP go_gc_heap_live_bytes Heap memory occupied by live objects that were marked by the previous GC. Sourced from /gc/heap/live:bytes.
+# TYPE go_gc_heap_live_bytes gauge
+go_gc_heap_live_bytes 7.8994e+06
+# HELP go_gc_heap_objects_objects Number of objects, live or unswept, occupying heap memory. Sourced from /gc/heap/objects:objects.
+# TYPE go_gc_heap_objects_objects gauge
+go_gc_heap_objects_objects 56081
+# HELP go_gc_heap_tiny_allocs_objects_total Count of small allocations that are packed together into blocks. These allocations are counted separately from other allocations because each individual allocation is not tracked by the runtime, only their block. Each block is already accounted for in allocs-by-size and frees-by-size. Sourced from /gc/heap/tiny/allocs:objects.
+# TYPE go_gc_heap_tiny_allocs_objects_total counter
+go_gc_heap_tiny_allocs_objects_total 109525
+# HELP go_gc_limiter_last_enabled_gc_cycle GC cycle the last time the GC CPU limiter was enabled. This metric is useful for diagnosing the root cause of an out-of-memory error, because the limiter trades memory for CPU time when the GC's CPU time gets too high. This is most likely to occur with use of SetMemoryLimit. The first GC cycle is cycle 1, so a value of 0 indicates that it was never enabled. Sourced from /gc/limiter/last-enabled:gc-cycle.
+# TYPE go_gc_limiter_last_enabled_gc_cycle gauge
+go_gc_limiter_last_enabled_gc_cycle 0
+# HELP go_gc_pauses_seconds Deprecated. Prefer the identical /sched/pauses/total/gc:seconds. Sourced from /gc/pauses:seconds.
+# TYPE go_gc_pauses_seconds histogram
+go_gc_pauses_seconds_bucket{le="6.399999999999999e-08"} 0
+go_gc_pauses_seconds_bucket{le="6.399999999999999e-07"} 0
+go_gc_pauses_seconds_bucket{le="7.167999999999999e-06"} 514
+go_gc_pauses_seconds_bucket{le="8.191999999999999e-05"} 982
+go_gc_pauses_seconds_bucket{le="0.0009175039999999999"} 1098
+go_gc_pauses_seconds_bucket{le="0.010485759999999998"} 1098
+go_gc_pauses_seconds_bucket{le="0.11744051199999998"} 1098
+go_gc_pauses_seconds_bucket{le="+Inf"} 1098
+go_gc_pauses_seconds_sum 0.013186304000000001
+go_gc_pauses_seconds_count 1098
+# HELP go_gc_scan_globals_bytes The total amount of global variable space that is scannable. Sourced from /gc/scan/globals:bytes.
+# TYPE go_gc_scan_globals_bytes gauge
+go_gc_scan_globals_bytes 472186
+# HELP go_gc_scan_heap_bytes The total amount of heap space that is scannable. Sourced from /gc/scan/heap:bytes.
+# TYPE go_gc_scan_heap_bytes gauge
+go_gc_scan_heap_bytes 4.304688e+06
+# HELP go_gc_scan_stack_bytes The number of bytes of stack that were scanned last GC cycle. Sourced from /gc/scan/stack:bytes.
+# TYPE go_gc_scan_stack_bytes gauge
+go_gc_scan_stack_bytes 17552
+# HELP go_gc_scan_total_bytes The total amount space that is scannable. Sum of all metrics in /gc/scan. Sourced from /gc/scan/total:bytes.
+# TYPE go_gc_scan_total_bytes gauge
+go_gc_scan_total_bytes 4.794426e+06
+# HELP go_gc_stack_starting_size_bytes The stack size of new goroutines. Sourced from /gc/stack/starting-size:bytes.
+# TYPE go_gc_stack_starting_size_bytes gauge
+go_gc_stack_starting_size_bytes 2048
+# HELP go_godebug_non_default_behavior_allowmultiplevcs_events_total The number of non-default behaviors executed by the cmd/go package due to a non-default GODEBUG=allowmultiplevcs=... setting. Sourced from /godebug/non-default-behavior/allowmultiplevcs:events.
+# TYPE go_godebug_non_default_behavior_allowmultiplevcs_events_total counter
+go_godebug_non_default_behavior_allowmultiplevcs_events_total 0
+# HELP go_godebug_non_default_behavior_asynctimerchan_events_total The number of non-default behaviors executed by the time package due to a non-default GODEBUG=asynctimerchan=... setting. Sourced from /godebug/non-default-behavior/asynctimerchan:events.
+# TYPE go_godebug_non_default_behavior_asynctimerchan_events_total counter
+go_godebug_non_default_behavior_asynctimerchan_events_total 0
+# HELP go_godebug_non_default_behavior_execerrdot_events_total The number of non-default behaviors executed by the os/exec package due to a non-default GODEBUG=execerrdot=... setting. Sourced from /godebug/non-default-behavior/execerrdot:events.
+# TYPE go_godebug_non_default_behavior_execerrdot_events_total counter
+go_godebug_non_default_behavior_execerrdot_events_total 0
+# HELP go_godebug_non_default_behavior_gocachehash_events_total The number of non-default behaviors executed by the cmd/go package due to a non-default GODEBUG=gocachehash=... setting. Sourced from /godebug/non-default-behavior/gocachehash:events.
+# TYPE go_godebug_non_default_behavior_gocachehash_events_total counter
+go_godebug_non_default_behavior_gocachehash_events_total 0
+# HELP go_godebug_non_default_behavior_gocachetest_events_total The number of non-default behaviors executed by the cmd/go package due to a non-default GODEBUG=gocachetest=... setting. Sourced from /godebug/non-default-behavior/gocachetest:events.
+# TYPE go_godebug_non_default_behavior_gocachetest_events_total counter
+go_godebug_non_default_behavior_gocachetest_events_total 0
+# HELP go_godebug_non_default_behavior_gocacheverify_events_total The number of non-default behaviors executed by the cmd/go package due to a non-default GODEBUG=gocacheverify=... setting. Sourced from /godebug/non-default-behavior/gocacheverify:events.
+# TYPE go_godebug_non_default_behavior_gocacheverify_events_total counter
+go_godebug_non_default_behavior_gocacheverify_events_total 0
+# HELP go_godebug_non_default_behavior_gotestjsonbuildtext_events_total The number of non-default behaviors executed by the cmd/go package due to a non-default GODEBUG=gotestjsonbuildtext=... setting. Sourced from /godebug/non-default-behavior/gotestjsonbuildtext:events.
+# TYPE go_godebug_non_default_behavior_gotestjsonbuildtext_events_total counter
+go_godebug_non_default_behavior_gotestjsonbuildtext_events_total 0
+# HELP go_godebug_non_default_behavior_gotypesalias_events_total The number of non-default behaviors executed by the go/types package due to a non-default GODEBUG=gotypesalias=... setting. Sourced from /godebug/non-default-behavior/gotypesalias:events.
+# TYPE go_godebug_non_default_behavior_gotypesalias_events_total counter
+go_godebug_non_default_behavior_gotypesalias_events_total 0
+# HELP go_godebug_non_default_behavior_http2client_events_total The number of non-default behaviors executed by the net/http package due to a non-default GODEBUG=http2client=... setting. Sourced from /godebug/non-default-behavior/http2client:events.
+# TYPE go_godebug_non_default_behavior_http2client_events_total counter
+go_godebug_non_default_behavior_http2client_events_total 0
+# HELP go_godebug_non_default_behavior_http2server_events_total The number of non-default behaviors executed by the net/http package due to a non-default GODEBUG=http2server=... setting. Sourced from /godebug/non-default-behavior/http2server:events.
+# TYPE go_godebug_non_default_behavior_http2server_events_total counter
+go_godebug_non_default_behavior_http2server_events_total 0
+# HELP go_godebug_non_default_behavior_httpcookiemaxnum_events_total The number of non-default behaviors executed by the net/http package due to a non-default GODEBUG=httpcookiemaxnum=... setting. Sourced from /godebug/non-default-behavior/httpcookiemaxnum:events.
+# TYPE go_godebug_non_default_behavior_httpcookiemaxnum_events_total counter
+go_godebug_non_default_behavior_httpcookiemaxnum_events_total 0
+# HELP go_godebug_non_default_behavior_httplaxcontentlength_events_total The number of non-default behaviors executed by the net/http package due to a non-default GODEBUG=httplaxcontentlength=... setting. Sourced from /godebug/non-default-behavior/httplaxcontentlength:events.
+# TYPE go_godebug_non_default_behavior_httplaxcontentlength_events_total counter
+go_godebug_non_default_behavior_httplaxcontentlength_events_total 0
+# HELP go_godebug_non_default_behavior_httpmuxgo121_events_total The number of non-default behaviors executed by the net/http package due to a non-default GODEBUG=httpmuxgo121=... setting. Sourced from /godebug/non-default-behavior/httpmuxgo121:events.
+# TYPE go_godebug_non_default_behavior_httpmuxgo121_events_total counter
+go_godebug_non_default_behavior_httpmuxgo121_events_total 0
+# HELP go_godebug_non_default_behavior_httpservecontentkeepheaders_events_total The number of non-default behaviors executed by the net/http package due to a non-default GODEBUG=httpservecontentkeepheaders=... setting. Sourced from /godebug/non-default-behavior/httpservecontentkeepheaders:events.
+# TYPE go_godebug_non_default_behavior_httpservecontentkeepheaders_events_total counter
+go_godebug_non_default_behavior_httpservecontentkeepheaders_events_total 0
+# HELP go_godebug_non_default_behavior_installgoroot_events_total The number of non-default behaviors executed by the go/build package due to a non-default GODEBUG=installgoroot=... setting. Sourced from /godebug/non-default-behavior/installgoroot:events.
+# TYPE go_godebug_non_default_behavior_installgoroot_events_total counter
+go_godebug_non_default_behavior_installgoroot_events_total 0
+# HELP go_godebug_non_default_behavior_multipartmaxheaders_events_total The number of non-default behaviors executed by the mime/multipart package due to a non-default GODEBUG=multipartmaxheaders=... setting. Sourced from /godebug/non-default-behavior/multipartmaxheaders:events.
+# TYPE go_godebug_non_default_behavior_multipartmaxheaders_events_total counter
+go_godebug_non_default_behavior_multipartmaxheaders_events_total 0
+# HELP go_godebug_non_default_behavior_multipartmaxparts_events_total The number of non-default behaviors executed by the mime/multipart package due to a non-default GODEBUG=multipartmaxparts=... setting. Sourced from /godebug/non-default-behavior/multipartmaxparts:events.
+# TYPE go_godebug_non_default_behavior_multipartmaxparts_events_total counter
+go_godebug_non_default_behavior_multipartmaxparts_events_total 0
+# HELP go_godebug_non_default_behavior_multipathtcp_events_total The number of non-default behaviors executed by the net package due to a non-default GODEBUG=multipathtcp=... setting. Sourced from /godebug/non-default-behavior/multipathtcp:events.
+# TYPE go_godebug_non_default_behavior_multipathtcp_events_total counter
+go_godebug_non_default_behavior_multipathtcp_events_total 0
+# HELP go_godebug_non_default_behavior_netedns0_events_total The number of non-default behaviors executed by the net package due to a non-default GODEBUG=netedns0=... setting. Sourced from /godebug/non-default-behavior/netedns0:events.
+# TYPE go_godebug_non_default_behavior_netedns0_events_total counter
+go_godebug_non_default_behavior_netedns0_events_total 0
+# HELP go_godebug_non_default_behavior_panicnil_events_total The number of non-default behaviors executed by the runtime package due to a non-default GODEBUG=panicnil=... setting. Sourced from /godebug/non-default-behavior/panicnil:events.
+# TYPE go_godebug_non_default_behavior_panicnil_events_total counter
+go_godebug_non_default_behavior_panicnil_events_total 0
+# HELP go_godebug_non_default_behavior_randautoseed_events_total The number of non-default behaviors executed by the math/rand package due to a non-default GODEBUG=randautoseed=... setting. Sourced from /godebug/non-default-behavior/randautoseed:events.
+# TYPE go_godebug_non_default_behavior_randautoseed_events_total counter
+go_godebug_non_default_behavior_randautoseed_events_total 0
+# HELP go_godebug_non_default_behavior_randseednop_events_total The number of non-default behaviors executed by the math/rand package due to a non-default GODEBUG=randseednop=... setting. Sourced from /godebug/non-default-behavior/randseednop:events.
+# TYPE go_godebug_non_default_behavior_randseednop_events_total counter
+go_godebug_non_default_behavior_randseednop_events_total 0
+# HELP go_godebug_non_default_behavior_rsa1024min_events_total The number of non-default behaviors executed by the crypto/rsa package due to a non-default GODEBUG=rsa1024min=... setting. Sourced from /godebug/non-default-behavior/rsa1024min:events.
+# TYPE go_godebug_non_default_behavior_rsa1024min_events_total counter
+go_godebug_non_default_behavior_rsa1024min_events_total 0
+# HELP go_godebug_non_default_behavior_tarinsecurepath_events_total The number of non-default behaviors executed by the archive/tar package due to a non-default GODEBUG=tarinsecurepath=... setting. Sourced from /godebug/non-default-behavior/tarinsecurepath:events.
+# TYPE go_godebug_non_default_behavior_tarinsecurepath_events_total counter
+go_godebug_non_default_behavior_tarinsecurepath_events_total 0
+# HELP go_godebug_non_default_behavior_tls10server_events_total The number of non-default behaviors executed by the crypto/tls package due to a non-default GODEBUG=tls10server=... setting. Sourced from /godebug/non-default-behavior/tls10server:events.
+# TYPE go_godebug_non_default_behavior_tls10server_events_total counter
+go_godebug_non_default_behavior_tls10server_events_total 0
+# HELP go_godebug_non_default_behavior_tls3des_events_total The number of non-default behaviors executed by the crypto/tls package due to a non-default GODEBUG=tls3des=... setting. Sourced from /godebug/non-default-behavior/tls3des:events.
+# TYPE go_godebug_non_default_behavior_tls3des_events_total counter
+go_godebug_non_default_behavior_tls3des_events_total 0
+# HELP go_godebug_non_default_behavior_tlsmaxrsasize_events_total The number of non-default behaviors executed by the crypto/tls package due to a non-default GODEBUG=tlsmaxrsasize=... setting. Sourced from /godebug/non-default-behavior/tlsmaxrsasize:events.
+# TYPE go_godebug_non_default_behavior_tlsmaxrsasize_events_total counter
+go_godebug_non_default_behavior_tlsmaxrsasize_events_total 0
+# HELP go_godebug_non_default_behavior_tlsrsakex_events_total The number of non-default behaviors executed by the crypto/tls package due to a non-default GODEBUG=tlsrsakex=... setting. Sourced from /godebug/non-default-behavior/tlsrsakex:events.
+# TYPE go_godebug_non_default_behavior_tlsrsakex_events_total counter
+go_godebug_non_default_behavior_tlsrsakex_events_total 0
+# HELP go_godebug_non_default_behavior_tlsunsafeekm_events_total The number of non-default behaviors executed by the crypto/tls package due to a non-default GODEBUG=tlsunsafeekm=... setting. Sourced from /godebug/non-default-behavior/tlsunsafeekm:events.
+# TYPE go_godebug_non_default_behavior_tlsunsafeekm_events_total counter
+go_godebug_non_default_behavior_tlsunsafeekm_events_total 0
+# HELP go_godebug_non_default_behavior_winreadlinkvolume_events_total The number of non-default behaviors executed by the os package due to a non-default GODEBUG=winreadlinkvolume=... setting. Sourced from /godebug/non-default-behavior/winreadlinkvolume:events.
+# TYPE go_godebug_non_default_behavior_winreadlinkvolume_events_total counter
+go_godebug_non_default_behavior_winreadlinkvolume_events_total 0
+# HELP go_godebug_non_default_behavior_winsymlink_events_total The number of non-default behaviors executed by the os package due to a non-default GODEBUG=winsymlink=... setting. Sourced from /godebug/non-default-behavior/winsymlink:events.
+# TYPE go_godebug_non_default_behavior_winsymlink_events_total counter
+go_godebug_non_default_behavior_winsymlink_events_total 0
+# HELP go_godebug_non_default_behavior_x509keypairleaf_events_total The number of non-default behaviors executed by the crypto/tls package due to a non-default GODEBUG=x509keypairleaf=... setting. Sourced from /godebug/non-default-behavior/x509keypairleaf:events.
+# TYPE go_godebug_non_default_behavior_x509keypairleaf_events_total counter
+go_godebug_non_default_behavior_x509keypairleaf_events_total 0
+# HELP go_godebug_non_default_behavior_x509negativeserial_events_total The number of non-default behaviors executed by the crypto/x509 package due to a non-default GODEBUG=x509negativeserial=... setting. Sourced from /godebug/non-default-behavior/x509negativeserial:events.
+# TYPE go_godebug_non_default_behavior_x509negativeserial_events_total counter
+go_godebug_non_default_behavior_x509negativeserial_events_total 0
+# HELP go_godebug_non_default_behavior_x509rsacrt_events_total The number of non-default behaviors executed by the crypto/x509 package due to a non-default GODEBUG=x509rsacrt=... setting. Sourced from /godebug/non-default-behavior/x509rsacrt:events.
+# TYPE go_godebug_non_default_behavior_x509rsacrt_events_total counter
+go_godebug_non_default_behavior_x509rsacrt_events_total 0
+# HELP go_godebug_non_default_behavior_x509usefallbackroots_events_total The number of non-default behaviors executed by the crypto/x509 package due to a non-default GODEBUG=x509usefallbackroots=... setting. Sourced from /godebug/non-default-behavior/x509usefallbackroots:events.
+# TYPE go_godebug_non_default_behavior_x509usefallbackroots_events_total counter
+go_godebug_non_default_behavior_x509usefallbackroots_events_total 0
+# HELP go_godebug_non_default_behavior_x509usepolicies_events_total The number of non-default behaviors executed by the crypto/x509 package due to a non-default GODEBUG=x509usepolicies=... setting. Sourced from /godebug/non-default-behavior/x509usepolicies:events.
+# TYPE go_godebug_non_default_behavior_x509usepolicies_events_total counter
+go_godebug_non_default_behavior_x509usepolicies_events_total 0
+# HELP go_godebug_non_default_behavior_zipinsecurepath_events_total The number of non-default behaviors executed by the archive/zip package due to a non-default GODEBUG=zipinsecurepath=... setting. Sourced from /godebug/non-default-behavior/zipinsecurepath:events.
+# TYPE go_godebug_non_default_behavior_zipinsecurepath_events_total counter
+go_godebug_non_default_behavior_zipinsecurepath_events_total 0
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 22
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.24.10"} 1
+# HELP go_memory_classes_heap_free_bytes Memory that is completely free and eligible to be returned to the underlying system, but has not been. This metric is the runtime's estimate of free address space that is backed by physical memory. Sourced from /memory/classes/heap/free:bytes.
+# TYPE go_memory_classes_heap_free_bytes gauge
+go_memory_classes_heap_free_bytes 1.662976e+06
+# HELP go_memory_classes_heap_objects_bytes Memory occupied by live objects and dead objects that have not yet been marked free by the garbage collector. Sourced from /memory/classes/heap/objects:bytes.
+# TYPE go_memory_classes_heap_objects_bytes gauge
+go_memory_classes_heap_objects_bytes 8.566016e+06
+# HELP go_memory_classes_heap_released_bytes Memory that is completely free and has been returned to the underlying system. This metric is the runtime's estimate of free address space that is still mapped into the process, but is not backed by physical memory. Sourced from /memory/classes/heap/released:bytes.
+# TYPE go_memory_classes_heap_released_bytes gauge
+go_memory_classes_heap_released_bytes 6.733824e+06
+# HELP go_memory_classes_heap_stacks_bytes Memory allocated from the heap that is reserved for stack space, whether or not it is currently in-use. Currently, this represents all stack memory for goroutines. It also includes all OS thread stacks in non-cgo programs. Note that stacks may be allocated differently in the future, and this may change. Sourced from /memory/classes/heap/stacks:bytes.
+# TYPE go_memory_classes_heap_stacks_bytes gauge
+go_memory_classes_heap_stacks_bytes 720896
+# HELP go_memory_classes_heap_unused_bytes Memory that is reserved for heap objects but is not currently used to hold heap objects. Sourced from /memory/classes/heap/unused:bytes.
+# TYPE go_memory_classes_heap_unused_bytes gauge
+go_memory_classes_heap_unused_bytes 3.287808e+06
+# HELP go_memory_classes_metadata_mcache_free_bytes Memory that is reserved for runtime mcache structures, but not in-use. Sourced from /memory/classes/metadata/mcache/free:bytes.
+# TYPE go_memory_classes_metadata_mcache_free_bytes gauge
+go_memory_classes_metadata_mcache_free_bytes 13288
+# HELP go_memory_classes_metadata_mcache_inuse_bytes Memory that is occupied by runtime mcache structures that are currently being used. Sourced from /memory/classes/metadata/mcache/inuse:bytes.
+# TYPE go_memory_classes_metadata_mcache_inuse_bytes gauge
+go_memory_classes_metadata_mcache_inuse_bytes 2416
+# HELP go_memory_classes_metadata_mspan_free_bytes Memory that is reserved for runtime mspan structures, but not in-use. Sourced from /memory/classes/metadata/mspan/free:bytes.
+# TYPE go_memory_classes_metadata_mspan_free_bytes gauge
+go_memory_classes_metadata_mspan_free_bytes 78240
+# HELP go_memory_classes_metadata_mspan_inuse_bytes Memory that is occupied by runtime mspan structures that are currently being used. Sourced from /memory/classes/metadata/mspan/inuse:bytes.
+# TYPE go_memory_classes_metadata_mspan_inuse_bytes gauge
+go_memory_classes_metadata_mspan_inuse_bytes 166560
+# HELP go_memory_classes_metadata_other_bytes Memory that is reserved for or used to hold runtime metadata. Sourced from /memory/classes/metadata/other:bytes.
+# TYPE go_memory_classes_metadata_other_bytes gauge
+go_memory_classes_metadata_other_bytes 3.850224e+06
+# HELP go_memory_classes_os_stacks_bytes Stack memory allocated by the underlying operating system. In non-cgo programs this metric is currently zero. This may change in the future.In cgo programs this metric includes OS thread stacks allocated directly from the OS. Currently, this only accounts for one stack in c-shared and c-archive build modes, and other sources of stacks from the OS are not measured. This too may change in the future. Sourced from /memory/classes/os-stacks:bytes.
+# TYPE go_memory_classes_os_stacks_bytes gauge
+go_memory_classes_os_stacks_bytes 0
+# HELP go_memory_classes_other_bytes Memory used by execution trace buffers, structures for debugging the runtime, finalizer and profiler specials, and more. Sourced from /memory/classes/other:bytes.
+# TYPE go_memory_classes_other_bytes gauge
+go_memory_classes_other_bytes 794251
+# HELP go_memory_classes_profiling_buckets_bytes Memory that is used by the stack trace hash map used for profiling. Sourced from /memory/classes/profiling/buckets:bytes.
+# TYPE go_memory_classes_profiling_buckets_bytes gauge
+go_memory_classes_profiling_buckets_bytes 1.473781e+06
+# HELP go_memory_classes_total_bytes All memory mapped by the Go runtime into the current process as read-write. Note that this does not include memory mapped by code called via cgo or via the syscall package. Sum of all metrics in /memory/classes. Sourced from /memory/classes/total:bytes.
+# TYPE go_memory_classes_total_bytes gauge
+go_memory_classes_total_bytes 2.735028e+07
+# HELP go_memstats_alloc_bytes Number of bytes allocated in heap and currently in use. Equals to /memory/classes/heap/objects:bytes.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 8.566016e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated in heap until now, even if released already. Equals to /gc/heap/allocs:bytes.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 1.43308928e+08
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table. Equals to /memory/classes/profiling/buckets:bytes.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.473781e+06
+# HELP go_memstats_frees_total Total number of heap objects frees. Equals to /gc/heap/frees:objects + /gc/heap/tiny/allocs:objects.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 1.186717e+06
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata. Equals to /memory/classes/metadata/other:bytes.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 3.850224e+06
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and currently in use, same as go_memstats_alloc_bytes. Equals to /memory/classes/heap/objects:bytes.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 8.566016e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used. Equals to /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 8.3968e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 1.1853824e+07
+# HELP go_memstats_heap_objects Number of currently allocated objects. Equals to /gc/heap/objects:objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 56081
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS. Equals to /memory/classes/heap/released:bytes.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 6.733824e+06
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes + /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 2.0250624e+07
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.7856074814890606e+09
+# HELP go_memstats_mallocs_total Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 1.242798e+06
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures. Equals to /memory/classes/metadata/mcache/inuse:bytes.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2416
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system. Equals to /memory/classes/metadata/mcache/inuse:bytes + /memory/classes/metadata/mcache/free:bytes.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 15704
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures. Equals to /memory/classes/metadata/mspan/inuse:bytes.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 166560
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system. Equals to /memory/classes/metadata/mspan/inuse:bytes + /memory/classes/metadata/mspan/free:bytes.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 244800
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place. Equals to /gc/heap/goal:bytes.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 1.6288538e+07
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations. Equals to /memory/classes/other:bytes.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 794251
+# HELP go_memstats_stack_inuse_bytes Number of bytes obtained from system for stack allocator in non-CGO environments. Equals to /memory/classes/heap/stacks:bytes.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 720896
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator. Equals to /memory/classes/heap/stacks:bytes + /memory/classes/os-stacks:bytes.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 720896
+# HELP go_memstats_sys_bytes Number of bytes obtained from system. Equals to /memory/classes/total:byte.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 2.735028e+07
+# HELP go_sched_gomaxprocs_threads The current runtime.GOMAXPROCS setting, or the number of operating system threads that can execute user-level Go code simultaneously. Sourced from /sched/gomaxprocs:threads.
+# TYPE go_sched_gomaxprocs_threads gauge
+go_sched_gomaxprocs_threads 2
+# HELP go_sched_goroutines_goroutines Count of live goroutines. Sourced from /sched/goroutines:goroutines.
+# TYPE go_sched_goroutines_goroutines gauge
+go_sched_goroutines_goroutines 22
+# HELP go_sched_latencies_seconds Distribution of the time goroutines have spent in the scheduler in a runnable state before actually running. Bucket counts increase monotonically. Sourced from /sched/latencies:seconds.
+# TYPE go_sched_latencies_seconds histogram
+go_sched_latencies_seconds_bucket{le="6.399999999999999e-08"} 61005
+go_sched_latencies_seconds_bucket{le="6.399999999999999e-07"} 63350
+go_sched_latencies_seconds_bucket{le="7.167999999999999e-06"} 69885
+go_sched_latencies_seconds_bucket{le="8.191999999999999e-05"} 86361
+go_sched_latencies_seconds_bucket{le="0.0009175039999999999"} 86889
+go_sched_latencies_seconds_bucket{le="0.010485759999999998"} 86925
+go_sched_latencies_seconds_bucket{le="0.11744051199999998"} 86926
+go_sched_latencies_seconds_bucket{le="+Inf"} 86926
+go_sched_latencies_seconds_sum 0.209202112
+go_sched_latencies_seconds_count 86926
+# HELP go_sched_pauses_stopping_gc_seconds Distribution of individual GC-related stop-the-world stopping latencies. This is the time it takes from deciding to stop the world until all Ps are stopped. This is a subset of the total GC-related stop-the-world time (/sched/pauses/total/gc:seconds). During this time, some threads may be executing. Bucket counts increase monotonically. Sourced from /sched/pauses/stopping/gc:seconds.
+# TYPE go_sched_pauses_stopping_gc_seconds histogram
+go_sched_pauses_stopping_gc_seconds_bucket{le="6.399999999999999e-08"} 0
+go_sched_pauses_stopping_gc_seconds_bucket{le="6.399999999999999e-07"} 700
+go_sched_pauses_stopping_gc_seconds_bucket{le="7.167999999999999e-06"} 871
+go_sched_pauses_stopping_gc_seconds_bucket{le="8.191999999999999e-05"} 1065
+go_sched_pauses_stopping_gc_seconds_bucket{le="0.0009175039999999999"} 1098
+go_sched_pauses_stopping_gc_seconds_bucket{le="0.010485759999999998"} 1098
+go_sched_pauses_stopping_gc_seconds_bucket{le="0.11744051199999998"} 1098
+go_sched_pauses_stopping_gc_seconds_bucket{le="+Inf"} 1098
+go_sched_pauses_stopping_gc_seconds_sum 0.004248192
+go_sched_pauses_stopping_gc_seconds_count 1098
+# HELP go_sched_pauses_stopping_other_seconds Distribution of individual non-GC-related stop-the-world stopping latencies. This is the time it takes from deciding to stop the world until all Ps are stopped. This is a subset of the total non-GC-related stop-the-world time (/sched/pauses/total/other:seconds). During this time, some threads may be executing. Bucket counts increase monotonically. Sourced from /sched/pauses/stopping/other:seconds.
+# TYPE go_sched_pauses_stopping_other_seconds histogram
+go_sched_pauses_stopping_other_seconds_bucket{le="6.399999999999999e-08"} 0
+go_sched_pauses_stopping_other_seconds_bucket{le="6.399999999999999e-07"} 0
+go_sched_pauses_stopping_other_seconds_bucket{le="7.167999999999999e-06"} 0
+go_sched_pauses_stopping_other_seconds_bucket{le="8.191999999999999e-05"} 0
+go_sched_pauses_stopping_other_seconds_bucket{le="0.0009175039999999999"} 0
+go_sched_pauses_stopping_other_seconds_bucket{le="0.010485759999999998"} 0
+go_sched_pauses_stopping_other_seconds_bucket{le="0.11744051199999998"} 0
+go_sched_pauses_stopping_other_seconds_bucket{le="+Inf"} 0
+go_sched_pauses_stopping_other_seconds_sum 0
+go_sched_pauses_stopping_other_seconds_count 0
+# HELP go_sched_pauses_total_gc_seconds Distribution of individual GC-related stop-the-world pause latencies. This is the time from deciding to stop the world until the world is started again. Some of this time is spent getting all threads to stop (this is measured directly in /sched/pauses/stopping/gc:seconds), during which some threads may still be running. Bucket counts increase monotonically. Sourced from /sched/pauses/total/gc:seconds.
+# TYPE go_sched_pauses_total_gc_seconds histogram
+go_sched_pauses_total_gc_seconds_bucket{le="6.399999999999999e-08"} 0
+go_sched_pauses_total_gc_seconds_bucket{le="6.399999999999999e-07"} 0
+go_sched_pauses_total_gc_seconds_bucket{le="7.167999999999999e-06"} 514
+go_sched_pauses_total_gc_seconds_bucket{le="8.191999999999999e-05"} 982
+go_sched_pauses_total_gc_seconds_bucket{le="0.0009175039999999999"} 1098
+go_sched_pauses_total_gc_seconds_bucket{le="0.010485759999999998"} 1098
+go_sched_pauses_total_gc_seconds_bucket{le="0.11744051199999998"} 1098
+go_sched_pauses_total_gc_seconds_bucket{le="+Inf"} 1098
+go_sched_pauses_total_gc_seconds_sum 0.013186304000000001
+go_sched_pauses_total_gc_seconds_count 1098
+# HELP go_sched_pauses_total_other_seconds Distribution of individual non-GC-related stop-the-world pause latencies. This is the time from deciding to stop the world until the world is started again. Some of this time is spent getting all threads to stop (measured directly in /sched/pauses/stopping/other:seconds). Bucket counts increase monotonically. Sourced from /sched/pauses/total/other:seconds.
+# TYPE go_sched_pauses_total_other_seconds histogram
+go_sched_pauses_total_other_seconds_bucket{le="6.399999999999999e-08"} 0
+go_sched_pauses_total_other_seconds_bucket{le="6.399999999999999e-07"} 0
+go_sched_pauses_total_other_seconds_bucket{le="7.167999999999999e-06"} 0
+go_sched_pauses_total_other_seconds_bucket{le="8.191999999999999e-05"} 0
+go_sched_pauses_total_other_seconds_bucket{le="0.0009175039999999999"} 0
+go_sched_pauses_total_other_seconds_bucket{le="0.010485759999999998"} 0
+go_sched_pauses_total_other_seconds_bucket{le="0.11744051199999998"} 0
+go_sched_pauses_total_other_seconds_bucket{le="+Inf"} 0
+go_sched_pauses_total_other_seconds_sum 0
+go_sched_pauses_total_other_seconds_count 0
+# HELP go_sync_mutex_wait_total_seconds_total Approximate cumulative time goroutines have spent blocked on a sync.Mutex, sync.RWMutex, or runtime-internal lock. This metric is useful for identifying global changes in lock contention. Collect a mutex or block profile using the runtime/pprof package for more detailed contention data. Sourced from /sync/mutex/wait/total:seconds.
+# TYPE go_sync_mutex_wait_total_seconds_total counter
+go_sync_mutex_wait_total_seconds_total 0.033226424
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 10
+# HELP livekit_node_cpu_load 
+# TYPE livekit_node_cpu_load gauge
+livekit_node_cpu_load{node_id="NE_examplenodeid01",node_type="SIP"} 0.0029963304473070718
+# HELP livekit_sip_available Whether node can accept new requests
+# TYPE livekit_sip_available gauge
+livekit_sip_available{node_id="NE_examplenodeid01"} 1
+# HELP livekit_sip_calls_active Number of currently active SIP calls
+# TYPE livekit_sip_calls_active gauge
+livekit_sip_calls_active{dir="in",node_id="NE_examplenodeid01",to="sip.example.invalid"} 0
+# HELP livekit_sip_calls_terminated Number of calls terminated by SIP bridge
+# TYPE livekit_sip_calls_terminated counter
+livekit_sip_calls_terminated{dir="in",node_id="NE_examplenodeid01",reason="hangup",to="sip.example.invalid"} 1
+# HELP livekit_sip_dur_call_sec SIP call duration (from successful pin to closed)
+# TYPE livekit_sip_dur_call_sec histogram
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="1"} 0
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="10"} 1
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="60"} 1
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="600"} 1
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="1800"} 1
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="3600"} 1
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="21600"} 1
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="43200"} 1
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="86400"} 1
+livekit_sip_dur_call_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="+Inf"} 1
+livekit_sip_dur_call_sec_sum{dir="in",node_id="NE_examplenodeid01"} 8.613975456
+livekit_sip_dur_call_sec_count{dir="in",node_id="NE_examplenodeid01"} 1
+# HELP livekit_sip_dur_check_sec SIP call check duration (from INVITE to an initial dispatch response)
+# TYPE livekit_sip_dur_check_sec histogram
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="0.1"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="0.5"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="1"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="2.5"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="5"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="10"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="20"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="30"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="60"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="180"} 1
+livekit_sip_dur_check_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="+Inf"} 1
+livekit_sip_dur_check_sec_sum{dir="in",node_id="NE_examplenodeid01"} 0.047239942
+livekit_sip_dur_check_sec_count{dir="in",node_id="NE_examplenodeid01"} 1
+# HELP livekit_sip_dur_join_sec SIP room join duration (from INVITE to mixed room audio)
+# TYPE livekit_sip_dur_join_sec histogram
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="0.1"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="0.5"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="1"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="2.5"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="5"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="10"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="20"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="30"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="60"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="180"} 1
+livekit_sip_dur_join_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="+Inf"} 1
+livekit_sip_dur_join_sec_sum{dir="in",node_id="NE_examplenodeid01"} 0.056595646
+livekit_sip_dur_join_sec_count{dir="in",node_id="NE_examplenodeid01"} 1
+# HELP livekit_sip_dur_session_sec SIP session duration (from INVITE to closed)
+# TYPE livekit_sip_dur_session_sec histogram
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="1"} 0
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="10"} 1
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="60"} 1
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="600"} 1
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="1800"} 1
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="3600"} 1
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="21600"} 1
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="43200"} 1
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="86400"} 1
+livekit_sip_dur_session_sec_bucket{dir="in",node_id="NE_examplenodeid01",le="+Inf"} 1
+livekit_sip_dur_session_sec_sum{dir="in",node_id="NE_examplenodeid01"} 8.670751059
+livekit_sip_dur_session_sec_count{dir="in",node_id="NE_examplenodeid01"} 1
+# HELP livekit_sip_invite_accepted Number of accepted SIP INVITE requests (that matched a trunk and passed auth)
+# TYPE livekit_sip_invite_accepted counter
+livekit_sip_invite_accepted{dir="in",node_id="NE_examplenodeid01",to="sip.example.invalid"} 1
+# HELP livekit_sip_invite_requests Number of valid SIP INVITE requests received
+# TYPE livekit_sip_invite_requests counter
+livekit_sip_invite_requests{dir="in",node_id="NE_examplenodeid01"} 1
+# HELP livekit_sip_invite_requests_raw Number of unvalidated SIP INVITE requests received
+# TYPE livekit_sip_invite_requests_raw counter
+livekit_sip_invite_requests_raw{node_id="NE_examplenodeid01"} 1
+# HELP livekit_sip_packets_rtp Number of RTP packets sent or received by SIP bridge
+# TYPE livekit_sip_packets_rtp counter
+livekit_sip_packets_rtp{dir="in",node_id="NE_examplenodeid01",op="recv",payload="G722/8000",to="sip.example.invalid"} 330
+livekit_sip_packets_rtp{dir="in",node_id="NE_examplenodeid01",op="send",payload="audio",to="sip.example.invalid"} 337
+# HELP livekit_sip_sdp_size_bytes SDP size in bytes
+# TYPE livekit_sip_sdp_size_bytes histogram
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="answer",le="100"} 0
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="answer",le="250"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="answer",le="500"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="answer",le="750"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="answer",le="1000"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="answer",le="1250"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="answer",le="1500"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="answer",le="+Inf"} 1
+livekit_sip_sdp_size_bytes_sum{node_id="NE_examplenodeid01",type="answer"} 226
+livekit_sip_sdp_size_bytes_count{node_id="NE_examplenodeid01",type="answer"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="offer",le="100"} 0
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="offer",le="250"} 0
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="offer",le="500"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="offer",le="750"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="offer",le="1000"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="offer",le="1250"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="offer",le="1500"} 1
+livekit_sip_sdp_size_bytes_bucket{node_id="NE_examplenodeid01",type="offer",le="+Inf"} 1
+livekit_sip_sdp_size_bytes_sum{node_id="NE_examplenodeid01",type="offer"} 356
+livekit_sip_sdp_size_bytes_count{node_id="NE_examplenodeid01",type="offer"} 1
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 31.35
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 524287
+# HELP process_network_receive_bytes_total Number of bytes received by the process over the network.
+# TYPE process_network_receive_bytes_total counter
+process_network_receive_bytes_total 1.19276578432e+11
+# HELP process_network_transmit_bytes_total Number of bytes sent by the process over the network.
+# TYPE process_network_transmit_bytes_total counter
+process_network_transmit_bytes_total 1.19529548307e+11
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 11
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 4.5211648e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.78554209767e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.9100672e+09
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes 1.8446744073709552e+19
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight 1
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{code="200"} 231
+promhttp_metric_handler_requests_total{code="500"} 0
+promhttp_metric_handler_requests_total{code="503"} 0
+# HELP sipgo_transport_packet_size_bytes Size of sent and received SIP packets
+# TYPE sipgo_transport_packet_size_bytes histogram
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="250"} 0
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="500"} 1
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1000"} 2
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1100"} 2
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1150"} 2
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1200"} 2
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1250"} 3
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1300"} 3
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1350"} 3
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1400"} 3
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1450"} 3
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="1500"} 3
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="read",le="+Inf"} 3
+sipgo_transport_packet_size_bytes_sum{transport="udp",type="read"} 2286
+sipgo_transport_packet_size_bytes_count{transport="udp",type="read"} 3
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="250"} 0
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="500"} 1
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1000"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1100"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1150"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1200"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1250"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1300"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1350"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1400"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1450"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="1500"} 5
+sipgo_transport_packet_size_bytes_bucket{transport="udp",type="write",le="+Inf"} 5
+sipgo_transport_packet_size_bytes_sum{transport="udp",type="write"} 3200
+sipgo_transport_packet_size_bytes_count{transport="udp",type="write"} 5

--- a/src/voicegateway/tests/integration/test_live_node_scrape.py
+++ b/src/voicegateway/tests/integration/test_live_node_scrape.py
@@ -1,0 +1,284 @@
+"""One real scrape, against real exporters, asserted column by column.
+
+Every other test of this worker feeds it a canned body. A canned body can only
+encode what we BELIEVE an exporter emits, and the whole point of the columns
+this file guards is that several of them were wired against documentation and
+were wrong. The bugs that motivated them all passed the fixture-based tests:
+
+* a histogram base name that matches no sample and stores NULL forever
+* ten livekit-sip entries scraped from livekit-server, which exports none of them
+* ``livekit_nack_total``, which does not exist on 1.10.1 under any name
+* ``series_found`` counting a value the repository then refused at coercion
+
+So this runs the real code path against real exporters and asserts what landed.
+
+**Read only, and it never writes the real database.** The scrape is a GET; the
+rows go to a SQLite file pytest made for the test and deletes after.
+
+Runs only when the exporters answer on localhost, so it skips everywhere else,
+and is marked ``integration`` so the unit matrix (``-m "not integration"``)
+deselects it.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+
+import pytest
+
+from voicegateway.middleware.node_samples_worker_middleware import (
+    SERIES,
+    SOURCE_LIVEKIT_SERVER,
+    SOURCE_LIVEKIT_SIP,
+    SOURCE_NODE_EXPORTER,
+    TARGETS_ENV_VAR,
+    NodeSamplesWorker,
+    targets_from_env,
+)
+from voicegateway.repository import node_samples_repository as repo
+from voicegateway.services.storage_service import StorageService
+
+NODE = "live-1"
+HOST_PORT = 9100  # node_exporter
+SIP_PORT = 6790  # livekit-sip
+SERVER_PORT = 6789  # livekit-server, behind basic auth
+
+# Invented here. The point of pointing an authenticated target at a real server
+# is to watch what the logger does with the credential, and a 401 exercises that
+# exactly as well as a 200 would.
+FAKE_USER = "metrics-reader"
+FAKE_SECRET = "not-a-real-password-9271"
+
+
+def _answers(port: int) -> bool:
+    with socket.socket() as sock:
+        sock.settimeout(0.3)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not (_answers(HOST_PORT) and _answers(SIP_PORT)),
+        reason=f"no exporter answering on localhost:{HOST_PORT} and :{SIP_PORT}",
+    ),
+]
+
+TARGETS = (
+    f"{SOURCE_NODE_EXPORTER}:{NODE}=http://localhost:{HOST_PORT}/metrics,"
+    f"{SOURCE_LIVEKIT_SIP}:{NODE}=http://localhost:{SIP_PORT}/metrics,"
+    f"{SOURCE_LIVEKIT_SERVER}:{NODE}="
+    f"http://{FAKE_USER}:{FAKE_SECRET}@localhost:{SERVER_PORT}/metrics"
+)
+
+
+@pytest.fixture(scope="module")
+async def scraped(tmp_path_factory):
+    """One real tick into a throwaway database, shared by every assertion.
+
+    Module-scoped so the exporters are hit once rather than once per test: this
+    talks to something outside the process and has no business hammering it.
+    """
+    db_path = tmp_path_factory.mktemp("live-scrape") / "nodes.db"
+    storage = StorageService(db_path=str(db_path))
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Capture(level=logging.DEBUG)
+    root = logging.getLogger()
+    previous = root.level
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
+    try:
+        await storage._ensure_initialized()
+        worker = NodeSamplesWorker(
+            storage, target_provider=lambda: _targets(), transport=None
+        )
+        written = await worker.tick_now()
+        rows = {}
+        async with storage._conn.session() as db:
+            for source in (
+                SOURCE_NODE_EXPORTER,
+                SOURCE_LIVEKIT_SIP,
+                SOURCE_LIVEKIT_SERVER,
+            ):
+                found = await repo.list_samples(db, node=NODE, source=source)
+                rows[source] = found[0] if found else None
+        yield {"written": written, "rows": rows, "records": records}
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(previous)
+        await storage.aclose()
+
+
+async def _targets():
+    return targets_from_env({TARGETS_ENV_VAR: TARGETS})
+
+
+def _populated(row) -> set[str]:
+    """Value columns actually carrying something, excluding derived markers."""
+    return {
+        column
+        for column in repo.VALUE_COLUMNS - repo.DERIVED_COLUMNS
+        if getattr(row, column) is not None
+    }
+
+
+# --------------------------------------------------------------------------
+# The scrape happened at all
+# --------------------------------------------------------------------------
+
+
+async def test_every_target_produced_a_row(scraped) -> None:
+    assert scraped["written"] == 3
+    assert all(row is not None for row in scraped["rows"].values())
+
+
+# --------------------------------------------------------------------------
+# series_found describes what STORED, not what matched
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source", [SOURCE_NODE_EXPORTER, SOURCE_LIVEKIT_SIP])
+async def test_the_count_equals_the_columns_that_landed(scraped, source) -> None:
+    """The defect this file is best placed to catch.
+
+    It only appears when a real exporter emits a value the repository refuses,
+    which no hand-written fixture would think to contain.
+    """
+    row = scraped["rows"][source]
+    assert row.outcome == "ok"
+    assert row.series_found == len(_populated(row)), source
+
+
+async def test_the_host_ceiling_is_the_one_that_gets_refused(scraped) -> None:
+    """Live proof of the drop, and of the count that used to ignore it.
+
+    node_filefd_maximum on this box does not survive a float64 round trip, so
+    the column is NULL while every sibling stores fine. Before the recount,
+    series_found would have claimed one more series than the row holds.
+    """
+    row = scraped["rows"][SOURCE_NODE_EXPORTER]
+    assert row.filefd_maximum is None
+    assert row.filefd_allocated is not None
+    matched = len(SERIES[SOURCE_NODE_EXPORTER])
+    assert row.series_found == matched - 1
+
+
+async def test_a_401_records_a_null_count_not_a_zero(scraped) -> None:
+    """No exposition was read, so nothing is known about how many series exist."""
+    row = scraped["rows"][SOURCE_LIVEKIT_SERVER]
+    assert row.outcome == "http_error"
+    assert row.series_found is None
+    assert _populated(row) == set()
+
+
+# --------------------------------------------------------------------------
+# The unbounded marker, against a kernel that really is unbounded
+# --------------------------------------------------------------------------
+
+
+async def test_the_ceiling_is_recorded_as_unbounded(scraped) -> None:
+    """1, not NULL. The value was measured; it just cannot be stored."""
+    assert scraped["rows"][SOURCE_NODE_EXPORTER].filefd_maximum_unbounded == 1
+
+
+async def test_the_marker_stays_null_where_the_series_does_not_exist(
+    scraped,
+) -> None:
+    """livekit-sip exports no host filefd pair, so it says nothing about one."""
+    assert scraped["rows"][SOURCE_LIVEKIT_SIP].filefd_maximum_unbounded is None
+
+
+# --------------------------------------------------------------------------
+# Every wired series resolves against the running binary
+# --------------------------------------------------------------------------
+
+
+async def test_every_livekit_sip_series_landed(scraped) -> None:
+    """A name that matches nothing stores NULL for the life of a deployment.
+
+    Nothing at runtime says so, which is why this is asserted against a real
+    binary rather than inferred from documentation.
+    """
+    row = scraped["rows"][SOURCE_LIVEKIT_SIP]
+    expected = {entry.column for entry in SERIES[SOURCE_LIVEKIT_SIP]}
+    assert _populated(row) == expected
+
+
+async def test_the_headroom_pair_is_real(scraped) -> None:
+    """The per-process rlimit, which is what the headroom gate judges."""
+    row = scraped["rows"][SOURCE_LIVEKIT_SIP]
+    assert row.process_open_fds is not None
+    assert row.process_max_fds is not None
+    assert 0 < row.process_open_fds < row.process_max_fds
+
+
+async def test_the_join_histogram_is_stored_as_sum_and_count(scraped) -> None:
+    """Not as summed buckets, which counts one observation once per bucket."""
+    row = scraped["rows"][SOURCE_LIVEKIT_SIP]
+    assert row.sip_join_sec_count is not None
+    assert row.sip_join_sec_sum is not None
+    # Every bucket count is bounded by the total, which a summed value is not.
+    assert row.sip_join_le1_count <= row.sip_join_sec_count
+    assert row.sip_join_le5_count <= row.sip_join_sec_count
+
+
+async def test_rtp_is_split_by_direction(scraped) -> None:
+    """One-way audio must not disappear into a single total."""
+    row = scraped["rows"][SOURCE_LIVEKIT_SIP]
+    assert row.sip_rtp_packets_recv is not None
+    assert row.sip_rtp_packets_send is not None
+
+
+# --------------------------------------------------------------------------
+# Nothing leaked across sources
+# --------------------------------------------------------------------------
+
+
+async def test_no_source_carries_another_source_columns(scraped) -> None:
+    """An entry in the wrong tuple reads exactly like a name that does not exist.
+
+    Asserted as a disjointness property so it holds for entries added later.
+    """
+    host = _populated(scraped["rows"][SOURCE_NODE_EXPORTER])
+    sip = _populated(scraped["rows"][SOURCE_LIVEKIT_SIP])
+    sip_only = {e.column for e in SERIES[SOURCE_LIVEKIT_SIP]} - {
+        e.column for e in SERIES[SOURCE_NODE_EXPORTER]
+    }
+    assert not (host & sip_only)
+    assert "filefd_allocated" in host
+    assert "filefd_allocated" not in sip
+
+
+async def test_the_deleted_nack_column_is_not_reachable(scraped) -> None:
+    row = scraped["rows"][SOURCE_LIVEKIT_SIP]
+    assert not hasattr(row, "nacks_total")
+
+
+# --------------------------------------------------------------------------
+# The credential, against a server that really challenges for it
+# --------------------------------------------------------------------------
+
+
+async def test_no_log_line_carries_the_credential(scraped) -> None:
+    """The live counterpart of the unit test, over every logger in the process.
+
+    Includes the HTTP client's own request line, which is where the password
+    used to be written four times a minute.
+    """
+    assert scraped["records"], "nothing was logged, so this proves nothing"
+    for record in scraped["records"]:
+        assert FAKE_SECRET not in record.getMessage(), record.name
+
+
+async def test_the_request_line_was_still_logged(scraped) -> None:
+    """Non-vacuous: the credential is absent because it was removed from the
+    URL, not because the line that would have carried it was suppressed."""
+    lines = [r.getMessage() for r in scraped["records"] if r.name == "httpx"]
+    assert any(f"localhost:{SERVER_PORT}" in line for line in lines), lines
+    assert any(f"localhost:{SIP_PORT}" in line for line in lines), lines

--- a/src/voicegateway/tests/loadtest/test_fd_headroom.py
+++ b/src/voicegateway/tests/loadtest/test_fd_headroom.py
@@ -1,0 +1,289 @@
+"""The file-descriptor headroom gate, from scrape to verdict.
+
+The pair was scraped into ``node_samples`` and never reached the gate: the judge
+hardcoded the reading as unmeasured, so ``resource_headroom/file_descriptors``
+returned UNKNOWN no matter what node-exporter reported. A criterion that can
+only ever be UNKNOWN is a criterion nobody can pass.
+
+Four properties are pinned here.
+
+**The per-process pair, not the host one.** On a real box the host maximum reads
+9.223372036854776e18, which is effectively unbounded, does not fit a 64-bit
+column, and yields no meaningful ratio; ``process_max_fds`` on the same box
+reads 524287, which is the ceiling the service actually hits.
+
+**Worst over the window, not last.** Headroom is a floor. A run that touched 95%
+once has demonstrated it can get there, whatever it settled back to.
+
+**Paired within one row.** An open count from one scrape against a limit from
+another describes an instant that never existed, exactly as with memory.
+
+**Both halves NULL stays UNKNOWN, with a reason.** This is the trap. The gate
+must never read an unmeasured pair as headroom nobody breached.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel
+
+from voicegateway.livekit_diag import gates
+from voicegateway.loadtest import aggregation, judge
+from voicegateway.models.node_sample_model import NodeSample  # noqa: F401
+from voicegateway.repository.node_correlation_repository import window_of
+from voicegateway.repository.node_samples_repository import (
+    NodeSampleInput,
+    insert_samples,
+)
+
+T0 = 1_785_520_800_000  # 2026-07-31T18:00:00Z
+SEC = 1000
+HEALTHY = {"name": "ramp-500", "attempted_calls": 15000, "succeeded_calls": 14985}
+
+
+@pytest.fixture
+async def db(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'fds.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            SQLModel.metadata.create_all,
+            tables=[SQLModel.metadata.tables["node_samples"]],
+        )
+    async with AsyncSession(engine) as session:
+        yield session
+    await engine.dispose()
+
+
+def _sample(offset_s: int, *, node: str = "sip-1", **values) -> NodeSampleInput:
+    return NodeSampleInput(
+        node=node,
+        source="livekit-sip",
+        at_ms=T0 + offset_s * SEC,
+        outcome="ok",
+        values=values,
+    )
+
+
+async def _aggregate(db: AsyncSession, last_offset_s: int):
+    return await aggregation.aggregate_test_window(
+        db, started_at_ms=T0, ended_at_ms=T0 + last_offset_s * SEC
+    )
+
+
+def _fd(agg) -> gates.HeadroomReading:
+    [reading] = agg.fd_readings
+    return reading
+
+
+# --------------------------------------------------------------------------
+# The pair reaches the aggregate
+# --------------------------------------------------------------------------
+
+
+async def test_the_pair_is_carried_onto_the_aggregate(db: AsyncSession) -> None:
+    await insert_samples(
+        db,
+        [
+            _sample(0, process_open_fds=11, process_max_fds=524287),
+            _sample(10, process_open_fds=300, process_max_fds=524287),
+        ],
+    )
+    agg = await _aggregate(db, 10)
+    assert agg is not None
+    reading = _fd(agg)
+    assert (reading.used, reading.limit) == (300.0, 524287.0)
+    assert reading.unmeasured_reason is None
+
+
+async def test_the_worst_reading_wins_not_the_last(db: AsyncSession) -> None:
+    """Headroom is a floor. Settling back does not undo having been there."""
+    await insert_samples(
+        db,
+        [
+            _sample(0, process_open_fds=100, process_max_fds=1000),
+            _sample(10, process_open_fds=950, process_max_fds=1000),  # 5% left
+            _sample(20, process_open_fds=120, process_max_fds=1000),
+        ],
+    )
+    agg = await _aggregate(db, 20)
+    assert agg is not None
+    assert _fd(agg).used == 950.0
+    # And the gate fails on it, rather than passing on the quiet last sample.
+    [gate] = gates.headroom_gates([_fd(agg)])
+    assert gate.status == gates.FAIL
+
+
+async def test_the_pair_is_read_from_one_row(db: AsyncSession) -> None:
+    """max(open) against max(limit) across rows describes no real instant.
+
+    Here the row with the most open descriptors also has the largest ceiling,
+    so a cross-row pairing would compute 900/1000 = 10% headroom left, when
+    every instant that occurred had at least 50%.
+    """
+    await insert_samples(
+        db,
+        [
+            _sample(0, process_open_fds=500, process_max_fds=1000),
+            _sample(10, process_open_fds=900, process_max_fds=2000),
+        ],
+    )
+    agg = await _aggregate(db, 10)
+    assert agg is not None
+    reading = _fd(agg)
+    # Both rows sit at exactly 50% used, so either pairing is the same ratio.
+    assert reading.used / reading.limit == pytest.approx(0.5)
+    [gate] = gates.headroom_gates([reading])
+    assert gate.status == gates.PASS
+
+
+# --------------------------------------------------------------------------
+# The trap: unmeasured stays UNKNOWN
+# --------------------------------------------------------------------------
+
+
+async def test_a_window_with_no_pair_is_unmeasured_with_a_reason(
+    db: AsyncSession,
+) -> None:
+    """The trap. Both halves NULL must never read as headroom to spare."""
+    await insert_samples(db, [_sample(0, rooms=3), _sample(10, rooms=4)])
+    agg = await _aggregate(db, 10)
+    assert agg is not None
+    reading = _fd(agg)
+    assert (reading.used, reading.limit) == (None, None)
+    assert reading.unmeasured_reason
+    [gate] = gates.headroom_gates([reading])
+    assert gate.status == gates.UNKNOWN
+    assert gate.status != gates.PASS
+
+
+async def test_a_row_missing_one_half_contributes_nothing(db: AsyncSession) -> None:
+    """An open count with no ceiling is not a ratio, and neither is the reverse."""
+    await insert_samples(
+        db,
+        [
+            _sample(0, process_open_fds=900),
+            _sample(10, process_max_fds=1000),
+        ],
+    )
+    agg = await _aggregate(db, 10)
+    assert agg is not None
+    assert _fd(agg).used is None
+    assert _fd(agg).unmeasured_reason
+
+
+async def test_a_zero_limit_is_not_divided_by(db: AsyncSession) -> None:
+    """A ceiling of zero is a broken scrape, not a node with no headroom."""
+    await insert_samples(db, [_sample(0, process_open_fds=5, process_max_fds=0)])
+    agg = await _aggregate(db, 0)
+    assert agg is not None
+    assert _fd(agg).used is None
+
+
+# --------------------------------------------------------------------------
+# The judge consumes what was measured
+# --------------------------------------------------------------------------
+
+
+async def test_the_gate_reports_the_measured_pair(db: AsyncSession) -> None:
+    """End to end: the reason this node exists.
+
+    Before this, the judge hardcoded the reading as unmeasured and this gate
+    could not pass whatever the box reported.
+    """
+    await insert_samples(
+        db,
+        [
+            _sample(0, cpu_seconds_total=1000.0, cpu_idle_seconds_total=800.0),
+            _sample(
+                10,
+                cpu_seconds_total=1040.0,
+                cpu_idle_seconds_total=830.0,
+                process_open_fds=11,
+                process_max_fds=524287,
+            ),
+        ],
+    )
+    agg = await _aggregate(db, 10)
+    assert agg is not None
+    results = judge.judge_test(HEALTHY, aggregate=agg)
+    [fd_gate] = [
+        r for r in results if r.subject and r.subject.endswith("/file_descriptors")
+    ]
+    assert fd_gate.status == gates.PASS
+
+
+async def test_an_unscraped_pair_leaves_the_gate_unknown(db: AsyncSession) -> None:
+    """Non-vacuous companion to the test above: it does not always pass."""
+    await insert_samples(
+        db,
+        [
+            _sample(0, cpu_seconds_total=1000.0, cpu_idle_seconds_total=800.0),
+            _sample(10, cpu_seconds_total=1040.0, cpu_idle_seconds_total=830.0),
+        ],
+    )
+    agg = await _aggregate(db, 10)
+    assert agg is not None
+    results = judge.judge_test(HEALTHY, aggregate=agg)
+    [fd_gate] = [
+        r for r in results if r.subject and r.subject.endswith("/file_descriptors")
+    ]
+    assert fd_gate.status == gates.UNKNOWN
+
+
+def test_an_aggregate_carrying_no_fd_readings_still_produces_the_gate() -> None:
+    """The silent-drop guard.
+
+    A caller that builds an aggregate without FD readings must not lose the
+    file-descriptor gate while keeping RTP ports and network. An absent gate
+    reads as a resource nobody had to satisfy; UNKNOWN says nobody measured it.
+    """
+    agg = aggregation.TestAggregate(
+        window=window_of(T0, T0 + 10 * SEC),
+        peak_cpu_utilisation=0.5,
+        peak_memory_utilisation=0.4,
+        node_samples_in_window=2,
+        cpu_readings=[
+            gates.NodeUtilisationReading(node="sfu-1", utilisation=0.5, samples=2)
+        ],
+        memory_readings=[
+            gates.NodeUtilisationReading(node="sfu-1", utilisation=0.4, samples=2)
+        ],
+    )
+    results = judge.judge_test(HEALTHY, aggregate=agg)
+    resources = {
+        r.subject.split("/")[-1] for r in results if r.subject and "/" in r.subject
+    }
+    assert {"file_descriptors", "rtp_ports", "network"} <= resources
+    [fd_gate] = [r for r in results if r.subject == "sfu-1/file_descriptors"]
+    assert fd_gate.status == gates.UNKNOWN
+
+
+# --------------------------------------------------------------------------
+# The host pair is deliberately not the one judged
+# --------------------------------------------------------------------------
+
+
+def test_the_judged_columns_are_the_per_process_pair() -> None:
+    """Named explicitly, because the host pair is the tempting wrong choice.
+
+    ``node_filefd_maximum`` on an observed box reads 9.223372036854776e18. A
+    ratio against that is zero for every workload that will ever run.
+    """
+    assert aggregation.FD_USED_COLUMN == "process_open_fds"
+    assert aggregation.FD_LIMIT_COLUMN == "process_max_fds"
+    assert "filefd" not in aggregation.FD_LIMIT_COLUMN
+
+
+async def test_the_host_filefd_pair_alone_does_not_satisfy_the_gate(
+    db: AsyncSession,
+) -> None:
+    """Behavioural, not textual. Scraping only the host pair judges nothing."""
+    await insert_samples(
+        db, [_sample(0, filefd_allocated=1216, filefd_maximum=9223372036854774784)]
+    )
+    agg = await _aggregate(db, 0)
+    assert agg is not None
+    assert _fd(agg).used is None
+    [gate] = gates.headroom_gates([_fd(agg)])
+    assert gate.status == gates.UNKNOWN

--- a/src/voicegateway/tests/loadtest/test_fd_headroom.py
+++ b/src/voicegateway/tests/loadtest/test_fd_headroom.py
@@ -287,3 +287,61 @@ async def test_the_host_filefd_pair_alone_does_not_satisfy_the_gate(
     assert _fd(agg).used is None
     [gate] = gates.headroom_gates([_fd(agg)])
     assert gate.status == gates.UNKNOWN
+
+
+# --------------------------------------------------------------------------
+# One node, several exporters: the gates must be tellable apart
+# --------------------------------------------------------------------------
+
+
+async def test_gates_for_one_node_across_sources_have_distinct_subjects(
+    db: AsyncSession,
+) -> None:
+    """Found by a live run, invisible to every single-source fixture.
+
+    A node is commonly scraped by three exporters, and only one of them carries
+    the per-process descriptor pair. The subject dropped the source, so the run
+    emitted three gates labelled identically reading PASS, UNKNOWN and UNKNOWN,
+    with nothing saying which exporter passed. A reader cannot act on that, and
+    the PASS is the half that looks like coverage.
+    """
+    await insert_samples(
+        db,
+        [
+            _sample(0, process_open_fds=11, process_max_fds=524287),
+            NodeSampleInput(
+                node="sip-1",
+                source="node-exporter",
+                at_ms=T0,
+                outcome="ok",
+                values={"filefd_allocated": 2496.0},
+            ),
+        ],
+    )
+    agg = await _aggregate(db, 0)
+    assert agg is not None
+    fd_gates = [
+        g
+        for g in judge.judge_test(HEALTHY, aggregate=agg)
+        if g.subject and g.subject.endswith("/file_descriptors")
+    ]
+    assert len(fd_gates) == 2
+    assert len({g.subject for g in fd_gates}) == 2, [g.subject for g in fd_gates]
+    # And the statuses really do differ, so the collision was not cosmetic.
+    assert {g.status for g in fd_gates} == {gates.PASS, gates.UNKNOWN}
+    # The one that passed says which exporter it came from.
+    [passed] = [g for g in fd_gates if g.status == gates.PASS]
+    assert "livekit-sip" in passed.subject
+    assert "livekit-sip" in passed.detail
+
+
+def test_a_reading_with_no_source_keeps_the_short_subject() -> None:
+    """A caller holding only a node name is unaffected by the change."""
+    [gate] = gates.headroom_gates(
+        [
+            gates.HeadroomReading(
+                node="sfu-1", resource="file_descriptors", used=400, limit=1000
+            )
+        ]
+    )
+    assert gate.subject == "sfu-1/file_descriptors"

--- a/src/voicegateway/tests/middleware/test_histogram_misuse.py
+++ b/src/voicegateway/tests/middleware/test_histogram_misuse.py
@@ -189,3 +189,86 @@ def test_the_map_is_validated_at_import_not_on_demand() -> None:
 
     source = inspect.getsource(module)
     assert "\nvalidate_series_map(SERIES)\n" in source
+
+
+# --------------------------------------------------------------------------
+# Every wired livekit-sip entry resolves against the real capture
+# --------------------------------------------------------------------------
+
+
+def test_every_sip_entry_resolves_against_the_capture(live) -> None:
+    """The point of wiring against a live box rather than documentation.
+
+    A name that matches nothing stores NULL for the life of a deployment, and
+    nothing at runtime says so. This is the only place that can catch it.
+    """
+    absent = [
+        f"{entry.metric} -> {entry.column}"
+        for entry in SERIES["livekit-sip"]
+        if sum_series(live, entry.metric, where=entry.where) is None
+    ]
+    assert not absent, f"mapped names absent from the capture: {absent}"
+
+
+def test_the_sip_tuple_holds_no_server_only_name(live) -> None:
+    """Placement is as easy to get wrong as the name itself.
+
+    An entry in the wrong tuple is scraped against a binary that does not
+    export it, which reads exactly like a name that does not exist.
+    """
+    for entry in SERIES["livekit-sip"]:
+        assert sum_series(live, entry.metric, where=entry.where) is not None
+
+
+def test_livekit_node_cpu_load_is_sip_only() -> None:
+    """It exists on livekit-sip and on none of the server's livekit_* families."""
+    server = {e.metric for e in SERIES["livekit-server"]}
+    sip = {e.metric for e in SERIES["livekit-sip"]}
+    assert "livekit_node_cpu_load" in sip
+    assert "livekit_node_cpu_load" not in server
+
+
+def test_no_sip_named_series_is_scraped_from_the_server() -> None:
+    leaked = [
+        e.metric for e in SERIES["livekit-server"] if e.metric.startswith("livekit_sip")
+    ]
+    assert not leaked, f"livekit-sip names in the server tuple: {leaked}"
+
+
+def test_rtp_is_split_by_direction_and_never_summed(live) -> None:
+    """One-way audio must not disappear into a single total.
+
+    A call that sent 337 and received 330 sums to 667, and a fleet losing its
+    inbound leg would look identical to a healthy one at that granularity.
+    """
+    entries = {
+        e.column: e
+        for e in SERIES["livekit-sip"]
+        if e.metric == "livekit_sip_packets_rtp"
+    }
+    assert set(entries) == {"sip_rtp_packets_recv", "sip_rtp_packets_send"}
+    for entry in entries.values():
+        assert entry.where and "op" in entry.where
+        # NOT filtered on payload: the send leg carries the literal "audio"
+        # rather than a codec name, so a payload filter would empty it.
+        assert "payload" not in entry.where
+    recv = sum_series(live, "livekit_sip_packets_rtp", where={"op": "recv"})
+    send = sum_series(live, "livekit_sip_packets_rtp", where={"op": "send"})
+    assert recv != send, "the fixture cannot distinguish the two directions"
+
+
+def test_the_unverifiable_server_names_were_not_guessed_in() -> None:
+    """Their columns exist and store NULL, which is the honest state.
+
+    A guessed name would store NULL for the life of a deployment while
+    series_found still read high because its siblings matched.
+    """
+    wired = {e.metric for entries in SERIES.values() for e in entries}
+    for name in (
+        "livekit_session_start_time_ms_sum",
+        "livekit_session_start_time_ms_count",
+        "livekit_track_published_total",
+        "livekit_track_subscribed_total",
+        "psrpc_stream_count",
+    ):
+        assert name not in wired, f"{name} was guessed into the map"

--- a/src/voicegateway/tests/middleware/test_histogram_misuse.py
+++ b/src/voicegateway/tests/middleware/test_histogram_misuse.py
@@ -1,0 +1,191 @@
+"""Two ways a metric map produces a believable wrong number, made impossible.
+
+Both were observed against a real livekit-sip 1.10.1 exposition, and the
+fixture beside this test is that capture with the hostname and node id
+replaced. A hand-written two-line exposition would not have caught either:
+what makes them dangerous is that they occur among 327 samples where
+everything else works.
+
+**Summing cumulative buckets.** Prometheus buckets are inclusive of every
+smaller bound, so adding them counts one observation once per bucket. On this
+capture the join histogram sums to 11.0 against a true ``_count`` of 1. At 500
+concurrent that is a smooth, plausible curve.
+
+**Naming the histogram base.** ``livekit_sip_dur_join_sec`` carries no sample of
+its own; only its ``_bucket``, ``_sum`` and ``_count`` do. An entry written
+against the base stores NULL for the life of the deployment, while
+``series_found`` still reads high because the sibling entries matched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voicegateway.middleware.node_samples_worker_middleware import (
+    SERIES,
+    _Series,
+    validate_series_map,
+)
+from voicegateway.middleware.prometheus_exposition import (
+    HistogramMisuse,
+    histogram_bases,
+    parse_exposition,
+    sum_series,
+)
+
+FIXTURE = (
+    Path(__file__).resolve().parent.parent / "fixtures" / ("livekit_sip_exposition.txt")
+)
+
+
+@pytest.fixture(scope="module")
+def live():
+    """A real capture, not a contrivance. 327 samples across 121 families."""
+    return parse_exposition(FIXTURE.read_text())
+
+
+def test_the_fixture_is_a_real_capture(live) -> None:
+    """Guards the premise. A trimmed fixture would weaken every test below."""
+    assert len(live) > 300
+    names = {s.name for s in live}
+    assert len(names) > 100
+    # The families the engagement actually turns on.
+    for name in (
+        "livekit_sip_dur_join_sec_bucket",
+        "livekit_sip_dur_join_sec_count",
+        "livekit_sip_packets_rtp",
+        "livekit_sip_available",
+    ):
+        assert name in names, name
+
+
+# --------------------------------------------------------------------------
+# Buckets
+# --------------------------------------------------------------------------
+
+
+def test_summing_buckets_is_refused(live) -> None:
+    with pytest.raises(HistogramMisuse) as excinfo:
+        sum_series(live, "livekit_sip_dur_join_sec_bucket")
+    assert "cumulative" in str(excinfo.value)
+    assert "le" in str(excinfo.value)
+
+
+def test_the_refused_sum_would_have_been_eleven_times_the_truth(live) -> None:
+    """Pins the wrong answer, so this test cannot pass by coincidence.
+
+    Reconstructed the way the old code did it, by summing the raw samples,
+    which is exactly what sum_series now refuses to do.
+    """
+    naive = sum(s.value for s in live if s.name == "livekit_sip_dur_join_sec_bucket")
+    true_count = sum_series(live, "livekit_sip_dur_join_sec_count")
+    assert naive == 11.0
+    assert true_count == 1.0
+    assert naive == 11 * true_count
+
+
+@pytest.mark.parametrize("le", ["0.1", "1", "5", "+Inf"])
+def test_an_explicit_le_selects_one_bucket(live, le: str) -> None:
+    value = sum_series(live, "livekit_sip_dur_join_sec_bucket", where={"le": le})
+    assert value is not None
+    # Every bucket is at most the total count, which a summed value is not.
+    assert value <= sum_series(live, "livekit_sip_dur_join_sec_count")
+
+
+def test_the_inf_bucket_equals_the_count(live) -> None:
+    """The one identity that proves the le selector is reading real buckets."""
+    assert sum_series(
+        live, "livekit_sip_dur_join_sec_bucket", where={"le": "+Inf"}
+    ) == sum_series(live, "livekit_sip_dur_join_sec_count")
+
+
+# --------------------------------------------------------------------------
+# Summing across LABELS is a different operation and must still work
+# --------------------------------------------------------------------------
+
+
+def test_label_summing_is_untouched(live) -> None:
+    """node_cpu_seconds_total and packets_rtp both depend on it.
+
+    Buckets and labels shared one code path, and the fix must not have taken
+    the legitimate one with it.
+    """
+    recv = sum_series(live, "livekit_sip_packets_rtp", where={"op": "recv"})
+    send = sum_series(live, "livekit_sip_packets_rtp", where={"op": "send"})
+    total = sum_series(live, "livekit_sip_packets_rtp")
+    assert (recv, send) == (330.0, 337.0)
+    assert total == recv + send == 667.0
+
+
+def test_an_absent_series_is_still_none_not_zero(live) -> None:
+    assert sum_series(live, "livekit_metric_that_does_not_exist") is None
+
+
+# --------------------------------------------------------------------------
+# Base histogram names
+# --------------------------------------------------------------------------
+
+
+def test_the_base_name_matches_nothing(live) -> None:
+    """The silent failure. It reads as an absent series, not as a mistake."""
+    assert sum_series(live, "livekit_sip_dur_join_sec") is None
+    assert sum_series(live, "livekit_sip_dur_check_sec") is None
+
+
+def test_histogram_bases_are_detectable(live) -> None:
+    bases = histogram_bases(live)
+    assert "livekit_sip_dur_join_sec" in bases
+    assert "livekit_sip_dur_check_sec" in bases
+    # A plain counter is not a base and must not be flagged.
+    assert "livekit_sip_packets_rtp" not in bases
+
+
+def test_no_series_entry_names_a_histogram_base(live) -> None:
+    """The check that cannot be made statically, run against real data.
+
+    An entry naming a base stores NULL forever while series_found reads high,
+    so nothing at runtime would ever surface it.
+    """
+    bases = histogram_bases(live)
+    offenders = [
+        f"{source}: {entry.metric} -> {entry.column}"
+        for source, entries in SERIES.items()
+        for entry in entries
+        if entry.metric in bases
+    ]
+    assert not offenders, f"SERIES entries naming a histogram base: {offenders}"
+
+
+# --------------------------------------------------------------------------
+# The map is validated at import
+# --------------------------------------------------------------------------
+
+
+def test_the_shipped_map_validates() -> None:
+    validate_series_map(SERIES)
+
+
+def test_a_bucket_entry_without_an_le_is_refused() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        validate_series_map({"src": (_Series("livekit_sip_dur_join_sec_bucket", "c"),)})
+    assert "le selector" in str(excinfo.value)
+    assert "livekit_sip_dur_join_sec_bucket" in str(excinfo.value)
+
+
+def test_a_bucket_entry_with_an_le_is_accepted() -> None:
+    """Non-vacuous: the guard blocks the mistake, not every bucket entry."""
+    validate_series_map(
+        {"src": (_Series("livekit_sip_dur_join_sec_bucket", "c", where={"le": "1"}),)}
+    )
+
+
+def test_the_map_is_validated_at_import_not_on_demand() -> None:
+    """A bad map must be a startup failure, not a column that stores garbage."""
+    import inspect
+
+    from voicegateway.middleware import node_samples_worker_middleware as module
+
+    source = inspect.getsource(module)
+    assert "\nvalidate_series_map(SERIES)\n" in source

--- a/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
+++ b/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
@@ -143,8 +143,11 @@ async def test_livekit_server_exposition_lands_in_columns(storage) -> None:
     # total, not a per-label split.
     assert row.packets_total == 10_000
     assert row.packet_bytes_total == 4_000_000_000  # > 2 GiB, the INT4 trap
-    assert row.nacks_total == 12
-    assert row.series_found == 5
+    # 4, not 5: livekit_nack_total is still in the fixture above but is no
+    # longer mapped, because it does not exist on livekit-server 1.10.1.
+    # An unmapped metric is ignored and uncounted, which is what this now
+    # also demonstrates.
+    assert row.series_found == 4
     # Nothing from another exporter leaked in.
     assert row.filefd_allocated is None
     assert row.sip_calls_active is None

--- a/src/voicegateway/tests/middleware/test_scrape_credentials.py
+++ b/src/voicegateway/tests/middleware/test_scrape_credentials.py
@@ -1,0 +1,297 @@
+"""A metrics credential must not end up in the log.
+
+A metrics endpoint behind basic auth is configured the obvious way, as
+``http://user:secret@host/metrics``, and httpx authenticates from that without
+being asked. It also logs the request line at INFO:
+
+    HTTP Request: GET http://user:secret@host/metrics "HTTP/1.1 200 OK"
+
+At a 15-second poll that is four copies of the password per minute, per target,
+for as long as the process runs, in a log people paste into issues.
+
+The fix is not to silence that logger. Silencing it would hide the one line an
+operator uses to see whether a scrape happened at all, and it would leave the
+credential in every other place a URL travels: a warning, an exception, a
+dataclass repr. Instead the credential is split out of the URL and carried as an
+httpx auth tuple, so the request still authenticates and the URL that gets
+logged is the URL without it.
+
+Every credential below is invented for this file.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+
+import httpx
+import pytest
+
+from voicegateway.middleware.node_samples_worker_middleware import (
+    SOURCE_LIVEKIT_SERVER,
+    SOURCE_NODE_EXPORTER,
+    TARGETS_ENV_VAR,
+    NodeSamplesWorker,
+    ScrapeTarget,
+    redact_url,
+    split_userinfo,
+    targets_from_env,
+)
+from voicegateway.services.storage_service import StorageService
+
+USER = "metrics-reader"
+SECRET = "not-a-real-password-9271"
+AUTHED_URL = f"http://{USER}:{SECRET}@10.0.0.4:6789/metrics"
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    service = StorageService(db_path=str(tmp_path / "creds.db"))
+    try:
+        yield service
+    finally:
+        await service.aclose()
+
+
+def _env(value: str) -> dict[str, str]:
+    return {TARGETS_ENV_VAR: value}
+
+
+# --------------------------------------------------------------------------
+# The split itself
+# --------------------------------------------------------------------------
+
+
+def test_the_credential_leaves_the_url(tmp_path) -> None:
+    url, auth = split_userinfo(AUTHED_URL)
+    assert url == "http://10.0.0.4:6789/metrics"
+    assert auth == (USER, SECRET)
+    assert SECRET not in url
+
+
+def test_a_url_without_a_credential_is_untouched() -> None:
+    """Non-vacuous: the common case must not acquire an empty auth tuple."""
+    url, auth = split_userinfo("http://10.0.0.4:9100/metrics")
+    assert url == "http://10.0.0.4:9100/metrics"
+    assert auth is None
+
+
+def test_the_credential_is_percent_decoded() -> None:
+    """A password containing @ or / is only expressible encoded in a URL.
+
+    Handing httpx the still-encoded form would send the wrong password and the
+    scrape would 401 with nothing saying why.
+    """
+    url, auth = split_userinfo("http://u:p%40ss%2Fword@host:6789/metrics")
+    assert auth == ("u", "p@ss/word")
+    assert url == "http://host:6789/metrics"
+
+
+def test_an_ipv6_host_survives_the_split() -> None:
+    """rpartition on "@", not a hostname parse: brackets and case are kept."""
+    url, auth = split_userinfo("http://u:pw@[2001:db8::1]:6789/metrics")
+    assert url == "http://[2001:db8::1]:6789/metrics"
+    assert auth == ("u", "pw")
+
+
+def test_targets_from_env_carries_the_credential_off_the_url() -> None:
+    [target] = targets_from_env(_env(f"livekit-server:sfu-1={AUTHED_URL}"))
+    assert target.url == "http://10.0.0.4:6789/metrics"
+    assert target.auth == (USER, SECRET)
+    assert SECRET not in target.url
+
+
+def test_a_target_does_not_print_its_own_credential() -> None:
+    """A dataclass repr is the other way a secret escapes.
+
+    Any exception, log line or debugger that renders a target would print it.
+    """
+    [target] = targets_from_env(_env(f"livekit-server:sfu-1={AUTHED_URL}"))
+    assert SECRET not in repr(target)
+    assert SECRET not in str(target)
+    assert "sfu-1" in repr(target)  # and the useful half is still there
+
+
+# --------------------------------------------------------------------------
+# The request still authenticates
+# --------------------------------------------------------------------------
+
+
+async def test_the_scrape_still_sends_the_credential(storage) -> None:
+    """Splitting it out must not quietly stop authenticating.
+
+    A silently unauthenticated scrape would 401 and record an http_error row
+    forever, which looks like a broken exporter rather than a broken fix.
+    """
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, text="livekit_room_total 3\n")
+
+    [target] = targets_from_env(_env(f"livekit-server:sfu-1={AUTHED_URL}"))
+
+    async def provider():
+        return [target]
+
+    worker = NodeSamplesWorker(
+        storage, target_provider=provider, transport=httpx.MockTransport(handler)
+    )
+    await worker.tick_now()
+
+    [request] = seen
+    header = request.headers["authorization"]
+    assert header.startswith("Basic ")
+    decoded = base64.b64decode(header.removeprefix("Basic ")).decode()
+    assert decoded == f"{USER}:{SECRET}"
+    # And it went as a header, not in the line httpx logs.
+    assert SECRET not in str(request.url)
+
+
+# --------------------------------------------------------------------------
+# The log, which is the whole point
+# --------------------------------------------------------------------------
+
+
+async def test_the_credential_never_reaches_the_log(storage, caplog) -> None:
+    """The defect, pinned end to end across every logger in the process."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="livekit_room_total 3\n")
+
+    [target] = targets_from_env(_env(f"livekit-server:sfu-1={AUTHED_URL}"))
+
+    async def provider():
+        return [target]
+
+    worker = NodeSamplesWorker(
+        storage, target_provider=provider, transport=httpx.MockTransport(handler)
+    )
+    with caplog.at_level(logging.DEBUG):
+        await worker.tick_now()
+
+    assert caplog.records, "nothing was logged, so this proves nothing"
+    for record in caplog.records:
+        assert SECRET not in record.getMessage(), record.name
+        assert USER not in record.getMessage(), record.name
+
+
+async def test_the_httpx_line_is_still_emitted(storage, caplog) -> None:
+    """Non-vacuous, and the reason this is not fixed by silencing httpx.
+
+    That line is how an operator sees a scrape happened at all. The fix has to
+    keep it and change what it says, not delete it.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="livekit_room_total 3\n")
+
+    [target] = targets_from_env(_env(f"livekit-server:sfu-1={AUTHED_URL}"))
+
+    async def provider():
+        return [target]
+
+    worker = NodeSamplesWorker(
+        storage, target_provider=provider, transport=httpx.MockTransport(handler)
+    )
+    with caplog.at_level(logging.INFO, logger="httpx"):
+        await worker.tick_now()
+
+    httpx_lines = [r.getMessage() for r in caplog.records if r.name == "httpx"]
+    assert httpx_lines, "the httpx request line was suppressed rather than cleaned"
+    assert any("10.0.0.4:6789/metrics" in line for line in httpx_lines)
+    assert not any(SECRET in line for line in httpx_lines)
+
+
+def test_the_httpx_logger_is_not_muzzled() -> None:
+    """Stated directly: no level, filter or disable was applied to it."""
+    httpx_logger = logging.getLogger("httpx")
+    assert httpx_logger.level in (logging.NOTSET, logging.INFO)
+    assert not httpx_logger.disabled
+    assert not httpx_logger.filters
+
+
+# --------------------------------------------------------------------------
+# A malformed entry is skipped, and the warning about it is clean too
+# --------------------------------------------------------------------------
+
+
+def test_a_malformed_entry_is_skipped_not_raised(caplog) -> None:
+    """A typo must not take down a process that is also serving the dashboard."""
+    with caplog.at_level(logging.WARNING):
+        targets = targets_from_env(_env(f"garbage-without-an-equals-{AUTHED_URL}"))
+    assert targets == []
+    assert caplog.records
+
+
+def test_the_warning_for_a_malformed_entry_hides_the_credential(caplog) -> None:
+    """The trap. A skipped entry is where a credential is MOST likely present.
+
+    It was never parsed, so nothing had a chance to take it out, and the
+    warning echoes the entry back verbatim.
+    """
+    with caplog.at_level(logging.WARNING):
+        targets_from_env(_env(f"livekit-server-sfu-1{AUTHED_URL}"))
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    assert SECRET not in logged
+    assert "***@" in logged
+
+
+def test_the_warning_for_an_unknown_source_hides_it_too(caplog) -> None:
+    """The other skip path, which parses far enough to look safe and is not."""
+    with caplog.at_level(logging.WARNING):
+        targets = targets_from_env(_env(f"livekit-sfu:sfu-1={AUTHED_URL}"))
+    assert targets == []
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    assert SECRET not in logged
+    assert "livekit-sfu" in logged  # the operator still learns what was wrong
+
+
+def test_a_good_entry_beside_a_bad_one_still_loads(caplog) -> None:
+    """Skipping is per entry: one typo must not empty the whole fleet."""
+    with caplog.at_level(logging.WARNING):
+        targets = targets_from_env(
+            _env(
+                f"nonsense,node-exporter:sfu-1=http://10.0.0.4:9100/metrics,"
+                f"livekit-server:sfu-1={AUTHED_URL}"
+            )
+        )
+    assert [t.source for t in targets] == [SOURCE_NODE_EXPORTER, SOURCE_LIVEKIT_SERVER]
+    assert SECRET not in " ".join(r.getMessage() for r in caplog.records)
+
+
+# --------------------------------------------------------------------------
+# Defence in depth: a target built by hand is redacted at the log site
+# --------------------------------------------------------------------------
+
+
+def test_redaction_covers_a_url_that_never_went_through_the_parser() -> None:
+    """targets_from_env is not the only way a target is constructed."""
+    assert redact_url(AUTHED_URL) == "http://***@10.0.0.4:6789/metrics"
+    assert redact_url("http://10.0.0.4:9100/metrics") == "http://10.0.0.4:9100/metrics"
+    assert SECRET not in redact_url(f"ignoring {AUTHED_URL}; expected a url")
+
+
+async def test_an_oversized_body_warning_is_redacted(storage, caplog) -> None:
+    """One of the two sites that logs a URL, exercised rather than read."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="livekit_room_total 1\n" * 5_000)
+
+    target = ScrapeTarget(node="sfu-1", url=AUTHED_URL, source=SOURCE_LIVEKIT_SERVER)
+
+    async def provider():
+        return [target]
+
+    worker = NodeSamplesWorker(
+        storage,
+        target_provider=provider,
+        max_response_bytes=512,
+        transport=httpx.MockTransport(handler),
+    )
+    with caplog.at_level(logging.WARNING):
+        await worker.tick_now()
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("exceeded" in w for w in warnings)
+    assert not any(SECRET in w for w in warnings)

--- a/src/voicegateway/tests/middleware/test_series_accounting.py
+++ b/src/voicegateway/tests/middleware/test_series_accounting.py
@@ -1,0 +1,289 @@
+"""``series_found`` counting what stored, and the unbounded-ceiling marker.
+
+Two accounting defects, both of which report a row as carrying more than it
+does.
+
+**series_found was counted at match time.** The worker incremented it when a
+series matched the exposition, and the repository refused some of those values
+later at coercion: a non-finite reading, or one that does not survive a 64-bit
+column. The count never heard about the refusal, so the row claimed a
+measurement it did not hold. It is exactly the unreadable columns that go
+missing, which makes the overstatement invisible in the one case it matters:
+an operator reading "9 of 9 series matched" next to an empty chart.
+
+**The host descriptor ceiling had two indistinguishable empty states.** VERIFIED
+LIVE: ``node_filefd_maximum`` reads 9.223372036854776e+18, whose ``int()`` is
+9223372036854775808, exactly ONE past the 64-bit ceiling. The value is dropped
+and the column is NULL, correctly. But "this limit cannot be reached" and
+"nobody measured this limit" were then the same NULL, and they support opposite
+conclusions about a fleet's headroom.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from voicegateway.middleware.node_samples_worker_middleware import (
+    SOURCE_LIVEKIT_SERVER,
+    SOURCE_NODE_EXPORTER,
+    NodeSamplesWorker,
+    ScrapeTarget,
+)
+from voicegateway.repository import node_samples_repository as repo
+from voicegateway.services.storage_service import StorageService
+
+# fs.file-max as a kernel with no limit reports it, verbatim off a live box.
+UNBOUNDED_HOST = """\
+node_filefd_allocated 1216
+node_filefd_maximum 9.223372036854776e+18
+node_load1 1.75
+"""
+
+# The same host with a real ceiling, which is the non-vacuous counterpart.
+BOUNDED_HOST = """\
+node_filefd_allocated 1216
+node_filefd_maximum 65536
+node_load1 1.75
+"""
+
+# Nothing said about descriptors at all.
+SILENT_HOST = "node_load1 1.75\n"
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    service = StorageService(db_path=str(tmp_path / "accounting.db"))
+    try:
+        yield service
+    finally:
+        await service.aclose()
+
+
+async def _scrape(
+    storage,
+    body: str,
+    *,
+    source: str = SOURCE_NODE_EXPORTER,
+    node: str = "sfu-1",
+):
+    """One tick against one canned body, returning the row it wrote.
+
+    ``node`` is a parameter because this table APPENDS: two ticks for one
+    node are two rows, and a caller scraping several bodies against one name
+    would read the first row back three times and see whatever it wants.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=body)
+
+    target = ScrapeTarget(node=node, url=f"http://{node}:9100/metrics", source=source)
+
+    async def provider():
+        return [target]
+
+    worker = NodeSamplesWorker(
+        storage, target_provider=provider, transport=httpx.MockTransport(handler)
+    )
+    await worker.tick_now()
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        rows = await repo.list_samples(db, node=node, source=source)
+    assert len(rows) == 1, f"{node} was scraped more than once"
+    return rows[0]
+
+
+# --------------------------------------------------------------------------
+# series_found counts what landed
+# --------------------------------------------------------------------------
+
+
+async def test_a_value_refused_at_coercion_is_counted_out(storage) -> None:
+    """The defect. Three series matched; one did not survive storage."""
+    row = await _scrape(storage, UNBOUNDED_HOST)
+    assert row.filefd_allocated == 1216
+    assert row.load1 == pytest.approx(1.75)
+    # Dropped rather than stored one past the 64-bit ceiling.
+    assert row.filefd_maximum is None
+    # 2, not the 3 that matched.
+    assert row.series_found == 2
+
+
+async def test_the_count_matches_the_columns_that_are_readable(storage) -> None:
+    """Stated as the invariant rather than as a number, so it cannot drift.
+
+    Whatever the fixture carries, the count and the populated value columns
+    must agree, because the count exists to tell an operator whether an empty
+    chart means a rename or a real zero.
+    """
+    row = await _scrape(storage, UNBOUNDED_HOST)
+    populated = sum(
+        1
+        for column in repo.VALUE_COLUMNS - repo.DERIVED_COLUMNS
+        if getattr(row, column) is not None
+    )
+    assert row.series_found == populated
+
+
+async def test_a_clean_scrape_is_unaffected(storage) -> None:
+    """Non-vacuous: the recount is not just subtracting from everything."""
+    row = await _scrape(storage, BOUNDED_HOST)
+    assert row.filefd_maximum == 65536
+    assert row.series_found == 3
+
+
+async def test_a_failed_scrape_keeps_a_null_count(storage) -> None:
+    """NULL is not zero. No exposition was read, so nothing is known."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    target = ScrapeTarget(
+        node="sfu-1", url="http://sfu-1:6789/metrics", source=SOURCE_LIVEKIT_SERVER
+    )
+
+    async def provider():
+        return [target]
+
+    worker = NodeSamplesWorker(
+        storage, target_provider=provider, transport=httpx.MockTransport(handler)
+    )
+    await worker.tick_now()
+    async with storage._conn.session() as db:
+        row = (await repo.list_samples(db, node="sfu-1", source=SOURCE_LIVEKIT_SERVER))[
+            0
+        ]
+    assert row.series_found is None
+    assert row.series_found != 0
+
+
+async def test_a_non_finite_value_is_counted_out_too(storage) -> None:
+    """The other refusal path. NaN is not a measurement of anything."""
+    row = await _scrape(storage, "node_load1 NaN\nnode_filefd_allocated 12\n")
+    assert row.load1 is None
+    assert row.filefd_allocated == 12
+    assert row.series_found == 1
+
+
+def test_a_derived_marker_is_not_counted_as_a_series() -> None:
+    """It is computed here, so counting it would claim the target exposed it."""
+    assert "filefd_maximum_unbounded" in repo.DERIVED_COLUMNS
+    assert repo.DERIVED_COLUMNS <= repo.VALUE_COLUMNS
+
+
+async def test_the_recount_holds_for_a_caller_that_is_not_the_worker(
+    storage,
+) -> None:
+    """insert_samples is the layer that knows, so the fix belongs there.
+
+    A caller writing its own count cannot know what coercion will refuse.
+    """
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        await repo.insert_samples(
+            db,
+            [
+                repo.NodeSampleInput(
+                    node="sfu-2",
+                    source=SOURCE_NODE_EXPORTER,
+                    at_ms=1_785_520_800_000,
+                    outcome="ok",
+                    series_found=2,  # the caller's optimistic count
+                    values={"filefd_allocated": 10.0, "load1": float("inf")},
+                )
+            ],
+        )
+        row = (await repo.list_samples(db, node="sfu-2", source=SOURCE_NODE_EXPORTER))[
+            0
+        ]
+    assert row.load1 is None
+    assert row.series_found == 1
+
+
+# --------------------------------------------------------------------------
+# The unbounded marker: three states, never collapsed
+# --------------------------------------------------------------------------
+
+
+async def test_an_unbounded_ceiling_is_recorded_as_such(storage) -> None:
+    row = await _scrape(storage, UNBOUNDED_HOST)
+    assert row.filefd_maximum is None  # still unstorable, still NULL
+    assert row.filefd_maximum_unbounded == 1
+
+
+async def test_a_real_ceiling_is_recorded_as_bounded(storage) -> None:
+    row = await _scrape(storage, BOUNDED_HOST)
+    assert row.filefd_maximum == 65536
+    assert row.filefd_maximum_unbounded == 0
+
+
+async def test_an_unscraped_ceiling_stays_null(storage) -> None:
+    """The trap. Unmeasured must never render as 0, which reads as bounded."""
+    row = await _scrape(storage, SILENT_HOST)
+    assert row.filefd_maximum is None
+    assert row.filefd_maximum_unbounded is None
+    assert row.filefd_maximum_unbounded != 0
+
+
+async def test_the_three_states_are_all_distinguishable(storage) -> None:
+    """Said once, directly: this is the property, not the three cases above."""
+    seen = {
+        (await _scrape(storage, body, node=name)).filefd_maximum_unbounded
+        for name, body in (
+            ("host-unbounded", UNBOUNDED_HOST),
+            ("host-bounded", BOUNDED_HOST),
+            ("host-silent", SILENT_HOST),
+        )
+    }
+    assert seen == {1, 0, None}
+
+
+async def test_the_threshold_is_below_the_ceiling_it_guards(storage) -> None:
+    """A float64 round trip near 2**63 is lossy in both directions.
+
+    Pinned against the live reading rather than against 2**63 itself, because
+    equality with the ceiling is exactly what the round trip destroys.
+    """
+    from voicegateway.middleware.node_samples_worker_middleware import (
+        FILEFD_UNBOUNDED_THRESHOLD,
+    )
+
+    assert 9.223372036854776e18 >= FILEFD_UNBOUNDED_THRESHOLD
+    assert FILEFD_UNBOUNDED_THRESHOLD < float(2**63)
+    # And a limit an operator might really set is nowhere near it.
+    assert 1_048_576.0 < FILEFD_UNBOUNDED_THRESHOLD
+
+
+# --------------------------------------------------------------------------
+# The deleted counter stays deleted
+# --------------------------------------------------------------------------
+
+
+def test_the_nack_counter_is_gone_from_every_registration() -> None:
+    """VERIFIED LIVE: zero occurrences of "nack" in a real 1.10.1 exposition.
+
+    A column nothing can populate is worse than no column: it is reachable by a
+    chart that reads NULL for the life of the deployment.
+    """
+    from voicegateway.middleware.node_samples_worker_middleware import SERIES
+    from voicegateway.models.node_sample_model import NodeSample
+
+    assert not [
+        e.metric for entries in SERIES.values() for e in entries if "nack" in e.metric
+    ]
+    assert "nacks_total" not in repo.VALUE_COLUMNS
+    assert "nacks_total" not in NodeSample.model_fields
+
+
+def test_no_module_docstring_still_advertises_it() -> None:
+    """A docstring naming a series that does not exist is a false claim.
+
+    Both of these described ``livekit_nack_total`` as a node counter this
+    schema carries, which would send a reader looking for a column that was
+    removed because the metric never existed.
+    """
+    from voicegateway.models import node_sample_model
+    from voicegateway.repository import node_correlation_repository
+
+    for module in (node_sample_model, node_correlation_repository):
+        assert "nack" not in (module.__doc__ or ""), module.__name__

--- a/src/voicegateway/tests/repository/test_node_samples_repository.py
+++ b/src/voicegateway/tests/repository/test_node_samples_repository.py
@@ -176,7 +176,6 @@ async def test_absent_series_stay_null_never_zero(db: AsyncSession) -> None:
     assert row.rooms == 4
     assert row.packets_total is None
     assert row.packet_bytes_total is None
-    assert row.nacks_total is None
 
 
 async def test_a_failed_scrape_is_a_row_with_no_values(db: AsyncSession) -> None:


### PR DESCRIPTION
Every metric name here was read off a running livekit-server 1.10.1, livekit-sip and node_exporter, with a real inbound SIP call placed so the counters were populated. Nothing is inferred from documentation, which matters because the names that were inferred from documentation turned out to be wrong.

## What a live target changed

**A histogram cannot be summed across its buckets.** Buckets are cumulative, so adding them counts one observation once per bucket. On the captured exposition the join histogram sums to 11.0 against a true count of 1. At 500 concurrent that is a smooth, plausible curve. `sum_series` now refuses a `_bucket` name without an `le` selector, and answer latency is stored as `_sum`/`_count` with two explicit bucket counts alongside.

**A histogram base name matches nothing.** `livekit_sip_dur_join_sec` carries no sample of its own. An entry written against it stores NULL for the life of a deployment while `series_found` still reads high, because the sibling entries matched. The metric map is validated at import, and a test checks it against the real capture, which is the only place that failure can be caught.

**`livekit_nack_total` does not exist.** Zero occurrences of "nack" anywhere in the exposition, under any name. The column is dropped rather than left reachable by a chart that would read NULL forever. No substitute is put in its place: the obvious candidate is declared a gauge while behaving cumulatively.

**Ten livekit-sip entries were scraped from livekit-server**, which exports none of them, after a splice anchored on a string that matched a constant declaration as well as the tuple. The result reads exactly like a metric that does not exist. Caught by counting entries per source, and the map is now rebuilt wholesale rather than patched.

## Five defects, four of them found by running against a real box

- **The file-descriptor headroom gate could not pass.** The judge hardcoded the reading as unmeasured, so `resource_headroom/file_descriptors` returned UNKNOWN whatever node_exporter reported. The pair is now measured during correlation, paired within one row and worst-over-window. On the live box that turns into a PASS at 99.998% headroom from 11 of 524287.
- **`series_found` overstated.** It was counted when a series matched, and the repository refused some of those values later at coercion. Every node-exporter scrape on the live box claimed 9 and held 8. It is exactly the unreadable columns that go missing, so the overstatement was invisible in the one case it matters.
- **An unbounded ceiling and an unmeasured one were the same NULL.** `node_filefd_maximum` reads 9.223372036854776e+18, whose `int()` is one past the 64-bit ceiling, so the column is correctly NULL. `filefd_maximum_unbounded` now carries three states: 1 unbounded, 0 bounded, NULL unmeasured.
- **The metrics credential was written to the log.** An endpoint behind basic auth is configured as `http://user:secret@host/metrics`, and the HTTP client logs its request line at INFO: four copies of the password per minute, per target, forever. It is now split off and sent as a header. The logger is not silenced, and a test asserts the line is still emitted.
- **Headroom gates for one node collided.** The subject dropped the source, so a node scraped by three exporters produced three gates labelled identically, reading PASS, UNKNOWN and UNKNOWN, with nothing saying which passed. Found by the live run; every fixture used a single source, where it cannot appear.

## Verification

`src/voicegateway/tests/integration/test_live_node_scrape.py` runs the real code path against real exporters and asserts what landed, column by column. Read only, into a SQLite file pytest creates and deletes. It skips unless the exporters answer on localhost and is marked `integration`, so the unit matrix deselects it.

Against the live box: node-exporter stored 8 of 9 matched series with `series_found` reading 8 and the unbounded marker at 1; all 22 livekit-sip entries resolved; the descriptor pair made the headroom gate return a verdict; a 401 recorded a NULL count and not a zero; an authenticated target pointed at a server that really challenges for the credential leaked nothing to any logger.

## Schema

One alembic revision, `d1f4b8c93a27`, adding 23 columns and dropping one. One revision on purpose: two landing in the same branch is how the chain forks, and a forked chain fails only at `alembic upgrade head` on a real deployment. Single head confirmed.

Every value column is nullable and NULL means not measured, never zero.

## Tests

2827 passing, up from a 2771 baseline, plus 15 integration tests run green against the live box. No existing test was edited or weakened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for authenticated scrape targets with credential redaction in logs.
  - Expanded node monitoring with SIP, process, runtime, socket, media, and file-descriptor metrics.
  - Added file-descriptor headroom readings and diagnostic reporting.
  - Improved diagnostics for metrics from multiple exporter sources.
- **Bug Fixes**
  - Corrected stored-series accounting when values are invalid or rejected.
  - Prevented unsafe cumulative histogram aggregation.
  - Removed obsolete NACK metric handling.
- **Documentation**
  - Documented HTTP Basic Authentication for scrape targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->