### PR TITLE
Report: correct thresholds, drop another product's limitations, and say when the run happened

### DIFF
--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -30,7 +30,11 @@ from voicegateway.loadtest.capacity import (
     capacity_table,
     derive_calls_per_node,
 )
-from voicegateway.loadtest.importer import build_plan, observations_for
+from voicegateway.loadtest.importer import (
+    build_plan,
+    limitations_from_notes,
+    observations_for,
+)
 from voicegateway.loadtest.judge import judge_run
 
 _cli = BaseCli()
@@ -560,6 +564,10 @@ def report(
         gate_results=[g.as_dict() for g in results],
         capacity=capacity,
         appendix=assets,
+        # Recovered from the row rather than recomputed: the artifacts may be
+        # long gone by the time somebody exports the report, and what the import
+        # could not answer is a property of that import.
+        limitations=limitations_from_notes(run.get("notes")),
     )
     out.mkdir(parents=True, exist_ok=True)
     json_path = out / f"{load_report_filename(run_id).removesuffix('.html')}.json"

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -98,6 +98,46 @@ NODE_MEMORY_GATE = "node_memory"
 HEADROOM_GATE = "resource_headroom"
 RETURN_TO_BASELINE_GATE = "return_to_baseline"
 
+#: Gates whose ``value`` and ``threshold`` are FRACTIONS in 0..1 that a reader
+#: thinks of as percentages. Every other gate carries an absolute: the latency
+#: and SFU gates are milliseconds.
+#:
+#: Declared here rather than inferred by a renderer, for two reasons. The
+#: distinction is a fact about what each gate measures, which is this module's
+#: business and not a display concern. And it cannot be recovered from the
+#: metric NAME: an unmeasured headroom gate carries ``metric=None`` and a real
+#: 0.2 threshold, so a name-based rule would render the contracted 20% as "0.2".
+#:
+#: A renderer that treats these as plain numbers misstates the contract. 0.995
+#: at one decimal place reads "1.0" and 0.75 reads "0.8", which is FIVE POINTS
+#: PERMISSIVE on the memory ceiling in the document whose purpose is to show the
+#: ceiling was held.
+RATIO_GATES: frozenset[str] = frozenset(
+    {
+        ESTABLISHMENT_GATE,
+        NODE_CPU_GATE,
+        NODE_MEMORY_GATE,
+        HEADROOM_GATE,
+        RETURN_TO_BASELINE_GATE,
+    }
+)
+
+#: Every gate id, so a new one has to be classified rather than defaulting into
+#: whichever branch a renderer happens to fall through to.
+ALL_GATES: frozenset[str] = frozenset(
+    {
+        AGENTS_GATE,
+        LATENCY_GATE,
+        SFU_QUALITY_GATE,
+        SFU_CAPACITY_GATE,
+        ESTABLISHMENT_GATE,
+        NODE_CPU_GATE,
+        NODE_MEMORY_GATE,
+        HEADROOM_GATE,
+        RETURN_TO_BASELINE_GATE,
+    }
+)
+
 # The two Go runtime series the teardown check reads. RSS is deliberately absent:
 # Go hands freed heap back to the OS lazily, so a drained process holds its
 # resident size long after the heap emptied, and gating on it would report a leak
