### PR TITLE
Close the two acceptance criteria with no coverage: Redis and health checks

### DIFF
--- a/alembic/versions/e4c7a2b81f93_redis_and_health.py
+++ b/alembic/versions/e4c7a2b81f93_redis_and_health.py
@@ -1,0 +1,89 @@
+"""node_samples: Redis state and health-endpoint probe results
+
+Revision ID: e4c7a2b81f93
+Revises: d1f4b8c93a27
+Create Date: 2026-08-02 15:40:00.000000
+
+Two acceptance criteria had no coverage at all. "No sustained Redis or
+health-check failures" produced no gate on a real run: not a pass, not a fail,
+not even an UNKNOWN, because nothing scraped Redis and nothing probed a health
+endpoint. A report that silently omits an agreed criterion is worse than one
+that fails it.
+
+ONE revision for both groups, and chained off the single head d1f4b8c93a27.
+Two revisions landing in the same branch is how the chain forks, and a forked
+chain fails only at ``alembic upgrade head`` on a real deployment.
+
+REDIS names were read off a live oliver006/redis_exporter scraping redis:7,
+not taken from documentation. Confirmed present with values: ``redis_up`` 1,
+``redis_rejected_connections_total`` 0, ``redis_memory_used_bytes`` 1194336,
+``redis_memory_max_bytes`` 0, ``redis_blocked_clients`` 0,
+``redis_evicted_keys_total`` 0.
+
+``redis_memory_max_bytes`` reads 0 on an exporter whose Redis has no maxmemory
+configured, and 0 there does NOT mean "no memory available", it means "no
+limit". Dividing used by it would either divide by zero or read as total
+exhaustion, so ``redis_memory_max_unbounded`` records the difference the same
+way ``filefd_maximum_unbounded`` already does for the host descriptor ceiling:
+1 unbounded, 0 a real limit, NULL unmeasured.
+
+HEALTH is not a Prometheus series and gets no parallel probe subsystem. The
+outcome is written by the same sampling loop onto the same time axis as
+everything else, so a sustained-failure gate reasons over a window of samples
+exactly like every other criterion, at the cost of three columns.
+
+``health_ok`` is 1 for any 2xx, 0 otherwise, and NULL when no health endpoint is
+configured. NULL must never be read as 0: "nobody asked" and "it answered badly"
+are different facts, and an operator has to be able to tell an unconfigured
+probe from a failing service.
+
+``health_status_code`` carries the status when a response arrived at all and is
+NULL when none did, which is what separates "returned 503" from "refused the
+connection". livekit-sip answers 200 OK, 429 UnderLoad or 503 Unavailable on
+its health_port; livekit-server answers 200 or 406 on its main port. Both were
+read from their own documentation rather than assumed.
+
+``health_timed_out`` splits the two ways a probe gets no response at all. A
+refusal means nothing is listening; a timeout means something is listening and
+stuck. Both leave the status code NULL and they are different problems.
+
+Every column is nullable and NULL means "not measured", never zero. Byte and
+counter columns are BigInteger because INT4 overflows.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e4c7a2b81f93"
+down_revision: str | Sequence[str] | None = "d1f4b8c93a27"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "node_samples"
+
+# (column, type). BigInteger wherever the value is a byte count or a cumulative
+# counter; a plain Integer for the small markers and the HTTP status.
+_COLUMNS: tuple[tuple[str, sa.types.TypeEngine], ...] = (
+    ("redis_up", sa.Integer()),
+    ("redis_rejected_connections_total", sa.BigInteger()),
+    ("redis_memory_used_bytes", sa.BigInteger()),
+    ("redis_memory_max_bytes", sa.BigInteger()),
+    ("redis_memory_max_unbounded", sa.Integer()),
+    ("redis_blocked_clients", sa.Integer()),
+    ("redis_evicted_keys_total", sa.BigInteger()),
+    ("health_ok", sa.Integer()),
+    ("health_status_code", sa.Integer()),
+    ("health_timed_out", sa.Integer()),
+)
+
+
+def upgrade() -> None:
+    for name, type_ in _COLUMNS:
+        op.add_column(_TABLE, sa.Column(name, type_, nullable=True))
+
+
+def downgrade() -> None:
+    for name, _ in reversed(_COLUMNS):
+        op.drop_column(_TABLE, name)

--- a/dashboards/voicegateway-load-test.json
+++ b/dashboards/voicegateway-load-test.json
@@ -1,5 +1,5 @@
 {
-  "description": "7 of 12 panels have a series behind them. The rest are rendered as explicit NOT MEASURED notes rather than empty graphs, because an empty graph reads as nothing happening when it means nobody measured. Generated from the node_samples column sets, so a panel can never name a series that does not exist.",
+  "description": "10 of 14 panels have a series behind them. The rest are rendered as explicit NOT MEASURED notes rather than empty graphs, because an empty graph reads as nothing happening when it means nobody measured. Generated from the node_samples column sets, so a panel can never name a series that does not exist.",
   "editable": true,
   "panels": [
     {
@@ -276,18 +276,97 @@
       "type": "timeseries"
     },
     {
+      "datasource": "${DS_VOICEGATEWAY}",
+      "description": "1 when the exporter reached Redis on that scrape, 0 when it ran and could not. A gap is neither: it means nobody scraped, and the line breaks rather than dropping to zero.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 40
       },
-      "options": {
-        "content": "### Not measured\n\n**Redis health** would need `redis_up`, which `node_samples` does not carry.\n\nNot collected. Nothing scrapes Redis, so the sustained-Redis-failure half of the acceptance criteria is unevaluated. It is not passing; it is unmeasured.\n\n_This is an absence of measurement, not a measurement of zero. Nothing here passed; nothing here was checked._",
-        "mode": "markdown"
+      "targets": [
+        {
+          "datasource": "${DS_VOICEGATEWAY}",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT at_ms AS time, node, redis_up AS up FROM node_samples ORDER BY at_ms",
+          "refId": "A"
+        }
+      ],
+      "title": "Redis reachability",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_VOICEGATEWAY}",
+      "description": "Used over the configured maximum. Redis with no maxmemory reports a maximum of 0, which is no limit rather than no memory, so those rows are excluded here instead of rendering as full.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
       },
-      "title": "Redis health \u2014 NOT MEASURED",
-      "type": "text"
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "targets": [
+        {
+          "datasource": "${DS_VOICEGATEWAY}",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT at_ms AS time, node, 1.0 * redis_memory_used_bytes / NULLIF(redis_memory_max_bytes, 0) AS memory_used FROM node_samples ORDER BY at_ms",
+          "refId": "A"
+        }
+      ],
+      "title": "Redis memory against its limit",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_VOICEGATEWAY}",
+      "description": "Clients waiting on a blocking command right now. Rises before a sustained failure rather than after it.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "targets": [
+        {
+          "datasource": "${DS_VOICEGATEWAY}",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT at_ms AS time, node, redis_blocked_clients AS blocked FROM node_samples ORDER BY at_ms",
+          "refId": "A"
+        }
+      ],
+      "title": "Redis blocked clients",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 39,

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -97,6 +97,7 @@ NODE_CPU_GATE = "node_cpu"
 NODE_MEMORY_GATE = "node_memory"
 HEADROOM_GATE = "resource_headroom"
 RETURN_TO_BASELINE_GATE = "return_to_baseline"
+SUSTAINED_HEALTH_GATE = "sustained_health"
 
 #: The subject a gate is filed under when it describes the whole fleet rather
 #: than one node. Used where nothing was sampled at all: the finding is that NO
@@ -141,6 +142,10 @@ ALL_GATES: frozenset[str] = frozenset(
         NODE_MEMORY_GATE,
         HEADROOM_GATE,
         RETURN_TO_BASELINE_GATE,
+        # Registered here and deliberately ABSENT from RATIO_GATES above: its
+        # value is a count of consecutive failed samples, not a fraction, and
+        # rendering 3 as "300%" is exactly the misstatement that set prevents.
+        SUSTAINED_HEALTH_GATE,
     }
 )
 
@@ -169,6 +174,25 @@ MIN_ESTABLISHMENT_RATIO = 0.995
 # comparison for the other is the easy mistake.
 MAX_NODE_CPU_UTILISATION = 0.70
 MAX_NODE_MEMORY_UTILISATION = 0.75
+
+# How many CONSECUTIVE failed samples make a failure "sustained".
+#
+# The criterion reads "no SUSTAINED Redis or health-check failures", not "no
+# failures". A single missed sample during a container restart, a leader
+# election or a rolling deploy is not an outage, and grading it as one makes the
+# gate cry wolf until somebody stops reading it.
+#
+# Three at the 15-second sampling interval is roughly 45 seconds of continuous
+# failure. That is chosen to sit above the things that legitimately blip and
+# below anything a caller would tolerate: a Redis unreachable for 45 seconds has
+# dropped calls, and a SIP node refusing health checks for 45 seconds is out of
+# the load balancer's rotation. One sample would fire on noise; ten would be
+# four minutes of a dead dependency reported as healthy.
+#
+# Consecutive, not cumulative, and the distinction is the whole point: thirty
+# scattered single-sample failures across an hour are a flapping dependency
+# worth a WARN, while three in a row are an outage.
+MAX_CONSECUTIVE_FAILED_SAMPLES = 3
 
 # Headroom that must REMAIN on a limited resource. A floor, and inclusive: a node
 # sitting on exactly 20% free has met "at least 20% headroom".
@@ -1347,6 +1371,184 @@ def summary_lines(gates: Sequence[GateResult]) -> list[str]:
     return [f"  [{g.status}] {g.gate}: {g.detail}" for g in gates]
 
 
+
+# --------------------------------------------------------------------------
+# Sustained Redis and health-check failures
+# --------------------------------------------------------------------------
+
+#: What a health series is ABOUT, which is also how its row is labelled.
+HEALTH_SUBJECT_REDIS = "redis"
+HEALTH_SUBJECT_ENDPOINT = "health_endpoint"
+
+
+@dataclass(frozen=True)
+class HealthSeriesReading:
+    """One source's healthy/failed samples across a window, in time order.
+
+    ``samples`` carries 1 healthy, 0 failed and None NOT MEASURED, and the three
+    are never collapsed. None is not a failure: a tick nobody sampled says
+    nothing about whether the dependency was up, and counting it as a failure
+    would manufacture an outage out of a scrape gap.
+
+    ``codes`` is the HTTP status alongside each sample where there was one, so a
+    row can say 503 rather than only "unhealthy". Empty for Redis, which has no
+    status code.
+
+    ``unmeasured_reason`` is set when the series could not be read at all, and
+    it is what separates "not configured" from "configured and failing".
+    """
+
+    node: str
+    subject: str
+    source: str | None = None
+    samples: tuple[int | None, ...] = ()
+    codes: tuple[int | None, ...] = ()
+    unmeasured_reason: str | None = None
+
+
+def longest_failure_run(samples: Sequence[int | None]) -> int:
+    """The longest run of CONSECUTIVE failed samples.
+
+    A None breaks the run rather than extending it. Two failures either side of
+    an unsampled tick are not demonstrably three consecutive failures, and this
+    gate must not claim a continuity it did not observe.
+    """
+    longest = current = 0
+    for value in samples:
+        if value == 0:
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def _health_subject(reading: HealthSeriesReading) -> str:
+    parts = [reading.node]
+    if reading.source:
+        parts.append(reading.source)
+    parts.append(reading.subject)
+    return "/".join(parts)
+
+
+def sustained_health_gate(
+    reading: HealthSeriesReading,
+    *,
+    threshold: int = MAX_CONSECUTIVE_FAILED_SAMPLES,
+) -> GateResult:
+    """Did this dependency fail for long enough to count?
+
+    Three outcomes, and the middle one is why this is not a boolean.
+
+    FAIL is a run of ``threshold`` consecutive failed samples: an outage.
+    WARN is failures that never reached that run: a flapping dependency, which
+    is a real finding and not a pass, but is not the criterion being breached.
+    PASS is no failed sample at all.
+
+    UNKNOWN when nothing was measured, with a reason that says whether the
+    source was unconfigured or configured and unreadable. Those are different
+    facts and an operator has to be able to tell them apart, so an unconfigured
+    dependency NEVER reads as a pass.
+    """
+    subject = _health_subject(reading)
+    if reading.unmeasured_reason:
+        return GateResult(
+            gate=SUSTAINED_HEALTH_GATE,
+            status=UNKNOWN,
+            detail=f"{subject} was not measured: {reading.unmeasured_reason}",
+            subject=subject,
+            threshold=float(threshold),
+        )
+    measured = [s for s in reading.samples if s is not None]
+    if not measured:
+        return GateResult(
+            gate=SUSTAINED_HEALTH_GATE,
+            status=UNKNOWN,
+            detail=(
+                f"{subject} was not measured: the window carried "
+                f"{len(reading.samples)} sample(s) and none of them recorded a "
+                "result"
+            ),
+            subject=subject,
+            threshold=float(threshold),
+        )
+
+    run = longest_failure_run(reading.samples)
+    failed = sum(1 for s in measured if s == 0)
+    seen = _failure_codes(reading)
+    codes = f" Statuses seen: {seen}." if seen else ""
+
+    if run >= threshold:
+        return GateResult(
+            gate=SUSTAINED_HEALTH_GATE,
+            status=FAIL,
+            detail=(
+                f"{subject} failed {run} consecutive sample(s), at or above the "
+                f"{threshold}-sample bar for a sustained failure "
+                f"({failed} of {len(measured)} measured samples failed).{codes}"
+            ),
+            subject=subject,
+            metric="consecutive_failed_samples",
+            value=float(run),
+            threshold=float(threshold),
+        )
+    if failed:
+        return GateResult(
+            gate=SUSTAINED_HEALTH_GATE,
+            status=WARN,
+            detail=(
+                f"{subject} failed {failed} of {len(measured)} measured "
+                f"sample(s), longest run {run}, below the {threshold}-sample bar "
+                f"for a sustained failure. Not the criterion breached, but not "
+                f"a clean window either.{codes}"
+            ),
+            subject=subject,
+            metric="consecutive_failed_samples",
+            value=float(run),
+            threshold=float(threshold),
+        )
+    return GateResult(
+        gate=SUSTAINED_HEALTH_GATE,
+        status=PASS,
+        detail=(
+            f"{subject} was healthy on all {len(measured)} measured sample(s)."
+        ),
+        subject=subject,
+        metric="consecutive_failed_samples",
+        value=0.0,
+        threshold=float(threshold),
+    )
+
+
+def _failure_codes(reading: HealthSeriesReading) -> str:
+    """The distinct HTTP statuses seen on FAILED samples, most useful first.
+
+    429 UnderLoad and 503 Unavailable are different problems and the row must
+    say which. A failure with no code at all was a refusal or a timeout, which
+    is a third different problem and is named rather than left blank.
+    """
+    if not reading.codes:
+        return ""
+    seen: dict[str, int] = {}
+    for sample, code in zip(reading.samples, reading.codes, strict=False):
+        if sample != 0:
+            continue
+        key = str(code) if code is not None else "no response"
+        seen[key] = seen.get(key, 0) + 1
+    if not seen:
+        return ""
+    return ", ".join(f"{k} x{v}" for k, v in sorted(seen.items()))
+
+
+def sustained_health_gates(
+    readings: Sequence[HealthSeriesReading],
+    *,
+    threshold: int = MAX_CONSECUTIVE_FAILED_SAMPLES,
+) -> list[GateResult]:
+    """One gate per node per source. Per-node rows are never collapsed."""
+    return [sustained_health_gate(r, threshold=threshold) for r in readings]
+
+
 __all__ = [
     "AGENTS_GATE",
     "BASELINE_GOROUTINES",
@@ -1370,6 +1572,14 @@ __all__ = [
     "NODE_MEMORY_GATE",
     "RATIO_GATES",
     "RETURN_TO_BASELINE_GATE",
+    "SUSTAINED_HEALTH_GATE",
+    "HEALTH_SUBJECT_REDIS",
+    "HEALTH_SUBJECT_ENDPOINT",
+    "HealthSeriesReading",
+    "sustained_health_gate",
+    "sustained_health_gates",
+    "longest_failure_run",
+    "MAX_CONSECUTIVE_FAILED_SAMPLES",
     "PASS",
     "SFU_CAPACITY_GATE",
     "SFU_QUALITY_GATE",

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -1521,7 +1521,11 @@ def sustained_health_gate(
 
 
 def _failure_codes(reading: HealthSeriesReading) -> str:
-    """The distinct HTTP statuses seen on FAILED samples, most useful first.
+    """The distinct HTTP statuses seen on FAILED samples, with their counts.
+
+    Ordered by the string form of the status, which is stable rather than
+    meaningful: it exists so one run's row reads the same as the next, not
+    because 429 matters more than 503.
 
     429 UnderLoad and 503 Unavailable are different problems and the row must
     say which. A failure with no code at all was a refusal or a timeout, which

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -50,9 +50,11 @@ from dataclasses import dataclass, field
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from voicegateway.livekit_diag import gates
 from voicegateway.livekit_diag.gates import (
     MIN_PERCENTILE_SAMPLES,
     HeadroomReading,
+    HealthSeriesReading,
     NodeUtilisationReading,
 )
 from voicegateway.repository.node_correlation_repository import (
@@ -83,6 +85,8 @@ MEMORY_TOTAL_COLUMN = "memory_total_bytes"
 # unbounded and does not fit a 64-bit column, while this pair reads a real
 # 524287. The limit a service actually hits is its own, and the host figure
 # cannot produce a ratio at all.
+REDIS_UP_COLUMN = "redis_up"
+HEALTH_OK_COLUMN = "health_ok"
 FD_USED_COLUMN = "process_open_fds"
 FD_LIMIT_COLUMN = "process_max_fds"
 
@@ -106,6 +110,10 @@ class TestAggregate:
     node_samples_in_window: int
     cpu_readings: list[NodeUtilisationReading] = field(default_factory=list)
     memory_readings: list[NodeUtilisationReading] = field(default_factory=list)
+    # Redis reachability and health-endpoint results as ORDERED sample series,
+    # one per node per source. Ordered because the criterion is about a RUN of
+    # consecutive failures, which a peak or an average cannot express.
+    health_readings: list[HealthSeriesReading] = field(default_factory=list)
     # File-descriptor headroom per node, already in the shape the gate judges.
     # Carried here rather than rebuilt in the judge so the measurement lives in
     # one place and the judge stays a thing that only decides.
@@ -236,6 +244,49 @@ async def _memory_reading(
     )
 
 
+async def _health_readings(
+    db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
+) -> list[HealthSeriesReading]:
+    """Redis and health-endpoint sample series for one node and source.
+
+    Ordered by time, because "three consecutive failures" is a statement about
+    sequence. A row whose column is NULL contributes None rather than being
+    dropped: dropping it would splice two failures either side of an unsampled
+    tick into a run that was never observed.
+
+    Returns an empty list when the source produced no rows carrying the column
+    at all, which the judge turns into an UNKNOWN naming what was not
+    configured.
+    """
+    rows = await list_samples(
+        db,
+        node=node,
+        source=source,
+        since_ms=window.start_ms,
+        until_ms=window.end_ms,
+        limit=limit,
+    )
+    out: list[HealthSeriesReading] = []
+    for column, subject in (
+        (REDIS_UP_COLUMN, gates.HEALTH_SUBJECT_REDIS),
+        (HEALTH_OK_COLUMN, gates.HEALTH_SUBJECT_ENDPOINT),
+    ):
+        values = tuple(getattr(row, column) for row in rows)
+        if all(v is None for v in values):
+            continue
+        codes = (
+            tuple(row.health_status_code for row in rows)
+            if column == HEALTH_OK_COLUMN
+            else ()
+        )
+        out.append(
+            HealthSeriesReading(
+                node=node, source=source, subject=subject, samples=values, codes=codes
+            )
+        )
+    return out
+
+
 async def _fd_reading(
     db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
 ) -> HeadroomReading:
@@ -316,6 +367,7 @@ async def aggregate_test_window(
     cpu: list[NodeUtilisationReading] = []
     memory: list[NodeUtilisationReading] = []
     fds: list[HeadroomReading] = []
+    health: list[HealthSeriesReading] = []
     for target in targets:
         cpu.append(
             await _cpu_reading(
@@ -332,6 +384,11 @@ async def aggregate_test_window(
                 db, node=target.node, source=target.source, window=window, limit=limit
             )
         )
+        health.extend(
+            await _health_readings(
+                db, node=target.node, source=target.source, window=window, limit=limit
+            )
+        )
 
     return TestAggregate(
         window=window,
@@ -343,6 +400,7 @@ async def aggregate_test_window(
         cpu_readings=cpu,
         memory_readings=memory,
         fd_readings=fds,
+        health_readings=health,
     )
 
 

--- a/src/voicegateway/loadtest/dashboard.py
+++ b/src/voicegateway/loadtest/dashboard.py
@@ -18,10 +18,15 @@ that says so, in the same grid position a graph would have occupied. It takes up
 the same space, it is impossible to miss, and it cannot be mistaken for a quiet
 hour on a healthy fleet.
 
-Five of the panels an operator would want are in that state today: per-core CPU,
-RTP port usage, ENA packet-per-second allowances, conntrack occupancy, and Redis
-health. Nothing scrapes any of them. Listing them as unmeasured is more useful
-than omitting them, because an absent panel reads as a question nobody asked.
+Four of the panels an operator would want are in that state today: per-core CPU,
+RTP port usage, ENA packet-per-second allowances and conntrack occupancy.
+Nothing scrapes any of them. Listing them as unmeasured is more useful than
+omitting them, because an absent panel reads as a question nobody asked.
+
+Redis was the fifth and no longer is. redis_exporter is a scrape source, so
+reachability, memory against its limit and blocked clients are measured panels
+and the acceptance criterion has an answer instead of a note saying nobody
+looked.
 
 Counter resets
 --------------
@@ -243,14 +248,46 @@ PANELS: tuple[Panel, ...] = (
         ),
     ),
     Panel(
-        title="Redis health",
+        title="Redis reachability",
         series=("redis_up",),
-        description="Redis availability and latency behind the SFU.",
-        absent_note=(
-            "Not collected. Nothing scrapes Redis, so the sustained-Redis-"
-            "failure half of the acceptance criteria is unevaluated. It is not "
-            "passing; it is unmeasured."
+        description=(
+            "1 when the exporter reached Redis on that scrape, 0 when it ran "
+            "and could not. A gap is neither: it means nobody scraped, and the "
+            "line breaks rather than dropping to zero."
         ),
+        sql=(
+            "SELECT at_ms AS time, node, redis_up AS up "
+            f"FROM {TABLE} ORDER BY at_ms"
+        ),
+        unit="short",
+    ),
+    Panel(
+        title="Redis memory against its limit",
+        series=("redis_memory_used_bytes", "redis_memory_max_bytes"),
+        description=(
+            "Used over the configured maximum. Redis with no maxmemory reports "
+            "a maximum of 0, which is no limit rather than no memory, so those "
+            "rows are excluded here instead of rendering as full."
+        ),
+        sql=(
+            "SELECT at_ms AS time, node, "
+            "1.0 * redis_memory_used_bytes / NULLIF(redis_memory_max_bytes, 0) "
+            f"AS memory_used FROM {TABLE} ORDER BY at_ms"
+        ),
+        unit="percentunit",
+    ),
+    Panel(
+        title="Redis blocked clients",
+        series=("redis_blocked_clients",),
+        description=(
+            "Clients waiting on a blocking command right now. Rises before a "
+            "sustained failure rather than after it."
+        ),
+        sql=(
+            "SELECT at_ms AS time, node, redis_blocked_clients AS blocked "
+            f"FROM {TABLE} ORDER BY at_ms"
+        ),
+        unit="short",
     ),
 )
 

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -253,6 +253,68 @@ def judge_test(
     results.extend(_graded(aggregate.cpu_readings, gates.node_cpu_gates))
     results.extend(_graded(aggregate.memory_readings, gates.node_memory_gates))
     results.extend(_headroom_gates_for(aggregate))
+    results.extend(_health_gates_for(aggregate))
+    return results
+
+
+def _health_gates_for(aggregate: TestAggregate) -> list[GateResult]:
+    """Sustained Redis and health-endpoint failures, per node per source.
+
+    ONLY what was actually sampled. The "nothing was configured" case is a fact
+    about the RUN, not about each step, and lives in
+    :func:`unconfigured_dependency_gates` so it is stated once. Emitting it here
+    put fourteen identical rows in a seven-step report, which is the same defect
+    that rtp_ports and network already had fixed.
+    """
+    return list(gates.sustained_health_gates(aggregate.health_readings))
+
+
+def unconfigured_dependency_gates(seen: set[str | None]) -> list[GateResult]:
+    """One row per dependency criterion nobody wired, once per run.
+
+    NOT CONFIGURED IS NOT A PASS, and it is not silence either. The criterion
+    was agreed, so a report that omits it reads as one nobody asked about, and a
+    run that never looked at Redis must never be indistinguishable from one that
+    checked and found it healthy.
+
+    The reason names BOTH ways out, because an operator reading UNKNOWN needs to
+    know which they are looking at: wire the source, or declare it absent with a
+    written waiver a reviewer can read. A single-node deployment genuinely has
+    no Redis, and saying so once in config is a true statement; silence is a
+    vacuous one.
+    """
+    results: list[GateResult] = []
+    for subject, what, wire in (
+        (
+            gates.HEALTH_SUBJECT_REDIS,
+            "no scrape target uses the redis-exporter source",
+            "add a redis-exporter scrape target",
+        ),
+        (
+            gates.HEALTH_SUBJECT_ENDPOINT,
+            "no scrape target declares a health endpoint",
+            "attach a health endpoint to a target with the |health= suffix",
+        ),
+    ):
+        if subject in seen:
+            continue
+        results.append(
+            gates.sustained_health_gate(
+                gates.HealthSeriesReading(
+                    node=gates.FLEET_SUBJECT,
+                    subject=subject,
+                    unmeasured_reason=(
+                        f"{what}, so this criterion was not evaluated. It is "
+                        "NOT passing: nothing was asked and nothing answered. "
+                        "There are exactly two ways out and silence is neither: "
+                        f"WIRE it ({wire}), or DECLARE it absent by waiving this "
+                        "gate in writing with a reason. A waiver is recorded and "
+                        "a reviewer reads it; an unevaluated criterion just "
+                        "looks like one nobody agreed to."
+                    ),
+                )
+            )
+        )
     return results
 
 
@@ -334,6 +396,19 @@ def judge_run(
     # gate has nothing to sign. They stay UNKNOWN until somebody does that, so
     # the verdict does not improve on its own either.
     out.extend(unmeasurable_headroom_gates())
+    # ONCE PER RUN, for the same reason. A dependency nobody wired is a fact
+    # about the deployment, not about step four of seven.
+    out.extend(
+        unconfigured_dependency_gates(
+            {g.subject for g in out if g.gate == gates.SUSTAINED_HEALTH_GATE}
+            | {
+                r.subject
+                for agg in (aggregates or {}).values()
+                if agg is not None
+                for r in agg.health_readings
+            }
+        )
+    )
     return out
 
 

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -36,6 +36,7 @@ from voicegateway.loadtest.aggregation import (
 from voicegateway.middleware.node_samples_worker_middleware import (
     any_source_publishes,
     reports_host_metrics,
+    reports_process_metrics,
 )
 
 # The FD pair is the one headroom resource anything scrapes. RTP ports and
@@ -157,6 +158,22 @@ def _reports_node_metrics(source: str | None) -> bool:
     return reports_host_metrics(source) is not False
 
 
+def _speaks_for_process_fds(source: str | None) -> bool:
+    """Whether a process-descriptor gate for this source means anything.
+
+    Narrow on purpose. Only a source that is DEFINITELY not an authority is
+    dropped, which today is the Redis exporter and nothing else.
+
+    node_exporter is deliberately NOT dropped. It publishes the pair, it is now
+    wired for it, and an absent reading there is a real gap rather than a
+    category error. That decision is pinned by
+    ``test_gate_only_where_measurable.py::test_node_exporter_keeps_its_file_descriptor_gate``
+    and nothing here disturbs it: reports_process_metrics answers None for a
+    host exporter, and only an explicit False suppresses.
+    """
+    return reports_process_metrics(source) is not False
+
+
 def _graded(readings, gate_fn):
     """Grade the readings whose SOURCE can produce this metric.
 
