### PR TITLE
Scrape the descriptor pair the gate asks for, and name the step on every row

### DIFF
--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -212,6 +212,21 @@ class GateResult:
     # field as well as inside ``detail`` so a surface that renders structured
     # data rather than prose still has to deal with it.
     waiver_reason: str | None = None
+    # Which step of a multi-step run produced this row. Part of the row's
+    # IDENTITY, not of its judgement: nothing here changes what is emitted or
+    # how anything grades.
+    #
+    # ``subject`` alone stopped being unique the moment the same resource was
+    # gated once per step. A seven-step run rendered seven rows reading
+    # ``sura-sip-01/node-exporter/file_descriptors`` with nothing to tell them
+    # apart, and a reader cannot know whether that is one finding or seven. The
+    # same collision was fixed once already for sources, by adding the source to
+    # the subject; the step is the other half of the same identity.
+    #
+    # None for gates that are genuinely run-level rather than per-step, which is
+    # the honest reading: stamping a step on a fleet-wide exclusion would claim
+    # it was evaluated once per step when it was evaluated once.
+    step: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         """A JSON-safe copy (the run payload is persisted and served as JSON).
@@ -222,10 +237,16 @@ class GateResult:
         served to the dashboard, and pinned by a test that asserts the key set.
         A waived gate is the only one that carries new information, so it is the
         only one whose payload grows.
+
+        ``step`` follows the same rule for the same reason. A diagnostics gate
+        belongs to no step and keeps the exact key set it has always had; only a
+        row that really is one of several per run grows a key.
         """
         out = asdict(self)
         if out.get("waiver_reason") is None:
             out.pop("waiver_reason", None)
+        if out.get("step") is None:
+            out.pop("step", None)
         return out
 
 

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -836,11 +836,23 @@ def _render_gates(payload: dict[str, Any]) -> str:
             else "unknown"
         )
         subject = gate.get("subject")
+        # The step is part of the row's identity, not decoration. Without it a
+        # seven-step run rendered seven rows reading
+        # "sura-sip-01/node-exporter/file_descriptors" with nothing to tell them
+        # apart, and a fleet run multiplies that by the node count. Suppressed
+        # when it merely repeats the subject, which is the establishment gate,
+        # whose subject IS the step.
+        step = gate.get("step")
+        identity = str(gate.get("gate") or "")
+        if step and step != subject:
+            identity = f"{_esc(identity)}<br>{_esc(step)}"
+        else:
+            identity = _esc(identity)
         value = _as_float(gate.get("value"))
         threshold = _as_float(gate.get("threshold"))
         rows.append(
             f'<tr><td><span class="tag {css}">{_esc(status)}</span></td>'
-            f'<td class="mono">{_esc(gate.get("gate"))}'
+            f'<td class="mono">{identity}'
             + (f"<br>{_esc(subject)}" if subject else "")
             + f"</td><td>{_esc(gate.get('detail'))}</td>"
             # A gate can legitimately carry no metric: agents_listing asserts the

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -23,6 +23,7 @@ already UNKNOWN, rather than being left out.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from voicegateway.livekit_diag import gates
@@ -289,7 +290,13 @@ def judge_run(
     out: list[GateResult] = []
     for test in tests:
         name = str(test.get("name") or "test")
-        out.extend(judge_test(test, aggregate=aggregates.get(name)))
+        # Stamped HERE and not inside judge_test, because the step is run-level
+        # identity: judge_test grades one step and has no idea whether it is one
+        # of seven. Identity only, so nothing about the verdict moves.
+        out.extend(
+            replace(result, step=name)
+            for result in judge_test(test, aggregate=aggregates.get(name))
+        )
     # ONCE PER RUN, not once per node per test. Nothing measures these on any
     # node, so eighteen identical rows on a three-step ramp said the same two
     # things eighteen times, above the table the client contracted for.

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -42,10 +42,22 @@ Every wired entry has since been read off a running binary. **Nothing in
 map degrades is one plausible entry added from documentation.
 
 MEASURED against livekit-sip 1.10.1 and node_exporter, with a real inbound call
-placed so every counter was populated: all 22 ``livekit-sip`` entries and all 9
+placed so every counter was populated: all 22 ``livekit-sip`` entries and all 11
 ``node-exporter`` entries. Every one resolves, asserted per entry against a
 captured exposition and again in
 ``tests/integration/test_live_node_scrape.py`` against the running exporters.
+
+The last two ``node-exporter`` entries are its own ``process_open_fds`` /
+``process_max_fds``, read off a live exporter as 8 and 524287. They were left
+unwired for a while on the reasoning that an exporter's own handles say nothing
+about a service under test, which is true. What made that untenable is that the
+descriptor headroom gate asks every scraped source for the pair regardless, so
+omitting them did not remove the question, it only guaranteed the answer was
+UNKNOWN: seven of one real seven-step run's nine UNKNOWN rows were this exporter
+being asked a question nothing had been wired to answer. Wiring them resolves
+that without suppressing a gate for a metric the source could have produced.
+Note the same 524287 rlimit livekit-sip and livekit-server report on the host,
+which is the cross-check that this is a per-process ceiling.
 
 MEASURED against livekit-server 1.10.1, by authenticated scrape of its metrics
 port: all 11 ``livekit-server`` entries. The four ``livekit_*`` families and the
@@ -310,6 +322,20 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         # which at 500 concurrent is a likelier wall than CPU.
         _Series("node_sockstat_UDP_inuse", "sockstat_udp_inuse"),
         _Series("node_netstat_Udp_NoPorts", "udp_no_ports_total"),
+        # ---- this exporter's own process ------------------------------------
+        # Wired because the descriptor headroom gate asks every scraped source
+        # for this pair, and a gate that is asked but not fed produced seven of
+        # one real run's nine UNKNOWNs. The two coherent positions are gate and
+        # scrape, or neither; the state before this was the middle one.
+        #
+        # READ WHAT THIS IS. These are node_exporter's OWN file handles, not any
+        # service's. The subject on the resulting gate is
+        # ``<node>/node-exporter/file_descriptors`` and it means exactly that.
+        # It is not evidence about livekit-sip's headroom and must never be read
+        # as such: the services under test report their own pair, and those are
+        # the rows that answer the acceptance criterion.
+        _Series("process_open_fds", "process_open_fds"),
+        _Series("process_max_fds", "process_max_fds"),
     ),
 }
 