@@ -1289,10 +1329,12 @@ __all__ = [
     "MAX_NODE_MEMORY_UTILISATION",
     "MIN_ESTABLISHMENT_RATIO",
     "MIN_HEADROOM_FRACTION",
+    "ALL_GATES",
     "MIN_PERCENTILE_SAMPLES",
     "MIN_SETTLE_MS",
     "NODE_CPU_GATE",
     "NODE_MEMORY_GATE",
+    "RATIO_GATES",
     "RETURN_TO_BASELINE_GATE",
     "PASS",
     "SFU_CAPACITY_GATE",

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -126,6 +126,22 @@ def _generated_at() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _utc(at_ms: Any) -> str | None:
+    """Epoch milliseconds as an ISO-8601 UTC instant, or None.
+
+    UTC and explicit about it. A capacity report is read months later by people
+    in other places, and a bare local timestamp is unresolvable by then.
+    """
+    value = _as_int(at_ms)
+    if value is None:
+        return None
+    return (
+        datetime.fromtimestamp(value / 1000, UTC)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
 # Verdicts are read, never derived, so this maps only what gates can produce.
 # UNKNOWN is spelled out at length because it is the whole reason the gate work
 # happened: a run that could not evaluate used to report a clean PASS, and a
@@ -1183,12 +1199,27 @@ def _render_limits(payload: dict[str, Any]) -> str:
         if payload.get("kind") == LOAD_REPORT_KIND
         else "A diagnostics run is a single-vantage snapshot"
     )
+    # The run's own gaps are a DIFFERENT claim from the structural ones and are
+    # rendered apart from them. "Nothing can measure this" and "nothing measured
+    # it this time" send a reader to two different places, and merging them into
+    # one list makes a fixable gap look permanent and a permanent one look like
+    # this run's bad luck.
+    run_limits = payload.get("run_limitations") or []
+    extra = ""
+    if run_limits:
+        entries = "".join(f"<li>{_esc(item)}</li>" for item in run_limits)
+        extra = (
+            "<h3>...and what THIS run did not measure</h3>"
+            "<p>These are gaps in the artifacts this report was built from, not "
+            "limits of the system. A later run can close them.</p>"
+            f"<ul>{entries}</ul>"
+        )
     return (
         "<h2>What this report does not measure</h2>"
         "<p>Read this section before acting on anything above. "
         f"{subject}, and these are its structural limits, not this "
         "run&rsquo;s bad luck.</p>"
-        f"<ul>{items}</ul>"
+        f"<ul>{items}</ul>{extra}"
     )
 
 
@@ -1413,6 +1444,7 @@ def build_load_payload(
     gate_results: list[dict[str, Any]] | None = None,
     capacity: dict[str, Any] | None = None,
     appendix: dict[str, list[dict[str, str]]] | None = None,
+    limitations: list[str] | None = None,
 ) -> dict[str, Any]:
     """The load-test report payload. The JSON export IS this; the HTML renders it.
 
@@ -1472,6 +1504,12 @@ def build_load_payload(
         # vantage point, is restated above in load terms; the packet-loss one is
         # already covered above with the reason that actually applies here.
         "not_measured": list(_LOAD_REPORT_LIMITS),
+        # What THIS RUN's artifacts could not answer, as opposed to what the
+        # system structurally never measures. The two are different claims and a
+        # reader needs both to tell "nothing can measure this" from "nothing
+        # measured it this time". Printed at import and carried nowhere until
+        # now, so the only person who ever saw them was whoever ran the import.
+        "run_limitations": list(limitations or []),
     }
 
 
@@ -1600,6 +1638,45 @@ padding:16px 20px;margin:0 0 24px;border-radius:6px}
 """
 
 
+def _render_run_identity(payload: dict[str, Any]) -> str:
+    """WHEN the run happened and WHICH artifacts it was built from.
+
+    A capacity report that does not say when the test ran is not filing-quality
+    evidence: it cannot be matched to a change window, an incident, or the
+    invoice for the hours it measured. The window lived in the payload and
+    nowhere in the document, which showed only when the EXPORT was produced, a
+    date that can be months later and says nothing about the test.
+
+    The checksum is here for the same reason. It is what ties this document to
+    the bytes it describes, and a reader holding two reports of two runs needs
+    to be able to tell them apart without opening the JSON.
+
+    Absent values are named as absent rather than omitted, because a header that
+    silently drops the window reads as a report that never had one.
+    """
+    run = payload.get("run") or {}
+    started = _utc(run.get("started_at_ms"))
+    ended = _utc(run.get("ended_at_ms"))
+    if started and ended:
+        window = f"{_esc(started)} to {_esc(ended)}"
+    elif started:
+        window = f"{_esc(started)}, end not recorded"
+    elif ended:
+        window = f"start not recorded, ended {_esc(ended)}"
+    else:
+        window = '<span class="nm">not recorded</span>'
+    checksum = run.get("artifact_sha256")
+    digest = (
+        f'<span class="mono">{_esc(str(checksum)[:16])}</span>'
+        if checksum
+        else '<span class="nm">no artifact checksum</span>'
+    )
+    return (
+        '<p class="sub">Run window (UTC) '
+        f"<strong>{window}</strong> &middot; artifacts {digest}</p>"
+    )
+
+
 def render_load_html(payload: dict[str, Any]) -> str:
     """Render a load-test payload as ONE self-contained HTML document.
 
@@ -1623,6 +1700,7 @@ def render_load_html(payload: dict[str, Any]) -> str:
             f'<p class="sub">VoiceGateway &middot; run '
             f'<span class="mono">{run_id}</span> &middot; provenance '
             f"<strong>{_esc(payload['data_provenance'])}</strong></p>",
+            _render_run_identity(payload),
             # Above the gate table it summarises, and below the stamp.
             _render_verdict(payload),
             _render_gates(payload),

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -658,6 +658,35 @@ def _num(value: float | None, unit: str, digits: int = 0) -> str:
     return f"{rendered}&nbsp;{_esc(unit)}" if unit else rendered
 
 
+def _ratio_pct(value: float) -> str:
+    """A 0..1 fraction as the percentage the acceptance criteria are written in.
+
+    Precision is adaptive and trailing zeros are dropped, so 0.995 reads "99.5%",
+    0.75 reads "75%" and 0.6666 reads "66.66%". Two decimal places in percent is
+    enough to render every contracted threshold EXACTLY, which is the property
+    that matters: a threshold shown at lower precision than the constant it came
+    from is a misstatement of the contract, not a rounding.
+    """
+    text = f"{value * 100:.2f}".rstrip("0").rstrip(".")
+    return f"{text}%"
+
+
+def _gate_number(value: float | None, gate: str | None) -> str:
+    """One gate's value or threshold, in the unit that gate measures in.
+
+    Ratio gates render as percentages; everything else keeps the previous
+    one-decimal rendering, because the latency and SFU gates carry milliseconds
+    and a percent sign on those would be a new defect replacing an old one.
+
+    The classification comes from :data:`gates.RATIO_GATES` rather than from the
+    metric name. An unmeasured headroom gate carries no metric and a real 0.2
+    threshold, so a name-based rule would still misstate the contracted 20%.
+    """
+    if value is None or gate not in gates.RATIO_GATES:
+        return _num(value, "", 1)
+    return _ratio_pct(value)
+
+
 def _plain(value: Any) -> str:
     """A measured string, or the "not measured" marker."""
     if value is None or value == "":
@@ -803,8 +832,8 @@ def _render_gates(payload: dict[str, Any]) -> str:
             # "not recorded" says that; calling a missing NAME "not measured"
             # would file it as a failed reading.
             f'<td class="mono">{_recorded(gate.get("metric"))}</td>'
-            f'<td class="num">{_num(value, "", 1)}</td>'
-            f'<td class="num">{_num(threshold, "", 1)}</td></tr>'
+            f'<td class="num">{_gate_number(value, gate.get("gate"))}</td>'
+            f'<td class="num">{_gate_number(threshold, gate.get("gate"))}</td></tr>'
         )
     if not rows:
         if stored:

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -1169,12 +1169,25 @@ def _render_latency(finding: dict[str, Any]) -> str:
 
 
 def _render_limits(payload: dict[str, Any]) -> str:
+    """The limits section, describing the run this payload actually came from.
+
+    Shared by both reports, so the preamble is chosen from the payload's kind
+    rather than assumed. It described every run as "a diagnostics run", which in
+    a load report is a reader's first hint that they were sent output from a
+    different tool.
+    """
     items = "".join(f"<li>{_esc(item)}</li>" for item in payload["not_measured"])
+    subject = (
+        "A load run measures a fleet from outside, through a generator placing "
+        "real calls"
+        if payload.get("kind") == LOAD_REPORT_KIND
+        else "A diagnostics run is a single-vantage snapshot"
+    )
     return (
         "<h2>What this report does not measure</h2>"
-        "<p>Read this section before acting on anything above. A diagnostics run "
-        "is a single-vantage snapshot, and these are its structural limits, not "
-        "this run&rsquo;s bad luck.</p>"
+        "<p>Read this section before acting on anything above. "
+        f"{subject}, and these are its structural limits, not this "
+        "run&rsquo;s bad luck.</p>"
         f"<ul>{items}</ul>"
     )
 
@@ -1281,6 +1294,9 @@ _LOAD_REPORT_LIMITS = [
     "reached each step. A ramp holding its arrival rate fixed while raising the "
     "target concurrency plateaus, and that plateau is the generator's ceiling "
     "rather than the node's.",
+    "Every call here was placed from ONE vantage point: the host that ran the "
+    "generator. The establishment rate is what that host achieved against this "
+    "deployment over that path, not what a caller on another network would see.",
 ]
 
 
@@ -1448,7 +1464,14 @@ def build_load_payload(
         # What it takes to run this again. Item-by-item cited; see
         # :func:`appendix_entry`.
         "appendix": appendix,
-        "not_measured": list(_REPORT_LIMITS) + list(_LOAD_REPORT_LIMITS),
+        # _REPORT_LIMITS is the PROBE's list and is deliberately absent. Its
+        # entries describe a prober's data-channel round trip, billed trial
+        # calls per agent and an agents check, none of which exists in a SIP
+        # load test, and a client reading them concludes they were sent output
+        # from a different tool. The one that IS true of a load run, the single
+        # vantage point, is restated above in load terms; the packet-loss one is
+        # already covered above with the reason that actually applies here.
+        "not_measured": list(_LOAD_REPORT_LIMITS),
     }
 
 

--- a/src/voicegateway/loadtest/importer.py
+++ b/src/voicegateway/loadtest/importer.py
@@ -172,12 +172,48 @@ def observations_for(parsed: ParsedTest) -> list[dict]:
     return []
 
 
+#: Heading under which a run's own gaps are recorded in ``load_runs.notes``, and
+#: the prefix each one carries. The report is exported by a LATER command, in a
+#: different process, reading the row rather than the artifacts, so a limitation
+#: computed at import and not written down is one nobody downstream can see.
+#:
+#: Stored as text in the notes column rather than behind a new column, because
+#: notes already carries exactly this kind of human-readable fact (the artifact
+#: checksum, the synthetic warning) and a migration to hold prose is a poor
+#: trade. The round trip is pinned by a test, since the cost of the choice is
+#: that the format is load-bearing.
+LIMITATIONS_HEADING = "Not measured by these artifacts:"
+_LIMITATION_PREFIX = "- "
+
+
+def limitations_from_notes(notes: str | None) -> list[str]:
+    """The run's own gaps, read back out of ``load_runs.notes``.
+
+    Returns [] for a row written before this was recorded, which reads as "no
+    gaps were noted" rather than as an error. That is the honest reading: the
+    absence of a record is not a record of absence, and the structural limits
+    list is unaffected either way.
+    """
+    if not notes or LIMITATIONS_HEADING not in notes:
+        return []
+    _, _, tail = notes.partition(LIMITATIONS_HEADING)
+    out: list[str] = []
+    for line in tail.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(_LIMITATION_PREFIX):
+            out.append(stripped[len(_LIMITATION_PREFIX) :])
+        elif stripped:
+            # A later section began. Stop rather than swallowing it.
+            break
+    return out
+
+
 def _limitations_for(parsed: ParsedTest) -> list[str]:
     """What this test's artifacts could not answer, in an operator's words."""
     out: list[str] = []
     if parsed.peak_concurrency is None:
         out.append(
-            f"{parsed.name}: no stat CSV, so peak concurrency is not measured. "
+            f"{parsed.name}: no stat file, so peak concurrency is not measured. "
             "The summary's active_calls is an end-of-run drain value and is not "
             "a substitute for it."
         )
@@ -186,10 +222,33 @@ def _limitations_for(parsed: ParsedTest) -> list[str]:
     if not parsed.failures_by_cause:
         out.append(f"{parsed.name}: no failure breakdown by cause.")
     if parsed.answer_latency is None:
-        out.append(
-            f"{parsed.name}: no answer latency. It comes from rtd.answer, which "
-            'requires start_rtd="answer" in the generator\'s scenario.'
-        )
+        # Two different causes, and naming the wrong one sends somebody to edit
+        # a scenario file that is already correct. Answer latency comes from
+        # rtd.answer, which the generator samples when a call reaches 200 OK. So
+        # a run where nothing was answered produces none however the scenario is
+        # written, and that is a fact about the run rather than the config.
+        if parsed.succeeded_calls == 0 and (parsed.attempted_calls or 0) > 0:
+            out.append(
+                f"{parsed.name}: no answer latency, because none of the "
+                f"{parsed.attempted_calls} calls reached 200 OK. rtd.answer is "
+                "sampled when a call is answered, so nothing here could produce "
+                "one. This says nothing about the generator's scenario."
+            )
+        elif parsed.succeeded_calls:
+            out.append(
+                f"{parsed.name}: no answer latency, although "
+                f"{parsed.succeeded_calls} calls established. Calls were "
+                "answered and no round-trip delay was reported, which points at "
+                'the scenario: rtd.answer needs start_rtd="answer" on the INVITE '
+                'and rtd="answer" on the response that ends the measurement.'
+            )
+        else:
+            out.append(
+                f"{parsed.name}: no answer latency, and no call totals either, "
+                "so whether any call was answered is unknown. The cause cannot "
+                "be attributed to the run or to the scenario from these "
+                "artifacts."
+            )
     if parsed.call_records_status == "absent":
         out.append(
             f"{parsed.name}: no per-call records, so no per-call observations "
@@ -198,8 +257,9 @@ def _limitations_for(parsed: ParsedTest) -> list[str]:
     elif parsed.call_records_status == "present":
         out.append(
             f"{parsed.name}: {parsed.call_records_count} call records were found "
-            f"but not interpreted. {CALL_RECORDS_FILENAME} has no documented "
-            "record schema, so nothing was read out of them."
+            f"but not interpreted. The {CALL_RECORDS_FILENAME} schema is known "
+            "and recorded, and nothing maps it into per-call observations yet, "
+            "so the aggregate columns carry what these artifacts measured."
         )
     elif parsed.call_records_status == "unreadable":
         out.append(f"{parsed.name}: {CALL_RECORDS_FILENAME} could not be read.")
@@ -254,6 +314,14 @@ def build_plan(
             "once these artifacts come from a real run."
         )
 
+    limitations: list[str] = []
+    for p in parsed:
+        limitations.extend(_limitations_for(p))
+    if limitations:
+        notes += f"\n\n{LIMITATIONS_HEADING}\n" + "\n".join(
+            f"{_LIMITATION_PREFIX}{line}" for line in limitations
+        )
+
     run = LoadRunInput(
         id=resolved_run_id,
         created_at_ms=now_ms,
@@ -304,10 +372,6 @@ def build_plan(
         )
         for index, p in enumerate(parsed)
     ]
-
-    limitations: list[str] = []
-    for p in parsed:
-        limitations.extend(_limitations_for(p))
 
     return ImportPlan(run=run, tests=tests, parsed=parsed, limitations=limitations)
 

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -50,6 +50,14 @@ _NO_WINDOW = (
 _NOT_ON_AGGREGATE = (
     f"the correlated window carried no {_FD_USED}/{_FD_LIMIT} reading for this node"
 )
+# The test HAS a window; nothing was scraped inside it. Distinct from _NO_WINDOW,
+# and the distinction is visible to a client: the CPU and memory gates on the
+# same run say "no node was sampled in the window", so reusing the no-window
+# wording here made one report explain one absence two incompatible ways.
+_NO_SAMPLES = (
+    "no node was sampled in the window, so no scrape carrying "
+    f"{_FD_USED}/{_FD_LIMIT} could be correlated to it"
+)
 
 
 def _fd_reading(
@@ -152,9 +160,7 @@ def _headroom_gates_for(aggregate: TestAggregate) -> list[GateResult]:
         # nobody measured.
         if (reading.node, reading.source) not in measured:
             readings.append(
-                _fd_reading(
-                    reading.node, reading.source, reason=_NOT_ON_AGGREGATE
-                )
+                _fd_reading(reading.node, reading.source, reason=_NOT_ON_AGGREGATE)
             )
         readings.extend(
             gates.unscraped_headroom_readings(reading.node, source=reading.source)
@@ -163,7 +169,10 @@ def _headroom_gates_for(aggregate: TestAggregate) -> list[GateResult]:
         # Nothing was scraped at all. Every resource is still reported, so an
         # unscraped run reads as three UNKNOWN gates rather than as a run where
         # file descriptors quietly went unjudged while the other two did not.
-        readings = [_fd_reading("fleet"), *gates.unscraped_headroom_readings("fleet")]
+        readings = [
+            _fd_reading("fleet", reason=_NO_SAMPLES),
+            *gates.unscraped_headroom_readings("fleet"),
+        ]
     return gates.headroom_gates(readings)
 
 

--- a/src/voicegateway/tests/livekit_diag/test_load_report_limits.py
+++ b/src/voicegateway/tests/livekit_diag/test_load_report_limits.py
@@ -1,0 +1,157 @@
+"""The load report's limits list, which belonged to a different product.
+
+The load report built its not-measured section as the probe's list plus its own,
+so a client reading a SIP load-test report was told about the prober's data
+channel, billed trial calls per agent, an agents check and the host that ran the
+probe. None of those exists in a load run. The reasonable conclusion for a
+reader is that they were sent output from a different tool, which costs more
+credibility than the numbers buy.
+
+The fix is not to empty the section. **The limits list is load-bearing honesty,
+not boilerplate**, and dropping an entry that IS true of a load run converts an
+honest disclosure into a silent omission, which is worse than the original
+defect. So each probe entry was judged on its merits:
+
+* packet loss: TRUE of a load run, and already stated in the load list with the
+  reason that actually applies. Kept there, dropped here, so it appears once.
+* SFU round-trip time through the prober's data channel: does not exist.
+* reply latency over billed trial calls: does not exist. The load report renders
+  no percentile, so the "max of N" rule it carries has nothing to qualify.
+* an idle agent invisible to the agents check: there is no agents check.
+* one vantage point: TRUE, and restated in load terms. Every call came from the
+  host running the generator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.livekit_diag import run_report
+
+# Phrases that can only be true of the diagnostics probe.
+#
+# Compared against the HTML through _esc, the SAME escaping the renderer uses.
+# Searching the raw text for "the prober's own message" would never match, since
+# the apostrophe is escaped on the way in, so the assertion would pass whether
+# or not the phrase was there. A vacuous test here is worse than none: it is a
+# green tick over the exact defect it names.
+PROBE_ONLY = [
+    "the prober's own message",
+    "SFU data channel",
+    "billed trial calls",
+    "agents check",
+    "the host that ran the probe",
+]
+
+
+@pytest.fixture(scope="module")
+def load_html() -> str:
+    payload = run_report.build_load_payload(
+        run={"id": "ramp-500", "artifact_sha256": "a" * 64}, tests=[]
+    )
+    return run_report.render_load_html(payload)
+
+
+@pytest.fixture(scope="module")
+def load_limits() -> list[str]:
+    payload = run_report.build_load_payload(
+        run={"id": "ramp-500", "artifact_sha256": "a" * 64}, tests=[]
+    )
+    return payload["not_measured"]
+
+
+# --------------------------------------------------------------------------
+# The other product's limitations are gone
+# --------------------------------------------------------------------------
+
+
+def test_the_escaping_matters_here() -> None:
+    """Guards the guard: at least one phrase really does change under _esc.
+
+    If every phrase were escape-identical the comparison above would look
+    careful and be doing nothing.
+    """
+    assert any(run_report._esc(p) != p for p in PROBE_ONLY)
+
+
+@pytest.mark.parametrize("phrase", PROBE_ONLY)
+def test_no_probe_only_phrase_reaches_the_load_report(load_html, phrase) -> None:
+    assert run_report._esc(phrase) not in load_html
+
+
+def test_the_probe_list_is_not_included_wholesale(load_limits) -> None:
+    """Checked against the real list, so a new probe entry cannot leak in."""
+    assert not set(run_report._REPORT_LIMITS) & set(load_limits)
+
+
+def test_the_preamble_does_not_call_this_a_diagnostics_run(load_html) -> None:
+    """The first hint a reader gets that they were sent the wrong document."""
+    assert "A diagnostics run" not in load_html
+    assert "load run" in load_html
+
+
+# --------------------------------------------------------------------------
+# ...and the diagnostics report is untouched, where they are correct
+# --------------------------------------------------------------------------
+
+
+def test_the_diagnostics_report_still_carries_its_own_limits() -> None:
+    """The trap. These entries are right there and must not be collateral."""
+    payload = run_report.build_payload(
+        run_report.RunRecord(
+            run_id="d1", checks=["agents"], config={}, status="done", created_at="t"
+        ),
+        livekit_url=None,
+    )
+    assert payload["not_measured"] == list(run_report._REPORT_LIMITS)
+    html = run_report.render_html(payload)
+    for phrase in PROBE_ONLY:
+        assert run_report._esc(phrase) in html, phrase
+    assert "A diagnostics run" in html
+
+
+# --------------------------------------------------------------------------
+# Nothing genuinely unmeasured went quiet
+# --------------------------------------------------------------------------
+
+
+def test_every_structurally_unmeasured_surface_is_still_named(load_limits) -> None:
+    """Removing a true entry would be worse than the defect being fixed.
+
+    Named by the thing each one is about, so a rewording does not fail this but
+    a deletion does.
+    """
+    joined = " ".join(load_limits).lower()
+    for subject in (
+        "rtp-port headroom",
+        "network headroom",
+        "packet loss",
+        "time window overlap",
+        "worst node",
+        "calls-per-node",
+        "one vantage point",
+    ):
+        assert subject in joined, subject
+
+
+def test_packet_loss_is_named_once_with_the_reason_that_applies(
+    load_limits,
+) -> None:
+    """It was in both lists, with two different reasons, one of them a probe's."""
+    mentions = [item for item in load_limits if "packet loss" in item.lower()]
+    assert len(mentions) == 1
+    assert "server-side surface" in mentions[0]
+    assert "probe" not in mentions[0].lower()
+
+
+def test_the_vantage_limitation_survived_in_load_terms(load_limits) -> None:
+    """True of a load run, so it had to stay; false as written, so it changed."""
+    [vantage] = [item for item in load_limits if "vantage point" in item]
+    assert "generator" in vantage
+    assert "probe" not in vantage.lower()
+
+
+def test_the_list_did_not_shrink_to_nothing(load_limits) -> None:
+    """A limits section that goes quiet reads as a clean bill of health."""
+    assert len(load_limits) >= len(run_report._LOAD_REPORT_LIMITS)
+    assert len(load_limits) >= 7

--- a/src/voicegateway/tests/livekit_diag/test_report_thresholds.py
+++ b/src/voicegateway/tests/livekit_diag/test_report_thresholds.py
@@ -1,0 +1,189 @@
+"""Contracted thresholds, as the HTML states them to a client.
+
+Both the observed value and the threshold went through ``_num(..., "", 1)``, one
+decimal place, which is fine for milliseconds and wrong for a fraction:
+
+    0.995 -> "1.0"    the contract says 99.5%
+    0.75  -> "0.8"    the contract says 75%
+
+The second is the one that would land badly. It is FIVE POINTS PERMISSIVE on the
+memory ceiling, in the document whose entire purpose is to show the ceiling was
+held, and the JSON payload beside it carries the correct 0.75, so the two
+exported artifacts contradict each other.
+
+Every expected string here is derived FROM the constant in ``gates`` rather than
+typed in. A test that hardcodes "99.5%" passes forever after somebody changes
+the constant and forgets the renderer, which is the failure it exists to catch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.livekit_diag import gates, run_report
+from voicegateway.livekit_diag.run_report import _gate_number, _ratio_pct
+
+
+def _pct(value: float) -> str:
+    """The percentage a reader should see, derived rather than written out."""
+    return _ratio_pct(value)
+
+
+# --------------------------------------------------------------------------
+# The two that were wrong
+# --------------------------------------------------------------------------
+
+
+def test_the_establishment_floor_is_not_rounded_to_one() -> None:
+    rendered = _gate_number(gates.MIN_ESTABLISHMENT_RATIO, gates.ESTABLISHMENT_GATE)
+    assert rendered == _pct(gates.MIN_ESTABLISHMENT_RATIO)
+    assert rendered == "99.5%"
+    assert rendered != "1.0"
+
+
+def test_the_memory_ceiling_is_not_rounded_up_five_points() -> None:
+    """The permissive one. "0.8" claims a ceiling the contract never granted."""
+    rendered = _gate_number(gates.MAX_NODE_MEMORY_UTILISATION, gates.NODE_MEMORY_GATE)
+    assert rendered == _pct(gates.MAX_NODE_MEMORY_UTILISATION)
+    assert rendered == "75%"
+    assert rendered != "0.8"
+
+
+@pytest.mark.parametrize(
+    ("constant", "gate"),
+    [
+        (gates.MIN_ESTABLISHMENT_RATIO, gates.ESTABLISHMENT_GATE),
+        (gates.MAX_NODE_CPU_UTILISATION, gates.NODE_CPU_GATE),
+        (gates.MAX_NODE_MEMORY_UTILISATION, gates.NODE_MEMORY_GATE),
+        (gates.MIN_HEADROOM_FRACTION, gates.HEADROOM_GATE),
+    ],
+)
+def test_every_contracted_threshold_renders_without_loss(constant, gate) -> None:
+    """The property, stated once: rendering must not change the number.
+
+    Parsed back out of the string and compared to the constant, so it holds for
+    thresholds nobody has thought of yet rather than only for today's four.
+    """
+    rendered = _gate_number(constant, gate)
+    assert rendered.endswith("%")
+    assert float(rendered.rstrip("%")) / 100 == pytest.approx(constant, abs=1e-9)
+
+
+# --------------------------------------------------------------------------
+# The trap: not every gate carries a ratio
+# --------------------------------------------------------------------------
+
+
+def test_milliseconds_do_not_acquire_a_percent_sign() -> None:
+    """A percent sign on a latency would be a new defect replacing an old one."""
+    for gate in gates.ALL_GATES - gates.RATIO_GATES:
+        rendered = _gate_number(1500.0, gate)
+        assert "%" not in rendered, gate
+        assert rendered == "1,500.0"
+
+
+def test_every_gate_is_classified() -> None:
+    """A new gate must be sorted into one bucket rather than defaulting.
+
+    Falling through to the numeric branch is what produced this defect: the
+    ratio gates were never distinguished from the millisecond ones at all.
+    """
+    assert gates.RATIO_GATES <= gates.ALL_GATES
+    declared = {
+        value
+        for name, value in vars(gates).items()
+        if name.endswith("_GATE") and isinstance(value, str)
+    }
+    assert declared == gates.ALL_GATES, declared ^ gates.ALL_GATES
+
+
+def test_an_unmeasured_value_is_still_not_measured() -> None:
+    """None must not become 0%, on either kind of gate."""
+    for gate in gates.ALL_GATES:
+        assert "not measured" in _gate_number(None, gate)
+        assert "0%" not in _gate_number(None, gate)
+
+
+def test_the_classification_is_not_inferred_from_the_metric_name() -> None:
+    """The reason RATIO_GATES exists rather than a suffix rule.
+
+    An unmeasured headroom gate carries no metric and a real 0.2 threshold. A
+    name-based rule would see None and render the contracted 20% as "0.2".
+    """
+    [unmeasured] = gates.headroom_gates(
+        [
+            gates.HeadroomReading(
+                node="n",
+                resource=gates.HEADROOM_RTP_PORTS,
+                used=None,
+                limit=None,
+                unmeasured_reason="nothing scrapes it",
+            )
+        ]
+    )
+    assert unmeasured.metric is None
+    assert unmeasured.threshold == gates.MIN_HEADROOM_FRACTION
+    assert _gate_number(unmeasured.threshold, unmeasured.gate) == _pct(
+        gates.MIN_HEADROOM_FRACTION
+    )
+
+
+# --------------------------------------------------------------------------
+# Through the renderer, not only the helper
+# --------------------------------------------------------------------------
+
+
+def _html_with(gate_results) -> str:
+    return run_report.render_load_html(
+        run_report.build_load_payload(
+            run={"id": "r", "artifact_sha256": "a" * 64},
+            tests=[],
+            gate_results=[g.as_dict() for g in gate_results],
+        )
+    )
+
+
+def test_the_rendered_html_states_the_contracted_thresholds() -> None:
+    """End to end, against the strings the constants produce."""
+    html = _html_with(
+        [
+            gates.establishment_gate(
+                attempted=15000,
+                succeeded=14985,
+                threshold=gates.MIN_ESTABLISHMENT_RATIO,
+                subject="ramp-500",
+            ),
+            *gates.node_memory_gates(
+                [
+                    gates.NodeUtilisationReading(
+                        node="sfu-1", utilisation=0.61, samples=12
+                    )
+                ]
+            ),
+        ]
+    )
+    assert _pct(gates.MIN_ESTABLISHMENT_RATIO) in html
+    assert _pct(gates.MAX_NODE_MEMORY_UTILISATION) in html
+    # And the shapes that used to appear in their place are gone.
+    assert ">1.0<" not in html
+    assert ">0.8<" not in html
+
+
+def test_the_html_and_the_payload_agree(tmp_path) -> None:
+    """The two exported artifacts must not contradict each other.
+
+    The JSON is the correct one and is not touched; this asserts the HTML now
+    says the same thing rather than the JSON being bent to match.
+    """
+    results = gates.node_memory_gates(
+        [gates.NodeUtilisationReading(node="sfu-1", utilisation=0.61, samples=12)]
+    )
+    payload = run_report.build_load_payload(
+        run={"id": "r", "artifact_sha256": "a" * 64},
+        tests=[],
+        gate_results=[g.as_dict() for g in results],
+    )
+    [gate] = payload["gates"]
+    assert gate["threshold"] == gates.MAX_NODE_MEMORY_UTILISATION
+    html = run_report.render_load_html(payload)
+    assert _pct(gate["threshold"]) in html

--- a/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
+++ b/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
@@ -1,0 +1,205 @@
+"""The deliverable itself, rendered from the one real capture and read.
+
+Both fixes are asserted here against the artifact a client's run actually
+produces, rather than against a hand-built payload: a threshold that renders
+correctly in a unit test and wrong in the exported file has not been fixed.
+
+The third assertion set came from READING the output. The gates table explained
+one absence two incompatible ways on the same page, telling a reader that no
+node was sampled in the window and, three rows down, that the test had no
+window. Both cannot be true, and a client who notices stops trusting the rest.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from voicegateway.cli._app import app
+from voicegateway.livekit_diag import gates, run_report
+from voicegateway.livekit_diag.run_report import _ratio_pct
+
+runner = CliRunner()
+
+CAPTURE = (
+    Path(__file__).resolve().parent.parent / "fixtures" / "loadtest" / "capture-01"
+)
+
+# Imported from the tests that own them, so this cannot drift from the real
+# self-containment rules while looking like it enforces them.
+from voicegateway.tests.cli.test_livekit_report_cli import (  # noqa: E402
+    _EXTERNAL_MARKERS as CLI_MARKERS,
+)
+from voicegateway.tests.server.test_diagnostics_report import (  # noqa: E402
+    _EXTERNAL_MARKERS as SERVER_MARKERS,
+)
+
+
+@pytest.fixture(scope="module")
+def exported(tmp_path_factory):
+    """Import the real capture and export both artifacts, into a throwaway db."""
+    tmp = tmp_path_factory.mktemp("r3")
+    monkey = pytest.MonkeyPatch()
+    monkey.delenv("VOICEGW_DB_PATH", raising=False)
+    config = tmp / "voicegw.yaml"
+    config.write_text(
+        yaml.dump(
+            {"cost_tracking": {"enabled": True, "db_path": str(tmp / "throwaway.db")}}
+        )
+    )
+    imported = runner.invoke(
+        app,
+        ["loadtest", "import", str(CAPTURE), "--captured", "--config", str(config)],
+    )
+    assert imported.exit_code == 0, imported.output
+    out = tmp / "out"
+    result = runner.invoke(
+        app,
+        [
+            "loadtest",
+            "report",
+            "capture-01",
+            "--config",
+            str(config),
+            "--out",
+            str(out),
+        ],
+    )
+    payload = json.loads(
+        next(p for p in out.iterdir() if p.suffix == ".json").read_text()
+    )
+    html = next(p for p in out.iterdir() if p.suffix == ".html").read_text()
+    monkey.undo()
+    return {"result": result, "payload": payload, "html": html}
+
+
+# --------------------------------------------------------------------------
+# The thresholds, as the exported file states them
+# --------------------------------------------------------------------------
+
+
+def test_the_contracted_thresholds_appear_as_percentages(exported) -> None:
+    """The two that were misstated, plus the two that shared the render site."""
+    html = exported["html"]
+    for constant in (
+        gates.MIN_ESTABLISHMENT_RATIO,
+        gates.MAX_NODE_CPU_UTILISATION,
+        gates.MAX_NODE_MEMORY_UTILISATION,
+        gates.MIN_HEADROOM_FRACTION,
+    ):
+        assert _ratio_pct(constant) in html, constant
+
+
+def test_the_old_rounded_forms_are_gone(exported) -> None:
+    """ ">1.0<" and ">0.8<" were what a client read where the contract said
+    99.5% and 75%."""
+    for cell in (">1.0</td>", ">0.8</td>"):
+        assert cell not in exported["html"], cell
+
+
+def test_the_html_and_the_json_agree_on_every_threshold(exported) -> None:
+    """The two exported artifacts contradicted each other. Checked per gate."""
+    for gate in exported["payload"]["gates"]:
+        threshold = gate.get("threshold")
+        if threshold is None:
+            continue
+        assert gate["gate"] in gates.RATIO_GATES, gate["gate"]
+        assert _ratio_pct(threshold) in exported["html"], gate
+
+
+# --------------------------------------------------------------------------
+# No other product's limitations
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "the prober's own message",
+        "SFU data channel",
+        "billed trial calls",
+        "agents check",
+        "the host that ran the probe",
+    ],
+)
+def test_no_probe_only_phrase_appears(exported, phrase) -> None:
+    """Compared through the renderer's own escaping, or it matches nothing."""
+    assert run_report._esc(phrase) not in exported["html"]
+
+
+def test_the_limits_still_name_what_this_run_did_not_measure(exported) -> None:
+    """Emptying the section would be worse than the defect it replaced."""
+    joined = " ".join(exported["payload"]["not_measured"]).lower()
+    for subject in (
+        "rtp-port headroom",
+        "network headroom",
+        "packet loss",
+        "time window overlap",
+        "worst node",
+        "calls-per-node",
+        "one vantage point",
+    ):
+        assert subject in joined, subject
+
+
+# --------------------------------------------------------------------------
+# Found by reading: one absence, one explanation
+# --------------------------------------------------------------------------
+
+
+def test_the_report_explains_the_missing_samples_one_way(exported) -> None:
+    """It said "no node was sampled in the window" and "the test has no window".
+
+    Both on the same page, about the same run. A client who reads carefully sees
+    a document contradicting itself and stops trusting the numbers above it.
+    """
+    html = exported["html"]
+    assert "no node was sampled in the window" in html
+    assert "the test has no window" not in html
+
+
+def test_every_unknown_gate_says_why(exported) -> None:
+    """UNKNOWN with no reason is indistinguishable from a gate that broke."""
+    unknown = [g for g in exported["payload"]["gates"] if g["status"] == gates.UNKNOWN]
+    assert unknown
+    for gate in unknown:
+        assert gate["detail"], gate
+        assert (
+            "not measured" in gate["detail"]
+            or "no node was sampled" in (gate["detail"])
+        ), gate["detail"]
+
+
+# --------------------------------------------------------------------------
+# Still a deliverable
+# --------------------------------------------------------------------------
+
+
+def test_the_run_is_measured_and_unstamped(exported) -> None:
+    payload = exported["payload"]
+    assert payload["data_provenance"] == run_report.PROVENANCE_MEASURED
+    assert run_report.SYNTHETIC_STAMP not in exported["html"]
+
+
+def test_the_html_is_self_contained(exported) -> None:
+    """Checked against the marker lists the two owning tests already use."""
+    html = exported["html"]
+    for marker in set(CLI_MARKERS) | set(SERVER_MARKERS):
+        assert marker not in html, marker
+
+
+def test_the_cli_still_exits_non_zero(exported) -> None:
+    assert exported["result"].exit_code != 0
+
+
+def test_no_number_reads_as_a_fabricated_zero(exported) -> None:
+    """The unmeasured cells must say so rather than showing 0."""
+    html = exported["html"]
+    assert html.count('class="nm"') >= 4
+    # The establishment value IS a measured zero and must NOT be suppressed.
+    assert re.search(r">0%</td>", html), "a measured 0% was rendered as absent"