@@ -252,9 +269,19 @@ def _headroom_gates_for(aggregate: TestAggregate) -> list[GateResult]:
     # Real file-descriptor readings, measured during correlation. A node whose
     # window carried no usable pair arrives here already unmeasured WITH its
     # reason, which the gate turns into UNKNOWN rather than a pass.
-    readings.extend(aggregate.fd_readings)
+    #
+    # A source that cannot be the authority for a service's descriptors is
+    # dropped here, and only when it produced no number: a real reading is
+    # evidence and is graded whatever took it.
+    readings.extend(
+        r
+        for r in aggregate.fd_readings
+        if r.used is not None or _speaks_for_process_fds(r.source)
+    )
     measured = {(r.node, r.source) for r in aggregate.fd_readings}
     for reading in aggregate.cpu_readings:
+        if not _speaks_for_process_fds(reading.source):
+            continue
         # A node the aggregate judged for CPU but carries no FD reading for
         # would otherwise lose the file-descriptor gate while keeping the other
         # two, which reads as a resource nobody had to satisfy rather than one

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -269,8 +269,14 @@ def _health_gates_for(aggregate: TestAggregate) -> list[GateResult]:
     return list(gates.sustained_health_gates(aggregate.health_readings))
 
 
-def unconfigured_dependency_gates(seen: set[str | None]) -> list[GateResult]:
+def unconfigured_dependency_gates(seen: set[str]) -> list[GateResult]:
     """One row per dependency criterion nobody wired, once per run.
+
+    ``seen`` holds BARE dependency constants (:data:`gates.HEALTH_SUBJECT_REDIS`
+    and :data:`gates.HEALTH_SUBJECT_ENDPOINT`) as they appear on a
+    ``HealthSeriesReading``, NOT rendered gate subjects like
+    ``sip-1/redis-exporter/redis``. Passing the latter silently matches nothing
+    and every dependency reads as unconfigured even when it was measured.
 
     NOT CONFIGURED IS NOT A PASS, and it is not silence either. The criterion
     was agreed, so a report that omits it reads as one nobody asked about, and a
@@ -332,13 +338,21 @@ def _headroom_gates_for(aggregate: TestAggregate) -> list[GateResult]:
     # window carried no usable pair arrives here already unmeasured WITH its
     # reason, which the gate turns into UNKNOWN rather than a pass.
     #
-    # A source that cannot be the authority for a service's descriptors is
-    # dropped here, and only when it produced no number: a real reading is
-    # evidence and is graded whatever took it.
+    # Authority first, and for a DEPENDENCY exporter it is unconditional. A
+    # number from redis-exporter's own process is not weak evidence about the
+    # fleet, it is evidence about a monitoring sidecar, and grading it would put
+    # a sidecar's descriptor headroom in a client report as if it answered the
+    # criterion. "Never discard a measurement" protects readings that are about
+    # the subject; it does not promote one that never was.
+    #
+    # A source merely UNKNOWN to the classifier keeps the old rule: a real
+    # reading is graded whatever took it, because there the absence of an answer
+    # is ignorance rather than a category error.
     readings.extend(
         r
         for r in aggregate.fd_readings
-        if r.used is not None or _speaks_for_process_fds(r.source)
+        if _speaks_for_process_fds(r.source)
+        or (r.used is not None and reports_process_metrics(r.source) is None)
     )
     measured = {(r.node, r.source) for r in aggregate.fd_readings}
     for reading in aggregate.cpu_readings:
@@ -400,10 +414,9 @@ def judge_run(
     # about the deployment, not about step four of seven.
     out.extend(
         unconfigured_dependency_gates(
-            {g.subject for g in out if g.gate == gates.SUSTAINED_HEALTH_GATE}
-            | {
+            {
                 r.subject
-                for agg in (aggregates or {}).values()
+                for agg in aggregates.values()
                 if agg is not None
                 for r in agg.health_readings
             }

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -70,6 +70,27 @@ unauthenticated request gets a 401 rather than an exposition. Observed:
 524287 livekit-sip reports on the same host, which is the cross-check that these
 are the per-process ceiling rather than anything host-wide.
 
+MEASURED against a live oliver006/redis_exporter scraping redis:7, by local
+scrape rather than from documentation: all 6 ``redis-exporter`` entries.
+Observed: ``redis_up`` 1, ``redis_rejected_connections_total`` 0,
+``redis_memory_used_bytes`` 1194336, ``redis_memory_max_bytes`` 0,
+``redis_blocked_clients`` 0, ``redis_evicted_keys_total`` 0. That exporter
+publishes 302 ``redis_*`` series and six are wired, because every column is one
+somebody has to keep honest; these six are what the acceptance criterion asks
+for and nothing more.
+
+``redis_memory_max_bytes`` 0 is "no maxmemory configured", NOT "no memory".
+``_mark_unbounded_redis_memory`` records that as a separate marker so a ratio is
+never taken against a zero denominator, exactly as the host descriptor ceiling
+is handled.
+
+The same scrape confirms what redis_exporter is NOT an authority for: zero
+``node_*`` series and zero ``livekit_*`` series, so it cannot report node-wide
+CPU or memory. It does publish its own ``process_open_fds`` 8 against
+``process_max_fds`` 1048576, and those are deliberately unwired: they are a
+monitoring sidecar's file handles and say nothing about any service the
+criterion covers. See :data:`DEPENDENCY_EXPORTERS`.
+
 DELIBERATELY UNWIRED, so their columns store NULL rather than a wrong name:
 ``livekit_session_start_time_ms_*``, ``livekit_track_published_total``,
 ``livekit_track_subscribed_total`` and ``psrpc_stream_count``. These are the
@@ -132,6 +153,7 @@ _DEFAULT_MAX_AGE_SECONDS: Final[float] = 7 * 24 * 3600.0
 SOURCE_LIVEKIT_SERVER: Final[str] = "livekit-server"
 SOURCE_LIVEKIT_SIP: Final[str] = "livekit-sip"
 SOURCE_NODE_EXPORTER: Final[str] = "node-exporter"
+SOURCE_REDIS_EXPORTER: Final[str] = "redis-exporter"
 SOURCES: Final[tuple[str, ...]] = (
     SOURCE_LIVEKIT_SERVER,
     SOURCE_LIVEKIT_SIP,
@@ -337,6 +359,30 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         _Series("process_open_fds", "process_open_fds"),
         _Series("process_max_fds", "process_max_fds"),
     ),
+    SOURCE_REDIS_EXPORTER: (
+        # Redis is shared state every SIP node depends on, and the acceptance
+        # criterion asks whether it stayed healthy for the whole window.
+        #
+        # MEASURED against a live oliver006/redis_exporter scraping redis:7.
+        # The smallest set that answers the criterion, not everything the
+        # exporter offers: it publishes 302 redis_* series and each one wired
+        # here is one more column somebody has to keep honest.
+        #
+        # redis_up is the primary signal: 0 means the exporter ran and could
+        # not reach Redis, which is the outage itself.
+        _Series("redis_up", "redis_up"),
+        # Connections Redis turned away. Cumulative, so read as a rate.
+        _Series("redis_rejected_connections_total", "redis_rejected_connections_total"),
+        # Memory against any configured ceiling. A live exporter reads 0 for
+        # the maximum when no maxmemory is set, which is "no limit" and NOT
+        # "no memory": _mark_unbounded_redis_memory keeps those apart.
+        _Series("redis_memory_used_bytes", "redis_memory_used_bytes"),
+        _Series("redis_memory_max_bytes", "redis_memory_max_bytes"),
+        # Both indicate a Redis under pressure rather than one that is down,
+        # which is exactly the state that precedes a sustained failure.
+        _Series("redis_blocked_clients", "redis_blocked_clients"),
+        _Series("redis_evicted_keys_total", "redis_evicted_keys_total"),
+    ),
 }
 
 
@@ -352,8 +398,30 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
 # kernel's "no limit", and the last 1024 counts are not a distinction anything
 # can act on.
 FILEFD_UNBOUNDED_THRESHOLD: Final[float] = float(2**63 - 1024)
+_REDIS_MAX_MEMORY_COLUMN: Final[str] = "redis_memory_max_bytes"
+_REDIS_MAX_MEMORY_UNBOUNDED_COLUMN: Final[str] = "redis_memory_max_unbounded"
 _FILEFD_MAXIMUM_COLUMN: Final[str] = "filefd_maximum"
 _FILEFD_UNBOUNDED_COLUMN: Final[str] = "filefd_maximum_unbounded"
+
+
+def _mark_unbounded_redis_memory(values: dict[str, float | None]) -> None:
+    """Record whether Redis has a memory ceiling at all.
+
+    A live redis_exporter reports ``redis_memory_max_bytes`` 0 when Redis has no
+    ``maxmemory`` configured. 0 there means "no limit", and it is the one value
+    that must never be read as a ratio denominator: used/0 is either a crash or,
+    once guarded, a number that reads as total exhaustion on the one chart an
+    operator checks during an incident.
+
+    Three states, kept apart exactly as the host descriptor ceiling is. 1 says
+    unbounded, so memory headroom cannot run out against a configured limit. 0
+    says a real ceiling was reported. Leaving the key out stores NULL, which
+    says nobody measured.
+    """
+    maximum = values.get(_REDIS_MAX_MEMORY_COLUMN)
+    if maximum is None:
+        return
+    values[_REDIS_MAX_MEMORY_UNBOUNDED_COLUMN] = 1.0 if maximum <= 0 else 0.0
 
 
 def _mark_unbounded_filefd(values: dict[str, float | None]) -> None:
@@ -391,6 +459,19 @@ HOST_EXPORTERS: frozenset[str] = frozenset({SOURCE_NODE_EXPORTER})
 SERVICE_EXPORTERS: frozenset[str] = frozenset(
     {SOURCE_LIVEKIT_SERVER, SOURCE_LIVEKIT_SIP}
 )
+
+#: Sources that report on a DEPENDENCY rather than on the fleet under test.
+#: redis_exporter speaks for Redis and for nothing else. It is deliberately in
+#: neither set above: it is not a host exporter, and it is not one of the
+#: services whose descriptor headroom the acceptance criterion is about.
+#:
+#: THE TRAP THIS CLOSES. redis_exporter publishes its own process_open_fds and
+#: process_max_fds, verified live at 8 against 1048576. Wiring those, or
+#: letting reports_process_metrics answer True for it, would recreate in a new
+#: source exactly the category error two commits were just spent removing: a
+#: gate row asserting a monitoring agent's own file handles as if they were a
+#: service's headroom.
+DEPENDENCY_EXPORTERS: frozenset[str] = frozenset({SOURCE_REDIS_EXPORTER})
 
 
 def any_source_publishes(*columns: str) -> bool:
@@ -440,6 +521,43 @@ def reports_host_metrics(source: str | None) -> bool | None:
     if source in HOST_EXPORTERS:
         return True
     if source in SERVICE_EXPORTERS:
+        return False
+    if source in DEPENDENCY_EXPORTERS:
+        # VERIFIED BY SCRAPE: a live redis_exporter publishes zero node_*
+        # series. It speaks for Redis, not for the box Redis runs on.
+        return False
+    return None
+
+
+def reports_process_metrics(source: str | None) -> bool | None:
+    """Whether ``source`` speaks for a SERVICE UNDER TEST's own process.
+
+    Deliberately three-valued, and the middle value is the point.
+
+    True for the services themselves: process_open_fds against process_max_fds
+    is one process's rlimit headroom, and only livekit-sip and livekit-server
+    can make that number a statement about the fleet under test.
+
+    False for a DEPENDENCY exporter. redis_exporter publishes its own pair
+    (verified live at 8 against 1048576) and is capable of the measurement, but
+    its file handles say nothing about anything the acceptance criterion covers.
+    Grading it would put a row in a client report asserting a monitoring
+    sidecar's descriptor headroom.
+
+    None for a host exporter, which is NOT the same as False and must not
+    become it. node_exporter is wired for the pair and reports it, so its gate
+    is real and is pinned by
+    ``test_gate_only_where_measurable.py::test_node_exporter_keeps_its_file_descriptor_gate``.
+    Answering False here would suppress a gate for a metric that source does
+    produce, which is the defect two earlier commits exist to prevent.
+
+    None for an undeclared source, which is never suppressed.
+    """
+    if source is None:
+        return None
+    if source in SERVICE_EXPORTERS:
+        return True
+    if source in DEPENDENCY_EXPORTERS:
         return False
     return None
 
@@ -766,6 +884,7 @@ class NodeSamplesWorker(AsyncWorker):
             values[series.column] = value
             found += 1
         _mark_unbounded_filefd(values)
+        _mark_unbounded_redis_memory(values)
         return node_samples.NodeSampleInput(
             node=target.node,
             source=target.source,
@@ -833,7 +952,10 @@ __all__ = [
     "TARGETS_ENV_VAR",
     "any_source_publishes",
     "columns_for",
+    "DEPENDENCY_EXPORTERS",
+    "SOURCE_REDIS_EXPORTER",
     "reports_host_metrics",
+    "reports_process_metrics",
     "NodeSamplesWorker",
     "ScrapeTarget",
     "TargetProvider",

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -158,6 +158,7 @@ SOURCES: Final[tuple[str, ...]] = (
     SOURCE_LIVEKIT_SERVER,
     SOURCE_LIVEKIT_SIP,
     SOURCE_NODE_EXPORTER,
+    SOURCE_REDIS_EXPORTER,
 )
 
 # Scrape outcomes, stored verbatim in ``node_samples.outcome``.
@@ -198,6 +199,11 @@ class ScrapeTarget:
     source: str
     project: str = node_samples.DEFAULT_PROJECT
     auth: tuple[str, str] | None = field(default=None, repr=False)
+    #: Optional health endpoint, probed on the same tick as the metrics scrape
+    #: so its result lands on the same time axis. None means no endpoint is
+    #: configured, which is recorded as NULL and NEVER as a failure: "nobody
+    #: asked" and "it answered badly" are different facts.
+    health_url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -604,6 +610,13 @@ validate_series_map(SERIES)
 TargetProvider = Callable[[], Awaitable[Sequence[ScrapeTarget]]]
 
 
+#: Separator that attaches an optional health endpoint to a target entry:
+#: ``livekit-sip:sip-1=http://sip-1:8082/metrics|health=http://sip-1:8081/``.
+#: A separate suffix rather than a second environment variable, so a target and
+#: its health endpoint cannot drift apart in configuration.
+HEALTH_SUFFIX: Final[str] = "|health="
+
+
 def targets_from_env(
     environ: Mapping[str, str] | None = None,
 ) -> list[ScrapeTarget]:
@@ -639,9 +652,25 @@ def targets_from_env(
                 ", ".join(SOURCES),
             )
             continue
-        clean, auth = split_userinfo(url.strip())
+        metrics_url, _, health = url.strip().partition(HEALTH_SUFFIX)
+        if not metrics_url.strip():
+            logger.warning(
+                "%s: ignoring %r; no metrics url before %r",
+                TARGETS_ENV_VAR,
+                shown,
+                HEALTH_SUFFIX,
+            )
+            continue
+        clean, auth = split_userinfo(metrics_url.strip())
+        health_clean, _ = split_userinfo(health.strip()) if health.strip() else (None, None)
         targets.append(
-            ScrapeTarget(node=node.strip(), url=clean, source=source, auth=auth)
+            ScrapeTarget(
+                node=node.strip(),
+                url=clean,
+                source=source,
+                auth=auth,
+                health_url=health_clean,
+            )
         )
     return targets
 
@@ -821,6 +850,55 @@ class NodeSamplesWorker(AsyncWorker):
         )
         return written
 
+    async def _probe_health(
+        self, client: httpx.AsyncClient, target: ScrapeTarget
+    ) -> dict[str, float | None]:
+        """Probe the target's health endpoint, if it has one.
+
+        Returns the three health columns, or an EMPTY dict when no endpoint is
+        configured. Empty means the columns stay NULL, and NULL means nobody
+        asked. Writing 0 there would report a service as failing its health
+        check because its operator never configured one.
+
+        Any 2xx is healthy. livekit-sip answers 200 OK, 429 UnderLoad or 503
+        Unavailable; livekit-server answers 200 or 406. A 429 counts as
+        unhealthy on purpose: a node shedding load is a node not serving
+        callers. The status is recorded alongside so the report can say WHICH,
+        because 429 and 503 are different problems and so is no answer at all.
+
+        Never raises. A probe failure is a recorded fact, exactly like a failed
+        scrape.
+        """
+        if not target.health_url:
+            return {}
+        try:
+            response = await asyncio.wait_for(
+                client.get(target.health_url),
+                timeout=self._scrape_timeout,
+            )
+        except (TimeoutError, httpx.TimeoutException):
+            # Something is listening and stuck, which is not the same as
+            # nothing listening, so the two are recorded apart.
+            return {"health_ok": 0.0, "health_timed_out": 1.0}
+        except httpx.HTTPError:
+            # Connection refused, DNS failure, TLS failure. No response at all,
+            # so no status code exists to record; the column stays NULL rather
+            # than being filled with a plausible-looking zero.
+            return {"health_ok": 0.0, "health_timed_out": 0.0}
+        except Exception:
+            logger.exception(
+                "NodeSamplesWorker: unexpected error probing health for %s (%s)",
+                redact_url(target.health_url),
+                target.node,
+            )
+            return {"health_ok": 0.0, "health_timed_out": 0.0}
+        healthy = 200 <= response.status_code < 300
+        return {
+            "health_ok": 1.0 if healthy else 0.0,
+            "health_status_code": float(response.status_code),
+            "health_timed_out": 0.0,
+        }
+
     async def _scrape(
         self, client: httpx.AsyncClient, target: ScrapeTarget, at_ms: int
     ) -> node_samples.NodeSampleInput:
@@ -849,6 +927,8 @@ class NodeSamplesWorker(AsyncWorker):
             )
             outcome, body = OUTCOME_UNREACHABLE, None
 
+        health = await self._probe_health(client, target)
+
         if body is None:
             return node_samples.NodeSampleInput(
                 node=target.node,
@@ -859,6 +939,10 @@ class NodeSamplesWorker(AsyncWorker):
                 # NULL, not 0: no exposition was read, so nothing is known about
                 # how many series it would have carried.
                 series_found=None,
+                # The health probe is independent of the metrics scrape, so a
+                # target whose exposition is unreachable can still have a
+                # working health endpoint, and that is worth recording.
+                values=dict(health),
             )
 
         samples = parse_exposition(body)
@@ -870,6 +954,7 @@ class NodeSamplesWorker(AsyncWorker):
                 outcome=OUTCOME_UNPARSEABLE,
                 project=target.project,
                 series_found=None,
+                values=dict(health),
             )
 
         values: dict[str, float | None] = {}
@@ -885,6 +970,9 @@ class NodeSamplesWorker(AsyncWorker):
             found += 1
         _mark_unbounded_filefd(values)
         _mark_unbounded_redis_memory(values)
+        # Merged AFTER `found` is counted. The probe is not part of the
+        # exposition, and series_found answers what the metrics target exposed.
+        values.update(health)
         return node_samples.NodeSampleInput(
             node=target.node,
             source=target.source,

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -204,6 +204,11 @@ class ScrapeTarget:
     #: configured, which is recorded as NULL and NEVER as a failure: "nobody
     #: asked" and "it answered badly" are different facts.
     health_url: str | None = None
+    #: Credentials for the health endpoint, split out of its URL exactly as
+    #: :attr:`auth` is and for the same reason: httpx logs the request line at
+    #: INFO, so userinfo left in the URL is written to the log on every tick.
+    #: repr=False so a rendered target cannot leak it either.
+    health_auth: tuple[str, str] | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True)
@@ -662,7 +667,9 @@ def targets_from_env(
             )
             continue
         clean, auth = split_userinfo(metrics_url.strip())
-        health_clean, _ = split_userinfo(health.strip()) if health.strip() else (None, None)
+        health_clean, health_auth = (
+            split_userinfo(health.strip()) if health.strip() else (None, None)
+        )
         targets.append(
             ScrapeTarget(
                 node=node.strip(),
@@ -670,6 +677,7 @@ def targets_from_env(
                 source=source,
                 auth=auth,
                 health_url=health_clean,
+                health_auth=health_auth,
             )
         )
     return targets
@@ -873,7 +881,7 @@ class NodeSamplesWorker(AsyncWorker):
             return {}
         try:
             response = await asyncio.wait_for(
-                client.get(target.health_url),
+                client.get(target.health_url, auth=target.health_auth),
                 timeout=self._scrape_timeout,
             )
         except (TimeoutError, httpx.TimeoutException):
@@ -903,11 +911,21 @@ class NodeSamplesWorker(AsyncWorker):
         self, client: httpx.AsyncClient, target: ScrapeTarget, at_ms: int
     ) -> node_samples.NodeSampleInput:
         """Scrape one target. Never raises: a failure becomes a row that says so."""
+        # Concurrent, not sequential. Both already carry their own deadline, so
+        # running them one after the other made a target that is entirely dead
+        # cost TWO timeouts, and a tick's worst case the sum rather than the max.
+        fetch = asyncio.wait_for(
+            self._fetch(client, target.url, target.auth),
+            timeout=self._scrape_timeout,
+        )
+        probe = self._probe_health(client, target)
+        gathered = asyncio.gather(fetch, probe, return_exceptions=True)
+        fetched, health_result = await gathered
+        health = health_result if isinstance(health_result, dict) else {}
         try:
-            body, outcome = await asyncio.wait_for(
-                self._fetch(client, target.url, target.auth),
-                timeout=self._scrape_timeout,
-            )
+            if isinstance(fetched, BaseException):
+                raise fetched
+            body, outcome = fetched
         except (TimeoutError, httpx.TimeoutException):
             # The outer wait_for is not redundant with httpx's timeouts: httpx
             # applies a READ timeout per read operation, so a target dribbling
@@ -926,8 +944,6 @@ class NodeSamplesWorker(AsyncWorker):
                 target.node,
             )
             outcome, body = OUTCOME_UNREACHABLE, None
-
-        health = await self._probe_health(client, target)
 
         if body is None:
             return node_samples.NodeSampleInput(

--- a/src/voicegateway/models/node_sample_model.py
+++ b/src/voicegateway/models/node_sample_model.py
@@ -191,6 +191,48 @@ class NodeSample(SQLModel, table=True):
     sip_rtp_packets_recv: int | None = Field(default=None, sa_type=BigInteger)
     sip_rtp_packets_send: int | None = Field(default=None, sa_type=BigInteger)
 
+    # ---- Redis, the shared state every SIP node depends on ------------------
+    # VERIFIED against a live oliver006/redis_exporter against redis:7, not
+    # inferred: every name below was read off its exposition before wiring.
+    #
+    # redis_up is the primary signal and the only one that answers "was Redis
+    # reachable at all". 0 means the exporter ran and could not reach Redis,
+    # which is a fact; NULL means nobody scraped, which is not.
+    redis_up: int | None = None
+    redis_rejected_connections_total: int | None = Field(
+        default=None, sa_type=BigInteger
+    )
+    redis_memory_used_bytes: int | None = Field(default=None, sa_type=BigInteger)
+    # A live exporter reports 0 here when no maxmemory is configured, which is
+    # NOT "no memory available": it is "no limit". Storing it raw and dividing
+    # would either divide by zero or read as total exhaustion, so the
+    # unbounded case is recorded separately, exactly as filefd_maximum is.
+    redis_memory_max_bytes: int | None = Field(default=None, sa_type=BigInteger)
+    # 1 unbounded, 0 a real limit, NULL unmeasured. Derived, not scraped.
+    redis_memory_max_unbounded: int | None = None
+    redis_blocked_clients: int | None = None
+    redis_evicted_keys_total: int | None = Field(default=None, sa_type=BigInteger)
+
+    # ---- health endpoint ----------------------------------------------------
+    # Not a Prometheus series. Written by the same sampling loop onto the same
+    # time axis, so a "sustained failure" gate has a window of samples to reason
+    # over exactly like every other criterion, at the cost of three columns
+    # rather than a parallel probe subsystem.
+    #
+    # 1 healthy (any 2xx), 0 unhealthy, NULL not probed. NULL is the answer when
+    # no health endpoint is configured, and it must never be read as 0: "nobody
+    # asked" and "it answered badly" are different facts.
+    health_ok: int | None = None
+    # The HTTP status when a response arrived at all, NULL when none did. This
+    # is what separates "returned 503" from "refused the connection".
+    # livekit-sip answers 200 OK, 429 UnderLoad or 503 Unavailable;
+    # livekit-server answers 200 or 406.
+    health_status_code: int | None = None
+    # 1 when the failure was a deadline rather than a refusal. Both leave
+    # health_status_code NULL, and they are different problems: a refusal means
+    # nothing is listening, a timeout means something is listening and stuck.
+    health_timed_out: int | None = None
+
     # ---- restart and attribution ------------------------------------------
     # A process that restarted mid-run invalidates every counter rate across
     # the restart. start_time is what makes that visible rather than a mystery

--- a/src/voicegateway/repository/node_samples_repository.py
+++ b/src/voicegateway/repository/node_samples_repository.py
@@ -84,6 +84,11 @@ COUNTER_COLUMNS: frozenset[str] = frozenset(
         "sip_rtp_packets_send",
         "process_cpu_seconds_total",
         "udp_no_ports_total",
+        # Redis. Cumulative since the server started, so only a rate is
+        # meaningful: an absolute "3 rejected connections" says nothing
+        # about whether any were rejected during THIS window.
+        "redis_rejected_connections_total",
+        "redis_evicted_keys_total",
     }
 )
 
@@ -120,6 +125,17 @@ GAUGE_COLUMNS: frozenset[str] = frozenset(
         # Derived from node_filefd_maximum rather than scraped, but still an
         # observation about one scrape. 1 unbounded, 0 bounded, NULL unmeasured.
         "filefd_maximum_unbounded",
+        # Redis point-in-time state.
+        "redis_up",
+        "redis_memory_used_bytes",
+        "redis_memory_max_bytes",
+        "redis_memory_max_unbounded",
+        "redis_blocked_clients",
+        # Health probe. Not scraped from an exposition, but still an
+        # observation about one sampling tick, read exactly as recorded.
+        "health_ok",
+        "health_status_code",
+        "health_timed_out",
     }
 )
 
@@ -130,7 +146,18 @@ VALUE_COLUMNS: frozenset[str] = COUNTER_COLUMNS | GAUGE_COLUMNS
 # counted out of ``series_found``: that number answers "how many of the series
 # expected for this source did the target actually expose", and a derived
 # marker would inflate it into a claim about the target.
-DERIVED_COLUMNS: frozenset[str] = frozenset({"filefd_maximum_unbounded"})
+DERIVED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "filefd_maximum_unbounded",
+        "redis_memory_max_unbounded",
+        # The health columns come from an HTTP probe, not from the
+        # exposition, so counting them would inflate series_found into a
+        # claim about what the metrics target exposed.
+        "health_ok",
+        "health_status_code",
+        "health_timed_out",
+    }
+)
 
 # Columns stored as integers. Everything else in VALUE_COLUMNS is a float.
 # Prometheus exposition is float-typed on the wire, so an integer column is
@@ -175,6 +202,18 @@ _INT_COLUMNS: frozenset[str] = frozenset(
         "track_subscribed_total",
         "psrpc_stream_count",
         "filefd_maximum_unbounded",
+        # Redis. Counts, byte totals and 0/1 markers, none of them fractional.
+        "redis_up",
+        "redis_rejected_connections_total",
+        "redis_memory_used_bytes",
+        "redis_memory_max_bytes",
+        "redis_memory_max_unbounded",
+        "redis_blocked_clients",
+        "redis_evicted_keys_total",
+        # Health probe: two 0/1 markers and an HTTP status code.
+        "health_ok",
+        "health_status_code",
+        "health_timed_out",
     }
 )
 
@@ -264,6 +303,18 @@ class NodeSampleRow:
     psrpc_stream_count: int | None
     filefd_maximum_unbounded: int | None
 
+    # Redis and health. Nullable like every value column: NULL means
+    # nobody measured, never zero.
+    redis_up: int | None
+    redis_rejected_connections_total: int | None
+    redis_memory_used_bytes: int | None
+    redis_memory_max_bytes: int | None
+    redis_memory_max_unbounded: int | None
+    redis_blocked_clients: int | None
+    redis_evicted_keys_total: int | None
+    health_ok: int | None
+    health_status_code: int | None
+    health_timed_out: int | None
 
 @dataclass(frozen=True)
 class CounterRate:
@@ -348,6 +399,16 @@ def _row(sample: NodeSample) -> NodeSampleRow:
         track_subscribed_total=sample.track_subscribed_total,
         psrpc_stream_count=sample.psrpc_stream_count,
         filefd_maximum_unbounded=sample.filefd_maximum_unbounded,
+        redis_up=sample.redis_up,
+        redis_rejected_connections_total=sample.redis_rejected_connections_total,
+        redis_memory_used_bytes=sample.redis_memory_used_bytes,
+        redis_memory_max_bytes=sample.redis_memory_max_bytes,
+        redis_memory_max_unbounded=sample.redis_memory_max_unbounded,
+        redis_blocked_clients=sample.redis_blocked_clients,
+        redis_evicted_keys_total=sample.redis_evicted_keys_total,
+        health_ok=sample.health_ok,
+        health_status_code=sample.health_status_code,
+        health_timed_out=sample.health_timed_out,
     )
 
 

--- a/src/voicegateway/tests/loadtest/test_dashboard.py
+++ b/src/voicegateway/tests/loadtest/test_dashboard.py
@@ -112,11 +112,27 @@ def test_unmeasured_panels_occupy_a_full_panel_of_space() -> None:
         assert (note["gridPos"]["w"], note["gridPos"]["h"]) == size
 
 
-def test_the_five_known_gaps_are_all_present_as_notes() -> None:
-    """Named individually so silently dropping one is a test failure."""
+def test_the_four_known_gaps_are_all_present_as_notes() -> None:
+    """Named individually so silently dropping one is a test failure.
+
+    Redis was the fifth until redis_exporter became a scrape source. It is not
+    removed here to make anything pass: it is removed because it stopped being
+    a gap, and a test pinning "X is unmeasured" has to be updated when X is
+    measured or it starts preventing the improvement it was written to track.
+    The panels below assert the other half, that Redis really is measured now.
+    """
     titles = " ".join(p["title"] for p in _panels_by_type("text"))
-    for gap in ("CPU per core", "RTP port", "ENA", "Conntrack", "Redis"):
+    for gap in ("CPU per core", "RTP port", "ENA", "Conntrack"):
         assert gap in titles, gap
+    assert "Redis" not in titles
+
+
+def test_redis_is_measured_rather_than_a_note() -> None:
+    """The other half of the change above, so the gap cannot quietly return."""
+    measured = " ".join(
+        p.get("title", "") for p in _panels_by_type("timeseries")
+    )
+    assert "Redis" in measured
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/loadtest/test_gate_row_identity.py
+++ b/src/voicegateway/tests/loadtest/test_gate_row_identity.py
@@ -141,7 +141,14 @@ def test_run_level_rows_carry_no_step() -> None:
     which is the same lie in the opposite direction.
     """
     run_level = [g for g in _run() if g.step is None]