--- a/src/voicegateway/tests/loadtest/test_gate_row_identity.py
+++ b/src/voicegateway/tests/loadtest/test_gate_row_identity.py
@@ -1,0 +1,243 @@
+"""No two gate rows in a report are indistinguishable.
+
+A real seven-step run rendered seven rows reading::
+
+    UNKNOWN | resource_headroom  sura-sip-01/node-exporter/file_descriptors | ...
+
+identically, with nothing saying which step each belonged to. A reader cannot
+tell whether that is one problem or seven, and the next run is a fleet: more
+steps and four nodes instead of one, so every per-step per-node resource gate
+multiplies the same way.
+
+This is the same collision class already fixed once for SOURCES. Three exporters
+on one node produced three rows labelled identically reading PASS, UNKNOWN and
+UNKNOWN, and the fix was to put the source into the subject. The step is the
+other half of that identity and was still missing.
+
+**Identity only.** Nothing here changes which gates are emitted or how any of
+them grades, and the tests below pin that explicitly: the statuses, the verdict
+and the row count are asserted to be exactly what they were before the step
+existed. If making rows unique had required suppressing a row or moving a
+status, that would have been a different change needing a different decision.
+"""
+
+from __future__ import annotations
+
+from voicegateway.livekit_diag import gates, run_report
+from voicegateway.loadtest import judge
+
+# Aliased: pytest collects any module-level name starting with "Test".
+from voicegateway.loadtest.aggregation import TestAggregate as _Aggregate
+from voicegateway.repository.node_correlation_repository import window_of
+
+WINDOW = window_of(1_785_661_201_000, 1_785_661_260_000)
+
+# A seven-step ramp, the shape that produced the collision.
+STEPS = [
+    {
+        "name": f"ramp-{n}",
+        "attempted_calls": 100,
+        "succeeded_calls": 100,
+        "sequence": i,
+    }
+    for i, n in enumerate((5, 10, 15, 20, 25, 30, 35))
+]
+
+# The collision only exists once nodes were actually correlated. With no
+# aggregate the judge falls back to using the step name as the subject, so the
+# rows are already unique and a fixture without one proves nothing. The real run
+# scraped ONE node under three sources on every step, which is what makes the
+# per-node subjects identical across steps.
+NODE = "sura-sip-01"
+SOURCES = ("node-exporter", "livekit-sip", "livekit-server")
+
+
+def _aggregate() -> _Aggregate:
+    cpu = [
+        gates.NodeUtilisationReading(
+            node=NODE,
+            source=source,
+            utilisation=0.42 if source == "node-exporter" else None,
+            samples=12 if source == "node-exporter" else 0,
+            unmeasured_reason=None
+            if source == "node-exporter"
+            else "publishes no node-wide series",
+        )
+        for source in SOURCES
+    ]
+    fds = [
+        gates.HeadroomReading(
+            node=NODE,
+            source=source,
+            resource=gates.HEADROOM_FILE_DESCRIPTORS,
+            used=120.0 if source != "node-exporter" else None,
+            limit=524287.0 if source != "node-exporter" else None,
+            unmeasured_reason=None
+            if source != "node-exporter"
+            else "no row in the window carried both",
+        )
+        for source in SOURCES
+    ]
+    return _Aggregate(
+        window=WINDOW,
+        peak_cpu_utilisation=0.42,
+        peak_memory_utilisation=0.5,
+        node_samples_in_window=len(cpu),
+        cpu_readings=cpu,
+        memory_readings=list(cpu),
+        fd_readings=fds,
+    )
+
+
+AGGREGATES = {step["name"]: _aggregate() for step in STEPS}
+
+
+def _run():
+    return judge.judge_run(STEPS, aggregates=AGGREGATES)
+
+
+def _identity(gate) -> tuple:
+    """What a reader can use to tell one row from another."""
+    return (gate.gate, gate.step, gate.subject)
+
+
+# --------------------------------------------------------------------------
+# The property
+# --------------------------------------------------------------------------
+
+
+def test_every_row_in_a_multi_step_run_is_distinguishable() -> None:
+    """The whole node, stated once."""
+    results = _run()
+    identities = [_identity(g) for g in results]
+    duplicates = {i for i in identities if identities.count(i) > 1}
+    assert not duplicates, duplicates
+
+
+def test_the_step_is_what_makes_them_unique() -> None:
+    """Non-vacuous. Without the step these rows really do collide.
+
+    Guards against the test passing for some unrelated reason, such as the
+    subjects happening to differ already.
+    """
+    results = _run()
+    per_step = [g for g in results if g.step is not None]
+    without_step = [(g.gate, g.subject) for g in per_step]
+    assert len(set(without_step)) < len(without_step)
+    assert len({_identity(g) for g in per_step}) == len(per_step)
+
+
+def test_every_per_step_row_names_its_step() -> None:
+    names = {s["name"] for s in STEPS}
+    for gate in _run():
+        if gate.step is not None:
+            assert gate.step in names, gate
+
+
+def test_run_level_rows_carry_no_step() -> None:
+    """The fleet exclusions are evaluated once per RUN, not once per step.
+
+    Stamping a step on them would claim seven evaluations where there was one,
+    which is the same lie in the opposite direction.
+    """
+    run_level = [g for g in _run() if g.step is None]
+    assert {g.subject for g in run_level} == {"fleet/network", "fleet/rtp_ports"}
+
+
+# --------------------------------------------------------------------------
+# Nothing about the judgement moved
+# --------------------------------------------------------------------------
+
+
+def test_the_row_count_is_unchanged() -> None:
+    """Identity, not emission. Seven steps still produce what they produced."""
+    results = _run()
+    per_step = [g for g in results if g.step is not None]
+    assert len(per_step) == len(
+        judge.judge_test(STEPS[0], aggregate=AGGREGATES[STEPS[0]["name"]])
+    ) * len(STEPS)
+
+
+def test_no_status_moved() -> None:
+    """Each step grades exactly as it did when judged on its own."""
+    stamped = [g for g in _run() if g.step == "ramp-25"]
+    alone = judge.judge_test(
+        next(s for s in STEPS if s["name"] == "ramp-25"),
+        aggregate=AGGREGATES["ramp-25"],
+    )
+    assert [g.status for g in stamped] == [g.status for g in alone]
+    assert [g.detail for g in stamped] == [g.detail for g in alone]
+
+
+def test_the_verdict_is_unchanged() -> None:
+    results = _run()
+    assert judge.verdict_for(results) == gates.UNKNOWN
+
+
+# --------------------------------------------------------------------------
+# The payload shape contract
+# --------------------------------------------------------------------------
+
+
+def test_a_gate_with_no_step_keeps_its_exact_key_set() -> None:
+    """A diagnostics gate belongs to no step and must not grow a key.
+
+    The payload shape is persisted with each run and served to the dashboard, so
+    only a row that really is one of several per run may grow.
+    """
+    checks = {"agents": {"ok": True, "result": {"agents": []}}}
+    [gate] = gates.evaluate_checks(checks, 1500.0)
+    assert "step" not in gate.as_dict()
+
+
+def test_a_stepped_gate_carries_it_in_the_payload() -> None:
+    [stepped] = [
+        g
+        for g in judge.judge_run(STEPS[:1], aggregates=AGGREGATES)
+        if g.step is not None
+    ][:1]
+    assert stepped.as_dict()["step"] == "ramp-5"
+
+
+# --------------------------------------------------------------------------
+# And it reaches the page a client reads
+# --------------------------------------------------------------------------
+
+
+def test_the_rendered_rows_are_distinguishable() -> None:
+    """The defect was found by reading the HTML, so it is checked there.
+
+    A payload that carries the step while the table still renders seven
+    identical rows would not have fixed anything.
+    """
+    results = _run()
+    html = run_report.render_load_html(
+        run_report.build_load_payload(
+            run={"id": "ramp", "artifact_sha256": "a" * 64},
+            tests=STEPS,
+            gate_results=[g.as_dict() for g in results],
+        )
+    )
+    body = html[html.index("<h2>Gates</h2>") :]
+    rows = [r for r in body.split("<tr>") if "resource_headroom" in r]
+    assert len(rows) > 1
+    assert len(set(rows)) == len(rows), "identical gate rows rendered"
+
+
+def test_the_establishment_row_does_not_repeat_its_own_name() -> None:
+    """Its subject IS the step, so printing both would read as a stutter."""
+    [establishment] = [
+        g
+        for g in judge.judge_run(STEPS[:1], aggregates=AGGREGATES)
+        if g.gate == "call_establishment"
+    ]
+    html = run_report.render_load_html(
+        run_report.build_load_payload(
+            run={"id": "ramp", "artifact_sha256": "a" * 64},
+            tests=STEPS[:1],
+            gate_results=[establishment.as_dict()],
+        )
+    )
+    body = html[html.index("<h2>Gates</h2>") :]
+    [row] = [r for r in body.split("<tr>") if "call_establishment" in r]
+    assert row.count("ramp-5") == 1

