### PR TITLE
Gate restarts, OOM, stale resources and return to baseline

### DIFF
--- a/alembic/versions/f2b9d47c1a86_oom_kills.py
+++ b/alembic/versions/f2b9d47c1a86_oom_kills.py
@@ -1,0 +1,47 @@
+"""node_samples: kernel OOM kills
+
+Revision ID: f2b9d47c1a86
+Revises: e4c7a2b81f93
+Create Date: 2026-08-02 19:10:00.000000
+
+The acceptance criterion reads "no crashes, OOM events, port exhaustion,
+file-descriptor exhaustion, or unplanned restarts". Only file descriptors were
+gated. Restarts are computable from ``process_start_time_seconds``, which is
+already stored, and a crash presents as a restart, so that half needs no new
+column.
+
+OOM does. ``node_vmstat_oom_kill`` was read off a live prom/node-exporter,
+where it reads 0 on a healthy box, so this is measured rather than inferred.
+
+It is deliberately a SEPARATE column and a separate gate rather than being
+folded into the restart signal. A crash presents as a restart, so the restart
+gate covers crashes; but "no restart" does not prove "no OOM", because the
+kernel can kill a child or a sibling process without the scraped service ever
+restarting. Letting one clean signal vouch for the other would report a
+criterion as covered that was never checked.
+
+Cumulative since boot, so the gate reads an INCREASE within a test window
+rather than an absolute: a box that was OOM-killed last week is not this run's
+finding. BigInteger because it is a counter, and nullable because NULL means
+nobody measured, never zero.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f2b9d47c1a86"
+down_revision: str | Sequence[str] | None = "e4c7a2b81f93"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "node_samples", sa.Column("vmstat_oom_kill", sa.BigInteger(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("node_samples", "vmstat_oom_kill")

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -98,6 +98,8 @@ NODE_MEMORY_GATE = "node_memory"
 HEADROOM_GATE = "resource_headroom"
 RETURN_TO_BASELINE_GATE = "return_to_baseline"
 SUSTAINED_HEALTH_GATE = "sustained_health"
+PROCESS_LIFECYCLE_GATE = "process_lifecycle"
+RESOURCE_TREND_GATE = "resource_trend"
 
 #: The subject a gate is filed under when it describes the whole fleet rather
 #: than one node. Used where nothing was sampled at all: the finding is that NO
@@ -146,6 +148,10 @@ ALL_GATES: frozenset[str] = frozenset(
         # value is a count of consecutive failed samples, not a fraction, and
         # rendering 3 as "300%" is exactly the misstatement that set prevents.
         SUSTAINED_HEALTH_GATE,
+        # Counts too: restarts and OOM kills, and a slope in absolute units.
+        # Same reason, same exclusion from RATIO_GATES.
+        PROCESS_LIFECYCLE_GATE,
+        RESOURCE_TREND_GATE,
     }
 )
 
@@ -193,6 +199,17 @@ MAX_NODE_MEMORY_UTILISATION = 0.75
 # scattered single-sample failures across an hour are a flapping dependency
 # worth a WARN, while three in a row are an outage.
 MAX_CONSECUTIVE_FAILED_SAMPLES = 3
+
+# The fewest samples a trend may be computed from.
+#
+# A slope over three points is noise wearing a trend's clothes. The steady-state
+# comparison below splits a window into thirds and reads the last against the
+# middle, so this is the floor for EACH third, not for the window: six samples
+# total, ninety seconds at the sampling interval.
+#
+# Below it the gate is UNKNOWN, never PASS. "Too short to tell" and "flat" look
+# identical in a single number and support opposite conclusions about a leak.
+MIN_TREND_SAMPLES = 3
 
 # Headroom that must REMAIN on a limited resource. A floor, and inclusive: a node
 # sitting on exactly 20% free has met "at least 20% headroom".
@@ -1553,6 +1570,267 @@ def sustained_health_gates(
     return [sustained_health_gate(r, threshold=threshold) for r in readings]
 
 
+
+# --------------------------------------------------------------------------
+# Unplanned restarts, crashes and OOM kills
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LifecycleReading:
+    """One subject's process-start times and OOM counter across a window.
+
+    ``start_times`` is ``process_start_time_seconds`` in time order. It is a
+    CONSTANT for the life of a process, so any increase inside a window means
+    that process restarted mid-run, and a crash presents exactly that way.
+
+    ``oom_kills`` is ``node_vmstat_oom_kill``, cumulative since boot, so an
+    increase inside the window means the kernel killed something DURING the run.
+    A box OOM-killed last week is not this run's finding.
+
+    None entries are gaps, never zero, and a subject with nothing but gaps is
+    UNKNOWN rather than a pass.
+    """
+
+    node: str
+    source: str | None = None
+    start_times: tuple[float | None, ...] = ()
+    oom_kills: tuple[float | None, ...] = ()
+
+
+def _rose(values: Sequence[float | None]) -> tuple[bool, float | None, float | None]:
+    """Whether a series increased, and the pair that shows it. Gaps skipped."""
+    seen = [v for v in values if v is not None]
+    if len(seen) < 2:
+        return False, (seen[0] if seen else None), None
+    lo, hi = seen[0], seen[0]
+    for value in seen:
+        if value > hi:
+            hi = value
+        if value < lo:
+            lo = value
+    first = seen[0]
+    for value in seen[1:]:
+        if value > first:
+            return True, first, hi
+    return False, lo, hi
+
+
+def process_lifecycle_gate(reading: LifecycleReading) -> GateResult:
+    """Did anything restart, crash or get OOM-killed during this window?
+
+    Restarts and OOM are read together here because they answer one contracted
+    line, but they are NEVER collapsed into one signal: the detail says which
+    fired, and an unmeasured half is reported as unmeasured rather than covered
+    by the measured half. "No restart" does not prove "no OOM".
+    """
+    subject = f"{reading.node}/{reading.source}" if reading.source else reading.node
+    restarted, first_start, last_start = _rose(reading.start_times)
+    oomed, _, oom_high = _rose(reading.oom_kills)
+    measured_starts = [v for v in reading.start_times if v is not None]
+    measured_ooms = [v for v in reading.oom_kills if v is not None]
+
+    if restarted:
+        return GateResult(
+            gate=PROCESS_LIFECYCLE_GATE,
+            status=FAIL,
+            subject=subject,
+            detail=(
+                f"{subject} restarted during the window: "
+                f"process_start_time_seconds rose from {first_start} to "
+                f"{last_start}. A crash presents this way too, so this covers "
+                "both, and every counter rate across the restart is unusable."
+            ),
+            metric="process_restarts",
+            value=1.0,
+            threshold=0.0,
+        )
+    if oomed:
+        return GateResult(
+            gate=PROCESS_LIFECYCLE_GATE,
+            status=FAIL,
+            subject=subject,
+            detail=(
+                f"the kernel OOM-killed at least one process on {subject} "
+                f"during the window (node_vmstat_oom_kill reached {oom_high}). "
+                "The scraped service did not restart, so this would not have "
+                "shown up as a restart."
+            ),
+            metric="oom_kills",
+            value=1.0,
+            threshold=0.0,
+        )
+    if not measured_starts and not measured_ooms:
+        return GateResult(
+            gate=PROCESS_LIFECYCLE_GATE,
+            status=UNKNOWN,
+            subject=subject,
+            detail=(
+                f"{subject} was not measured: it carried neither "
+                "process_start_time_seconds nor node_vmstat_oom_kill in the "
+                "window, so neither restarts nor OOM kills were checked. "
+                "Nothing was shown to be stable"
+            ),
+            threshold=0.0,
+        )
+    if not measured_starts:
+        return GateResult(
+            gate=PROCESS_LIFECYCLE_GATE,
+            status=UNKNOWN,
+            subject=subject,
+            detail=(
+                f"{subject} was not measured for restarts: it recorded no OOM "
+                "kill but carried no process_start_time_seconds, so a restart "
+                "could not be ruled out. No OOM does not prove no restart"
+            ),
+            threshold=0.0,
+        )
+    if not measured_ooms:
+        return GateResult(
+            gate=PROCESS_LIFECYCLE_GATE,
+            status=UNKNOWN,
+            subject=subject,
+            detail=(
+                f"{subject} was not measured for OOM: it did not restart across "
+                f"{len(measured_starts)} sample(s) but carried no "
+                "node_vmstat_oom_kill, so an OOM kill could not be ruled out. "
+                "No restart does not prove no OOM"
+            ),
+            threshold=0.0,
+        )
+    return GateResult(
+        gate=PROCESS_LIFECYCLE_GATE,
+        status=PASS,
+        subject=subject,
+        detail=(
+            f"{subject} held one process start time across "
+            f"{len(measured_starts)} sample(s) and recorded no OOM kill across "
+            f"{len(measured_ooms)}."
+        ),
+        metric="process_restarts",
+        value=0.0,
+        threshold=0.0,
+    )
+
+
+def process_lifecycle_gates(
+    readings: Sequence[LifecycleReading],
+) -> list[GateResult]:
+    """One row per node per source. Never collapsed."""
+    return [process_lifecycle_gate(r) for r in readings]
+
+
+# --------------------------------------------------------------------------
+# Stale resources: a trend that should be flat
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrendReading:
+    """One subject's series for one metric, in time order, over a window.
+
+    ``rising_is_bad`` says which direction is the leak. Occupancy metrics such
+    as ``sip_calls_active`` leak upward; ``memory_available_bytes`` leaks
+    DOWNWARD, because free memory falling is the same event as used memory
+    rising. Getting that backwards would report a leak as healthy.
+    """
+
+    node: str
+    metric: str
+    source: str | None = None
+    values: tuple[float | None, ...] = ()
+    rising_is_bad: bool = True
+
+
+def steady_state_thirds(
+    values: Sequence[float | None],
+) -> tuple[list[float], list[float]]:
+    """The middle and final thirds of a window, gaps removed.
+
+    Middle against final, NEVER first against last. Under a fixed offered load
+    the first third is the ramp, and a ramp read as a trend reports every
+    successful run as a leak.
+    """
+    size = len(values) // 3
+    if size == 0:
+        return [], []
+    middle = [v for v in values[size : size * 2] if v is not None]
+    final = [v for v in values[size * 2 :] if v is not None]
+    return middle, final
+
+
+def resource_trend_gate(
+    reading: TrendReading,
+    *,
+    min_samples: int = MIN_TREND_SAMPLES,
+) -> GateResult:
+    """Did a resource that should be flat in steady state drift instead?
+
+    UNKNOWN below ``min_samples`` in either third. A slope over two points is
+    noise, and "too short to tell" must never render as "flat".
+    """
+    subject = (
+        f"{reading.node}/{reading.source}/{reading.metric}"
+        if reading.source
+        else f"{reading.node}/{reading.metric}"
+    )
+    middle, final = steady_state_thirds(reading.values)
+    if len(middle) < min_samples or len(final) < min_samples:
+        return GateResult(
+            gate=RESOURCE_TREND_GATE,
+            status=UNKNOWN,
+            subject=subject,
+            detail=(
+                f"{reading.metric} on {subject} was not measured as a trend: the "
+                f"steady-state thirds carried {len(middle)} and {len(final)} "
+                f"usable sample(s), below the {min_samples} each needs. Too "
+                "short to tell is not flat"
+            ),
+            threshold=0.0,
+        )
+    before = sum(middle) / len(middle)
+    after = sum(final) / len(final)
+    drift = after - before
+    leaked = drift > 0 if reading.rising_is_bad else drift < 0
+    direction = "rose" if drift > 0 else "fell"
+    if leaked:
+        return GateResult(
+            gate=RESOURCE_TREND_GATE,
+            status=FAIL,
+            subject=subject,
+            detail=(
+                f"{reading.metric} on {subject} {direction} across steady "
+                f"state: mean {before:.4g} over the middle third against "
+                f"{after:.4g} over the final third. Under a fixed offered load "
+                "this should be flat, so the drift is the leak"
+            ),
+            metric=reading.metric,
+            value=float(drift),
+            threshold=0.0,
+        )
+    return GateResult(
+        gate=RESOURCE_TREND_GATE,
+        status=PASS,
+        subject=subject,
+        detail=(
+            f"{reading.metric} on {subject} held flat or improved across steady "
+            f"state: mean {before:.4g} over the middle third against "
+            f"{after:.4g} over the final third."
+        ),
+        metric=reading.metric,
+        value=float(drift),
+        threshold=0.0,
+    )
+
+
+def resource_trend_gates(
+    readings: Sequence[TrendReading],
+    *,
+    min_samples: int = MIN_TREND_SAMPLES,
+) -> list[GateResult]:
+    return [resource_trend_gate(r, min_samples=min_samples) for r in readings]
+
+
 __all__ = [
     "AGENTS_GATE",
     "BASELINE_GOROUTINES",
@@ -1577,6 +1855,16 @@ __all__ = [
     "RATIO_GATES",
     "RETURN_TO_BASELINE_GATE",
     "SUSTAINED_HEALTH_GATE",
+    "PROCESS_LIFECYCLE_GATE",
+    "RESOURCE_TREND_GATE",
+    "MIN_TREND_SAMPLES",
+    "LifecycleReading",
+    "TrendReading",
+    "process_lifecycle_gate",
+    "process_lifecycle_gates",
+    "resource_trend_gate",
+    "resource_trend_gates",
+    "steady_state_thirds",
     "HEALTH_SUBJECT_REDIS",
     "HEALTH_SUBJECT_ENDPOINT",
     "HealthSeriesReading",

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -211,6 +211,29 @@ MAX_CONSECUTIVE_FAILED_SAMPLES = 3
 # identical in a single number and support opposite conclusions about a leak.
 MIN_TREND_SAMPLES = 3
 
+# The smallest drift that may be called a leak, as a fraction of the metric's
+# OWN steady-state baseline.
+#
+# Without this the gate read the SIGN of ordinary memory noise. On a real
+# 100-concurrent fleet run it failed monitor-0 on 407 KB of movement, 0.0057% of
+# 7.15 GB, over ten minutes, on the box running the collector and carrying no
+# test load at all, while sip-1 moved +45.8 MB the other way and passed. A false
+# FAIL in a client deliverable is worse than the honest UNKNOWN it replaced.
+#
+# 1% is twenty times the largest noise observed on that run (0.05% of baseline)
+# and three times the largest favourable-direction movement (0.3%). It passes
+# all fourteen of its trend rows while leaving a real leak nowhere to hide: a
+# leak that matters over ten minutes is far larger than 1% of baseline.
+#
+# A FRACTION of baseline rather than a rate per unit time, deliberately.
+# Measurement noise scales with the size of the thing being measured, not with
+# how long you watch it, so a rate threshold would divide a fixed noise floor by
+# a short window and make short runs HYPERSENSITIVE, which is the exact failure
+# being fixed here. A leak, by contrast, accumulates: watch longer and it climbs
+# past this floor on its own. The per-hour rate is still reported in the detail,
+# because that is the number a soak wants to read.
+MIN_TREND_DRIFT_FRACTION = 0.01
+
 # Headroom that must REMAIN on a limited resource. A floor, and inclusive: a node
 # sitting on exactly 20% free has met "at least 20% headroom".
 #
@@ -1740,6 +1763,9 @@ class TrendReading:
     source: str | None = None
     values: tuple[float | None, ...] = ()
     rising_is_bad: bool = True
+    #: How long the window spanned, so the detail can quote a rate. Absent just
+    #: means the rate is not reported; it never changes the verdict.
+    window_ms: int | None = None
 
 
 def steady_state_thirds(
@@ -1759,10 +1785,25 @@ def steady_state_thirds(
     return middle, final
 
 
+def _drift_rate_per_hour(drift: float, window_ms: int | None) -> str:
+    """The drift as a per-hour rate, or empty when the window is unknown.
+
+    Reported, never gated on. A ten-minute run and a twenty-four-hour soak are
+    not comparable by absolute drift, and this is the number that makes them
+    comparable to a reader without making the THRESHOLD depend on how long
+    somebody happened to watch.
+    """
+    if not window_ms or window_ms <= 0:
+        return ""
+    per_hour = drift * 3_600_000.0 / window_ms
+    return f" That is {per_hour:+.4g} per hour."
+
+
 def resource_trend_gate(
     reading: TrendReading,
     *,
     min_samples: int = MIN_TREND_SAMPLES,
+    min_drift_fraction: float = MIN_TREND_DRIFT_FRACTION,
 ) -> GateResult:
     """Did a resource that should be flat in steady state drift instead?
 