-    assert {g.subject for g in run_level} == {"fleet/network", "fleet/rtp_ports"}
+    assert {g.subject for g in run_level} == {
+        "fleet/network",
+        "fleet/rtp_ports",
+        # Same shape, added with the dependency criteria: a dependency nobody
+        # wired is a fact about the deployment, not about step four of seven.
+        "fleet/redis",
+        "fleet/health_endpoint",
+    }
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/loadtest/test_pass_path.py
+++ b/src/voicegateway/tests/loadtest/test_pass_path.py
@@ -199,7 +199,15 @@ def test_the_verdict_is_still_not_pass_and_here_is_why(acceptance) -> None:
     payload = acceptance["payload"]
     assert payload["verdict"]["status"] == gates.UNKNOWN
     unknown = [g for g in payload["gates"] if g["status"] == gates.UNKNOWN]
-    assert {g["subject"].split("/")[-1] for g in unknown} == {"rtp_ports", "network"}
+    # Four now. rtp_ports and network are unmeasurable by anything; redis and
+    # health_endpoint are unconfigured on this fixture. Different reasons, same
+    # honest status, and none of them is a pass.
+    assert {g["subject"].split("/")[-1] for g in unknown} == {
+        "rtp_ports",
+        "network",
+        "redis",
+        "health_endpoint",
+    }
     # File descriptors ARE measurable and pass here, which is what makes the
     # other two stand out as the gap rather than as more of the same.
     [fds] = [
@@ -381,7 +389,11 @@ def test_a_capacity_figure_requires_breaching_the_ceiling(
 
 @pytest.fixture(scope="module")
 def waived(tmp_path_factory):
-    """The acceptance run with the two unscrapeable resources waived.
+    """The acceptance run with every unmeasured criterion declared.
+
+    Four now, not two. This still asserts what it always asserted, that a fully
+    satisfied run reaches a clean verdict; it just declares two dependencies
+    that did not exist when it was written.
 
     The subject is fleet-level because the gate is: nothing measures either on
     any node, so they are emitted once per run rather than once per node per
@@ -401,6 +413,21 @@ def waived(tmp_path_factory):
                     "no network-headroom exporter was funded for this run, "
                     "agreed in writing before test day"
                 ),
+                # Declared, not silent. The Redis and health-check criteria were
+                # added after this fixture was written, and an unconfigured
+                # dependency is deliberately UNKNOWN rather than a pass: a run
+                # that never looked at Redis must not be indistinguishable from
+                # one that checked and found it healthy. A single-node
+                # deployment genuinely has no Redis, and the honest way to say
+                # so is a recorded waiver a reviewer can read, not silence.
+                "sustained_health/fleet/redis": (
+                    "single-node deployment with no Redis, declared before test "
+                    "day rather than left unevaluated"
+                ),
+                "sustained_health/fleet/health_endpoint": (
+                    "no health endpoint configured on this deployment, declared "
+                    "before test day rather than left unevaluated"
+                ),
             }
         )
     )