--- a/src/voicegateway/tests/loadtest/test_node_exporter_process_fds.py
+++ b/src/voicegateway/tests/loadtest/test_node_exporter_process_fds.py
@@ -1,0 +1,232 @@
+"""node_exporter's own descriptor pair is scraped, so the gate has data.
+
+A real seven-step run produced 44 gates, and seven of its nine UNKNOWNs were one
+row repeated once per step::
+
+    sura-sip-01/node-exporter/file_descriptors
+    "was not measured: no row in the window carried both process_open_fds and
+     process_max_fds"
+
+**The resolution is to scrape it, not to suppress it.** There were three
+positions available and only two of them are coherent:
+
+* gate it and scrape it
+* gate neither
+* gate it but refuse to scrape it, which is what produced those seven rows
+
+Suppressing was tried and rejected on the record: an earlier attempt keyed the
+decision off :data:`SERIES` omitting the pair, and
+``test_gate_only_where_measurable.py::test_node_exporter_keeps_its_file_descriptor_gate``
+exists specifically to catch that. Its reasoning stands: node_exporter CAN
+produce the pair (a live one reads ``process_open_fds`` 8 against
+``process_max_fds`` 524287), so an absent reading was a gap rather than a
+category error, and dropping the gate would hide a producible metric. Wiring the
+series honours that decision rather than reversing it.
+
+**What this does NOT claim.** These are node_exporter's own file handles. The
+gate reads ``<node>/node-exporter/file_descriptors`` and means precisely that.
+It is not evidence about livekit-sip's headroom, and the tests below pin the
+services' own rows as the ones that answer the acceptance criterion.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel
+
+from voicegateway.livekit_diag import gates
+from voicegateway.loadtest import aggregation, judge
+from voicegateway.middleware.node_samples_worker_middleware import (
+    SERIES,
+    SOURCE_LIVEKIT_SERVER,
+    SOURCE_LIVEKIT_SIP,
+    SOURCE_NODE_EXPORTER,
+    columns_for,
+)
+from voicegateway.models.node_sample_model import NodeSample  # noqa: F401
+from voicegateway.repository.node_samples_repository import (
+    NodeSampleInput,
+    insert_samples,
+)
+
+T0 = 1_785_520_800_000  # 2026-07-31T18:00:00Z
+SEC = 1000
+HEALTHY = {"name": "ramp-500", "attempted_calls": 15000, "succeeded_calls": 14985}
+
+# Read off a live node_exporter, which is the only reason these are wired.
+LIVE_OPEN_FDS = 8
+LIVE_MAX_FDS = 524287
+
+
+@pytest.fixture
+async def db(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'procfds.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            SQLModel.metadata.create_all,
+            tables=[SQLModel.metadata.tables["node_samples"]],
+        )
+    async with AsyncSession(engine) as session:
+        yield session
+    await engine.dispose()
+
+
+def _sample(source: str, *, node: str = "sip-1", offset_s: int = 0, **values):
+    return NodeSampleInput(
+        node=node,
+        source=source,
+        at_ms=T0 + offset_s * SEC,
+        outcome="ok",
+        values=values,
+    )
+
+
+async def _fd_gates(db: AsyncSession):
+    agg = await aggregation.aggregate_test_window(
+        db, started_at_ms=T0, ended_at_ms=T0 + 60 * SEC
+    )
+    assert agg is not None
+    return [
+        g
+        for g in judge.judge_test(HEALTHY, aggregate=agg)
+        if g.subject and g.subject.endswith("/file_descriptors")
+    ]
+
+
+# --------------------------------------------------------------------------
+# The map
+# --------------------------------------------------------------------------
+
+
+def test_node_exporter_is_wired_for_its_own_descriptor_pair() -> None:
+    columns = columns_for(SOURCE_NODE_EXPORTER)
+    assert "process_open_fds" in columns
+    assert "process_max_fds" in columns
+
+
+def test_the_metric_names_are_the_unprefixed_process_collector_ones() -> None:
+    """node_exporter prefixes its COLLECTOR series with node_, not these.
+
+    process_open_fds comes from the Go process collector every Prometheus client
+    registers by default, so it carries no node_ prefix. Wiring it as
+    node_process_open_fds would store NULL for the life of the deployment while
+    nothing at runtime said so, which is the exact failure this map's provenance
+    note exists to prevent.
+    """
+    metrics = {e.metric for e in SERIES[SOURCE_NODE_EXPORTER]}
+    assert "process_open_fds" in metrics
+    assert "node_process_open_fds" not in metrics
+
+
+def test_the_same_pair_is_wired_for_the_services_under_test() -> None:
+    """Non-vacuous: the services keep theirs, and theirs are the evidence."""
+    for source in (SOURCE_LIVEKIT_SIP, SOURCE_LIVEKIT_SERVER):
+        assert "process_open_fds" in columns_for(source)
+        assert "process_max_fds" in columns_for(source)
+
+
+def test_the_host_pair_is_still_node_exporter_alone() -> None:
+    """The node-wide criterion is a different resource and has not moved."""
+    assert "filefd_allocated" in columns_for(SOURCE_NODE_EXPORTER)
+    for source in (SOURCE_LIVEKIT_SIP, SOURCE_LIVEKIT_SERVER):
+        assert "filefd_allocated" not in columns_for(source)
+
+
+# --------------------------------------------------------------------------
+# What the gate does with the data
+# --------------------------------------------------------------------------
+
+
+async def test_a_scraped_node_exporter_now_grades_instead_of_unknown(
+    db: AsyncSession,
+) -> None:
+    """The seven rows, resolved. Same numbers a live exporter reports."""
+    await insert_samples(
+        db,
+        [
+            _sample(
+                SOURCE_NODE_EXPORTER,
+                process_open_fds=LIVE_OPEN_FDS,
+                process_max_fds=LIVE_MAX_FDS,
+            )
+        ],
+    )
+    [gate] = await _fd_gates(db)
+    assert gate.subject == "sip-1/node-exporter/file_descriptors"
+    assert gate.status == gates.PASS
+
+
+async def test_the_row_names_the_exporter_so_it_cannot_be_read_as_the_service(
+    db: AsyncSession,
+) -> None:
+    """The concern this change does not remove, pinned so it stays visible.
+
+    A PASS here says node_exporter's own process has descriptor headroom. That
+    is a true and narrow statement, and the only thing keeping it from reading
+    as a claim about the SIP service is that the subject and the detail both
+    name the exporter. If either ever stops doing so, this fails.
+    """
+    await insert_samples(
+        db,
+        [
+            _sample(
+                SOURCE_NODE_EXPORTER,
+                process_open_fds=LIVE_OPEN_FDS,
+                process_max_fds=LIVE_MAX_FDS,
+            ),
+            _sample(
+                SOURCE_LIVEKIT_SIP, process_open_fds=120, process_max_fds=LIVE_MAX_FDS
+            ),
+        ],
+    )
+    fd = await _fd_gates(db)
+    assert sorted(g.subject or "" for g in fd) == [
+        "sip-1/livekit-sip/file_descriptors",
+        "sip-1/node-exporter/file_descriptors",
+    ]
+    for gate in fd:
+        source = (gate.subject or "").split("/")[1]
+        assert source in gate.detail, gate
+
+
+async def test_an_unscraped_node_exporter_is_still_unknown(db: AsyncSession) -> None:
+    """The prior decision, untouched.
+
+    Wiring the series does not mean every run carries them. An exporter that
+    could have reported the pair and did not is still UNKNOWN, which is what
+    ``test_node_exporter_keeps_its_file_descriptor_gate`` protects.
+    """
+    await insert_samples(db, [_sample(SOURCE_NODE_EXPORTER, filefd_allocated=2496.0)])
+    [gate] = await _fd_gates(db)
+    assert gate.status == gates.UNKNOWN
+
+
+async def test_a_breaching_service_still_fails_next_to_a_passing_exporter(
+    db: AsyncSession,
+) -> None:
+    """The rows must not drown each other out.
+
+    node_exporter passing at 8 of 524287 says nothing about the service, and a
+    service at its ceiling must still FAIL in the same run.
+    """
+    await insert_samples(
+        db,
+        [
+            _sample(
+                SOURCE_NODE_EXPORTER,
+                process_open_fds=LIVE_OPEN_FDS,
+                process_max_fds=LIVE_MAX_FDS,
+            ),
+            _sample(
+                SOURCE_LIVEKIT_SIP,
+                process_open_fds=520000,
+                process_max_fds=LIVE_MAX_FDS,
+            ),
+        ],
+    )
+    fd = await _fd_gates(db)
+    [failed] = [g for g in fd if g.status == gates.FAIL]
+    assert "livekit-sip" in (failed.subject or "")
+    [passed] = [g for g in fd if g.status == gates.PASS]
+    assert "node-exporter" in (passed.subject or "")


### PR DESCRIPTION
Two changes to the load-test gates, both prompted by reading a real seven-step run's report. Neither changes how anything grades.

## 1. Scrape node_exporter's own descriptor pair (`a198f78`)

The headroom gate asks **every** scraped source for `process_open_fds` against `process_max_fds`. node_exporter was asked and nothing was wired to answer, so seven of that run's nine UNKNOWN rows were one exporter being asked a question the scrape configuration had guaranteed it could not answer.

Three positions were available and only two are coherent: gate and scrape, gate neither, or gate without scraping. The last is what produced those rows.

**Suppressing the gate was tried before and rejected on the record.** `test_gate_only_where_measurable.py::test_node_exporter_keeps_its_file_descriptor_gate` exists specifically to catch it, and its reasoning stands: node_exporter *can* produce the pair (a live one reads `process_open_fds` 8 against `process_max_fds` 524287), so an absent reading is a gap rather than a category error, and dropping the gate would hide a producible metric. Wiring the series honours that decision instead of reversing it. **All three tests that pin the existing behaviour pass unedited.**

Two details that mattered:

- The metric names carry **no** `node_` prefix. They come from the Go process collector every Prometheus client registers, not from node_exporter's own collectors. Wiring them as `node_process_open_fds` would have stored NULL for the life of the deployment with nothing at runtime saying so.
- No migration. `node_samples` already carries both columns as `BigInteger` and the livekit sources already populate them (4719 / 4720 rows).

`test_histogram_misuse.py` pins `len(SERIES[source])` against a count claimed in the module docstring, so the docstring's "all 9 node-exporter entries" became 11, with provenance. That is the map's own claim about itself, so the source was edited rather than the test.

### Read what the resulting row means

These are node_exporter's **own** file handles. The gate reads `<node>/node-exporter/file_descriptors` and means exactly that. It is not evidence about livekit-sip's headroom; the services under test report their own pair and those are the rows that answer the acceptance criterion. `test_the_row_names_the_exporter_so_it_cannot_be_read_as_the_service` fails if the subject or detail ever stops naming the exporter.

### This does not retroactively fix the delivered Stage 2 report

The map governs what the scraper **writes**. `sura-stage2-full`'s 5376 node-exporter rows were written before this change and carry NULL in both columns, and the report reads stored rows rather than re-scraping. Those seven UNKNOWNs are a property of that run's recorded data. The fix earns its place on the next run, on the fleet, where a clean pass would otherwise read UNKNOWN because of a monitoring agent's own file handles.

## 2. Give every per-step gate row the step it belongs to (`7eeae24`)

The same run rendered seven rows reading `sura-sip-01/node-exporter/file_descriptors` with nothing to tell them apart. A reader cannot know whether that is one problem or seven, and the next run is a fleet: more steps and four nodes instead of one, so every per-step per-node resource gate multiplies the same way.

This is the same collision already fixed once for **sources**. Three exporters on one node produced three identically labelled rows reading PASS, UNKNOWN and UNKNOWN, and the fix was to put the source in the subject. The step is the other half of that identity and was still missing.

- `GateResult` carries a `step`, stamped in `judge_run` rather than `judge_test`, because the step is run-level identity: `judge_test` grades one step and has no idea whether it is one of seven.
- Run-level rows (the fleet scope exclusions) carry **none**. Stamping them would claim seven evaluations where there was one, which is the same lie pointing the other way.
- The payload follows the `waiver_reason` rule and omits the key when None, so a diagnostics gate keeps the exact key set pinned at `test_gates.py:465`.
- Rendered into the existing identity cell, so the table gains no column, and suppressed when it merely repeats the subject (the establishment gate, whose subject *is* the step).

### Identity only, verified against the real run

| | Before | After |
|---|---|---|
| Gate rows | 44 | 44 |
| Statuses | 33 PASS / 9 UNKNOWN / 2 FAIL | identical, **in order** |
| Details | | identical, in order |
| Verdict / calls_per_node | FAIL / 15 | FAIL / 15 |
| Distinct rendered rows | repeats | **44 of 44 distinct** |

## Gates

- `backend`: ruff clean, mypy clean on 283 files, **3073 passed**, 13 skipped (3054 on main, +19 new tests, zero failures)
- `docs`: PASS, 90 pages, 90 nav refs
- **No existing test was edited.**

## Before Stage 3 scraping starts

The collector on the monitoring host is on the old map. Merging is necessary but not sufficient: that host has to be updated to a revision containing `a198f78` **and** the collector started fresh. A restart alone will not pick up the new series, and neither will a pull that predates this merge. Otherwise the fleet run reproduces exactly the situation this fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer step identification for gate results in multi-step load-test reports.
  * Improved report rendering by escaping gate identifiers and preventing duplicate step labels.
  * Added monitoring for process open and maximum file-descriptor metrics.

* **Bug Fixes**
  * Improved distinction between exporter and service metrics, including accurate PASS, FAIL, and UNKNOWN results.

* **Tests**
  * Added regression coverage for multi-step gate identity, report rendering, and file-descriptor metric evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->