### PR TITLE
The livekit-server process block is measured, and nothing in SERIES is inferred

### DIFF
--- a/alembic/versions/d1f4b8c93a27_node_samples_live_verified.py
+++ b/alembic/versions/d1f4b8c93a27_node_samples_live_verified.py
@@ -31,7 +31,10 @@ unbounded, 0 bounded, NULL unmeasured) rather than a boolean, so it travels the
 same coercion path as every other column instead of needing a parallel one.
 
 ``nacks_total`` is DROPPED. ``livekit_nack_total`` does not exist on 1.10.1:
-there are zero occurrences of "nack" anywhere in the exposition under any name.
+zero occurrences of "nack" under any name in the full 77 KB livekit-server
+exposition, read by authenticated scrape. livekit-server is where that series
+would have lived, so this is the capture that settles it rather than an absence
+noticed somewhere it was never expected.
 A column nothing can ever populate is worse than no column, because it is
 reachable by a chart that will read NULL forever. No substitute is put in its
 place: the obvious candidate is declared a gauge while behaving cumulatively.

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -26,8 +26,8 @@ cannot be the guarantee.
 carry stays NULL and is counted out of ``series_found``. Nothing is stored as 0
 unless a target reported 0.
 
-WHICH NAMES ARE MEASURED, AND WHICH ARE STILL INFERRED
-------------------------------------------------------
+WHERE THESE NAMES CAME FROM: ALL OF THEM MEASURED
+-------------------------------------------------
 These names were originally taken from
 ``docs/superpowers/specs/2026-07-29-end-to-end-profiling-scope.md`` (§2 "What is
 actually observable"), which was written against the SDKs installed here rather
@@ -36,40 +36,41 @@ livekit-server or livekit-sip BINARY an operator runs, and inferring a metric
 name is how a column ends up storing NULL for the life of a deployment while
 nothing at runtime says so. Three names taken that way were wrong.
 
-So the map is now split by provenance, and the distinction is kept because it is
-the difference between a column that works and one that only looks like it does.
+Every wired entry has since been read off a running binary. **Nothing in
+:data:`SERIES` is inferred.** The provenance note is kept, and a count check in
+``tests/middleware/test_histogram_misuse.py`` enforces it, because the way this
+map degrades is one plausible entry added from documentation.
 
 MEASURED against livekit-sip 1.10.1 and node_exporter, with a real inbound call
 placed so every counter was populated: all 22 ``livekit-sip`` entries and all 9
-``node-exporter`` entries. Every one resolves, asserted per entry in
-``tests/middleware/test_histogram_misuse.py`` against a captured exposition and
-again in ``tests/integration/test_live_node_scrape.py`` against the running
-exporters.
+``node-exporter`` entries. Every one resolves, asserted per entry against a
+captured exposition and again in
+``tests/integration/test_live_node_scrape.py`` against the running exporters.
 
-MEASURED against livekit-server 1.10.1: ``livekit_room_total``,
-``livekit_participant_total``, ``livekit_packet_total``, ``livekit_packet_bytes``,
-``go_memstats_heap_inuse_bytes`` and ``go_goroutines``.
-
-**STILL INFERRED**, and the one remaining gap: the five ``process_*`` entries in
-the ``livekit-server`` tuple. They are the standard prometheus/client_golang
-process collector and they resolve against livekit-sip, which registers the same
-library, so they are very likely right. Very likely is not measured. Closing this
-needs one authenticated scrape of a livekit-server metrics port, which is
-commonly behind basic auth; until then those five columns may store NULL on a
-real deployment and ``series_found`` will say so rather than hide it.
+MEASURED against livekit-server 1.10.1, by authenticated scrape of its metrics
+port: all 11 ``livekit-server`` entries. The four ``livekit_*`` families and the
+two Go runtime series came first; the five ``process_*`` entries were the last to
+be confirmed, because that port is commonly behind basic auth and an
+unauthenticated request gets a 401 rather than an exposition. Observed:
+``process_open_fds`` 20, ``process_max_fds`` 524287,
+``process_start_time_seconds`` 1.78553687934e+09, ``process_cpu_seconds_total``
+111.39, ``process_resident_memory_bytes`` 7.3125888e+07. That rlimit is the same
+524287 livekit-sip reports on the same host, which is the cross-check that these
+are the per-process ceiling rather than anything host-wide.
 
 DELIBERATELY UNWIRED, so their columns store NULL rather than a wrong name:
 ``livekit_session_start_time_ms_*``, ``livekit_track_published_total``,
-``livekit_track_subscribed_total`` and ``psrpc_stream_count``. An unwired column
-is honest; a guessed one is invisible.
+``livekit_track_subscribed_total`` and ``psrpc_stream_count``. These are the
+names that could not be found on a live server under any spelling. An unwired
+column is honest; a guessed one is invisible.
 
 node_exporter names come from its filefd / loadavg / cpu / meminfo / sockstat /
 netstat collectors and have been stable since node_exporter 0.18 (current 1.9).
 
-That residual uncertainty is exactly why an unmatched series stores NULL and why
-every row records ``series_found``: an operator on a release that renamed
-something sees the count fall on the row instead of an unexplainable empty chart,
-and fixing it is one entry in :data:`SERIES`.
+A metric name can still be renamed by a release, which is why an unmatched
+series stores NULL and why every row records ``series_found``: an operator on a
+release that renamed something sees the count fall on the row instead of an
+unexplainable empty chart, and fixing it is one entry in :data:`SERIES`.
 """
 
 from __future__ import annotations

--- a/src/voicegateway/tests/middleware/test_histogram_misuse.py
+++ b/src/voicegateway/tests/middleware/test_histogram_misuse.py
@@ -19,6 +19,7 @@ against the base stores NULL for the life of the deployment, while
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -319,27 +320,68 @@ def test_the_exporter_names_both_boundaries_itself(live) -> None:
     assert "from INVITE to mixed room audio" in help_line
 
 
-def test_the_docstring_does_not_claim_the_server_process_block_is_verified() -> None:
-    """The one gap left, stated where somebody adding an entry will read it.
+def test_the_docstring_accounts_for_every_wired_entry() -> None:
+    """Provenance is a claim about a COUNT, so the count is what is checked.
 
-    livekit-server's metrics port is commonly behind basic auth, so the five
-    process_* entries in its tuple are inferred from livekit-sip registering the
-    same prometheus/client_golang collector. That is a good reason to expect
-    them and it is not a measurement, and this map's whole doctrine is that the
-    difference is what decides whether a column works or only looks like it.
+    Replaces an earlier test that pinned the one unverified block, which was the
+    livekit-server process_* entries. Those have since been read off a live
+    server by authenticated scrape, so nothing in the map is inferred and there
+    is no gap left to pin.
+
+    The failure this now guards is the one that is actually likely: somebody
+    adds a plausible-looking entry from documentation, and the docstring goes on
+    claiming every entry was measured. Asserting the stated counts against the
+    real tuple lengths makes that a red test rather than a sentence nobody
+    reread. It is deliberately mechanical: the doc has to be edited, which is
+    where the decision about provenance gets made.
     """
     from voicegateway.middleware import node_samples_worker_middleware as module
 
     doc = module.__doc__ or ""
-    assert "STILL INFERRED" in doc
-    assert "process_*" in doc
-    # And the claim is specific about which source, since the same names ARE
-    # measured on livekit-sip.
-    server_process = [
+    for source in SERIES:
+        # \s+ rather than a literal space: the docstring is wrapped, and a
+        # claim must not stop being checkable because it fell across a line.
+        claimed = re.search(rf"all\s+(\d+)\s+``{re.escape(source)}``\s+entries", doc)
+        assert claimed, f"the docstring makes no count claim for {source}"
+        assert int(claimed.group(1)) == len(SERIES[source]), (
+            f"{source}: docstring says {claimed.group(1)}, map has "
+            f"{len(SERIES[source])}"
+        )
+
+
+def test_the_docstring_claims_no_inferred_entry() -> None:
+    """The state this map is meant to be in, said once and checked.
+
+    Kept separate from the counts because they answer different questions: the
+    counts catch an entry added without a decision, this catches the decision
+    itself being reversed without the note being updated.
+    """
+    from voicegateway.middleware import node_samples_worker_middleware as module
+
+    doc = module.__doc__ or ""
+    assert "Nothing in" in doc and "is inferred" in doc
+    # The deliberately-unwired names are a different thing and must survive:
+    # they are absent on purpose, not unverified.
+    assert "DELIBERATELY UNWIRED" in doc
+
+
+def test_the_server_process_block_is_recorded_as_measured() -> None:
+    """The five that were confirmed last, with the cross-check that dates them.
+
+    Their per-process rlimit is the same 524287 livekit-sip reports on the same
+    host, which is what distinguishes them from anything host-wide.
+    """
+    from voicegateway.middleware import node_samples_worker_middleware as module
+
+    doc = module.__doc__ or ""
+    assert "authenticated scrape" in doc
+    assert "524287" in doc
+    server_process = {
         e.metric for e in SERIES["livekit-server"] if e.metric.startswith("process_")
-    ]
+    }
     assert len(server_process) == 5
+    # The same names on livekit-sip, where they were confirmed first.
     sip_process = {
         e.metric for e in SERIES["livekit-sip"] if e.metric.startswith("process_")
     }
-    assert set(server_process) <= sip_process
+    assert server_process <= sip_process


### PR DESCRIPTION
Closes the last gap flagged in #194.

An authenticated scrape of livekit-server 1.10.1 confirms all five `process_*` entries: `process_open_fds` 20, `process_max_fds` 524287, `process_start_time_seconds` 1.78553687934e+09, `process_cpu_seconds_total` 111.39, `process_resident_memory_bytes` 7.3125888e+07.

That rlimit is the same 524287 livekit-sip reports on the same host, which is the cross-check that these are the per-process ceiling rather than anything host-wide. Every wired entry in `SERIES` has now been read off a running binary.

**The nack deletion is settled by the same capture.** Zero occurrences of "nack" under any name in the full 77 KB livekit-server exposition. That is where the series would have lived, so an absence there is evidence; the earlier absence in the livekit-sip capture was only an absence somewhere it was never expected.

## The test is replaced, not deleted

The old test pinned the one unverified block. That fact no longer exists, so keeping the test would have meant asserting something false, and deleting it would have left the note unguarded.

The failure worth guarding has changed shape: it is now "somebody adds a plausible-looking entry from documentation and the provenance note goes on claiming every entry was measured". So the docstring's stated count per source is checked against the real tuple length. Editing the map without editing the note is a red test, which is where the provenance decision gets forced.

Verified it bites by injecting an entry without touching the note: `docstring says 9, map has 10`. It also caught a real vagueness in the note on its first run, where the livekit-server line said "all 11 entries" without naming the source.

2832 passing, up from 2830. Comments and tests only, no behaviour change.