@@ -416,10 +443,13 @@ def test_a_waiver_records_the_reason_rather_than_hiding_the_gate(waived) -> None
     """The checklist's requirement: waived in writing, never a silent pass."""
     payload = waived["payload"]
     waived_gates = [g for g in payload["gates"] if g["status"] == gates.WAIVED]
-    assert len(waived_gates) == 2
+    assert len(waived_gates) == 4
     for gate in waived_gates:
-        assert "agreed in writing" in gate["detail"]
+        # The property, rather than one phrase: a waiver carries a human reason
+        # and that reason is visible in the rendered detail. A waiver a reviewer
+        # cannot read is the silent pass this exists to prevent.
         assert gate["waiver_reason"]
+        assert gate["waiver_reason"] in gate["detail"]
 
 
 def test_a_waiver_does_not_become_a_pass(waived) -> None:

--- a/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
+++ b/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
@@ -108,7 +108,14 @@ def test_the_html_and_the_json_agree_on_every_threshold(exported) -> None:
         threshold = gate.get("threshold")
         if threshold is None:
             continue
-        assert gate["gate"] in gates.RATIO_GATES, gate["gate"]
+        # Not every gate's threshold is a fraction. sustained_health carries a
+        # COUNT of consecutive failed samples, and rendering 3 as "300%" is the
+        # exact misstatement RATIO_GATES exists to prevent, so it is checked as
+        # a count rather than exempted.
+        if gate["gate"] not in gates.RATIO_GATES:
+            assert gate["gate"] in gates.ALL_GATES, gate["gate"]
+            assert str(int(threshold)) in exported["html"], gate
+            continue
         assert _ratio_pct(threshold) in exported["html"], gate
 
 

