### PR TITLE
Store a terminal diagnostics run before publishing it, and order history once

### DIFF
--- a/src/voicegateway/server/api/dashboard/diagnostics.py
+++ b/src/voicegateway/server/api/dashboard/diagnostics.py
@@ -48,6 +48,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from collections.abc import Iterable
+from dataclasses import replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -182,19 +184,29 @@ async def _history(store: Any) -> list[_Run]:
     why the result can exceed the stored read limit by up to ``_HISTORY_CAP``.
     """
     stored = await _load_history(store)
+    working = [_RUNS[rid] for rid in _ORDER]
     if not stored:
-        # Nothing persisted (storage disabled, or no run has been recorded on
-        # this database yet): the working set is the whole history, in exactly
-        # the order this endpoint has always returned it.
-        return [_RUNS[rid] for rid in reversed(_ORDER)]
+        # Nothing persisted: storage disabled, or no run recorded on this
+        # database yet. Sorted by the SAME key as the branch below rather than
+        # by insertion order, because otherwise one endpoint documented as
+        # "newest first" has two different meanings, and which one a caller gets
+        # depends on whether a write has landed yet.
+        return _newest_first(working)
     merged: dict[str, _Run] = {r.run_id: r for r in stored}
-    for rid in _ORDER:
-        merged[rid] = _RUNS[rid]
-    # Same sort key as the repository's ORDER BY: ISO-8601 created_at descending,
-    # run_id as the stable tiebreak.
-    return sorted(
-        merged.values(), key=lambda r: (r.created_at, r.run_id), reverse=True
-    )
+    for run in working:
+        merged[run.run_id] = run
+    return _newest_first(merged.values())
+
+
+def _newest_first(runs: Iterable[_Run]) -> list[_Run]:
+    """Runs newest first: created_at descending, run_id as the stable tiebreak.
+
+    The same key as the repository's ORDER BY, so a history read before a
+    restart and one read after it agree. ISO-8601 sorts correctly as a string
+    because every writer formats it the same way, and run_id breaks the tie so
+    two runs created in the same microsecond do not swap between reads.
+    """
+    return sorted(runs, key=lambda r: (r.created_at, r.run_id), reverse=True)
 
 
 async def _load_history(store: Any) -> list[_Run]:
@@ -235,6 +247,19 @@ async def _execute(run: _Run, creds: Any, store: Any = None) -> None:
     # its process (restart, OOM, deploy) leaves its last observed state on disk
     # instead of vanishing, and the history shows that it started.
     await _persist(store, run)
+    # The terminal state is built in LOCALS and published in one step below,
+    # after it is durable. Assigning it to ``run`` as it is computed would
+    # publish it immediately: ``run`` is the very object /runs serves, so a
+    # reader polling for completion would see "done" while storage still said
+    # "running". Anything acting on that signal -- exporting the report, reading
+    # the row from another process, the CLI -- could then read a run that this
+    # process considers finished and the database does not.
+    #
+    # Seeded from the current status so a CANCELLATION, which is not an
+    # Exception and so reaches the finally block uncaught, still persists
+    # exactly what it persisted before this change.
+    status, error = run.status, run.error
+    results, verdict = run.results, run.verdict
     try:
         out = await asyncio.wait_for(
             service.execute_run(
@@ -242,21 +267,35 @@ async def _execute(run: _Run, creds: Any, store: Any = None) -> None:
             ),
             _OVERALL_RUN_TIMEOUT_SECONDS,
         )
-        run.results = out
-        run.verdict = out.get("verdict")
-        run.status = "done"
+        results = out
+        verdict = out.get("verdict")
+        status = "done"
     except TimeoutError:
-        run.status = "failed"
-        run.error = "run timed out"
+        status, error = "failed", "run timed out"
     except Exception as exc:  # noqa: BLE001 - a run must never crash the loop
-        run.status = "failed"
-        run.error = str(exc)
+        status, error = "failed", str(exc)
     finally:
-        run.ended_at = _now()
+        ended_at = _now()
         # The terminal write. Reached on the success, timeout and failure paths
         # alike, so a stored run cannot be left at "running" by an outcome this
         # process actually observed.
-        await _persist(store, run)
+        await _persist(
+            store,
+            replace(
+                run,
+                status=status,
+                results=results,
+                verdict=verdict,
+                error=error,
+                ended_at=ended_at,
+            ),
+        )
+        # Published only now. A reader that sees a terminal status can rely on
+        # the row existing, which is what makes "done" mean something to anyone
+        # outside this process.
+        run.results, run.verdict = results, verdict
+        run.error, run.ended_at = error, ended_at
+        run.status = status
 
 
 # ---------------------------------------------------------------------------

--- a/src/voicegateway/tests/server/test_diagnostics_persistence.py
+++ b/src/voicegateway/tests/server/test_diagnostics_persistence.py
@@ -445,3 +445,163 @@ def test_the_poll_budget_and_the_run_timeout_stay_coupled() -> None:
     )
     assert "setTimeout(resolve, 2000)" in source, "the poll interval moved"
     assert 180 * 2000 / 1000 == d._OVERALL_RUN_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# A terminal status is durable BEFORE anyone can see it
+# ---------------------------------------------------------------------------
+#
+# Both properties below were found by CI failing intermittently on py3.13 while
+# 3.11 and 3.12 passed, which is what a race looks like from the outside. They
+# are asserted directly here rather than left to timing.
+
+
+class _OrderWatchingStore:
+    """A store that records what the LIVE run object looked like at write time.
+
+    This is what makes the ordering testable at all. Polling for "done" and then
+    reading storage only catches the bug when the scheduler cooperates, which is
+    exactly the intermittency that sent this to CI instead of to a test. Here the
+    write itself reports whether the terminal status had already been published,
+    so the assertion holds on every run.
+    """
+
+    def __init__(self, run) -> None:
+        self._run = run
+        self.writes: list[tuple[str, str]] = []
+
+    async def upsert_diagnostics_run(self, **kw) -> None:
+        # (what this write carries, what a reader of the live object sees now)
+        self.writes.append((kw["status"], self._run.status))
+
+
+async def test_a_terminal_status_is_stored_before_it_is_published(
+    monkeypatch,
+) -> None:
+    """The race, pinned deterministically.
+
+    ``_execute`` used to assign run.status = "done" and only then await the
+    write. ``run`` is the object /runs serves, so between those two statements
+    the API reported a finished run whose row still said "running", and anything
+    keying off completion could act on a run the database did not agree was over.
+    """
+    from voicegateway.server.api.dashboard import diagnostics as d
+
+    monkeypatch.setattr(d, "_make_probes", lambda _store: _FakeProbes())
+    run = d._Run(
+        run_id="r1", checks=["agents"], config={}, created_at="2026-08-01T00:00:00Z"
+    )
+    store = _OrderWatchingStore(run)
+
+    await d._execute(run, _FAKE_CREDS, store)
+
+    assert run.status == "done"
+    terminal = [w for w in store.writes if w[0] in ("done", "failed")]
+    assert terminal, f"no terminal write was made; got {store.writes}"
+    written, visible_at_write_time = terminal[-1]
+    assert visible_at_write_time != written, (
+        "the terminal status was already visible to readers when it was written"
+    )
+    assert visible_at_write_time == "running"
+
+
+async def test_the_row_is_complete_when_the_status_lands(monkeypatch) -> None:
+    """A terminal row carrying no results is a run nobody can report on.
+
+    The results and the status have to reach storage in the SAME write, or a
+    reader that trusts the status finds a row it cannot build a report from.
+    """
+    from voicegateway.server.api.dashboard import diagnostics as d
+
+    monkeypatch.setattr(d, "_make_probes", lambda _store: _FakeProbes())
+    run = d._Run(
+        run_id="r2",
+        checks=["agents", "sfu"],
+        config={},
+        created_at="2026-08-01T00:00:00Z",
+    )
+    seen: list[dict] = []
+
+    class _Recorder:
+        async def upsert_diagnostics_run(self, **kw):
+            seen.append(kw)
+
+    await d._execute(run, _FAKE_CREDS, _Recorder())
+
+    [terminal] = [w for w in seen if w["status"] == "done"]
+    assert terminal["verdict"] is not None
+    assert terminal["ended_at"] is not None
+    assert "agents" in terminal["results"]["checks"]
+
+
+async def test_a_visible_terminal_status_is_already_stored(client, gateway) -> None:
+    """The same property end to end, through the real endpoint and storage.
+
+    Kept alongside the deterministic test above because it exercises the wiring
+    rather than the function: it would catch a regression that reintroduced the
+    window somewhere other than _execute.
+    """
+    run_id = await _start(client, ["agents"])
+    for _ in range(400):
+        body = (await client.get(f"/api/diagnostics/runs/{run_id}")).json()
+        if body["status"] in ("done", "failed"):
+            stored = await gateway.storage.get_diagnostics_run(run_id)
+            assert stored is not None, "terminal over the API, absent from storage"
+            assert stored["status"] == body["status"]
+            assert stored["ended_at"] is not None
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"run {run_id} never reached a terminal state")
+
+
+# ---------------------------------------------------------------------------
+# One ordering, whether or not storage has caught up
+# ---------------------------------------------------------------------------
+
+
+async def test_the_history_order_does_not_depend_on_storage(client, gateway) -> None:
+    """Two branches of _history used two different orderings.
+
+    With storage empty it returned insertion order; with storage populated it
+    sorted by created_at. Both were documented as "newest first", so the same
+    endpoint meant two things depending on whether a write had landed, and the
+    rehydrated history could disagree with the live one about the order of the
+    same runs.
+    """
+    await _run_to_completion(client, ["agents"])
+    await _run_to_completion(client, ["sfu"])
+
+    merged = [r["run_id"] for r in (await client.get("/api/diagnostics/runs")).json()]
+
+    # The same working set with storage taken out of the picture, which is the
+    # branch that used insertion order.
+    from voicegateway.server.api.dashboard import diagnostics as d
+
+    memory_only = [r.run_id for r in await d._history(None)]
+    assert memory_only == merged
+
+    _simulate_restart()
+    from_storage = [
+        r["run_id"] for r in (await client.get("/api/diagnostics/runs")).json()
+    ]
+    assert from_storage == merged
+
+
+async def test_runs_created_in_the_same_instant_do_not_swap(client) -> None:
+    """created_at alone is not a total order, so run_id breaks the tie.
+
+    Without a tiebreak two runs sharing a timestamp order arbitrarily, and the
+    history flips between reads for no reason a user can see.
+    """
+    from voicegateway.server.api.dashboard import diagnostics as d
+
+    same = "2026-08-01T20:41:30.482092+00:00"
+    for rid in ("bbb", "aaa", "ccc"):
+        d._RUNS[rid] = d._Run(
+            run_id=rid, checks=["agents"], config={}, status="done", created_at=same
+        )
+        d._ORDER.append(rid)
+
+    once = [r.run_id for r in await d._history(None)]
+    twice = [r.run_id for r in await d._history(None)]
+    assert once == twice == ["ccc", "bbb", "aaa"]


### PR DESCRIPTION
Fixes the intermittent CI failures seen on #195 and #196. Two races in one file, both surfacing on py3.13 while 3.11 and 3.12 passed, which is what a race looks like from the outside.

## 1. A terminal status was visible before it was durable

`_execute` assigned `run.status = "done"` and only then awaited the write:

```python
run.status = "done"          # <- run is the object /runs serves
...
await _persist(store, run)   # <- the row is still "running" until this returns
```

Between those two statements the API reported a finished run whose row said `running`. Anything keying off completion could act on a run the database did not agree was over: exporting the report, reading the row from another process, the CLI.

Observed as `assert 'running' == 'done'` in `test_terminal_state_and_results_reach_storage`.

The terminal state is now built in locals, written, and only then published. The locals are seeded from the current state so a **cancellation** — which is not an `Exception` and reaches the `finally` block uncaught — still persists exactly what it persisted before.

## 2. History had two orderings

```python
if not stored:
    return [_RUNS[rid] for rid in reversed(_ORDER)]   # insertion order
...
return sorted(merged.values(), key=lambda r: (r.created_at, r.run_id), reverse=True)
```

Both documented as "newest first". So the endpoint meant two different things depending on whether a write had landed yet, and a rehydrated history could disagree with the live one about the order of the same two runs.

Observed as `test_rehydrated_history_serializes_to_identical_bytes` failing with the two runs swapped.

Both branches now use one sort key, extracted into `_newest_first` so there is one definition rather than two that agree by inspection.

## On the tests

My first test for the write ordering polled the API and then read storage. **It passed against the unfixed code.** It only catches the race when the scheduler cooperates, which is precisely the weakness that let this reach CI instead of a test, so it would have been worse than no test: a green tick over an unfixed bug.

It is replaced by a store that records what the live run object looked like at write time, so the assertion holds on every run:

```python
async def upsert_diagnostics_run(self, **kw):
    self.writes.append((kw["status"], self._run.status))
```

Both guards were verified by reverting each fix in turn: reverting the publish order fails `test_a_terminal_status_is_stored_before_it_is_published`, reverting the ordering fails `test_runs_created_in_the_same_instant_do_not_swap`.

The end-to-end polling test is kept alongside the deterministic one, since it would catch a regression that reintroduced the window somewhere other than `_execute`.

2835 passing. The previously flaky file was run five times in a row clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics run history ordering, including consistent handling of identical timestamps.
  * Ensured completed runs are fully saved before appearing in live or API-visible results.
  * Preserved timeout and exception handling while recording terminal status and completion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->