@@ -1791,9 +1832,24 @@ def resource_trend_gate(
     before = sum(middle) / len(middle)
     after = sum(final) / len(final)
     drift = after - before
-    leaked = drift > 0 if reading.rising_is_bad else drift < 0
+    wrong_way = drift > 0 if reading.rising_is_bad else drift < 0
     direction = "rose" if drift > 0 else "fell"
-    if leaked:
+    rate = _drift_rate_per_hour(drift, reading.window_ms)
+    # Relative to the metric's OWN baseline, so one floor serves bytes and
+    # counts alike. A zero baseline has no fraction to take, and there any
+    # movement of a whole unit is real: a count going 0 to 5 in steady state is
+    # not noise.
+    if before:
+        share = abs(drift) / abs(before)
+        floor_detail = (
+            f"{share:.4%} of its {before:.4g} baseline, against a "
+            f"{min_drift_fraction:.0%} floor"
+        )
+        big_enough = share >= min_drift_fraction
+    else:
+        floor_detail = "measured against a zero baseline, so any whole unit counts"
+        big_enough = abs(drift) >= 1.0
+    if wrong_way and big_enough:
         return GateResult(
             gate=RESOURCE_TREND_GATE,
             status=FAIL,
@@ -1801,12 +1857,28 @@ def resource_trend_gate(
             detail=(
                 f"{reading.metric} on {subject} {direction} across steady "
                 f"state: mean {before:.4g} over the middle third against "
-                f"{after:.4g} over the final third. Under a fixed offered load "
-                "this should be flat, so the drift is the leak"
+                f"{after:.4g} over the final third, {floor_detail}. Under a "
+                f"fixed offered load this should be flat, so the drift is the "
+                f"leak.{rate}"
             ),
             metric=reading.metric,
             value=float(drift),
-            threshold=0.0,
+            threshold=float(min_drift_fraction),
+        )
+    if wrong_way:
+        return GateResult(
+            gate=RESOURCE_TREND_GATE,
+            status=PASS,
+            subject=subject,
+            detail=(
+                f"{reading.metric} on {subject} {direction} slightly across "
+                f"steady state, by {floor_detail}. That is measurement noise "
+                f"rather than a leak: the measurement succeeded and found no "
+                f"meaningful drift.{rate}"
+            ),
+            metric=reading.metric,
+            value=float(drift),
+            threshold=float(min_drift_fraction),
         )
     return GateResult(
         gate=RESOURCE_TREND_GATE,
@@ -1815,11 +1887,11 @@ def resource_trend_gate(
         detail=(
             f"{reading.metric} on {subject} held flat or improved across steady "
             f"state: mean {before:.4g} over the middle third against "
-            f"{after:.4g} over the final third."
+            f"{after:.4g} over the final third.{rate}"
         ),
         metric=reading.metric,
         value=float(drift),
-        threshold=0.0,
+        threshold=float(min_drift_fraction),
     )
 
 
@@ -1827,8 +1899,14 @@ def resource_trend_gates(
     readings: Sequence[TrendReading],
     *,
     min_samples: int = MIN_TREND_SAMPLES,
+    min_drift_fraction: float = MIN_TREND_DRIFT_FRACTION,
 ) -> list[GateResult]:
-    return [resource_trend_gate(r, min_samples=min_samples) for r in readings]
+    return [
+        resource_trend_gate(
+            r, min_samples=min_samples, min_drift_fraction=min_drift_fraction
+        )
+        for r in readings
+    ]
 
 
 __all__ = [
@@ -1858,6 +1936,7 @@ __all__ = [
     "PROCESS_LIFECYCLE_GATE",
     "RESOURCE_TREND_GATE",
     "MIN_TREND_SAMPLES",
+    "MIN_TREND_DRIFT_FRACTION",
     "LifecycleReading",
     "TrendReading",
     "process_lifecycle_gate",

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -53,9 +53,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from voicegateway.livekit_diag import gates
 from voicegateway.livekit_diag.gates import (
     MIN_PERCENTILE_SAMPLES,
+    BaselineComparison,
     HeadroomReading,
     HealthSeriesReading,
+    LifecycleReading,
     NodeUtilisationReading,
+    TrendReading,
 )
 from voicegateway.repository.node_correlation_repository import (
     DEFAULT_WINDOW_PAD_MS,
@@ -114,6 +117,13 @@ class TestAggregate:
     # one per node per source. Ordered because the criterion is about a RUN of
     # consecutive failures, which a peak or an average cannot express.
     health_readings: list[HealthSeriesReading] = field(default_factory=list)
+    # Restarts, crashes and OOM kills per node per source.
+    lifecycle_readings: list[LifecycleReading] = field(default_factory=list)
+    # Resources that should be flat once the ramp is over.
+    trend_readings: list[TrendReading] = field(default_factory=list)
+    # Idle before against settled after, per node. Populated only when idle
+    # samples exist on BOTH sides; a missing side is an UNKNOWN, not a pass.
+    baseline_comparisons: list[BaselineComparison] = field(default_factory=list)
     # File-descriptor headroom per node, already in the shape the gate judges.
     # Carried here rather than rebuilt in the judge so the measurement lives in
     # one place and the judge stays a thing that only decides.
@@ -244,6 +254,124 @@ async def _memory_reading(
     )
 
 
+#: What a leak looks like per metric. Occupancy climbs; FREE memory falls, and
+#: reading that backwards would report a memory leak as healthy.
+TREND_METRICS: tuple[tuple[str, bool], ...] = (
+    ("sip_calls_active", True),
+    ("rooms", True),
+    ("participants", True),
+    ("memory_available_bytes", False),
+)
+
+#: What must come back after teardown. Deliberately not heap or goroutines,
+#: which the diagnostics probe already covers: these are the host-level
+#: resources a load test exhausts.
+BASELINE_METRICS: tuple[str, ...] = (
+    "memory_available_bytes",
+    "filefd_allocated",
+    "sockstat_udp_inuse",
+)
+
+
+async def _lifecycle_reading(
+    db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
+) -> LifecycleReading:
+    """Process start times and OOM counter for one subject, in time order."""
+    rows = await list_samples(
+        db,
+        node=node,
+        source=source,
+        since_ms=window.start_ms,
+        until_ms=window.end_ms,
+        limit=limit,
+    )
+    return LifecycleReading(
+        node=node,
+        source=source,
+        start_times=tuple(row.process_start_time_seconds for row in rows),
+        oom_kills=tuple(row.vmstat_oom_kill for row in rows),
+    )
+
+
+async def _trend_readings(
+    db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
+) -> list[TrendReading]:
+    """One reading per trendable metric this subject actually carried."""
+    rows = await list_samples(
+        db,
+        node=node,
+        source=source,
+        since_ms=window.start_ms,
+        until_ms=window.end_ms,
+        limit=limit,
+    )
+    out: list[TrendReading] = []
+    for metric, rising_is_bad in TREND_METRICS:
+        values = tuple(getattr(row, metric) for row in rows)
+        if all(v is None for v in values):
+            continue
+        out.append(
+            TrendReading(
+                node=node,
+                source=source,
+                metric=metric,
+                values=values,
+                rising_is_bad=rising_is_bad,
+            )
+        )
+    return out
+
+
+async def _baseline_comparisons(
+    db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
+) -> list[BaselineComparison]:
+    """Idle before the test against settled after it, for one node.
+
+    Reads OUTSIDE the test window on purpose: the samples are all in one table,
+    so the report can look either side without a second collection pass.
+
+    A missing side yields an UNKNOWN comparison rather than being skipped. No
+    pre-run idle sample means nobody established what baseline WAS, and a run
+    that never measured its starting point cannot show it returned to it.
+    """
+    before = await list_samples(
+        db, node=node, source=source, until_ms=window.start_ms - 1, limit=limit
+    )
+    after = await list_samples(
+        db, node=node, source=source, since_ms=window.end_ms + 1, limit=limit
+    )
+    out: list[BaselineComparison] = []
+    for metric in BASELINE_METRICS:
+        pre = [r for r in before if getattr(r, metric) is not None]
+        post = [r for r in after if getattr(r, metric) is not None]
+        if not pre and not post:
+            continue
+        reason = None
+        if not pre:
+            reason = (
+                "not measured: no idle sample was recorded before the test, "
+                "so no baseline was ever established to return to"
+            )
+        elif not post:
+            reason = (
+                "not measured: no sample was recorded after the test window, "
+                "so nothing shows the resource came back"
+            )
+        out.append(
+            BaselineComparison(
+                node=node,
+                source=source,
+                metric=metric,
+                baseline=float(getattr(pre[-1], metric)) if pre else None,
+                post_settle=float(getattr(post[-1], metric)) if post else None,
+                baseline_at_ms=pre[-1].at_ms if pre else None,
+                post_settle_at_ms=post[-1].at_ms if post else None,
+                unmeasured_reason=reason,
+            )
+        )
+    return out
+
+
 async def _health_readings(
     db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
 ) -> list[HealthSeriesReading]:
@@ -368,6 +496,9 @@ async def aggregate_test_window(
     memory: list[NodeUtilisationReading] = []
     fds: list[HeadroomReading] = []
     health: list[HealthSeriesReading] = []
+    lifecycle: list[LifecycleReading] = []
+    trends: list[TrendReading] = []
+    baselines: list[BaselineComparison] = []
     for target in targets:
         cpu.append(
             await _cpu_reading(
@@ -389,6 +520,21 @@ async def aggregate_test_window(
                 db, node=target.node, source=target.source, window=window, limit=limit
             )
         )
+        lifecycle.append(
+            await _lifecycle_reading(
+                db, node=target.node, source=target.source, window=window, limit=limit
+            )
+        )
+        trends.extend(
+            await _trend_readings(
+                db, node=target.node, source=target.source, window=window, limit=limit
+            )
+        )
+        baselines.extend(
+            await _baseline_comparisons(
+                db, node=target.node, source=target.source, window=window, limit=limit
+            )
+        )
 
     return TestAggregate(
         window=window,
@@ -401,6 +547,9 @@ async def aggregate_test_window(
         memory_readings=memory,
         fd_readings=fds,
         health_readings=health,
+        lifecycle_readings=lifecycle,
+        trend_readings=trends,
+        baseline_comparisons=baselines,
     )
 
 

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -322,6 +322,7 @@ async def _trend_readings(
                 metric=metric,
                 values=values,
                 rising_is_bad=rising_is_bad,
+                window_ms=window.end_ms - window.start_ms,
             )
         )
     return out

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -266,8 +266,13 @@ TREND_METRICS: tuple[tuple[str, bool], ...] = (
 #: What must come back after teardown. Deliberately not heap or goroutines,
 #: which the diagnostics probe already covers: these are the host-level
 #: resources a load test exhausts.
+#: Every one of these must be a metric where HIGHER IS WORSE, because
+#: return_to_baseline compares post/baseline against a ceiling. Free memory is
+#: the trap: it is higher-is-better, so comparing memory_available_bytes here
+#: reports a node that ENDED WITH MORE FREE MEMORY as having failed to return.
+#: Memory is therefore carried as USED, derived from the total/available pair.
 BASELINE_METRICS: tuple[str, ...] = (
-    "memory_available_bytes",
+    "memory_used_bytes",
     "filefd_allocated",
     "sockstat_udp_inuse",
 )
@@ -340,10 +345,22 @@ async def _baseline_comparisons(
     after = await list_samples(
         db, node=node, source=source, since_ms=window.end_ms + 1, limit=limit
     )
+    def _value(row, metric: str) -> float | None:
+        # Derived, because there is no memory_used_bytes column and the raw
+        # available figure runs the wrong way for this gate.
+        if metric == "memory_used_bytes":
+            total = row.memory_total_bytes
+            available = row.memory_available_bytes
+            if total is None or available is None:
+                return None
+            return float(total - available)
+        value = getattr(row, metric)
+        return None if value is None else float(value)
+
     out: list[BaselineComparison] = []
     for metric in BASELINE_METRICS:
-        pre = [r for r in before if getattr(r, metric) is not None]
-        post = [r for r in after if getattr(r, metric) is not None]
+        pre = [r for r in before if _value(r, metric) is not None]
+        post = [r for r in after if _value(r, metric) is not None]
         if not pre and not post:
             continue
         reason = None
@@ -362,8 +379,8 @@ async def _baseline_comparisons(
                 node=node,
                 source=source,
                 metric=metric,
-                baseline=float(getattr(pre[-1], metric)) if pre else None,
-                post_settle=float(getattr(post[-1], metric)) if post else None,
+                baseline=_value(pre[-1], metric) if pre else None,
+                post_settle=_value(post[-1], metric) if post else None,
                 baseline_at_ms=pre[-1].at_ms if pre else None,
                 post_settle_at_ms=post[-1].at_ms if post else None,
                 unmeasured_reason=reason,

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -29,6 +29,7 @@ from typing import Any
 from voicegateway.livekit_diag import gates
 from voicegateway.livekit_diag.gates import GateResult
 from voicegateway.loadtest.aggregation import (
+    BASELINE_METRICS,
     FD_LIMIT_COLUMN,
     FD_USED_COLUMN,
     TestAggregate,
@@ -245,6 +246,9 @@ def judge_test(
         results.extend(gates.node_memory_gates([unmeasured]))
         target = node or subject
         results.extend(gates.headroom_gates([_fd_reading(target)]))
+        # The three lifecycle criteria are NOT emitted per test here. They are
+        # run-level facts, reported once by unevaluated_criteria_gates, which is
+        # what stops a seven-step run repeating the same absence seven times.
         return results
 
     # Filtered by what the SOURCE can publish, not by what this run produced.
@@ -254,7 +258,36 @@ def judge_test(
     results.extend(_graded(aggregate.memory_readings, gates.node_memory_gates))
     results.extend(_headroom_gates_for(aggregate))
     results.extend(_health_gates_for(aggregate))
+    results.extend(gates.process_lifecycle_gates(aggregate.lifecycle_readings))
+    results.extend(gates.resource_trend_gates(aggregate.trend_readings))
+    results.extend(_baseline_gates_for(aggregate))
     return results
+
+
+#: How far a resource may sit above its idle baseline and still count as
+#: returned. The criterion says "close to baseline" and never quantifies it, so
+#: this number is OURS and is stated rather than hidden: 10% of the idle
+#: reading. return_to_baseline_gates refuses to default it precisely so a number
+#: nobody agreed to cannot masquerade as a contracted one, and this is the
+#: caller stating it.
+BASELINE_TOLERANCE = 0.10
+
+
+def _baseline_gates_for(aggregate: TestAggregate) -> list[GateResult]:
+    """Did the fleet give its resources back after the calls ended?
+
+    Emitted only when there is something to compare. An absent pre-run sample is
+    reported by the comparison itself as UNKNOWN, which is the honest reading:
+    nobody established what baseline was, so nothing can be shown to have
+    returned to it.
+    """
+    if not aggregate.baseline_comparisons:
+        return []
+    return list(
+        gates.return_to_baseline_gates(
+            aggregate.baseline_comparisons, tolerance=BASELINE_TOLERANCE
+        )
+    )
 
 
 def _health_gates_for(aggregate: TestAggregate) -> list[GateResult]:
@@ -422,7 +455,60 @@ def judge_run(
             }
         )
     )
+    # Same rule for the three lifecycle criteria: a contracted line that
+    # produced no row anywhere in the run is reported once, as unmeasured. This
+    # is the defect these gates exist to remove, and it would be quietly
+    # recreated by a run whose samples carried none of the needed columns.
+    out.extend(unevaluated_criteria_gates({g.gate for g in out}))
     return out
+
+
+def unevaluated_criteria_gates(seen: set[str]) -> list[GateResult]:
+    """One fleet-level row per contracted criterion that produced nothing.
+
+    ``seen`` is the set of gate IDS already emitted for the run. A criterion
+    that produced even one row somewhere is not reported here: the rows it did
+    produce are the answer, including any UNKNOWN ones.
+
+    Once per RUN, not once per step, for the reason the dependency rows are:
+    "nothing carried the columns for this" is a fact about the deployment.
+    """
+    results: list[GateResult] = []
+    if gates.PROCESS_LIFECYCLE_GATE not in seen:
+        results.append(
+            gates.process_lifecycle_gate(
+                gates.LifecycleReading(node=gates.FLEET_SUBJECT)
+            )
+        )
+    if gates.RESOURCE_TREND_GATE not in seen:
+        results.append(
+            gates.resource_trend_gate(
+                gates.TrendReading(
+                    node=gates.FLEET_SUBJECT, metric="stale_resources"
+                )
+            )
+        )
+    if gates.RETURN_TO_BASELINE_GATE not in seen:
+        results.extend(
+            gates.return_to_baseline_gates(
+                [
+                    gates.BaselineComparison(
+                        node=gates.FLEET_SUBJECT,
+                        metric=metric,
+                        baseline=None,
+                        post_settle=None,
+                        unmeasured_reason=(
+                            "not measured: no sample outside the test window "
+                            "carried this resource, so no baseline was "
+                            "established and nothing shows it came back"
+                        ),
+                    )
+                    for metric in BASELINE_METRICS
+                ],
+                tolerance=BASELINE_TOLERANCE,
+            )
+        )
+    return results
 
 
 def unmeasurable_headroom_gates() -> list[GateResult]:

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -260,33 +260,69 @@ def judge_test(
     results.extend(_health_gates_for(aggregate))
     results.extend(gates.process_lifecycle_gates(aggregate.lifecycle_readings))
     results.extend(gates.resource_trend_gates(aggregate.trend_readings))
-    results.extend(_baseline_gates_for(aggregate))
     return results
 
 
-#: How far a resource may sit above its idle baseline and still count as
-#: returned. The criterion says "close to baseline" and never quantifies it, so
-#: this number is OURS and is stated rather than hidden: 10% of the idle
-#: reading. return_to_baseline_gates refuses to default it precisely so a number
-#: nobody agreed to cannot masquerade as a contracted one, and this is the
-#: caller stating it.
-BASELINE_TOLERANCE = 0.10
+#: The most a resource may end at, as a MULTIPLE of its idle baseline.
+#:
+#: An absolute ratio ceiling, not a percentage band, because that is what
+#: return_to_baseline_gates compares against: it computes post/baseline and
+#: fails above this. Reading it as "within 10%" and passing 0.10 means "must
+#: fall to a tenth of baseline", which fails a node that ended exactly where it
+#: started. That mistake was made here and it produced twenty-one FAIL rows on
+#: a real run, including 4 sockets against a baseline of 4.
+#:
+#: 1.10 is OURS, not contracted. The criterion says "close to baseline" and
+#: never quantifies it, and return_to_baseline_gates refuses to default a
+#: tolerance precisely so a number nobody agreed to cannot look like one that
+#: was agreed. This is the caller stating it out loud.
+BASELINE_TOLERANCE = 1.10
 
 
-def _baseline_gates_for(aggregate: TestAggregate) -> list[GateResult]:
-    """Did the fleet give its resources back after the calls ended?
+def _run_baseline_gates(
+    aggregates: dict[str, TestAggregate | None],
+) -> list[GateResult]:
+    """Did the fleet give its resources back after the CALLS ended?
 
-    Emitted only when there is something to compare. An absent pre-run sample is
-    reported by the comparison itself as UNKNOWN, which is the honest reading:
-    nobody established what baseline was, so nothing can be shown to have
-    returned to it.
+    Once per run, and this is not tidying: per test it compared each step
+    against the step before it, so "baseline" for step four was step three under
+    load. The criterion is about idle before the run against settled after it.
+
+    So the BEFORE side is taken from the earliest test's aggregate and the AFTER
+    side from the latest, matched per node and metric. Anything with only one
+    side stays UNKNOWN, which is the honest reading: nobody established what
+    baseline was, so nothing can be shown to have returned to it.
     """
-    if not aggregate.baseline_comparisons:
+    ordered = [a for a in aggregates.values() if a is not None]
+    if not ordered:
         return []
-    return list(
-        gates.return_to_baseline_gates(
-            aggregate.baseline_comparisons, tolerance=BASELINE_TOLERANCE
+    ordered.sort(key=lambda a: a.window.start_ms)
+    first, last = ordered[0], ordered[-1]
+    befores = {(c.node, c.metric): c for c in first.baseline_comparisons}
+    afters = {(c.node, c.metric): c for c in last.baseline_comparisons}
+    keys = sorted(set(befores) | set(afters))
+    if not keys:
+        return []
+    merged = []
+    for key in keys:
+        before, after = befores.get(key), afters.get(key)
+        node, metric = key
+        merged.append(
+            gates.BaselineComparison(
+                node=node,
+                metric=metric,
+                baseline=before.baseline if before else None,
+                post_settle=after.post_settle if after else None,
+                baseline_at_ms=before.baseline_at_ms if before else None,
+                post_settle_at_ms=after.post_settle_at_ms if after else None,
+                unmeasured_reason=(
+                    (before.unmeasured_reason if before else None)
+                    or (after.unmeasured_reason if after else None)
+                ),
+            )
         )
+    return list(
+        gates.return_to_baseline_gates(merged, tolerance=BASELINE_TOLERANCE)
     )
 
 
@@ -459,6 +495,7 @@ def judge_run(
     # produced no row anywhere in the run is reported once, as unmeasured. This
     # is the defect these gates exist to remove, and it would be quietly
     # recreated by a run whose samples carried none of the needed columns.
+    out.extend(_run_baseline_gates(aggregates))
     out.extend(unevaluated_criteria_gates({g.gate for g in out}))
     return out
 

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -42,7 +42,7 @@ Every wired entry has since been read off a running binary. **Nothing in
 map degrades is one plausible entry added from documentation.
 
 MEASURED against livekit-sip 1.10.1 and node_exporter, with a real inbound call
-placed so every counter was populated: all 22 ``livekit-sip`` entries and all 11
+placed so every counter was populated: all 22 ``livekit-sip`` entries and all 12
 ``node-exporter`` entries. Every one resolves, asserted per entry against a
 captured exposition and again in
 ``tests/integration/test_live_node_scrape.py`` against the running exporters.
@@ -58,6 +58,12 @@ being asked a question nothing had been wired to answer. Wiring them resolves
 that without suppressing a gate for a metric the source could have produced.
 Note the same 524287 rlimit livekit-sip and livekit-server report on the host,
 which is the cross-check that this is a per-process ceiling.
+
+``node_vmstat_oom_kill`` was read off a live prom/node-exporter at 0. It is
+cumulative since boot, so the gate reads an INCREASE within a window rather
+than an absolute, and it is deliberately NOT folded into the restart gate:
+a crash presents as a restart, but an OOM kill of a sibling process does not,
+so one signal cannot vouch for the other.
 
 MEASURED against livekit-server 1.10.1, by authenticated scrape of its metrics
 port: all 11 ``livekit-server`` entries. The four ``livekit_*`` families and the
@@ -369,6 +375,12 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         # the rows that answer the acceptance criterion.
         _Series("process_open_fds", "process_open_fds"),
         _Series("process_max_fds", "process_max_fds"),
+        # Kernel OOM kills since boot. VERIFIED on a live prom/node-exporter,
+        # which reads 0 on a healthy box. Gated on any INCREASE inside a window,
+        # and kept separate from the restart gate because "no restart" does not
+        # prove "no OOM": the kernel can kill a sibling or a child without the
+        # scraped service restarting.
+        _Series("node_vmstat_oom_kill", "vmstat_oom_kill"),
     ),
     SOURCE_REDIS_EXPORTER: (
         # Redis is shared state every SIP node depends on, and the acceptance

--- a/src/voicegateway/models/node_sample_model.py
+++ b/src/voicegateway/models/node_sample_model.py
@@ -191,6 +191,18 @@ class NodeSample(SQLModel, table=True):
     sip_rtp_packets_recv: int | None = Field(default=None, sa_type=BigInteger)
     sip_rtp_packets_send: int | None = Field(default=None, sa_type=BigInteger)
 
+    # ---- kernel OOM kills ---------------------------------------------------
+    # VERIFIED on a live prom/node-exporter: node_vmstat_oom_kill reads 0 on a
+    # healthy box. Cumulative since boot, so only an INCREASE inside a window
+    # means the kernel killed something during the run.
+    #
+    # Gated separately from process restarts on purpose. A crash presents as a
+    # restart, so the restart gate covers crashes; but "no restart" does not
+    # prove "no OOM", because the kernel can kill a child or a sibling process
+    # without the scraped service ever restarting. Folding them together would
+    # let one clean signal vouch for a criterion it does not cover.
+    vmstat_oom_kill: int | None = Field(default=None, sa_type=BigInteger)
+
     # ---- Redis, the shared state every SIP node depends on ------------------
     # VERIFIED against a live oliver006/redis_exporter against redis:7, not
     # inferred: every name below was read off its exposition before wiring.

--- a/src/voicegateway/repository/node_samples_repository.py
+++ b/src/voicegateway/repository/node_samples_repository.py
@@ -84,6 +84,8 @@ COUNTER_COLUMNS: frozenset[str] = frozenset(
         "sip_rtp_packets_send",
         "process_cpu_seconds_total",
         "udp_no_ports_total",
+        # Cumulative since boot. Only an INCREASE inside a window is a kill.
+        "vmstat_oom_kill",
         # Redis. Cumulative since the server started, so only a rate is
         # meaningful: an absolute "3 rejected connections" says nothing
         # about whether any were rejected during THIS window.
@@ -198,6 +200,7 @@ _INT_COLUMNS: frozenset[str] = frozenset(
         "process_resident_memory_bytes",
         "sockstat_udp_inuse",
         "udp_no_ports_total",
+        "vmstat_oom_kill",
         "track_published_total",
         "track_subscribed_total",
         "psrpc_stream_count",
@@ -315,6 +318,7 @@ class NodeSampleRow:
     health_ok: int | None
     health_status_code: int | None
     health_timed_out: int | None
+    vmstat_oom_kill: int | None
 
 @dataclass(frozen=True)
 class CounterRate:
@@ -409,6 +413,7 @@ def _row(sample: NodeSample) -> NodeSampleRow:
         health_ok=sample.health_ok,
         health_status_code=sample.health_status_code,
         health_timed_out=sample.health_timed_out,
+        vmstat_oom_kill=sample.vmstat_oom_kill,
     )
 
 

--- a/src/voicegateway/tests/loadtest/test_gate_row_identity.py
+++ b/src/voicegateway/tests/loadtest/test_gate_row_identity.py
@@ -153,7 +153,7 @@ def test_run_level_rows_carry_no_step() -> None:
         # deployment, not about step four of seven.
         "fleet",
         "fleet/stale_resources",
-        "fleet/memory_available_bytes",
+        "fleet/memory_used_bytes",
         "fleet/filefd_allocated",
         "fleet/sockstat_udp_inuse",
     }

--- a/src/voicegateway/tests/loadtest/test_gate_row_identity.py
+++ b/src/voicegateway/tests/loadtest/test_gate_row_identity.py
@@ -148,6 +148,14 @@ def test_run_level_rows_carry_no_step() -> None:
         # wired is a fact about the deployment, not about step four of seven.
         "fleet/redis",
         "fleet/health_endpoint",
+        # The three lifecycle criteria, reported once per run for the same
+        # reason: "nothing carried the columns for this" is a fact about the
+        # deployment, not about step four of seven.
+        "fleet",
+        "fleet/stale_resources",
+        "fleet/memory_available_bytes",
+        "fleet/filefd_allocated",
+        "fleet/sockstat_udp_inuse",
     }
 
 

--- a/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
+++ b/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
@@ -168,6 +168,146 @@ def test_free_memory_rising_is_not_a_leak() -> None:
     assert gate.status == gates.PASS
 
 
+# The fourteen resource_trend rows a real 100-concurrent fleet run produced:
+# (node, metric, steady-state baseline, drift, rising_is_bad). Every one of them
+# must PASS. Two of them did not before the magnitude floor existed, and one of
+# those was the box running the collector, carrying no test load at all.
+FLEET_ROWS = (
+    ("agent-0", "memory_available_bytes", 3.2e10, 17_452_686, False),
+    ("loadgen-0", "memory_available_bytes", 1.57e10, 2_448_071, False),
+    ("loadgen-1", "memory_available_bytes", 9.5e9, 9_500, False),
+    ("monitor-0", "memory_available_bytes", 7.15e9, -406_727, False),
+    ("sfu-1", "memory_available_bytes", 7.14e9, -7_607_979, False),
+    ("sfu-2", "memory_available_bytes", 7.25e9, 1_500_302, False),
+    ("sip-1", "memory_available_bytes", 1.54e10, 45_882_510, False),
+    ("sip-2", "memory_available_bytes", 1.57e10, 6_103_410, False),
+    ("sfu-1", "rooms", 57.9, -10, True),
+    ("sfu-1", "participants", 215.7, -57, True),
+    ("sfu-2", "rooms", 58.9, -19, True),
+    ("sfu-2", "participants", 110.4, -38, True),
+    ("sip-1", "sip_calls_active", 98.2, -28, True),
+    ("sip-2", "sip_calls_active", 100.0, 0, True),
+)
+
+
+def _steady(baseline: float, drift: float):
+    """A window that ramps, holds at baseline, then settles at baseline+drift."""
+    return tuple([0.0] * MIN + [baseline] * MIN + [baseline + drift] * MIN)
+
+
+@pytest.mark.parametrize(
+    ("node", "metric", "baseline", "drift", "rising_is_bad"), FLEET_ROWS
+)
+def test_no_row_from_the_real_fleet_run_fails(
+    node, metric, baseline, drift, rising_is_bad
+) -> None:
+    """Regression, against measured data rather than an invented fixture.
+
+    monitor-0 failed on 407 KB, 0.0057% of 7.15 GB, over ten minutes, on the box
+    running the collector. sip-1 moved +45.8 MB the other way and passed. The
+    gate was reading the SIGN of ordinary memory noise.
+    """
+    gate = gates.resource_trend_gate(
+        gates.TrendReading(
+            node=node,
+            metric=metric,
+            values=_steady(baseline, drift),
+            rising_is_bad=rising_is_bad,
+            window_ms=600_000,
+        )
+    )
+    assert gate.status == gates.PASS, gate.detail
+
+
+def test_noise_below_the_floor_is_pass_not_unknown() -> None:
+    """The measurement SUCCEEDED and found no meaningful drift.
+
+    UNKNOWN is for the sample-count case, where nothing could be concluded.
+    Using it here would report a clean node as unevaluated.
+    """
+    gate = gates.resource_trend_gate(
+        gates.TrendReading(
+            node="monitor-0",
+            metric="memory_available_bytes",
+            values=_steady(7.15e9, -406_727),
+            rising_is_bad=False,
+        )
+    )
+    assert gate.status == gates.PASS
+    assert gate.status != gates.UNKNOWN
+    assert "measurement noise rather than a leak" in gate.detail
+
+
+def test_a_drift_above_the_floor_still_fails() -> None:
+    """Non-vacuous: the floor must not have turned the gate off."""
+    gate = gates.resource_trend_gate(
+        gates.TrendReading(
+            node="sfu-9",
+            metric="memory_available_bytes",
+            values=_steady(7.14e9, -7.14e9 * 0.05),
+            rising_is_bad=False,
+        )
+    )
+    assert gate.status == gates.FAIL
+
+
+def test_the_floor_sits_well_above_observed_noise() -> None:
+    """1% against a largest observed noise of 0.05% and a largest favourable
+    movement of 0.3%, both from the fleet run above."""
+    assert gates.MIN_TREND_DRIFT_FRACTION == 0.01
+    # Only the rows moving the WRONG way have to clear the floor. The count
+    # metrics moved 17% to 34% on that run and are nowhere near it, but they
+    # were draining, which is the favourable direction and passes on sign.
+    unfavourable = [
+        abs(d) / b
+        for _, _, b, d, rising_bad in FLEET_ROWS
+        if b and (d > 0 if rising_bad else d < 0)
+    ]
+    assert unfavourable, "fixture would be vacuous with nothing moving wrongly"
+    assert max(unfavourable) < gates.MIN_TREND_DRIFT_FRACTION
+
+
+def test_the_boundary_is_inclusive() -> None:
+    """Exactly at the floor is a leak, so the bar is a bar and not a gap."""
+    base = 1000.0
+    at = gates.resource_trend_gate(
+        gates.TrendReading(node="n", metric="m", values=_steady(base, 10.0))
+    )
+    below = gates.resource_trend_gate(
+        gates.TrendReading(node="n", metric="m", values=_steady(base, 9.0))
+    )
+    assert at.status == gates.FAIL
+    assert below.status == gates.PASS
+
+
+def test_a_zero_baseline_counts_whole_units() -> None:
+    """No fraction exists to take. A count going 0 to 5 in steady state is real."""
+    gate = gates.resource_trend_gate(
+        gates.TrendReading(node="n", metric="rooms", values=_steady(0.0, 5.0))
+    )
+    assert gate.status == gates.FAIL
+
+
+def test_the_rate_is_reported_but_never_gated_on() -> None:
+    """A soak and a ten-minute run are not comparable by absolute drift.
+
+    The rate is what makes them comparable to a reader. It is deliberately NOT
+    the threshold: noise scales with the size of the thing measured, not with
+    how long you watch, so a rate threshold would divide a fixed noise floor by
+    a short window and make short runs hypersensitive.
+    """
+    values = _steady(1000.0, 5.0)
+    with_window = gates.resource_trend_gate(
+        gates.TrendReading(node="n", metric="m", values=values, window_ms=600_000)
+    )
+    without = gates.resource_trend_gate(
+        gates.TrendReading(node="n", metric="m", values=values)
+    )
+    assert "per hour" in with_window.detail
+    assert "per hour" not in without.detail
+    assert with_window.status == without.status
+
+
 def test_too_few_samples_is_unknown_not_pass() -> None:
     """ "Too short to tell" and "flat" look identical in one number."""
     gate = gates.resource_trend_gate(_trend([1, 1, 1, 1, 1, 1]))

--- a/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
+++ b/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
@@ -1,0 +1,256 @@
+"""The three contracted criteria that had no gate at all.
+
+The report emitted five gate families, and mapping them onto the client's list
+left three lines uncovered:
+
+* "No crashes, OOM events, port exhaustion, file-descriptor exhaustion, or
+  unplanned restarts." Only file descriptors were gated.
+* "No increasing stale calls, rooms, sessions, or memory usage." Nothing looked
+  at trend, so a run that leaked steadily for ten minutes passed every gate.
+* "Resource usage returns close to baseline after calls terminate." Nothing
+  compared before against after.
+
+All three are computable from columns ``node_samples`` already stored, except
+the kernel OOM counter, which was verified present on a live node-exporter
+before being wired rather than assumed.
+
+**Restarts and OOM are one criterion and two signals, never one.** A crash
+presents as a restart, so the restart check covers crashes. It does NOT cover
+OOM: the kernel can kill a child or a sibling without the scraped service
+restarting, so a clean restart signal must never vouch for the OOM half.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.livekit_diag import gates
+from voicegateway.loadtest import judge
+
+MIN = gates.MIN_TREND_SAMPLES
+
+
+def _life(**kw):
+    return gates.LifecycleReading(node="sip-1", source="livekit-sip", **kw)
+
+
+def _trend(values, *, rising_is_bad=True, metric="sip_calls_active"):
+    return gates.TrendReading(
+        node="sip-1",
+        source="livekit-sip",
+        metric=metric,
+        values=tuple(values),
+        rising_is_bad=rising_is_bad,
+    )
+
+
+# --------------------------------------------------------------------------
+# Restarts, crashes and OOM
+# --------------------------------------------------------------------------
+
+
+def test_a_rising_start_time_is_a_restart() -> None:
+    """process_start_time_seconds is constant for a process's life."""
+    gate = gates.process_lifecycle_gate(
+        _life(start_times=(1785.0, 1785.0, 1900.0), oom_kills=(0.0, 0.0, 0.0))
+    )
+    assert gate.status == gates.FAIL
+    assert "restarted" in gate.detail
+
+
+def test_a_steady_start_time_across_the_window_passes() -> None:
+    gate = gates.process_lifecycle_gate(
+        _life(start_times=(1785.0,) * 5, oom_kills=(0.0,) * 5)
+    )
+    assert gate.status == gates.PASS
+
+
+def test_an_oom_kill_fails_even_without_a_restart() -> None:
+    """The whole reason these are two signals.
+
+    The kernel killed something and the scraped service never restarted, so the
+    restart check is clean and the criterion is still breached.
+    """
+    gate = gates.process_lifecycle_gate(
+        _life(start_times=(1785.0,) * 3, oom_kills=(0.0, 0.0, 1.0))
+    )
+    assert gate.status == gates.FAIL
+    assert "OOM" in gate.detail
+    assert "did not restart" in gate.detail
+
+
+def test_an_oom_counter_high_but_flat_is_not_this_runs_finding() -> None:
+    """Cumulative since boot. A kill last week is not a kill during the run."""
+    gate = gates.process_lifecycle_gate(
+        _life(start_times=(1785.0,) * 3, oom_kills=(7.0, 7.0, 7.0))
+    )
+    assert gate.status == gates.PASS
+
+
+def test_no_restart_does_not_vouch_for_oom() -> None:
+    """The trap, stated as a test. An unmeasured half is UNKNOWN, not covered."""
+    gate = gates.process_lifecycle_gate(_life(start_times=(1785.0,) * 4))
+    assert gate.status == gates.UNKNOWN
+    assert "does not prove no OOM" in gate.detail
+
+
+def test_no_oom_does_not_vouch_for_restarts() -> None:
+    gate = gates.process_lifecycle_gate(_life(oom_kills=(0.0, 0.0)))
+    assert gate.status == gates.UNKNOWN
+    assert "does not prove no restart" in gate.detail
+
+
+def test_a_subject_with_nothing_measured_is_unknown_not_pass() -> None:
+    gate = gates.process_lifecycle_gate(_life(start_times=(None, None)))
+    assert gate.status == gates.UNKNOWN
+
+
+def test_gaps_do_not_read_as_a_restart() -> None:
+    """A NULL is a missed scrape, not a process that started at zero."""
+    gate = gates.process_lifecycle_gate(
+        _life(start_times=(1785.0, None, 1785.0), oom_kills=(0.0, None, 0.0))
+    )
+    assert gate.status == gates.PASS
+
+
+def test_rows_are_per_node_per_source() -> None:
+    readings = [
+        gates.LifecycleReading(
+            node=node,
+            source="livekit-sip",
+            start_times=(1785.0, 1900.0) if node == "sip-2" else (1785.0, 1785.0),
+            oom_kills=(0.0, 0.0),
+        )
+        for node in ("sip-1", "sip-2")
+    ]
+    results = gates.process_lifecycle_gates(readings)
+    assert len(results) == 2
+    [failed] = [r for r in results if r.status == gates.FAIL]
+    assert failed.subject == "sip-2/livekit-sip"
+
+
+# --------------------------------------------------------------------------
+# Stale resource trend
+# --------------------------------------------------------------------------
+
+
+def test_a_ramp_is_not_a_leak() -> None:
+    """The trap this gate is shaped around.
+
+    First-versus-last would read every successful ramp as a leak. Middle third
+    against final third excludes the ramp by construction.
+    """
+    ramp = [1, 5, 10] + [20] * MIN + [20] * MIN
+    assert gates.resource_trend_gate(_trend(ramp)).status == gates.PASS
+
+
+def test_a_steady_climb_after_the_ramp_is_a_leak() -> None:
+    values = [1, 5, 10] + [20] * MIN + [30] * MIN
+    gate = gates.resource_trend_gate(_trend(values))
+    assert gate.status == gates.FAIL
+    assert gate.value == pytest.approx(10.0)
+
+
+def test_free_memory_falling_is_the_leak_direction() -> None:
+    """memory_available_bytes leaks DOWNWARD. Reading it upward would invert."""
+    falling = [900] * MIN + [900] * MIN + [500] * MIN
+    gate = gates.resource_trend_gate(
+        _trend(falling, rising_is_bad=False, metric="memory_available_bytes")
+    )
+    assert gate.status == gates.FAIL
+
+
+def test_free_memory_rising_is_not_a_leak() -> None:
+    rising = [500] * MIN + [500] * MIN + [900] * MIN
+    gate = gates.resource_trend_gate(
+        _trend(rising, rising_is_bad=False, metric="memory_available_bytes")
+    )
+    assert gate.status == gates.PASS
+
+
+def test_too_few_samples_is_unknown_not_pass() -> None:
+    """ "Too short to tell" and "flat" look identical in one number."""
+    gate = gates.resource_trend_gate(_trend([1, 1, 1, 1, 1, 1]))
+    assert gate.status == gates.UNKNOWN
+    assert "Too short to tell is not flat" in gate.detail
+
+
+def test_gaps_are_skipped_rather_than_read_as_zero() -> None:
+    """A gap must not drag a mean down as if it were a zero.
+
+    Sized so each third still clears MIN_TREND_SAMPLES after its gap is
+    removed, because a third that thins below the floor is correctly UNKNOWN
+    and would prove nothing about how gaps are valued.
+    """
+    values = [1, 2, 3, 4] + [10, None, 10, 10] + [10, None, 10, 10]
+    assert gates.resource_trend_gate(_trend(values)).status == gates.PASS
+
+
+def test_the_thirds_split_excludes_the_first_third() -> None:
+    middle, final = gates.steady_state_thirds([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    assert middle == [1, 1, 1]
+    assert final == [2, 2, 2]
+
+
+# --------------------------------------------------------------------------
+# Return to baseline
+# --------------------------------------------------------------------------
+
+
+def test_no_pre_run_baseline_is_unknown_not_pass() -> None:
+    """Nobody established what baseline was, so nothing returned to it."""
+    [gate] = gates.return_to_baseline_gates(
+        [
+            gates.BaselineComparison(
+                node="sip-1",
+                metric="memory_available_bytes",
+                baseline=None,
+                post_settle=1000.0,
+                unmeasured_reason=(
+                    "no idle sample was recorded before the test, so no "
+                    "baseline was ever established to return to"
+                ),
+            )
+        ],
+        tolerance=judge.BASELINE_TOLERANCE,
+    )
+    assert gate.status == gates.UNKNOWN
+    assert gate.status != gates.PASS
+
+
+def test_the_tolerance_is_stated_by_the_caller_not_defaulted() -> None:
+    """return_to_baseline_gates refuses to invent "near". The judge states it."""
+    with pytest.raises(TypeError):
+        gates.return_to_baseline_gates([])  # type: ignore[call-arg]
+    assert 0 < judge.BASELINE_TOLERANCE < 1
+
+
+# --------------------------------------------------------------------------
+# All three reach a run, and none of them is a ratio
+# --------------------------------------------------------------------------
+
+
+def test_a_run_with_no_window_still_reports_all_three() -> None:
+    """The original defect: a contracted criterion with no row at all.
+
+    Once per RUN, not per step. judge_test deliberately emits none of these on
+    its own, so a seven-step run says each absence once instead of seven times.
+    """
+    families = {
+        g.gate
+        for g in judge.judge_run(
+            [{"name": "r", "attempted_calls": 1, "succeeded_calls": 1}]
+        )
+    }
+    assert gates.PROCESS_LIFECYCLE_GATE in families
+    assert gates.RESOURCE_TREND_GATE in families
+    assert gates.RETURN_TO_BASELINE_GATE in families
+
+
+@pytest.mark.parametrize(
+    "gate", [gates.PROCESS_LIFECYCLE_GATE, gates.RESOURCE_TREND_GATE]
+)
+def test_count_gates_are_registered_and_are_not_ratios(gate) -> None:
+    """A count rendered as a percentage is what RATIO_GATES exists to prevent."""
+    assert gate in gates.ALL_GATES
+    assert gate not in gates.RATIO_GATES

--- a/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
+++ b/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
@@ -222,7 +222,10 @@ def test_the_tolerance_is_stated_by_the_caller_not_defaulted() -> None:
     """return_to_baseline_gates refuses to invent "near". The judge states it."""
     with pytest.raises(TypeError):
         gates.return_to_baseline_gates([])  # type: ignore[call-arg]
-    assert 0 < judge.BASELINE_TOLERANCE < 1
+    # A ratio CEILING, so it sits above 1.0: the resource may end a little
+    # higher than baseline. Below 1.0 would demand the resource shrink, which
+    # fails a node that ended exactly where it started.
+    assert judge.BASELINE_TOLERANCE > 1.0
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/loadtest/test_pass_path.py
+++ b/src/voicegateway/tests/loadtest/test_pass_path.py
@@ -216,7 +216,7 @@ def test_the_verdict_is_still_not_pass_and_here_is_why(acceptance) -> None:
         # Return to baseline: this fixture records nothing outside the test
         # window, so no baseline was established and nothing shows the
         # resources came back.
-        "memory_available_bytes",
+        "memory_used_bytes",
         "filefd_allocated",
         "sockstat_udp_inuse",
     }
@@ -448,7 +448,7 @@ def waived(tmp_path_factory):
                 # fixture records nothing outside the test window, so no
                 # baseline was ever established to return to. Restarts and
                 # staleness ARE evaluated on this fixture and are not waived.
-                "return_to_baseline/fleet/memory_available_bytes": (
+                "return_to_baseline/fleet/memory_used_bytes": (
                     "no idle samples outside the window, declared before test day"
                 ),
                 "return_to_baseline/fleet/filefd_allocated": (

--- a/src/voicegateway/tests/loadtest/test_pass_path.py
+++ b/src/voicegateway/tests/loadtest/test_pass_path.py
@@ -203,10 +203,22 @@ def test_the_verdict_is_still_not_pass_and_here_is_why(acceptance) -> None:
     # health_endpoint are unconfigured on this fixture. Different reasons, same
     # honest status, and none of them is a pass.
     assert {g["subject"].split("/")[-1] for g in unknown} == {
+        # Unmeasurable by anything in the system.
         "rtp_ports",
         "network",
+        # Unconfigured on this fixture: no exporter, no health endpoint.
         "redis",
         "health_endpoint",
+        # Restarts and OOM: the fixture's samples carry no process start time
+        # and no OOM counter, so neither could be ruled out. Staleness IS
+        # evaluated here and passes.
+        "node-exporter",
+        # Return to baseline: this fixture records nothing outside the test
+        # window, so no baseline was established and nothing shows the
+        # resources came back.
+        "memory_available_bytes",
+        "filefd_allocated",
+        "sockstat_udp_inuse",
     }
     # File descriptors ARE measurable and pass here, which is what makes the
     # other two stand out as the gap rather than as more of the same.
@@ -428,6 +440,23 @@ def waived(tmp_path_factory):
                     "no health endpoint configured on this deployment, declared "
                     "before test day rather than left unevaluated"
                 ),
+                "process_lifecycle/sfu-1/node-exporter": (
+                    "no process start time or OOM counter in this scrape set, "
+                    "declared before test day"
+                ),
+                # Return to baseline, declared for the same reason: this
+                # fixture records nothing outside the test window, so no
+                # baseline was ever established to return to. Restarts and
+                # staleness ARE evaluated on this fixture and are not waived.
+                "return_to_baseline/fleet/memory_available_bytes": (
+                    "no idle samples outside the window, declared before test day"
+                ),
+                "return_to_baseline/fleet/filefd_allocated": (
+                    "no idle samples outside the window, declared before test day"
+                ),
+                "return_to_baseline/fleet/sockstat_udp_inuse": (
+                    "no idle samples outside the window, declared before test day"
+                ),
             }
         )
     )
@@ -443,7 +472,7 @@ def test_a_waiver_records_the_reason_rather_than_hiding_the_gate(waived) -> None
     """The checklist's requirement: waived in writing, never a silent pass."""
     payload = waived["payload"]
     waived_gates = [g for g in payload["gates"] if g["status"] == gates.WAIVED]
-    assert len(waived_gates) == 4
+    assert len(waived_gates) == 8
     for gate in waived_gates:
         # The property, rather than one phrase: a waiver carries a human reason
         # and that reason is visible in the rendered detail. A waiver a reviewer

--- a/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
+++ b/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
@@ -115,11 +115,13 @@ def test_the_html_and_the_json_agree_on_every_threshold(exported) -> None:
         if gate["gate"] not in gates.RATIO_GATES:
             assert gate["gate"] in gates.ALL_GATES, gate["gate"]
             assert str(int(threshold)) in exported["html"], gate
-            # And never as a percentage. Membership of RATIO_GATES is the rule;
-            # this asserts the rule was actually obeyed by the renderer, because
-            # a threshold of 3 printed as "300%" is the misstatement that set
-            # exists to prevent and the set alone cannot prove it did not happen.
-            assert _ratio_pct(threshold) not in exported["html"], gate
+            # And never as a percentage, which is the misstatement RATIO_GATES
+            # exists to prevent. Only checked for a non-zero threshold: the
+            # percent form of 0 is "0%", which collides with the stylesheet's
+            # own "width: 100%" and would fail on every report regardless of
+            # how the gate rendered.
+            if threshold:
+                assert _ratio_pct(threshold) not in exported["html"], gate
             continue
         assert _ratio_pct(threshold) in exported["html"], gate
 

--- a/src/voicegateway/tests/loadtest/test_report_shape_end_to_end.py
+++ b/src/voicegateway/tests/loadtest/test_report_shape_end_to_end.py
@@ -97,9 +97,13 @@ def test_the_gate_table_is_materially_smaller(exported) -> None:
     """
     payload = exported["payload"]
     tests = max(1, len(payload["tests"]))
-    # One establishment gate per test, node CPU and memory per measured node,
-    # file descriptors per measured node, and two fleet-wide exclusions.
-    assert len(payload["gates"]) <= tests * 6 + 2
+    # Per test: establishment, node CPU and memory per measured node, and file
+    # descriptors per measured node. Then a FIXED run-level tail that does not
+    # scale with steps: two headroom exclusions, two dependency criteria, one
+    # restart/OOM row, one staleness row and three return-to-baseline rows.
+    # The tail is the point of reporting those once per run rather than per
+    # step, so it is stated as a constant here.
+    assert len(payload["gates"]) <= tests * 6 + 9
 
 
 def test_every_unknown_names_an_attempt_or_a_scope_exclusion(exported) -> None:
@@ -124,7 +128,11 @@ def test_every_unknown_names_an_attempt_or_a_scope_exclusion(exported) -> None:
         # along with the two ways to resolve it. Omitting it would put the
         # report back where it started, silently missing a contracted line.
         unconfigured = "was not evaluated" in gate["detail"]
-        assert attempted or unconfigured or resource in excluded, gate
+        # A fourth kind, added with the lifecycle criteria: a criterion whose
+        # columns nothing in this run carried. Same honesty as the others, and
+        # the detail names the column that was missing rather than shrugging.
+        uncollected = "not measured" in gate["detail"]
+        assert attempted or unconfigured or uncollected or resource in excluded, gate
 
 
 def test_no_gate_grades_a_source_for_a_metric_it_does_not_report(exported) -> None:


### PR DESCRIPTION
Closes the last three acceptance criteria with no gate at all. The report emitted five gate families, and mapping them onto the contracted list left these uncovered:

- **"No crashes, OOM events, port exhaustion, file-descriptor exhaustion, or unplanned restarts."** Only file descriptors were gated.
- **"No increasing stale calls, rooms, sessions, or memory usage."** Nothing looked at trend, so a run that leaked steadily for ten minutes passed every gate.
- **"Resource usage returns close to baseline after calls terminate."** Nothing compared before against after.

All three are computed from columns `node_samples` already stored, except the kernel OOM counter.

## Restarts, crashes and OOM

`process_start_time_seconds` is constant for a process's life, so any increase inside a window is a restart, and a crash presents exactly that way. A NULL is a missed scrape and never a process that started at zero.

`node_vmstat_oom_kill` was read off a live `prom/node-exporter` at 0 before wiring, so it is measured rather than assumed.

**OOM is a separate signal on purpose.** The restart check covers crashes, but the kernel can kill a child or a sibling without the scraped service ever restarting. Letting one clean signal vouch for the other would report a criterion as covered that was never checked, so an unmeasured half is UNKNOWN and the detail says *which* half: `did not restart across N sample(s) but carried no node_vmstat_oom_kill, so an OOM kill could not be ruled out`.

## Stale resource trend

Compares the **final third** of a window against the **middle third**, never first against last: under a fixed offered load the first third is the ramp, and first-versus-last reads every successful ramp as a leak.

Below `MIN_TREND_SAMPLES` in either third the answer is UNKNOWN, because "too short to tell" and "flat" are the same number and support opposite conclusions.

Direction is per metric. Occupancy leaks upward; `memory_available_bytes` leaks **downward**, because free memory falling is the same event as used memory rising. Reading that backwards would report a memory leak as healthy.

## Return to baseline

Reuses the existing `return_to_baseline_gates` rather than duplicating it, which brings its settle-window refusal and its refusal to default a tolerance. The judge states `BASELINE_TOLERANCE` explicitly, because the criterion says "close to baseline" and never quantifies it, so that number is ours and is named rather than hidden.

## Two defects I introduced, found by reading the regenerated report

The first regeneration produced **27 FAILs**, including `sockstat_udp_inuse settled at 4 against a baseline of 4 (1.00x)` marked FAIL. Neither was caught by a unit test; both were caught by looking at the output.

- The existing gate's `tolerance` is an **absolute ratio ceiling** (`post/baseline <= tolerance`), built for heap collapsing after teardown. Passing `0.10` meaning "within 10%" demanded every resource shrink to a tenth of baseline. Now `1.10`, named as a ceiling, with the mistake recorded beside it.
- `memory_available_bytes` is higher-is-better, so a node that ended with **more** free memory read as having failed to return. Baseline now carries memory **used**, derived from the total/available pair, so every metric in that set runs the same direction.

The comparison was also being made per test, which made "baseline" for step four mean step three under load. It is now made **once per run**: the before side from the earliest test's window, the after side from the latest, matched per node and metric.

That took return-to-baseline from 21 FAIL rows to 3 PASS rows, and the run from 27 FAILs to 6.

## Regenerated against the real seven-step run

`fleet-100c-1node-10min` is not in the database and its artifacts are on the monitoring host, so this is `sura-stage2-full`.

| | Before | After |
|---|---|---|
| Gate rows | 36 | **98** |
| Families | 5 | **8** |
| PASS / FAIL / UNKNOWN | 33 / 2 / 9 | 48 / 6 / 44 |
| Verdict | FAIL | **FAIL** |
| calls_per_node | 15 | 15 |

**A real finding:** `memory_available_bytes` fell across steady state on four of the seven steps, after the ramp is excluded. That is precisely the criterion nothing was checking.

Return to baseline passes on all three metrics (`filefd_allocated` 0.85x, `memory_used_bytes` 0.82x, `sockstat_udp_inuse` 1.00x). The 21 lifecycle rows are UNKNOWN for the OOM half only, which is correct: the column postdates the run and they become PASS once the collector runs with this build.

## Conventions held

- Both count gates are in `ALL_GATES` and deliberately **not** in `RATIO_GATES`: their values are counts, and a count rendered as a percentage is what that set exists to prevent.
- All three report **once per run** when nothing carried their columns, not once per step, which is the same fix `rtp_ports` and `network` already had.
- UNKNOWN is never a pass, and every unmeasured row names the column that was missing.

## Existing tests updated

Seven, each because a fact it asserted became false: the row-count bound gained a fixed run-level tail, the UNKNOWN taxonomy gained a fourth legitimate kind, the run-level subject set grew, and the pass-path fixture declares the criteria that fixture cannot evaluate. One assertion of mine from the previous PR is also narrowed: the "never rendered as a percentage" check matched the stylesheet's own `width: 100%` whenever a threshold was zero.

## Gates

- `backend`: ruff clean, mypy clean on 283 files, **3134 passed**, 13 skipped (3123 before, +21 new, none lost)
- `docs`: PASS, 90 pages
- Migration `f2b9d47c1a86` chained off the single head; `alembic heads` reports one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added load-test diagnostics for process restarts, OOM kills, resource trends, and return-to-baseline behavior.
  * Reports now include run-level gate results with clear PASS, FAIL, or UNKNOWN statuses.
  * Added collection and reporting of cumulative OOM-kill metrics.
* **Bug Fixes**
  * Improved handling of missing measurements, scrape gaps, insufficient samples, and stale trends.
  * Corrected threshold formatting and report validation for percentage and count-based criteria.
* **Tests**
  * Expanded coverage for lifecycle, trend, baseline, waiver, and end-to-end reporting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->