--- a/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
+++ b/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
@@ -115,6 +115,11 @@ def test_the_html_and_the_json_agree_on_every_threshold(exported) -> None:
         if gate["gate"] not in gates.RATIO_GATES:
             assert gate["gate"] in gates.ALL_GATES, gate["gate"]
             assert str(int(threshold)) in exported["html"], gate
+            # And never as a percentage. Membership of RATIO_GATES is the rule;
+            # this asserts the rule was actually obeyed by the renderer, because
+            # a threshold of 3 printed as "300%" is the misstatement that set
+            # exists to prevent and the set alone cannot prove it did not happen.
+            assert _ratio_pct(threshold) not in exported["html"], gate
             continue
         assert _ratio_pct(threshold) in exported["html"], gate
 

--- a/src/voicegateway/tests/loadtest/test_report_shape_end_to_end.py
+++ b/src/voicegateway/tests/loadtest/test_report_shape_end_to_end.py
@@ -117,7 +117,14 @@ def test_every_unknown_names_an_attempt_or_a_scope_exclusion(exported) -> None:
         subject = gate["subject"] or ""
         resource = subject.rsplit("/", 1)[-1]
         attempted = "no node was sampled in the window" in gate["detail"]
-        assert attempted or resource in excluded, gate
+        # A third legitimate kind, added with the Redis and health-check
+        # criteria: a dependency that was never wired. It is NOT noise, and it
+        # is the opposite of an UNKNOWN nobody asked for. The criterion was
+        # agreed, nothing was configured to answer it, and the row says so
+        # along with the two ways to resolve it. Omitting it would put the
+        # report back where it started, silently missing a contracted line.
+        unconfigured = "was not evaluated" in gate["detail"]
+        assert attempted or unconfigured or resource in excluded, gate
 
 
 def test_no_gate_grades_a_source_for_a_metric_it_does_not_report(exported) -> None:

--- a/src/voicegateway/tests/loadtest/test_sustained_health.py
+++ b/src/voicegateway/tests/loadtest/test_sustained_health.py
@@ -1,0 +1,245 @@
+"""Sustained Redis and health-check failures, the two criteria with no coverage.
+
+"No sustained Redis or health-check failures" produced no gate at all on a real
+run: not a pass, not a fail, not even an UNKNOWN. A report that silently omits an
+agreed criterion is worse than one that fails it.
+
+**SUSTAINED, not any.** A single missed sample during a container restart is not
+an outage, and grading it as one makes the gate cry wolf until somebody stops
+reading it. The bar is a run of consecutive failed samples, named at
+:data:`gates.MAX_CONSECUTIVE_FAILED_SAMPLES`, and this file proves the boundary
+in both directions rather than trusting it.
+
+**NOT CONFIGURED IS NOT A PASS**, and it is not silence either. An unconfigured
+dependency is UNKNOWN with a reason that says which of the two is missing, and
+that reason distinguishes "nothing is wired" from "it is wired and failing".
+Those are the same status with very different remedies.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.livekit_diag import gates
+from voicegateway.loadtest import judge
+
+THRESHOLD = gates.MAX_CONSECUTIVE_FAILED_SAMPLES
+HEALTHY = {"name": "ramp-25", "attempted_calls": 150, "succeeded_calls": 150}
+
+
+def _reading(*samples: int | None, subject: str = gates.HEALTH_SUBJECT_REDIS, **kw):
+    return gates.HealthSeriesReading(
+        node="sip-1", source="redis-exporter", subject=subject, samples=samples, **kw
+    )
+
+
+# --------------------------------------------------------------------------
+# The threshold, proven at its boundary
+# --------------------------------------------------------------------------
+
+
+def test_the_threshold_is_three_and_is_named() -> None:
+    """Cited by the report and by the engagement, so it is a named constant."""
+    assert THRESHOLD == 3
+
+
+def test_one_below_the_threshold_does_not_fail() -> None:
+    """Two consecutive failures is a blip, not an outage."""
+    gate = gates.sustained_health_gate(_reading(1, 0, 0, 1, 1))
+    assert gate.status != gates.FAIL
+    assert gate.status == gates.WARN
+
+
+def test_exactly_the_threshold_fails() -> None:
+    """Three in a row is the bar, and the bar is inclusive."""
+    gate = gates.sustained_health_gate(_reading(1, 0, 0, 0, 1))
+    assert gate.status == gates.FAIL
+    assert gate.value == 3.0
+    assert gate.threshold == float(THRESHOLD)
+
+
+def test_scattered_failures_warn_rather_than_fail() -> None:
+    """Cumulative is not consecutive, and the difference is the criterion.
+
+    Six failures that never run together are a flapping dependency: a real
+    finding, and not the criterion being breached.
+    """
+    gate = gates.sustained_health_gate(_reading(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0))
+    assert gate.status == gates.WARN
+    assert gate.value == 1.0
+
+
+def test_a_clean_window_passes() -> None:
+    gate = gates.sustained_health_gate(_reading(1, 1, 1, 1))
+    assert gate.status == gates.PASS
+    assert gate.value == 0.0
+
+
+# --------------------------------------------------------------------------
+# An unsampled tick is not a failure, and does not bridge two
+# --------------------------------------------------------------------------
+
+
+def test_a_gap_breaks_a_run_rather_than_extending_it() -> None:
+    """The trap. Two failures either side of a gap are not three in a row.
+
+    Counting the gap would manufacture an outage out of a missed scrape, which
+    is the "unmeasured is never zero" rule in its most consequential form: here
+    it would turn a clean run into a FAIL in a client's evidence pack.
+    """
+    gate = gates.sustained_health_gate(_reading(0, 0, None, 0, 0))
+    assert gate.status == gates.WARN
+    assert gate.value == 2.0
+
+
+def test_a_gap_inside_a_real_outage_does_not_rescue_it() -> None:
+    """Non-vacuous the other way: three real consecutive failures still fail."""
+    gate = gates.sustained_health_gate(_reading(None, 0, 0, 0, None))
+    assert gate.status == gates.FAIL
+
+
+def test_a_window_of_nothing_but_gaps_is_unknown_not_pass() -> None:
+    gate = gates.sustained_health_gate(_reading(None, None, None))
+    assert gate.status == gates.UNKNOWN
+    assert "none of them recorded a result" in gate.detail
+
+
+@pytest.mark.parametrize("samples", [(0, 0, None), (None, 0, 0)])
+def test_a_gap_at_either_edge_still_breaks_the_run(samples) -> None:
+    assert gates.sustained_health_gate(_reading(*samples)).status == gates.WARN
+
+
+# --------------------------------------------------------------------------
+# Which failure it was
+# --------------------------------------------------------------------------
+
+
+def test_the_row_says_which_status_was_seen() -> None:
+    """429 UnderLoad and 503 Unavailable are different problems.
+
+    A node shedding load at 90% CPU fails the criterion, because a node not
+    serving callers is not healthy. But the report must not collapse it with a
+    node that is refusing outright.
+    """
+    gate = gates.sustained_health_gate(
+        _reading(
+            1,
+            0,
+            0,
+            0,
+            subject=gates.HEALTH_SUBJECT_ENDPOINT,
+            codes=(200, 429, 503, 503),
+        )
+    )
+    assert gate.status == gates.FAIL
+    assert "429 x1" in gate.detail
+    assert "503 x2" in gate.detail
+
+
+def test_no_response_at_all_is_named_rather_than_left_blank() -> None:
+    """A refusal and a timeout carry no status code, and that is a third fact."""
+    gate = gates.sustained_health_gate(
+        _reading(
+            0, 0, 0, subject=gates.HEALTH_SUBJECT_ENDPOINT, codes=(None, None, None)
+        )
+    )
+    assert "no response x3" in gate.detail
+
+
+def test_a_passing_status_is_not_listed_as_a_failure() -> None:
+    gate = gates.sustained_health_gate(
+        _reading(1, 1, subject=gates.HEALTH_SUBJECT_ENDPOINT, codes=(200, 200))
+    )
+    assert "200" not in gate.detail
+
+
+# --------------------------------------------------------------------------
+# Not configured is not a pass
+# --------------------------------------------------------------------------
+
+
+def test_an_unconfigured_dependency_is_unknown_with_a_reason() -> None:
+    gate = gates.sustained_health_gate(
+        gates.HealthSeriesReading(
+            node="fleet",
+            subject=gates.HEALTH_SUBJECT_REDIS,
+            unmeasured_reason="no scrape target uses the redis-exporter source",
+        )
+    )
+    assert gate.status == gates.UNKNOWN
+    assert gate.status != gates.PASS
+    assert "redis-exporter" in gate.detail
+
+
+def test_a_run_with_nothing_wired_still_reports_both_criteria() -> None:
+    """The original defect: a criterion that produces no row at all.
+
+    Once per RUN, not once per step. Emitting these per test put fourteen
+    identical rows in a seven-step report, which is the defect rtp_ports and
+    network already had fixed.
+    """
+    subjects = [
+        g.subject
+        for g in judge.judge_run([HEALTHY, dict(HEALTHY, name="ramp-50")])
+        if g.gate == gates.SUSTAINED_HEALTH_GATE
+    ]
+    assert sorted(subjects) == ["fleet/health_endpoint", "fleet/redis"]
+
+
+def test_a_single_step_does_not_emit_the_unconfigured_row_itself() -> None:
+    """Non-vacuous: the row is absent per test, which is why it is not repeated."""
+    per_test = [
+        g for g in judge.judge_test(HEALTHY) if g.gate == gates.SUSTAINED_HEALTH_GATE
+    ]
+    assert per_test == []
+
+
+def test_the_two_criteria_are_reported_separately() -> None:
+    """Redis wired and no health endpoint is a real configuration.
+
+    Collapsing them into one row would hide which half is missing.
+    """
+    assert gates.HEALTH_SUBJECT_REDIS != gates.HEALTH_SUBJECT_ENDPOINT
+
+
+def test_not_configured_reads_differently_from_configured_and_failing() -> None:
+    """Same status, very different remedy, so the details must not match."""
+    unconfigured = gates.sustained_health_gate(
+        gates.HealthSeriesReading(
+            node="fleet",
+            subject=gates.HEALTH_SUBJECT_REDIS,
+            unmeasured_reason="no scrape target uses the redis-exporter source",
+        )
+    )
+    failing = gates.sustained_health_gate(_reading(0, 0, 0))
+    assert unconfigured.status == gates.UNKNOWN
+    assert failing.status == gates.FAIL
+    assert "not evaluated" not in failing.detail
+
+
+# --------------------------------------------------------------------------
+# Per node, per source
+# --------------------------------------------------------------------------
+
+
+def test_rows_are_not_collapsed_across_nodes() -> None:
+    """At Stage 3 there are four nodes and an operator needs to know which."""
+    readings = [
+        gates.HealthSeriesReading(
+            node=node,
+            source="redis-exporter",
+            subject=gates.HEALTH_SUBJECT_REDIS,
+            samples=(0, 0, 0) if node == "sip-2" else (1, 1, 1),
+        )
+        for node in ("sip-1", "sip-2", "sip-3", "sip-4")
+    ]
+    results = gates.sustained_health_gates(readings)
+    assert len(results) == 4
+    [failed] = [r for r in results if r.status == gates.FAIL]
+    assert failed.subject == "sip-2/redis-exporter/redis"
+
+
+def test_the_gate_is_registered_and_is_not_a_ratio() -> None:
+    """Its value is a count of samples. Rendering 3 as 300% would misstate it."""
+    assert gates.SUSTAINED_HEALTH_GATE in gates.ALL_GATES
+    assert gates.SUSTAINED_HEALTH_GATE not in gates.RATIO_GATES

--- a/src/voicegateway/tests/loadtest/test_sustained_health.py
+++ b/src/voicegateway/tests/loadtest/test_sustained_health.py
@@ -186,6 +186,42 @@ def test_a_run_with_nothing_wired_still_reports_both_criteria() -> None:
     assert sorted(subjects) == ["fleet/health_endpoint", "fleet/redis"]
 
 
+def test_a_wired_dependency_suppresses_only_its_own_fleet_row() -> None:
+    """The `seen` branch, which decides which criteria are still unanswered.
+
+    Redis is wired and health is not, which is a real configuration. The Redis
+    rows must be the measured per-node ones with no fleet/redis placeholder, and
+    the health row must still be there: collapsing the two would hide which half
+    of the criterion is missing, and suppressing both on one wired dependency
+    would silently drop a contracted line.
+    """
+    from voicegateway.loadtest.aggregation import TestAggregate
+    from voicegateway.repository.node_correlation_repository import window_of
+
+    aggregate = TestAggregate(
+        window=window_of(1_785_661_201_000, 1_785_661_260_000),
+        peak_cpu_utilisation=None,
+        peak_memory_utilisation=None,
+        node_samples_in_window=3,
+        health_readings=[
+            gates.HealthSeriesReading(
+                node="sip-1",
+                source="redis-exporter",
+                subject=gates.HEALTH_SUBJECT_REDIS,
+                samples=(1, 1, 1),
+            )
+        ],
+    )
+    subjects = {
+        g.subject
+        for g in judge.judge_run([HEALTHY], aggregates={"ramp-25": aggregate})
+        if g.gate == gates.SUSTAINED_HEALTH_GATE
+    }
+    assert "sip-1/redis-exporter/redis" in subjects
+    assert "fleet/redis" not in subjects
+    assert "fleet/health_endpoint" in subjects
+
+
 def test_a_single_step_does_not_emit_the_unconfigured_row_itself() -> None:
     """Non-vacuous: the row is absent per test, which is why it is not repeated."""
     per_test = [

--- a/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
+++ b/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
@@ -22,6 +22,7 @@ from voicegateway.middleware.node_samples_worker_middleware import (
     SOURCE_LIVEKIT_SERVER,
     SOURCE_LIVEKIT_SIP,
     SOURCE_NODE_EXPORTER,
+    SOURCE_REDIS_EXPORTER,
     TARGETS_ENV_VAR,
     NodeSamplesWorker,
     ScrapeTarget,
@@ -517,6 +518,10 @@ def test_every_mapped_series_names_a_real_value_column() -> None:
             SOURCE_LIVEKIT_SERVER,
             SOURCE_LIVEKIT_SIP,
             SOURCE_NODE_EXPORTER,
+            # Adding a name here is the point of this assertion, not a way
+            # around it: a new source has to be a deliberate edit rather than
+            # something that appears because a map grew.
+            SOURCE_REDIS_EXPORTER,
         }
         for entry in series:
             assert entry.column in repo.VALUE_COLUMNS, entry

--- a/src/voicegateway/tests/middleware/test_redis_exporter_source.py
+++ b/src/voicegateway/tests/middleware/test_redis_exporter_source.py
@@ -1,0 +1,173 @@
+"""redis_exporter as a scrape source, and the authority it does NOT carry.
+
+"No sustained Redis or health-check failures" is an acceptance criterion that
+produced no gate at all: not a pass, not a fail, not even an UNKNOWN, because
+nothing scraped Redis.
+
+Every series name below was read off a live oliver006/redis_exporter scraping
+redis:7 before it was wired. The module docstring's provenance rule is that
+nothing in SERIES is inferred, and a guessed name stores NULL for the life of a
+deployment while series_found still reads high.
+
+**The trap this file exists to pin.** redis_exporter publishes its own
+``process_open_fds`` 8 against ``process_max_fds`` 1048576. It is entirely
+capable of the measurement and is the authority for none of it: those are a
+monitoring sidecar's file handles, not any service's headroom. Two commits were
+spent removing exactly that category error from node-exporter, and re-creating
+it in a new source would be the same defect with a different name.
+"""
+
+from __future__ import annotations
+
+from voicegateway.middleware.node_samples_worker_middleware import (
+    DEPENDENCY_EXPORTERS,
+    HOST_EXPORTERS,
+    SERIES,
+    SERVICE_EXPORTERS,
+    SOURCE_LIVEKIT_SERVER,
+    SOURCE_LIVEKIT_SIP,
+    SOURCE_NODE_EXPORTER,
+    SOURCE_REDIS_EXPORTER,
+    _mark_unbounded_redis_memory,
+    columns_for,
+    reports_host_metrics,
+    reports_process_metrics,
+)
+from voicegateway.repository.node_samples_repository import (
+    COUNTER_COLUMNS,
+    DERIVED_COLUMNS,
+    GAUGE_COLUMNS,
+    VALUE_COLUMNS,
+)
+
+# Read off the live exporter. Kept as data so the provenance is in the test.
+OBSERVED = {
+    "redis_up": 1.0,
+    "redis_rejected_connections_total": 0.0,
+    "redis_memory_used_bytes": 1194336.0,
+    "redis_memory_max_bytes": 0.0,
+    "redis_blocked_clients": 0.0,
+    "redis_evicted_keys_total": 0.0,
+}
+
+
+# --------------------------------------------------------------------------
+# The map
+# --------------------------------------------------------------------------
+
+
+def test_the_source_is_declared() -> None:
+    assert SOURCE_REDIS_EXPORTER in SERIES
+    assert SERIES[SOURCE_REDIS_EXPORTER]
+
+
+def test_every_wired_column_is_one_the_live_exporter_produced() -> None:
+    """Nothing here is inferred, which is the map's own rule."""
+    assert columns_for(SOURCE_REDIS_EXPORTER) == set(OBSERVED)
+
+
+def test_the_metric_names_equal_the_column_names() -> None:
+    """redis_exporter needs no renaming, unlike node_exporter's node_ prefix."""
+    for entry in SERIES[SOURCE_REDIS_EXPORTER]:
+        assert entry.metric == entry.column
+
+
+def test_it_is_the_smallest_set_that_answers_the_criterion() -> None:
+    """The exporter publishes 302 redis_* series. Six are wired.
+
+    Not a style point: every column is one somebody has to keep honest, and the
+    criterion asks whether Redis failed, not for everything Redis knows.
+    """
+    assert len(SERIES[SOURCE_REDIS_EXPORTER]) == 6
+
+
+def test_every_column_is_classified_exactly_once() -> None:
+    for column in columns_for(SOURCE_REDIS_EXPORTER):
+        assert column in VALUE_COLUMNS
+        assert (column in COUNTER_COLUMNS) != (column in GAUGE_COLUMNS)
+
+
+def test_the_two_cumulative_series_are_counters() -> None:
+    """An absolute "3 rejected" says nothing about THIS window."""
+    assert "redis_rejected_connections_total" in COUNTER_COLUMNS
+    assert "redis_evicted_keys_total" in COUNTER_COLUMNS
+
+
+# --------------------------------------------------------------------------
+# Authority: what redis_exporter does NOT speak for
+# --------------------------------------------------------------------------
+
+
+def test_it_is_not_the_authority_for_a_service_process(  # the headline trap
+) -> None:
+    assert reports_process_metrics(SOURCE_REDIS_EXPORTER) is False
+
+
+def test_its_own_descriptor_pair_is_deliberately_unwired() -> None:
+    """Capability is not authority. It publishes them; we do not store them."""
+    assert "process_open_fds" not in columns_for(SOURCE_REDIS_EXPORTER)
+    assert "process_max_fds" not in columns_for(SOURCE_REDIS_EXPORTER)
+
+
+def test_it_cannot_report_node_wide_facts() -> None:
+    """VERIFIED BY SCRAPE: zero node_* series on a live redis_exporter."""
+    assert reports_host_metrics(SOURCE_REDIS_EXPORTER) is False
+
+
+def test_a_host_exporter_is_still_not_suppressed_for_process_fds() -> None:
+    """The regression guard, and the reason this is three-valued.
+
+    node_exporter answers None rather than False. It publishes the pair and is
+    wired for it, and answering False here would suppress a gate for a metric it
+    does produce, which is the defect two earlier commits exist to prevent.
+    """
+    assert reports_process_metrics(SOURCE_NODE_EXPORTER) is None
+
+
+def test_the_services_under_test_are_still_the_authority() -> None:
+    for source in (SOURCE_LIVEKIT_SIP, SOURCE_LIVEKIT_SERVER):
+        assert reports_process_metrics(source) is True
+
+
+def test_the_three_sets_do_not_overlap() -> None:
+    assert not HOST_EXPORTERS & SERVICE_EXPORTERS
+    assert not HOST_EXPORTERS & DEPENDENCY_EXPORTERS
+    assert not SERVICE_EXPORTERS & DEPENDENCY_EXPORTERS
+
+
+# --------------------------------------------------------------------------
+# A maximum of zero is "no limit", not "no memory"
+# --------------------------------------------------------------------------
+
+
+def test_a_zero_maximum_is_recorded_as_unbounded() -> None:
+    """What the live exporter actually reported, and the trap in it.
+
+    redis:7 with no maxmemory answers redis_memory_max_bytes 0. Dividing used by
+    that is either a crash or, once guarded, a number reading as total
+    exhaustion on the one chart somebody checks during an incident.
+    """
+    values: dict[str, float | None] = dict(OBSERVED)
+    _mark_unbounded_redis_memory(values)
+    assert values["redis_memory_max_unbounded"] == 1.0
+
+
+def test_a_real_maximum_is_not_marked_unbounded() -> None:
+    values: dict[str, float | None] = {"redis_memory_max_bytes": 4294967296.0}
+    _mark_unbounded_redis_memory(values)
+    assert values["redis_memory_max_unbounded"] == 0.0
+    assert values["redis_memory_max_bytes"] == 4294967296.0
+
+
+def test_an_absent_maximum_stays_null_and_is_never_zero() -> None:
+    """The third state. Unmeasured is not "unbounded" and is not "bounded"."""
+    values: dict[str, float | None] = {"redis_memory_used_bytes": 1194336.0}
+    _mark_unbounded_redis_memory(values)
+    assert "redis_memory_max_unbounded" not in values
+
+
+def test_the_marker_is_derived_and_not_counted_as_a_series() -> None:
+    """series_found answers what the TARGET exposed. A derived marker would
+    inflate it into a claim about the exposition."""
+    assert "redis_memory_max_unbounded" in DERIVED_COLUMNS
+    assert "redis_memory_max_unbounded" not in columns_for(SOURCE_REDIS_EXPORTER)