--- a/src/voicegateway/tests/loadtest/test_report_identity_and_limits.py
+++ b/src/voicegateway/tests/loadtest/test_report_identity_and_limits.py
@@ -1,0 +1,267 @@
+"""What the report says about itself, and about this run in particular.
+
+Three gaps, all of which cost a reader something specific.
+
+**When the run happened.** The window was in the payload and nowhere in the
+document, which showed only when the EXPORT was produced. That date can be
+months later and says nothing about the test, so the report could not be matched
+to a change window, an incident, or the hours it measured.
+
+**What THIS run could not answer.** The import computed those and printed them
+to whoever ran it, then dropped them. They are the answer to "why is this column
+empty", and without them a reader cannot tell a quantity nothing can measure
+from one that simply was not measured this time.
+
+**Which of two causes applied.** The answer-latency note named a scenario
+setting, and the scenario used for the real capture HAS that setting. Every call
+timed out before 200 OK, so no round-trip delay could be sampled however the
+scenario was written. Naming the wrong cause sends somebody to edit a file that
+is already correct.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from voicegateway.cli._app import app
+from voicegateway.livekit_diag import run_report
+from voicegateway.loadtest.artifacts import ParsedTest
+from voicegateway.loadtest.importer import (
+    LIMITATIONS_HEADING,
+    _limitations_for,
+    limitations_from_notes,
+)
+
+runner = CliRunner()
+
+CAPTURE = (
+    Path(__file__).resolve().parent.parent / "fixtures" / "loadtest" / "capture-01"
+)
+
+
+@pytest.fixture(scope="module")
+def exported(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("identity")
+    monkey = pytest.MonkeyPatch()
+    monkey.delenv("VOICEGW_DB_PATH", raising=False)
+    config = tmp / "voicegw.yaml"
+    config.write_text(
+        yaml.dump(
+            {"cost_tracking": {"enabled": True, "db_path": str(tmp / "throwaway.db")}}
+        )
+    )
+    assert (
+        runner.invoke(
+            app,
+            ["loadtest", "import", str(CAPTURE), "--captured", "--config", str(config)],
+        ).exit_code
+        == 0
+    )
+    out = tmp / "out"
+    runner.invoke(
+        app,
+        [
+            "loadtest",
+            "report",
+            "capture-01",
+            "--config",
+            str(config),
+            "--out",
+            str(out),
+        ],
+    )
+    payload = json.loads(
+        next(p for p in out.iterdir() if p.suffix == ".json").read_text()
+    )
+    html = next(p for p in out.iterdir() if p.suffix == ".html").read_text()
+    monkey.undo()
+    return {"payload": payload, "html": html}
+
+
+# --------------------------------------------------------------------------
+# 1. When the run happened, and which artifacts it describes
+# --------------------------------------------------------------------------
+
+
+def test_the_run_window_is_in_the_document(exported) -> None:
+    """Derived from the payload, so the two exports cannot disagree."""
+    run = exported["payload"]["run"]
+    started = run_report._utc(run["started_at_ms"])
+    ended = run_report._utc(run["ended_at_ms"])
+    assert started and ended
+    assert started in exported["html"]
+    assert ended in exported["html"]
+
+
+def test_the_window_is_labelled_utc(exported) -> None:
+    """A bare timestamp is unresolvable by whoever reads this months later."""
+    assert "Run window (UTC)" in exported["html"]
+    assert run_report._utc(exported["payload"]["run"]["started_at_ms"]).endswith("Z")
+
+
+def test_the_window_is_not_the_export_time(exported) -> None:
+    """The footer date is when the file was made, not when the test ran.
+
+    Showing only that was the defect: it looks like a date and answers a
+    different question.
+    """
+    generated = exported["payload"]["generated_at"]
+    started = run_report._utc(exported["payload"]["run"]["started_at_ms"])
+    assert not generated.startswith(started[:10] + "T" + started[11:19])
+
+
+def test_the_artifact_checksum_identifies_the_document(exported) -> None:
+    """Two reports of two runs must be tellable apart without opening the JSON."""
+    checksum = exported["payload"]["run"]["artifact_sha256"]
+    assert checksum[:16] in exported["html"]
+
+
+def test_an_unrecorded_window_says_so_rather_than_vanishing() -> None:
+    """A header that silently drops it reads as a report that never had one."""
+    html = run_report.render_load_html(
+        run_report.build_load_payload(
+            run={"id": "r", "artifact_sha256": None}, tests=[]
+        )
+    )
+    assert "Run window (UTC)" in html
+    assert "not recorded" in html
+    assert "no artifact checksum" in html
+
+
+# --------------------------------------------------------------------------
+# 2. This run's own gaps reach the reader
+# --------------------------------------------------------------------------
+
+
+def test_the_run_limitations_reach_the_payload(exported) -> None:
+    assert exported["payload"]["run_limitations"]
+
+
+def test_they_are_rendered_apart_from_the_structural_limits(exported) -> None:
+    """One says never, the other says not this run. Merging them misleads twice.
+
+    A permanent limit shown as this run's bad luck invites a pointless re-run; a
+    fixable gap shown as permanent stops somebody fixing it.
+    """
+    html = exported["html"]
+    assert "what THIS run did not measure" in html
+    assert "not limits of the system" in html
+    structural = set(exported["payload"]["not_measured"])
+    run_specific = set(exported["payload"]["run_limitations"])
+    assert not structural & run_specific
+
+
+def test_each_run_limitation_is_in_the_html(exported) -> None:
+    for item in exported["payload"]["run_limitations"]:
+        assert run_report._esc(item) in exported["html"], item
+
+
+def test_a_run_with_no_gaps_shows_no_empty_section() -> None:
+    """An empty heading reads as a section somebody forgot to fill in."""
+    html = run_report.render_load_html(
+        run_report.build_load_payload(
+            run={"id": "r", "artifact_sha256": "a" * 64}, tests=[], limitations=[]
+        )
+    )
+    assert "what THIS run did not measure" not in html
+    # The structural list is unaffected either way.
+    assert "RTP-port headroom" in html
+
+
+def test_the_notes_round_trip_survives(exported) -> None:
+    """The format is load-bearing, since the report is exported by a LATER
+    command reading the row rather than the artifacts."""
+    notes = f"artifact sha256: {'a' * 64}\n\n{LIMITATIONS_HEADING}\n- one\n- two"
+    assert limitations_from_notes(notes) == ["one", "two"]
+
+
+def test_a_row_written_before_this_reads_as_no_gaps_noted() -> None:
+    """Absence of a record is not a record of absence, and not an error."""
+    assert limitations_from_notes("artifact sha256: abc") == []
+    assert limitations_from_notes(None) == []
+
+
+def test_a_later_section_is_not_swallowed() -> None:
+    notes = f"{LIMITATIONS_HEADING}\n- one\n\nSomething else entirely\n- not mine"
+    assert limitations_from_notes(notes) == ["one"]
+
+
+# --------------------------------------------------------------------------
+# 3. The answer-latency note names the cause that actually applied
+# --------------------------------------------------------------------------
+
+
+def _parsed(**kw) -> ParsedTest:
+    base = {
+        "name": "ramp-500",
+        "peak_concurrency": 3,
+        "attempted_calls": 3,
+        "succeeded_calls": 0,
+        "failed_calls": 3,
+        "failures_by_cause": {"timeout": 3},
+        "answer_latency": None,
+        "call_records_status": "absent",
+        "call_records_count": None,
+    }
+    base.update(kw)
+    return ParsedTest(
+        **{k: v for k, v in base.items() if k in ParsedTest.__annotations__}
+    )
+
+
+def test_nothing_answered_blames_the_run_not_the_scenario(exported) -> None:
+    """The real capture. Every call timed out before 200 OK.
+
+    The scenario it used carries start_rtd="answer"; naming that setting sent a
+    reader to fix a file that was already correct.
+    """
+    [latency] = [
+        item
+        for item in exported["payload"]["run_limitations"]
+        if "answer latency" in item
+    ]
+    assert "reached 200 OK" in latency
+    assert "says nothing about the generator's scenario" in latency
+    assert "start_rtd" not in latency
+
+
+def test_calls_answered_but_no_latency_points_at_the_scenario() -> None:
+    """The other cause, which is the one the old wording always claimed."""
+    [latency] = [
+        item
+        for item in _limitations_for(_parsed(succeeded_calls=2900))
+        if "answer latency" in item
+    ]
+    assert "start_rtd" in latency
+    assert "2900 calls established" in latency
+
+
+def test_unknown_totals_attribute_nothing() -> None:
+    """With no counts, neither cause can be asserted, so neither is."""
+    [latency] = [
+        item
+        for item in _limitations_for(
+            _parsed(attempted_calls=None, succeeded_calls=None)
+        )
+        if "answer latency" in item
+    ]
+    assert "cannot be attributed" in latency
+    assert "start_rtd" not in latency
+
+
+def test_the_record_note_no_longer_claims_the_schema_is_undocumented(
+    exported,
+) -> None:
+    """It was captured and written down; the gap is that nothing maps it."""
+    [records] = [
+        item
+        for item in exported["payload"]["run_limitations"]
+        if "call records" in item
+    ]
+    assert "no documented record schema" not in records
+    assert "schema is known and recorded" in records


### PR DESCRIPTION
Six defects in the HTML load report. Three came from an adversarial readiness review, one from rendering the real capture and reading it, and two more from following the third to its cause. All are presentational or explanatory, and all would land badly in front of a paying client.

## 1. The HTML misstated two contracted thresholds

The gates table sent both the observed value and the threshold through `_num(..., "", 1)`, one decimal place. Right for milliseconds, wrong for a fraction:

```
0.995 -> "1.0"     the contract says 99.5%
0.75  -> "0.8"     the contract says 75%
```

The second **overstates the memory ceiling by five points**, in the document whose entire purpose is to show the ceiling was held, and the JSON beside it carried the correct `0.75`, so the two exported artifacts contradicted each other. The JSON was already right and is untouched.

`_num` is not changed: 21 call sites render milliseconds, megabytes and seconds through it. The render site now picks a formatter per gate.

**Which gates carry fractions is declared in `gates.py`**, beside the thresholds, not inferred by the renderer. It cannot be recovered from the metric name: an unmeasured headroom gate carries `metric=None` and a real `0.2` threshold, so a name-based rule would still have printed the contracted 20% as "0.2". Latency and SFU gates keep their rendering, since a percent sign on a millisecond would be a new defect replacing an old one.

## 2. The load report carried the diagnostics probe's limitations

A client reading a SIP load-test report was told about the prober's data channel, billed trial calls per agent, an agents check, and the host that ran the probe. None exists in a load run, and the reasonable conclusion is that they were sent output from a different tool.

The section is not emptied. Each entry was judged on its merits:

| probe entry | verdict |
|---|---|
| packet loss | true, already stated in the load list with the reason that applies here. Now appears once, not twice with two explanations. |
| SFU round-trip through the prober's data channel | does not exist in a load run |
| reply latency over billed trial calls | does not exist; the load report renders no percentile |
| idle agent invisible to the agents check | there is no agents check |
| one vantage point | true, restated in load terms |

The shared preamble called every run "a diagnostics run". It now picks its wording from the payload's kind. The diagnostics report is untouched, asserted.

## 3. One absence, explained two incompatible ways

Found by rendering the real capture and reading it. The CPU and memory rows said *no node was sampled in the window*; the file-descriptor row three lines down said *the test has no window*. Both cannot be true of one run. The headroom fallback was reusing the no-window wording for a run that has a window and no samples in it.

## 4. The report never said when the run happened

The window was in the payload and nowhere in the document, which showed only when the **export** was produced, a date that can be months later. A capacity report that cannot be matched to a change window, an incident, or the hours it measured is not filing-quality evidence.

The header now carries the run window in UTC and the artifact checksum, so the document also identifies the bytes it describes without anybody opening the JSON. An absent window is named as absent rather than dropped.

## 5. The import's own findings reached nobody

`plan.limitations` was printed to whoever ran the import and went no further, so the answer to "why is this column empty" was lost the moment it was computed. They are now written into the run's notes and read back at export time, since the report is produced by a later command reading the row rather than the artifacts.

They render in **their own section**, apart from the structural list. "Nothing can measure this" and "nothing measured it this time" send a reader to two different places: merging them makes a fixable gap look permanent and a permanent one look like this run's bad luck. A run with no gaps shows no empty heading.

## 6. The answer-latency note misdiagnosed

It named `start_rtd="answer"` in the generator's scenario. **The scenario behind the real capture has it.** Every call timed out before 200 OK, so no round-trip delay could be sampled however the scenario was written, and naming that setting sends somebody to edit a file that is already correct.

The two causes are now distinguished by what the run actually did, and where the counts support neither conclusion, neither is asserted.

Two adjacent notes were also stale: the call-record one still claimed the schema is undocumented, which stopped being true when it was captured and written down (the gap is that nothing maps it yet), and another still said "no stat CSV" after discovery stopped matching on the extension.

## Verification

Every fix is asserted against the artifact a real run produces, not a hand-built payload: a threshold that renders correctly in a unit test and wrong in the exported file has not been fixed. Reverting each fix reds its tests (8 of 12 for the thresholds, 8 of 13 for the limits).

One note on the tests: probe phrases are compared through the renderer's own `_esc`. Searching raw HTML for `the prober's own message` can never match, because the apostrophe is escaped on the way in, so that assertion would have passed whether or not the phrase was present. A further test asserts at least one phrase really does change under escaping, so the comparison cannot quietly become decorative.

2965 passing against a 2919 baseline. Single alembic head, no migration: the run limitations ride in the existing free-text `notes` column, and the round trip is pinned by tests since that format is load-bearing.