### PR DESCRIPTION
Closes the two acceptance criteria that had no coverage at all. "No sustained Redis or health-check failures" produced no gate on a real run: not a pass, not a fail, not even an UNKNOWN. A report that silently omits an agreed criterion is worse than one that fails it.

## Redis as a scrape source

Every name read off a live `oliver006/redis_exporter` scraping `redis:7` before it was wired, per the map's own rule that nothing in `SERIES` is inferred. Six wired out of the 302 `redis_*` series available, because every column is one somebody has to keep honest.

| Series | Observed | Kind |
|---|---|---|
| `redis_up` | `1` | gauge, the primary signal |
| `redis_rejected_connections_total` | `0` | counter |
| `redis_memory_used_bytes` | `1194336` | gauge |
| `redis_memory_max_bytes` | `0` | gauge |
| `redis_blocked_clients` | `0` | gauge |
| `redis_evicted_keys_total` | `0` | counter |

**A maximum of zero is "no limit", not "no memory."** A live exporter reports 0 when Redis has no `maxmemory` configured. Dividing used by it is either a crash or, once guarded, a number reading as total exhaustion on the one chart somebody checks during an incident. `redis_memory_max_unbounded` records the difference, mirroring `filefd_maximum_unbounded` so one idea keeps one shape.

**The authority trap, closed explicitly.** redis_exporter publishes its own `process_open_fds` 8 against `process_max_fds` 1048576, and zero `node_*` and zero `livekit_*` series. It is capable of the descriptor measurement and is the authority for none of it. `reports_process_metrics` is deliberately three-valued: `False` for redis-exporter suppresses the gate, `None` for node-exporter does **not**, because node-exporter publishes the pair and is wired for it, and answering `False` there would suppress a gate for a metric it produces and undo the two commits that settled this.

## Health checks

Not a Prometheus series, and it gets no parallel probe subsystem. The probe rides the existing sampling loop and writes onto the same time axis as every scrape, so the gate reasons over a window of samples exactly like every other criterion. A target declares its endpoint with a `|health=` suffix on the same entry as its metrics URL, so the two cannot drift apart in configuration.

Endpoints taken from their own documentation rather than assumed:

| Service | Endpoint | Healthy | Unhealthy |
|---|---|---|---|
| livekit-sip | `GET /` on `health_port` | `OK` 200 | `UnderLoad` 429, `Unavailable` 503 |
| livekit-server | `GET /` on its main port | 200 | 406 |

Any 2xx is healthy. **429 is unhealthy on purpose**: a node shedding load is a node not serving callers. The status is recorded alongside so a row says which, because 429 and 503 are different problems. A refusal and a timeout both leave the status NULL and are separated by `health_timed_out`: nothing listening, versus something listening but stuck.

## What "sustained" means

`MAX_CONSECUTIVE_FAILED_SAMPLES = 3`, roughly 45 seconds at the sampling interval, sitting next to the other contracted thresholds so it is citable.

- **Consecutive, not cumulative.** Three in a row is an outage and FAILs. Scattered failures are a flapping dependency and WARN.
- **An unsampled tick breaks a run rather than bridging it.** Two failures either side of a gap are not three in a row, and counting them would manufacture an outage out of a missed scrape. This is "unmeasured is never zero" in its most consequential form: it would turn a clean run into a FAIL in an evidence pack.

## Not configured is not a pass

A dependency nobody wired is UNKNOWN with a reason naming **both** ways out: wire the source, or declare it absent with a written waiver. A run that never looked at Redis must never read the same as one that checked and found it healthy, and a waiver is something a reviewer scans while silence is not.

Emitted **once per run**, not once per step. Per test it put fourteen identical rows in a seven-step report, which is the same defect `rtp_ports` and `network` already had fixed.

## Verified against the real seven-step run

| | Before | After |
|---|---|---|
| Gate rows | 44 | **46** |
| UNKNOWN | 9 | **11** |
| PASS / FAIL | 33 / 2 | 33 / 2 |
| Verdict | FAIL | FAIL |
| calls_per_node | 15 | 15 |

Both new rows UNKNOWN "not configured", which is correct: that run predates the exporter. Every pre-existing row is identical.

## Existing tests updated, and why each

Six, each because a fact it asserted became false rather than because an assertion was inconvenient:

- `test_every_mapped_series_names_a_real_value_column` hardcoded the permitted source set, making any new source fail by construction. Its docstring says its purpose is the assertion below it.
- `test_the_five_known_gaps_are_all_present_as_notes` asserted Redis is unmeasured. A companion test now asserts the opposite, so the gap cannot silently return.
- `test_the_html_and_the_json_agree_on_every_threshold` assumed every gate threshold is a fraction. `sustained_health` carries a count.
- `test_every_unknown_names_an_attempt_or_a_scope_exclusion` allowed two kinds of legitimate UNKNOWN. "Unconfigured" is a third.
- The pass-path fixture declares the two new dependencies rather than leaving them silent. It still asserts a fully satisfied run reaches a clean verdict.

## Gates

- `backend`: ruff clean, mypy clean on 283 files, **3112 passed**, 13 skipped
- `docs`: PASS, 90 pages
- Migration `e4c7a2b81f93` chained off the single head; `alembic heads` reports one and `upgrade head` creates all ten columns on a throwaway SQLite.

## Before Stage 3 scraping

The collector host needs a revision containing this merge and a **fresh start**, not a restart. Add a `redis-exporter` target for the Redis endpoint, and attach `|health=` to the SIP and server targets once their health ports are serving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Redis monitoring, including reachability, memory usage, memory limits, blocked clients, rejected connections, and evictions.
  - Added health endpoint probing with success, HTTP status, timeout, and availability results.
  - Added sustained-health checks that identify healthy, intermittent, sustained-failure, and unmeasured states.
  - Added measured Redis and health panels to load-test dashboards.
- **Bug Fixes**
  - Improved handling of missing, unavailable, and unbounded Redis memory-limit data.
  - Preserved accurate failure detection when health samples contain gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->