### PR TITLE
Measure network and RTP-port headroom instead of excluding them

### DIFF
--- a/alembic/versions/a1c6e39b7f24_network_and_port_headroom.py
+++ b/alembic/versions/a1c6e39b7f24_network_and_port_headroom.py
@@ -1,0 +1,89 @@
+"""node_samples: network allowance counters and media-port headroom
+
+Revision ID: a1c6e39b7f24
+Revises: f2b9d47c1a86
+Create Date: 2026-08-03 09:20:00.000000
+
+Two acceptance criteria reported UNKNOWN in every report, and not because the
+fleet hosts were quiet. The hosts publish all nine of these series; the
+collector's series map simply did not know the names, so the scrape matched
+nothing, stored nothing, and the gate had no column to read. An UNKNOWN that
+comes from a missing map entry is indistinguishable in the report from an
+UNKNOWN that comes from an unreachable node, which is the worse half of the
+problem: the report looked like it was telling the truth.
+
+NETWORK HEADROOM. Cloud hosts shape traffic rather than dropping it silently,
+and the five ethtool allowance counters are where that shaping is admitted. A
+throttled instance presents to a caller as jitter and loss that no application
+metric explains, so without these columns the criterion could only ever be
+argued, never measured. ``network_receive_bytes_total`` and
+``network_transmit_bytes_total`` are the throughput the allowances are a ceiling
+on, split by direction and never summed: a total hides one-way audio, the same
+reason the sip_rtp_packets pair is stored split.
+
+The allowance counters are CUMULATIVE SINCE DRIVER RESET, so only a DELTA over
+the test window is attributable to the run. This is not a theoretical caution:
+one real SIP node reads 9613 on bw_in from before the engagement started while
+its twin, same instance type and same config, reads 0. Gating on the absolute
+would fail the first node for throttling it never suffered during the test and
+pass the second for the same behaviour. BigInteger on all five, because they are
+unbounded counters and an INT4 that overflows is a 500 on PostgreSQL and a
+silent wrong number on SQLite.
+
+RTP PORT HEADROOM. ``media_ports_in_use`` counts UDP sockets bound inside the
+configured media range, which is narrower and more useful than
+``sockstat_udp_inuse``: the latter counts every UDP socket on the host,
+signalling and DNS included, so it cannot be read as a fraction of the range.
+
+``media_ports_total`` is a DECLARED CONFIG VALUE rather than a measurement: it
+is the size of the configured rtp_port range (10001 on the fleet), published by
+the host because only the host knows what it was started with. It is stored per
+sample so a ratio is taken against the range in force at that instant rather
+than against whatever the config file says at read time. A node that publishes
+in_use without total must therefore report UNKNOWN headroom. Dividing by a
+guessed range size would mint a percentage nobody measured, and a saturation
+chart is exactly where an invented denominator does the most damage.
+
+None of the nine is derived. All are scraped from an exposition, so all nine
+count toward ``series_found`` and none belongs in DERIVED_COLUMNS.
+
+Chained off the single head f2b9d47c1a86. Every column is nullable, and NULL
+means "not measured", never zero.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1c6e39b7f24"
+down_revision: str | Sequence[str] | None = "f2b9d47c1a86"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "node_samples"
+
+# (column, type). BigInteger for the cumulative counters and the byte totals;
+# a plain Integer for the two port gauges, which are bounded by the size of a
+# port range.
+_COLUMNS: tuple[tuple[str, sa.types.TypeEngine], ...] = (
+    ("media_ports_total", sa.Integer()),
+    ("media_ports_in_use", sa.Integer()),
+    ("ethtool_bw_in_allowance_exceeded", sa.BigInteger()),
+    ("ethtool_bw_out_allowance_exceeded", sa.BigInteger()),
+    ("ethtool_pps_allowance_exceeded", sa.BigInteger()),
+    ("ethtool_conntrack_allowance_exceeded", sa.BigInteger()),
+    ("ethtool_linklocal_allowance_exceeded", sa.BigInteger()),
+    ("network_receive_bytes_total", sa.BigInteger()),
+    ("network_transmit_bytes_total", sa.BigInteger()),
+)
+
+
+def upgrade() -> None:
+    for name, type_ in _COLUMNS:
+        op.add_column(_TABLE, sa.Column(name, type_, nullable=True))
+
+
+def downgrade() -> None:
+    for name, _ in reversed(_COLUMNS):
+        op.drop_column(_TABLE, name)

--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -33,6 +33,7 @@ from voicegateway.loadtest.capacity import (
 from voicegateway.loadtest.importer import (
     build_plan,
     limitations_from_notes,
+    network_baselines_from_notes,
     observations_for,
     plan_from_notes,
 )
@@ -107,12 +108,27 @@ def import_run(
             "cannot be derived across a multi-step ramp."
         ),
     ),
+    network_baseline: Path = typer.Option(
+        None,
+        "--network-baseline",
+        help=(
+            "JSON mapping NODE name to its published network baseline in bits "
+            'per second, e.g. \'{"sip-1": {"in_bps": 3125000000, "out_bps": '
+            "3125000000}}'. Nothing measures it: the ENA driver reports no link "
+            "speed. A node with no entry has no denominator and reports UNKNOWN."
+        ),
+    ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show what would be written, write nothing"
     ),
 ) -> None:
     """Import one directory of artifacts as a run with a row per test."""
     declared = _plan_from_file(targets) if targets is not None else {}
+    baselines = (
+        _network_baselines_from_file(network_baseline)
+        if network_baseline is not None
+        else {}
+    )
     try:
         plan = build_plan(
             directory,
@@ -122,6 +138,7 @@ def import_run(
             captured=captured,
             now_ms=int(time.time() * 1000),
             declared_targets=declared,
+            declared_network_baselines=baselines,
         )
     except ArtifactError as exc:
         # Named errors carry which surface disagreed and how, so they are shown
@@ -343,6 +360,102 @@ def _plan_from_file(path: Path) -> dict[str, dict[str, float]]:
             )
         plan[str(name)] = entry
     return plan
+
+
+#: The only two fields a declared baseline may carry. Both are required and
+#: neither has a default, because the point of the file is to be the one place a
+#: figure nobody can measure is written down by hand.
+_NETWORK_BASELINE_DIRECTIONS = ("in_bps", "out_bps")
+
+
+def _network_baselines_from_file(path: Path) -> dict[str, dict[str, float]]:
+    """Read the per-node link capacity that nothing on the host reports.
+
+    There is no measurable denominator for bandwidth headroom on these nodes. The
+    AWS ENA driver publishes no link speed, so ``node_network_speed_bytes`` is
+    absent for the interface carrying the media, and every attempt to compute a
+    utilisation from the byte counters alone divides by something that does not
+    exist. The only figure that does exist is the baseline AWS publishes for the
+    instance type, in a document, which is why an operator declares it here
+    rather than anything scraping it.
+
+    Shape, keyed by NODE name::
+
+        {"sip-1": {"in_bps": 3125000000, "out_bps": 3125000000}}
+
+    In bits per second, both directions, always both. The two are separate
+    allowances on the instance and separate counters on the host, and letting one
+    number cover both would put an assumption inside a declaration that exists to
+    hold none.
+
+    THIS FILE IS THE ONLY SOURCE. No instance type is mapped to a bandwidth
+    anywhere in this code, and none may be added. A lookup table would hand a
+    denominator to a node whose instance type nobody verified, and the report
+    would then carry a percentage of a guess where it owes an UNKNOWN. An
+    undeclared node stays undeclared all the way through to the gate.
+
+    A declaration is not a measurement, and this one under-claims by
+    construction: the published baseline is a FLOOR, since the instance can burst
+    well above it (a c7i.2xlarge baselines at 3.125 Gbps and peaks at 12.5), so a
+    utilisation computed against it reads higher than the truth. That is the safe
+    direction for a headroom check, and it is recorded in the run notes so nobody
+    downstream reads the figure as a measured link capacity.
+
+    A misspelled field is refused rather than ignored, because a silently dropped
+    direction is a node that looks declared and is not.
+    """
+    try:
+        raw = json.loads(path.read_text())
+    except OSError as exc:
+        raise typer.BadParameter(f"cannot read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise typer.BadParameter(
+            f"{path}: expected an object mapping node name to its declared "
+            "network baseline, e.g. "
+            '{"sip-1": {"in_bps": 3125000000, "out_bps": 3125000000}}'
+        )
+
+    baselines: dict[str, dict[str, float]] = {}
+    for node, value in raw.items():
+        if not isinstance(value, dict):
+            raise typer.BadParameter(
+                f"{path}: {node!r} must be an object carrying in_bps and "
+                f"out_bps, got {value!r}. There is no short form: ingress and "
+                "egress are separate allowances, and one figure covering both "
+                "would be an assumption nobody declared."
+            )
+        # Unknown keys are caught BEFORE the missing-field check, so that
+        # {"in_bps": x, "out_bsp": y} names the typo rather than reporting the
+        # field it caused to go missing.
+        unknown = sorted(set(value) - set(_NETWORK_BASELINE_DIRECTIONS))
+        if unknown:
+            raise typer.BadParameter(
+                f"{path}: {node!r} has unknown field(s) {unknown}. Known fields "
+                f"are {list(_NETWORK_BASELINE_DIRECTIONS)}; a misspelled one "
+                "would be silently ignored and the declaration incomplete."
+            )
+        entry: dict[str, float] = {}
+        for direction in _NETWORK_BASELINE_DIRECTIONS:
+            number = value.get(direction)
+            if not isinstance(number, (int, float)) or isinstance(number, bool):
+                raise typer.BadParameter(
+                    f"{path}: {node!r} needs a numeric {direction} in bits per "
+                    f"second, got {number!r}. It cannot be defaulted: no "
+                    "instance-type lookup exists here, and a node with no "
+                    "declared baseline reports UNKNOWN rather than a percentage "
+                    "of a guess."
+                )
+            if number <= 0:
+                raise typer.BadParameter(
+                    f"{path}: {node!r} {direction} must be positive, got "
+                    f"{number!r}. A zero baseline is not a saturated link, it is "
+                    "a denominator nobody supplied."
+                )
+            entry[direction] = float(number)
+        baselines[str(node)] = entry
+    return baselines
 
 
 def _waivers_from_file(path: Path) -> dict[str, str]:
@@ -605,7 +718,15 @@ def report(
                 ended_at_ms=test.get("ended_at_ms"),
             )
         )
-    results = judge_run(tests, aggregates=aggregates)
+    # Declared at import and carried in the run notes, exactly as the ramp plan
+    # is. A node with no declaration reaches the bandwidth gate as UNKNOWN: the
+    # instance type is never read to infer a baseline, because a guessed
+    # denominator would look identical to a measured one in the report.
+    results = judge_run(
+        tests,
+        aggregates=aggregates,
+        network_baselines=network_baselines_from_notes(run.get("notes")),
+    )
     results, unmatched = _apply_waivers(
         results, _waivers_from_file(waive) if waive is not None else {}
     )

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -100,6 +100,7 @@ RETURN_TO_BASELINE_GATE = "return_to_baseline"
 SUSTAINED_HEALTH_GATE = "sustained_health"
 PROCESS_LIFECYCLE_GATE = "process_lifecycle"
 RESOURCE_TREND_GATE = "resource_trend"
+NETWORK_ALLOWANCE_GATE = "network_allowance"
 
 #: The subject a gate is filed under when it describes the whole fleet rather
 #: than one node. Used where nothing was sampled at all: the finding is that NO
@@ -152,6 +153,11 @@ ALL_GATES: frozenset[str] = frozenset(
         # Same reason, same exclusion from RATIO_GATES.
         PROCESS_LIFECYCLE_GATE,
         RESOURCE_TREND_GATE,
+        # A count of allowance-exceeded EVENTS over the window, so the same
+        # exclusion again. "9613" rendered as "961300%" would be the exact
+        # misstatement RATIO_GATES exists to prevent, and this gate is one where
+        # the number is quoted back to a client as evidence of throttling.
+        NETWORK_ALLOWANCE_GATE,
     }
 )
 
@@ -247,11 +253,48 @@ MIN_TREND_DRIFT_FRACTION = 0.01
 # them.
 MIN_HEADROOM_FRACTION = 0.20
 
-# The resources the criterion names. Only the first is scraped today; the other
-# two are carried so the report cannot go quiet about them.
+# The resources the criterion names, one per HeadroomReading.resource.
+#
+# Network is TWO resources, not one, and the split is not cosmetic. A cloud
+# instance meters inbound and outbound against SEPARATE credit buckets: a node
+# can be shaped on egress while ingress sits nowhere near its allowance, and the
+# fleet's own counters agree (bw_in and bw_out are distinct series that move
+# independently). A single combined row would have to silently pick a direction,
+# and whichever it picked would be the one nobody asked about.
+#
+# The two ids are also what keeps the ROWS distinct. One "network" resource
+# emitted two gates whose subject was `node/network` with different answers and
+# nothing to tell them apart, which is the same subject collision that was fixed
+# once already by putting the source in the subject. Two resources, two
+# subjects, two answers.
 HEADROOM_FILE_DESCRIPTORS = "file_descriptors"
 HEADROOM_RTP_PORTS = "rtp_ports"
-HEADROOM_NETWORK = "network"
+HEADROOM_NETWORK_IN = "network_in"
+HEADROOM_NETWORK_OUT = "network_out"
+
+# Packets per second. A PERMANENT SCOPE EXCLUSION with a stated reason, not a
+# gap waiting on an exporter, and the distinction is the whole point of writing
+# it down here.
+#
+# Packets-per-second headroom cannot be expressed as a percentage by anyone,
+# including AWS, because no per-instance-type PPS allowance is published under
+# any API or document. There is a numerator (the observed packet rate) and there
+# is no denominator to divide it by, anywhere, at any price. Every "PPS
+# headroom" figure in existence is somebody's guess at the allowance wearing a
+# percentage sign.
+#
+# So this must NEVER be turned into a headroom gate, and it is named here
+# precisely so the next person to notice PPS is missing from the headroom rows
+# finds the reason instead of filing it as unfinished work. Wiring an exporter
+# does not lift this one: the counter that is missing is not a metric anybody
+# collects, it is a constant only the hypervisor knows.
+#
+# PPS saturation is still DETECTED, which is why the exclusion is honest rather
+# than a hole. node_ethtool_pps_allowance_exceeded feeds
+# :data:`NETWORK_ALLOWANCE_GATE`, which reads the counter as an EVENT ("the
+# instance was throttled during this window") rather than as a fraction of a
+# limit. The event is measurable and gated; only the headroom is not.
+HEADROOM_PPS = "pps"
 
 
 @dataclass(frozen=True)
@@ -1032,8 +1075,16 @@ class HeadroomReading:
     the pair was not measured, and ``unmeasured_reason`` says why.
 
     File descriptors come from the ``filefd_allocated`` / ``filefd_maximum``
-    gauge pair. RTP ports and network are named by the criterion and scraped by
-    nothing today, which is what :func:`unscraped_headroom_readings` exists for.
+    gauge pair. RTP ports come from ``media_ports_in_use`` /
+    ``media_ports_total``, where the total is the DECLARED size of the
+    configured media port range rather than a measurement, which is exactly why
+    it is stored per sample: the ratio is taken against the range in force at
+    that instant. Network is two resources, :data:`HEADROOM_NETWORK_IN` and
+    :data:`HEADROOM_NETWORK_OUT`, because the buckets are separate.
+
+    A pair this reading cannot be built from is not silently dropped:
+    :func:`unscraped_headroom_readings` exists so an unmeasured resource still
+    files a row saying so.
     """
 
     node: str
@@ -1047,16 +1098,25 @@ class HeadroomReading:
 def unscraped_headroom_readings(
     node: str, *, source: str | None = None
 ) -> list[HeadroomReading]:
-    """The headroom resources nothing measures yet, as explicit non-readings.
+    """The headroom resources a caller could not measure, as explicit
+    non-readings.
 
     The criterion asks for headroom on network, RTP ports and system limits.
-    Only system limits (file descriptors) are scraped. Emitting the other two as
-    ``not_measured`` is the whole point of this helper: a report that simply
-    omits them shows one green row and reads as full coverage of a three-part
-    requirement.
+    Emitting the ones a run could not compute as ``not_measured`` is the whole
+    point of this helper: a report that simply omits them shows one green
+    file-descriptor row and reads as full coverage of a three-part requirement.
 
     A helper rather than a note in a docstring, because a caller that has to
     remember to add them is a caller that eventually does not.
+
+    Network appears TWICE, once per direction, for the reason given at
+    :data:`HEADROOM_NETWORK_IN`: the credit buckets are separate, and a single
+    row cannot be un-measured in one direction and measured in the other.
+
+    :data:`HEADROOM_PPS` is deliberately NOT here. It is a stated permanent
+    exclusion, not something awaiting a scrape, and filing it as an unmeasured
+    headroom row would put it in the queue of things somebody could fix. Nobody
+    can fix it: see the comment on that constant.
     """
     return [
         HeadroomReading(
@@ -1070,13 +1130,22 @@ def unscraped_headroom_readings(
         for resource, reason in (
             (
                 HEADROOM_RTP_PORTS,
-                "no exporter in the scrape set publishes an RTP port-range "
-                "usage series, so nothing measures it",
+                "no scrape correlated to this window carried the "
+                "media_ports_in_use / media_ports_total pair, so the range size "
+                "that would be the denominator is unknown and nothing "
+                "measures it",
             ),
             (
-                HEADROOM_NETWORK,
-                "no exporter in the scrape set publishes a network saturation "
-                "series (PPS or conntrack), so nothing measures it",
+                HEADROOM_NETWORK_IN,
+                "network_receive_bytes_total has no denominator here: no "
+                "exporter in the scrape set publishes the instance INBOUND "
+                "bandwidth allowance, so nothing measures it",
+            ),
+            (
+                HEADROOM_NETWORK_OUT,
+                "network_transmit_bytes_total has no denominator here: no "
+                "exporter in the scrape set publishes the instance OUTBOUND "
+                "bandwidth allowance, so nothing measures it",
             ),
         )
     ]
@@ -1167,8 +1236,16 @@ def headroom_gates(
                 gate=HEADROOM_GATE,
                 status=UNKNOWN,
                 detail=(
-                    "no headroom reading was supplied, so no limit was shown to "
-                    "have room left. Nothing measured is not room to spare"
+                    # "not measured" is load-bearing wording, not prose. Every
+                    # UNKNOWN row in a report has to say which kind of absence
+                    # it is, and two end-to-end tests enforce that every UNKNOWN
+                    # detail carries either "not measured" or "no node was
+                    # sampled". The older phrasing said "Nothing measured" and
+                    # satisfied neither, so this row read as a gate that broke
+                    # rather than as a resource nobody supplied a reading for.
+                    "no headroom reading was supplied, so this resource was not "
+                    "measured and no limit was shown to have room left. Nothing "
+                    "measured is not room to spare"
                 ),
                 threshold=threshold,
             )
@@ -1909,6 +1986,251 @@ def resource_trend_gates(
     ]
 
 
+# --------------------------------------------------------------------------
+# Hypervisor network allowances: throttling no application metric explains
+# --------------------------------------------------------------------------
+#
+# A cloud host does not drop your traffic when you exceed an allowance, it
+# QUEUES it, and the queue is invisible from inside the guest. It presents to a
+# caller as jitter and one-way audio that CPU, memory and application latency
+# all decline to explain. The ethtool allowance counters are the only place the
+# hypervisor admits it happened, which is what makes them worth a gate of their
+# own rather than a footnote under headroom.
+#
+# This gate answers "were you throttled", never "how close were you". The
+# second question is the headroom gate's, and for three of these five counters
+# it has no answer at all: see :data:`HEADROOM_PPS`.
+
+
+#: The five counters, in the order a row prints them, split by WHAT A NON-ZERO
+#: READING PROVES. The split is the reason this gate exists, so it is data here
+#: rather than a branch inside the gate: the sentence a reader gets has to
+#: follow from which counter fired.
+#:
+#: bw_in, bw_out and pps count packets QUEUED OR DROPPED, and the hypervisor
+#: never separates the two. A delta there is proof of SHAPING and is not proof
+#: of loss, and a report that says "packets dropped" off this counter has
+#: claimed something the counter cannot tell it.
+_ALLOWANCE_SHAPED: tuple[str, ...] = ("bw_in", "bw_out", "pps")
+#: conntrack and linklocal count DROPS ONLY. There is no queue behind these: a
+#: non-zero delta is traffic that did not arrive, which is an unambiguous
+#: failure and has to read differently from the three above.
+_ALLOWANCE_DROPPED: tuple[str, ...] = ("conntrack", "linklocal")
+_ALLOWANCE_COUNTERS: tuple[str, ...] = _ALLOWANCE_SHAPED + _ALLOWANCE_DROPPED
+
+
+@dataclass(frozen=True)
+class AllowanceReading:
+    """One node's five hypervisor allowance counters as DELTAS over the window.
+
+    **Deltas, never absolutes, and the gate depends on the caller honouring
+    that.** ``node_ethtool_*_allowance_exceeded`` is cumulative since driver
+    reset, so an absolute reading carries every throttling event since the
+    instance booted. This is not theoretical: one real SIP node reads 9613 on
+    ``bw_in`` from before the engagement started while its twin, same instance
+    type behind the same load balancer, reads 0. Gating the absolute would fail
+    a node for shaping it never suffered during the test and pass its twin, and
+    the report would name the wrong box.
+
+    The caller supplies the subtraction because the caller is the one holding
+    both endpoints of the window. This gate therefore treats a large value as a
+    large delta and nothing else, and a NEGATIVE value as a counter reset rather
+    than as traffic being handed back.
+
+    ``None`` means that counter was not measured. It is never read as zero: a
+    counter nobody scraped says nothing about whether the instance was
+    throttled, and scoring it 0 would manufacture a clean window out of a scrape
+    gap.
+    """
+
+    node: str
+    source: str | None = None
+    # delta over the window per counter; None means not measured
+    bw_in: float | None = None
+    bw_out: float | None = None
+    pps: float | None = None
+    conntrack: float | None = None
+    linklocal: float | None = None
+
+
+def _allowance_subject(reading: AllowanceReading) -> str:
+    """``node`` or ``node/source``, and never blank.
+
+    Same rule as :func:`_headroom_gate`: one node is commonly scraped by several
+    exporters, and dropping the source produced rows with identical subjects and
+    different answers. The fleet fallback covers a reading built with no node
+    name at all, because an empty cell in a table where every other row
+    identifies itself reads as a rendering fault rather than as a finding.
+    """
+    node = reading.node.strip() if reading.node else ""
+    if not node:
+        return FLEET_SUBJECT
+    return f"{node}/{reading.source}" if reading.source else node
+
+
+def _allowance_names(names: Sequence[str]) -> str:
+    """``a``, ``a and b``, ``a, b and c``. Prose, because the detail is prose."""
+    if len(names) == 1:
+        return names[0]
+    return f"{', '.join(names[:-1])} and {names[-1]}"
+
+
+def network_allowance_gate(reading: AllowanceReading) -> GateResult:
+    """Did the hypervisor throttle this node during the window?
+
+    PASS is every measured counter at a delta of zero. FAIL is any measured
+    counter above zero. UNKNOWN is no counter measured at all, which is not a
+    pass: an instance nobody asked about its allowances is not an instance that
+    stayed inside them.
+
+    **The detail is the deliverable here, more than the status is.** A bare
+    "FAIL, 9613" invites exactly one wrong reading, that 9613 packets were lost,
+    and the number does not support it. Two facts change what the number means
+    and both are stated on every row that carries one:
+
+    * ``bw_in``, ``bw_out`` and ``pps`` count packets QUEUED OR DROPPED, with no
+      way to tell which. Non-zero is evidence of shaping. It is not evidence of
+      loss, and a client who is told it is will go looking for a fault that
+      leaves no other trace.
+    * ``conntrack`` and ``linklocal`` count DROPS ONLY. Non-zero there is
+      traffic that did not arrive, full stop, and it must not be softened into
+      the same sentence as the first three.
+
+    A partial window still PASSES on what it measured and SAYS what it did not,
+    because "three of five counters were clean" and "the node was clean" are
+    different claims and only the first one was earned.
+    """
+    subject = _allowance_subject(reading)
+    values = {name: getattr(reading, name) for name in _ALLOWANCE_COUNTERS}
+
+    fired = [(n, v) for n, v in values.items() if v is not None and v > 0]
+    clean = [n for n, v in values.items() if v is not None and v == 0]
+    # A delta below zero is not traffic being credited back, it is the counter
+    # having reset under the window (driver reload, live migration, an instance
+    # replaced mid-run). The window's true delta is then unknowable, so the
+    # counter is dropped from the evidence rather than scored as clean.
+    reset = [n for n, v in values.items() if v is not None and v < 0]
+    unmeasured = [n for n, v in values.items() if v is None]
+
+    if fired:
+        named = ", ".join(f"{n} {v:+g}" for n, v in fired)
+        shaped = [n for n, _ in fired if n in _ALLOWANCE_SHAPED]
+        dropped = [n for n, _ in fired if n in _ALLOWANCE_DROPPED]
+        clauses = []
+        if shaped:
+            verb = "counts" if len(shaped) == 1 else "count"
+            clauses.append(
+                f"{_allowance_names(shaped)} {verb} packets QUEUED OR DROPPED "
+                "and the hypervisor never separates the two, so a non-zero "
+                "delta there is evidence of shaping, not necessarily loss."
+            )
+        if dropped:
+            verb = "counts" if len(dropped) == 1 else "count"
+            clauses.append(
+                f"{_allowance_names(dropped)} {verb} outright drops, so a "
+                "non-zero delta there is traffic that did not arrive rather "
+                "than traffic that was delayed."
+            )
+        return GateResult(
+            gate=NETWORK_ALLOWANCE_GATE,
+            status=FAIL,
+            subject=subject,
+            detail=(
+                f"{subject} exceeded a hypervisor network allowance during the "
+                f"window: {named} (delta over the window, not an absolute). "
+                + " ".join(clauses)
+            ),
+            metric="allowance_events",
+            value=float(sum(v for _, v in fired)),
+            threshold=0.0,
+        )
+
+    if clean:
+        gaps = ""
+        if unmeasured:
+            gaps = (
+                f" Not measured: {_allowance_names(unmeasured)}, so those were "
+                "not ruled out."
+            )
+        resets = ""
+        if reset:
+            resets = (
+                f" Excluded as counter resets: {_allowance_names(reset)}, which "
+                "fell over the window and cannot yield a delta."
+            )
+        return GateResult(
+            gate=NETWORK_ALLOWANCE_GATE,
+            status=PASS,
+            subject=subject,
+            detail=(
+                f"{subject} recorded no hypervisor allowance event during the "
+                f"window: {_allowance_names(clean)} held at a delta of 0."
+                f"{gaps}{resets}"
+            ),
+            metric="allowance_events",
+            value=0.0,
+            threshold=0.0,
+        )
+
+    if reset:
+        return GateResult(
+            gate=NETWORK_ALLOWANCE_GATE,
+            status=UNKNOWN,
+            subject=subject,
+            detail=(
+                f"{subject} was not measured: every counter that reported "
+                f"({_allowance_names(reset)}) fell across the window, which "
+                "means the counter reset rather than that traffic was allowed, "
+                "so the window's real delta is unknowable. A reset counter is "
+                "not a quiet network"
+            ),
+            threshold=0.0,
+        )
+
+    return GateResult(
+        gate=NETWORK_ALLOWANCE_GATE,
+        status=UNKNOWN,
+        subject=subject,
+        detail=(
+            f"{subject} was not measured: none of the five ethtool allowance "
+            f"counters ({_allowance_names(_ALLOWANCE_COUNTERS)}) carried a "
+            "delta for this window, so neither shaping nor drops were ruled "
+            "out. A counter nobody read is not a quiet network"
+        ),
+        threshold=0.0,
+    )
+
+
+def network_allowance_gates(
+    readings: Sequence[AllowanceReading],
+) -> list[GateResult]:
+    """One row per node per source. Never collapsed.
+
+    Collapsing would lose the finding. On a real fleet one SIP node carries
+    a non-zero ``bw_in`` and its twin carries zero, and which box was shaped is
+    the entire actionable content of the row.
+    """
+    if not readings:
+        return [
+            GateResult(
+                gate=NETWORK_ALLOWANCE_GATE,
+                status=UNKNOWN,
+                # Fleet-scoped for the same reason as _resource_gates: the
+                # finding is that nothing reported, so naming a node would be
+                # wrong and naming nothing prints an empty cell.
+                subject=FLEET_SUBJECT,
+                detail=(
+                    "no node was sampled in the window, so no hypervisor "
+                    "allowance counter was read and no node was shown to have "
+                    "escaped throttling. A window with no samples is not a "
+                    "quiet fleet"
+                ),
+                threshold=0.0,
+            )
+        ]
+    return [network_allowance_gate(r) for r in readings]
+
+
 __all__ = [
     "AGENTS_GATE",
     "BASELINE_GOROUTINES",
@@ -1918,7 +2240,9 @@ __all__ = [
     "FAIL",
     "HEADROOM_FILE_DESCRIPTORS",
     "HEADROOM_GATE",
-    "HEADROOM_NETWORK",
+    "HEADROOM_NETWORK_IN",
+    "HEADROOM_NETWORK_OUT",
+    "HEADROOM_PPS",
     "HEADROOM_RTP_PORTS",
     "LATENCY_GATE",
     "MAX_NODE_CPU_UTILISATION",
@@ -1935,6 +2259,10 @@ __all__ = [
     "SUSTAINED_HEALTH_GATE",
     "PROCESS_LIFECYCLE_GATE",
     "RESOURCE_TREND_GATE",
+    "NETWORK_ALLOWANCE_GATE",
+    "AllowanceReading",
+    "network_allowance_gate",
+    "network_allowance_gates",
     "MIN_TREND_SAMPLES",
     "MIN_TREND_DRIFT_FRACTION",
     "LifecycleReading",

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -1318,12 +1318,22 @@ SYNTHETIC_STAMP = "SYNTHETIC DATA: NOT A DELIVERABLE"
 #: a limits list that goes quiet as coverage grows reads as a clean bill of
 #: health rather than as an unchanged gap.
 _LOAD_REPORT_LIMITS = [
-    "RTP-port headroom is NOT measured. Nothing scrapes the media port range, so "
-    "the port-exhaustion half of the headroom requirement is unevaluated rather "
-    "than passing.",
-    "Network headroom is NOT measured. No interface saturation figure is "
-    "collected, so a run that stayed under every CPU and memory ceiling may still "
-    "have been near a link limit nothing here would show.",
+    "RTP-port headroom IS measured, from the media port range's own occupancy "
+    "against its configured size. The range size is a DECLARED configuration "
+    "value rather than a measurement, so a node publishing occupancy without it "
+    "reports unmeasured rather than being divided by a guess.",
+    "Network headroom is measured against a DECLARED baseline, not a measured "
+    "capacity. The ENA driver reports no link speed, so there is no capacity to "
+    "measure; the denominator is the instance type's published baseline, "
+    "supplied by an operator at import. The instance can burst above it, so that "
+    "figure is a floor rather than a ceiling and the ratio over-reads rather "
+    "than under-reads. Inbound and outbound are judged separately because the "
+    "hypervisor maintains separate credit buckets.",
+    "Packets-per-second headroom is NOT measured and never will be. No "
+    "per-instance-type PPS allowance is published by anyone, including AWS, so "
+    "there is no denominator to divide by. PPS saturation is still detected as "
+    "an EVENT by the allowance gate; what cannot be quantified is how much "
+    "headroom remained.",
     "Per-call packet loss is NOT measured. No server-side surface attributes loss "
     "to one participant's leg, so no loss figure appears per call anywhere in "
     "this report.",
@@ -1706,10 +1716,12 @@ def _render_scope_exclusions(payload: dict[str, Any]) -> str:
     )
     return (
         '<div class="exclusions"><h2>Not in scope for this report</h2>'
-        f"<p>The acceptance criterion asks for headroom on network, RTP ports "
-        f"and system limits. {len(exclusions)} of those three are outside what "
-        "this system measures, so the requirement is <strong>not fully "
-        "covered</strong> whatever the verdict above says.</p>"
+        "<p>The acceptance criterion asks for headroom on network, RTP ports "
+        "and system limits. Everything listed below is outside what this system "
+        "can measure at all, so the requirement is <strong>not fully "
+        "covered</strong> whatever the verdict above says. These are not gaps "
+        "in what this run collected: they are quantities nobody publishes a "
+        "denominator for.</p>"
         f"<ul>{items}</ul></div>"
     )
 

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -53,6 +53,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from voicegateway.livekit_diag import gates
 from voicegateway.livekit_diag.gates import (
     MIN_PERCENTILE_SAMPLES,
+    AllowanceReading,
     BaselineComparison,
     HeadroomReading,
     HealthSeriesReading,
@@ -124,6 +125,21 @@ class TestAggregate:
     # Idle before against settled after, per node. Populated only when idle
     # samples exist on BOTH sides; a missing side is an UNKNOWN, not a pass.
     baseline_comparisons: list[BaselineComparison] = field(default_factory=list)
+    # Media-port occupancy per node per source, already in headroom shape. This
+    # is a real measurement and replaces the sockstat_udp_inuse proxy, which
+    # counted every UDP socket in the namespace including the SFU's own ICE
+    # range and was therefore an upper bound rather than a count.
+    rtp_port_readings: list[HeadroomReading] = field(default_factory=list)
+    # Hypervisor allowance events per node per source, as DELTAS over the
+    # window. Never absolutes: these counters are cumulative since driver reset
+    # and one real SIP node carries 9613 from before the engagement.
+    allowance_readings: list[AllowanceReading] = field(default_factory=list)
+    # Peak observed throughput in BITS per second, keyed by (node, direction)
+    # where direction is "in" or "out". The denominator is not here on purpose:
+    # there is no measurable link capacity, so the ratio is completed in the
+    # judge against a baseline the operator DECLARED, and a node with no
+    # declaration must reach the gate as UNKNOWN rather than as a guess.
+    bandwidth_peaks: dict[tuple[str, str], float] = field(default_factory=dict)
     # File-descriptor headroom per node, already in the shape the gate judges.
     # Carried here rather than rebuilt in the judge so the measurement lives in
     # one place and the judge stays a thing that only decides.
@@ -390,6 +406,153 @@ async def _baseline_comparisons(
     return out
 
 
+#: The five hypervisor allowance counters, and the AllowanceReading field each
+#: lands on. Read as a delta over the window, never as an absolute.
+ALLOWANCE_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("ethtool_bw_in_allowance_exceeded", "bw_in"),
+    ("ethtool_bw_out_allowance_exceeded", "bw_out"),
+    ("ethtool_pps_allowance_exceeded", "pps"),
+    ("ethtool_conntrack_allowance_exceeded", "conntrack"),
+    ("ethtool_linklocal_allowance_exceeded", "linklocal"),
+)
+
+MEDIA_PORTS_USED_COLUMN = "media_ports_in_use"
+MEDIA_PORTS_TOTAL_COLUMN = "media_ports_total"
+
+#: Throughput counters and the direction each answers for. Inbound and outbound
+#: are kept apart because the hypervisor maintains SEPARATE credit buckets, so
+#: one combined figure would hide a node saturating in one direction only.
+THROUGHPUT_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("network_receive_bytes_total", "in"),
+    ("network_transmit_bytes_total", "out"),
+)
+
+_BITS_PER_BYTE = 8
+
+
+async def _rtp_port_reading(
+    db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
+) -> HeadroomReading | None:
+    """One subject's WORST media-port headroom over the window.
+
+    Worst, not last, and the drain matters as much as the load: occupancy can
+    peak AFTER the last call ends, while sockets linger in the range.
+
+    The measured shape on a real fleet is about 3.4 in-range sockets per call,
+    not one, which is why this is counted rather than inferred from call count.
+
+    ``media_ports_total`` is a DECLARED configuration value rather than a
+    measurement, so a node publishing occupancy without it is unmeasured with a
+    reason naming which half is missing. Dividing by a guessed range size would
+    put a fabricated ratio in a client report.
+    """
+    rows = await list_samples(
+        db,
+        node=node,
+        source=source,
+        since_ms=window.start_ms,
+        until_ms=window.end_ms,
+        limit=limit,
+    )
+    used = [
+        float(v)
+        for row in rows
+        if (v := getattr(row, MEDIA_PORTS_USED_COLUMN)) is not None
+    ]
+    totals = [
+        float(v)
+        for row in rows
+        if (v := getattr(row, MEDIA_PORTS_TOTAL_COLUMN)) is not None and v > 0
+    ]
+    if not used and not totals:
+        return None
+    if not used or not totals:
+        missing = (
+            MEDIA_PORTS_TOTAL_COLUMN if not totals else MEDIA_PORTS_USED_COLUMN
+        )
+        return HeadroomReading(
+            node=node,
+            source=source,
+            resource=gates.HEADROOM_RTP_PORTS,
+            used=None,
+            limit=None,
+            unmeasured_reason=(
+                f"the window carried {MEDIA_PORTS_USED_COLUMN} or "
+                f"{MEDIA_PORTS_TOTAL_COLUMN} but not both, and {missing} is the "
+                "half that was missing"
+            ),
+        )
+    return HeadroomReading(
+        node=node,
+        source=source,
+        resource=gates.HEADROOM_RTP_PORTS,
+        used=max(used),
+        limit=max(totals),
+    )
+
+
+async def _allowance_reading(
+    db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
+) -> AllowanceReading | None:
+    """Deltas of the five hypervisor allowance counters over the window.
+
+    A DELTA, because these are cumulative since driver reset and the absolute
+    says nothing about this run: one real SIP node reads 9613 from before the
+    engagement while its twin reads 0. They were confirmed static across a two
+    minute idle window, which is what makes a delta attributable to the load.
+
+    A negative delta is passed through rather than clamped. It means the counter
+    reset under the window, and the gate reports that as unknowable rather than
+    as a quiet network.
+    """
+    rows = await list_samples(
+        db,
+        node=node,
+        source=source,
+        since_ms=window.start_ms,
+        until_ms=window.end_ms,
+        limit=limit,
+    )
+    deltas: dict[str, float | None] = {}
+    for column, field_name in ALLOWANCE_COLUMNS:
+        seen = [
+            float(v) for row in rows if (v := getattr(row, column)) is not None
+        ]
+        deltas[field_name] = seen[-1] - seen[0] if len(seen) >= 2 else None
+    if all(v is None for v in deltas.values()):
+        return None
+    return AllowanceReading(node=node, source=source, **deltas)
+
+
+async def _bandwidth_peaks(
+    db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
+) -> dict[tuple[str, str], float]:
+    """Peak throughput per direction, in BITS per second.
+
+    The peak rather than the mean: a link allowance is breached at the peak, and
+    an average over a ten minute window hides a minute of saturation.
+
+    Rates come from :func:`read_counter_rate`, so a counter reset arrives as
+    None and is skipped rather than becoming a negative or a zero.
+    """
+    peaks: dict[tuple[str, str], float] = {}
+    for column, direction in THROUGHPUT_COLUMNS:
+        rates = await read_counter_rate(
+            db,
+            node=node,
+            source=source,
+            column=column,
+            since_ms=window.start_ms,
+            until_ms=window.end_ms,
+            limit=limit,
+        )
+        measured = [r.per_second for r in rates if r.per_second is not None]
+        if not measured:
+            continue
+        peaks[(node, direction)] = max(measured) * _BITS_PER_BYTE
+    return peaks
+
+
 async def _health_readings(
     db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
 ) -> list[HealthSeriesReading]:
@@ -517,6 +680,9 @@ async def aggregate_test_window(
     lifecycle: list[LifecycleReading] = []
     trends: list[TrendReading] = []
     baselines: list[BaselineComparison] = []
+    rtp_ports: list[HeadroomReading] = []
+    allowances: list[AllowanceReading] = []
+    peaks: dict[tuple[str, str], float] = {}
     for target in targets:
         cpu.append(
             await _cpu_reading(
@@ -553,6 +719,21 @@ async def aggregate_test_window(
                 db, node=target.node, source=target.source, window=window, limit=limit
             )
         )
+        rtp = await _rtp_port_reading(
+            db, node=target.node, source=target.source, window=window, limit=limit
+        )
+        if rtp is not None:
+            rtp_ports.append(rtp)
+        allowance = await _allowance_reading(
+            db, node=target.node, source=target.source, window=window, limit=limit
+        )
+        if allowance is not None:
+            allowances.append(allowance)
+        peaks.update(
+            await _bandwidth_peaks(
+                db, node=target.node, source=target.source, window=window, limit=limit
+            )
+        )
 
     return TestAggregate(
         window=window,
@@ -568,6 +749,9 @@ async def aggregate_test_window(
         lifecycle_readings=lifecycle,
         trend_readings=trends,
         baseline_comparisons=baselines,
+        rtp_port_readings=rtp_ports,
+        allowance_readings=allowances,
+        bandwidth_peaks=peaks,
     )
 
 

--- a/src/voicegateway/loadtest/importer.py
+++ b/src/voicegateway/loadtest/importer.py
@@ -250,6 +250,118 @@ def plan_from_notes(notes: str | None) -> dict[str, dict[str, float]]:
     return out
 
 
+#: Heading under which a DECLARED per-node network baseline is recorded in
+#: ``load_runs.notes``, the prefix each node carries, and the sentence written
+#: under them. Same mechanism and same reason as :data:`PLAN_HEADING`: the report
+#: is exported by a later command reading the row, and a figure nothing measured
+#: has no column to live in.
+#:
+#: This one is declared because there is nothing to measure it WITH. The ENA
+#: driver on these instances reports no link speed, so ``node_network_speed_bytes``
+#: yields nothing for the interface the traffic actually crosses, and a bandwidth
+#: utilisation without a denominator is not a number. The only figure available
+#: is the one AWS publishes per instance type, and it is published in a document
+#: rather than on the host, so an operator is the only thing that can carry it
+#: across.
+#:
+#: Published, for orientation only: c7i.2xlarge is a 3.125 Gbps baseline with a
+#: 12.5 Gbps burst peak, c6i.xlarge is 1.562 Gbps with the same 12.5 peak.
+#:
+#: There is deliberately NO instance-type-to-bandwidth mapping anywhere in this
+#: code. Writing one would mean a node whose type nobody checked still gets a
+#: denominator, from a table that was never confirmed against the machine the run
+#: was on, and the gate would then print a confident percentage where it owes an
+#: UNKNOWN. A node with no line under this heading has no baseline, and that has
+#: to stay visible.
+NETWORK_BASELINE_HEADING = (
+    "Declared network baseline (operator-supplied published figure, not measured):"
+)
+_NETWORK_BASELINE_PREFIX = "- "
+_NETWORK_BASELINE_CAVEAT = (
+    "These are the instance type's PUBLISHED baseline, in bits per second, "
+    "declared by an operator at import. Nothing here measured them. The instance "
+    "can burst above its baseline, so each figure is a FLOOR on the link and not "
+    "a ceiling: utilisation computed against it over-reads rather than under-reads."
+)
+
+
+def network_baselines_to_notes(baselines: dict[str, dict[str, float]]) -> str:
+    """The declared network baselines as the text appended to a run's notes.
+
+    Keyed by NODE, not by test. A ramp step is a slice of time and every node in
+    the fleet is under it; the link is a property of the machine, and two nodes
+    in one run are routinely different instance types with different baselines.
+
+    Both directions are always written. Ingress and egress are separate
+    allowances on these instances and separate counters on the host, and one
+    figure standing in for both would be an assumption in the middle of a
+    declaration whose whole purpose is to carry no assumptions.
+
+    The float is written as-is rather than rounded into Gbps, because the read
+    side has to return the same number the operator declared: a report that
+    quotes a denominator different from the one the gate divided by is worse than
+    one that quotes none.
+    """
+    lines = []
+    for node in sorted(baselines):
+        declared = baselines[node]
+        lines.append(
+            f"{_NETWORK_BASELINE_PREFIX}{node}: "
+            f"in_bps={declared['in_bps']} out_bps={declared['out_bps']}"
+        )
+    return (
+        f"\n\n{NETWORK_BASELINE_HEADING}\n"
+        + "\n".join(lines)
+        + f"\n{_NETWORK_BASELINE_CAVEAT}"
+    )
+
+
+def network_baselines_from_notes(notes: str | None) -> dict[str, dict[str, float]]:
+    """The declared network baselines, read back out of ``load_runs.notes``.
+
+    Returns {} when nothing was declared, which is what makes the headroom gate
+    report UNKNOWN for a node rather than divide its throughput by a number
+    nobody supplied. Nothing in this function invents, defaults or infers a
+    baseline for an undeclared node, and nothing may be added that does: the
+    absent case is the common one, and it is the one an operator has to be able
+    to see in the report.
+
+    An unparseable line is skipped rather than raising, exactly as in
+    :func:`plan_from_notes`: a malformed note must not stop a report exporting.
+
+    A node is kept only when BOTH directions parsed. Half a declaration would
+    let ingress be judged while egress quietly vanished, and in a report "nothing
+    scraped this" and "nothing declared a denominator for this" would then look
+    identical. Dropping the node reports UNKNOWN for both directions, which
+    under-claims in the safe direction.
+    """
+    if not notes or NETWORK_BASELINE_HEADING not in notes:
+        return {}
+    _, _, tail = notes.partition(NETWORK_BASELINE_HEADING)
+    out: dict[str, dict[str, float]] = {}
+    for line in tail.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith(_NETWORK_BASELINE_PREFIX):
+            # The caveat sentence, or a later section. Either way this one ended.
+            break
+        body = stripped[len(_NETWORK_BASELINE_PREFIX) :]
+        name, _, rest = body.partition(":")
+        entry: dict[str, float] = {}
+        for token in rest.split():
+            key, _, raw = token.partition("=")
+            if key not in ("in_bps", "out_bps"):
+                continue
+            try:
+                entry[key] = float(raw)
+            except ValueError:
+                continue
+        if "in_bps" in entry and "out_bps" in entry:
+            out[name.strip()] = entry
+    return out
+
+
 def limitations_from_notes(notes: str | None) -> list[str]:
     """The run's own gaps, read back out of ``load_runs.notes``.
 
@@ -352,6 +464,7 @@ def build_plan(
     captured: bool = False,
     now_ms: int,
     declared_targets: dict[str, dict[str, float]] | None = None,
+    declared_network_baselines: dict[str, dict[str, float]] | None = None,
 ) -> ImportPlan:
     """Read a directory of artifacts and plan the rows it would become.
 
@@ -361,6 +474,12 @@ def build_plan(
     ``captured`` is the operator asserting these artifacts came from a real run.
     Left False, the checksum is computed and recorded in the notes but not
     promoted to ``artifact_sha256``, so every report stamps itself synthetic.
+
+    ``declared_network_baselines`` is the published per-node link baseline, keyed
+    by node. It is an operator's declaration for the same reason
+    ``declared_targets`` is: nothing in the artifacts or on the host carries it.
+    Left None, no baseline is recorded and none is invented, so the bandwidth
+    headroom gate has no denominator and says so.
     """
     directory = Path(directory)
     test_dirs = discover_tests(directory)
@@ -398,6 +517,12 @@ def build_plan(
                 for name, step in declared_targets.items()
             }
         )
+
+    # Only written when something was declared. An empty section would read as a
+    # fleet whose baselines are all known to be nothing, and the gate would have
+    # to tell that apart from a run imported before this existed.
+    if declared_network_baselines:
+        notes += network_baselines_to_notes(declared_network_baselines)
 
     limitations: list[str] = []
     for p in parsed:

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -32,6 +32,8 @@ from voicegateway.loadtest.aggregation import (
     BASELINE_METRICS,
     FD_LIMIT_COLUMN,
     FD_USED_COLUMN,
+    MEDIA_PORTS_TOTAL_COLUMN,
+    MEDIA_PORTS_USED_COLUMN,
     TestAggregate,
 )
 from voicegateway.middleware.node_samples_worker_middleware import (
@@ -103,10 +105,39 @@ def _fd_reading(
 #: exclusion by itself and the resource returns to being a real per-node gate.
 HEADROOM_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     gates.HEADROOM_FILE_DESCRIPTORS: (FD_USED_COLUMN, FD_LIMIT_COLUMN),
-    gates.HEADROOM_RTP_PORTS: ("sockstat_udp_inuse", "rtp_port_range_size"),
-    gates.HEADROOM_NETWORK: (
-        "network_throughput_bytes",
-        "network_link_capacity_bytes",
+    # A real measurement now, and it replaces the sockstat_udp_inuse proxy
+    # entirely. That counted every UDP socket in the network namespace,
+    # including the SFU's own ICE range, so it was an upper bound rather than a
+    # count of media ports. media_ports_total is a DECLARED range size, which is
+    # why a node publishing occupancy without it reaches the gate as UNKNOWN.
+    gates.HEADROOM_RTP_PORTS: (
+        MEDIA_PORTS_USED_COLUMN,
+        MEDIA_PORTS_TOTAL_COLUMN,
+    ),
+    # Only the NUMERATOR is a column. There is no measurable link capacity: the
+    # ENA driver reports no speed, so node_network_speed_bytes yields nothing
+    # for the real interface. The denominator is the instance type's published
+    # baseline, declared by an operator at import, so it can never appear here.
+    # A node with throughput and no declaration is UNKNOWN at the gate, which is
+    # a different and more useful answer than the whole resource being excluded.
+    gates.HEADROOM_NETWORK_IN: ("network_receive_bytes_total",),
+    gates.HEADROOM_NETWORK_OUT: ("network_transmit_bytes_total",),
+}
+
+#: Resources excluded for a reason no exporter can ever lift.
+#:
+#: Distinct from :data:`HEADROOM_REQUIREMENTS`, whose exclusions are DERIVED
+#: from whether a column is published and therefore self-healing. This one is
+#: not waiting on work: the denominator does not exist anywhere to be collected.
+PERMANENT_HEADROOM_EXCLUSIONS: dict[str, str] = {
+    gates.HEADROOM_PPS: (
+        "packets-per-second headroom cannot be expressed as a percentage by "
+        "anyone, including AWS: no per-instance-type PPS allowance is published "
+        "under any API or document, so there is no denominator to divide by. "
+        "This is not a gap awaiting work. PPS saturation is still DETECTED as an "
+        "event by the network_allowance gate, which reads the "
+        "pps_allowance_exceeded counter; what cannot be quantified is how much "
+        "headroom remained."
     ),
 }
 
@@ -125,7 +156,7 @@ def excluded_headroom_resources() -> dict[str, str]:
     off UNKNOWN and a headline that improves while the disclosure shrinks is the
     one outcome this must not produce.
     """
-    excluded: dict[str, str] = {}
+    excluded: dict[str, str] = dict(PERMANENT_HEADROOM_EXCLUSIONS)
     for resource, columns in HEADROOM_REQUIREMENTS.items():
         if any_source_publishes(*columns):
             continue
@@ -209,6 +240,7 @@ def judge_test(
     *,
     aggregate: TestAggregate | None = None,
     node: str | None = None,
+    network_baselines: dict[str, dict[str, float]] | None = None,
 ) -> list[GateResult]:
     """Every acceptance gate for one test, in report order.
 
@@ -260,7 +292,78 @@ def judge_test(
     results.extend(_health_gates_for(aggregate))
     results.extend(gates.process_lifecycle_gates(aggregate.lifecycle_readings))
     results.extend(gates.resource_trend_gates(aggregate.trend_readings))
+    # Guarded, because headroom_gates([]) returns ONE row with no subject at
+    # all, and calling it twice on a window that measured neither produced two
+    # identical unidentified rows per step. That is the subject collision this
+    # file has already fixed twice: once by putting the source in the subject,
+    # once by adding the step. A criterion nothing measured is reported ONCE per
+    # run instead, by unmeasured_resource_gates below.
+    if aggregate.rtp_port_readings:
+        results.extend(gates.headroom_gates(aggregate.rtp_port_readings))
+    if aggregate.allowance_readings:
+        results.extend(gates.network_allowance_gates(aggregate.allowance_readings))
+    results.extend(_bandwidth_gates_for(aggregate, network_baselines or {}))
     return results
+
+
+#: How much of a declared baseline may be used before headroom is breached.
+#: The contracted criterion is 20% remaining, and the headroom gate expresses
+#: that as a floor on what is LEFT, so nothing here restates 0.80.
+def _bandwidth_gates_for(
+    aggregate: TestAggregate,
+    baselines: dict[str, dict[str, float]],
+) -> list[GateResult]:
+    """Peak throughput against the instance type's PUBLISHED baseline.
+
+    The only way the contracted "20% remaining" is obtainable for network. There
+    is no measurable link capacity: the ENA driver reports no speed, so
+    node_network_speed_bytes yields nothing for the real interface.
+
+    So the denominator is DECLARED, and a node nobody declared one for is
+    UNKNOWN rather than measured against an inferred figure. The instance type
+    is never read from a string to look a number up: that would be a guess
+    wearing a measurement's clothes.
+
+    Inbound and outbound are separate rows because the hypervisor maintains
+    separate credit buckets, and a node can saturate one direction while the
+    other idles.
+    """
+    if not aggregate.bandwidth_peaks:
+        return []
+    readings: list[gates.HeadroomReading] = []
+    for (node, direction), peak_bps in sorted(aggregate.bandwidth_peaks.items()):
+        resource = (
+            gates.HEADROOM_NETWORK_IN
+            if direction == "in"
+            else gates.HEADROOM_NETWORK_OUT
+        )
+        declared = baselines.get(node) or {}
+        baseline_bps = declared.get(f"{direction}_bps")
+        if not baseline_bps:
+            readings.append(
+                gates.HeadroomReading(
+                    node=node,
+                    resource=resource,
+                    used=None,
+                    limit=None,
+                    unmeasured_reason=(
+                        f"{node} carried throughput but no "
+                        f"{direction}bound baseline was declared for it, and "
+                        "there is nothing to measure link capacity against. The "
+                        "instance type is deliberately not read to infer one"
+                    ),
+                )
+            )
+            continue
+        readings.append(
+            gates.HeadroomReading(
+                node=node,
+                resource=resource,
+                used=peak_bps,
+                limit=baseline_bps,
+            )
+        )
+    return gates.headroom_gates(readings)
 
 
 #: The most a resource may end at, as a MULTIPLE of its idle baseline.
@@ -451,6 +554,7 @@ def judge_run(
     tests: list[dict[str, Any]],
     *,
     aggregates: dict[str, TestAggregate | None] | None = None,
+    network_baselines: dict[str, dict[str, float]] | None = None,
 ) -> list[GateResult]:
     """Every gate for every test in a run, flattened in test order.
 
@@ -467,7 +571,11 @@ def judge_run(
         # of seven. Identity only, so nothing about the verdict moves.
         out.extend(
             replace(result, step=name)
-            for result in judge_test(test, aggregate=aggregates.get(name))
+            for result in judge_test(
+                test,
+                aggregate=aggregates.get(name),
+                network_baselines=network_baselines,
+            )
         )
     # ONCE PER RUN, not once per node per test. Nothing measures these on any
     # node, so eighteen identical rows on a three-step ramp said the same two
@@ -497,7 +605,65 @@ def judge_run(
     # recreated by a run whose samples carried none of the needed columns.
     out.extend(_run_baseline_gates(aggregates))
     out.extend(unevaluated_criteria_gates({g.gate for g in out}))
+    out.extend(unmeasured_resource_gates(out))
     return out
+
+
+def unmeasured_resource_gates(emitted: list[GateResult]) -> list[GateResult]:
+    """One fleet row per newly measurable criterion that measured nothing.
+
+    These resources stopped being scope exclusions the moment the columns were
+    wired, which is correct: they ARE measurable now. But a run whose scrape
+    carried none of the new series would then have emitted no row for them at
+    all, and a contracted criterion that produces no row reads as one nobody
+    agreed to. That is the defect these gates exist to remove, recreated one
+    level down.
+
+    Once per RUN, not per step, and keyed on the SUBJECT rather than the gate
+    id: resource_headroom is shared with file descriptors, which always emits,
+    so a gate-id check would never fire.
+    """
+    seen = {(g.subject or "").rsplit("/", 1)[-1] for g in emitted}
+    results: list[GateResult] = []
+    missing = [
+        resource
+        for resource in (
+            gates.HEADROOM_RTP_PORTS,
+            gates.HEADROOM_NETWORK_IN,
+            gates.HEADROOM_NETWORK_OUT,
+        )
+        if resource not in seen
+    ]
+    if missing:
+        results.extend(
+            gates.headroom_gates(
+                [
+                    gates.HeadroomReading(
+                        node=gates.FLEET_SUBJECT,
+                        resource=resource,
+                        used=None,
+                        limit=None,
+                        # No "not measured" prefix here: headroom_gate already
+                        # opens with "was not measured:", and carrying it twice
+                        # printed the phrase back to back in a client report.
+                        unmeasured_reason=(
+                            "nothing in this run's scrape carried the series it "
+                            "needs. The criterion is measurable, so this is a "
+                            "gap in what was collected rather than a limit of "
+                            "the system"
+                        ),
+                    )
+                    for resource in missing
+                ]
+            )
+        )
+    if not any(g.gate == gates.NETWORK_ALLOWANCE_GATE for g in emitted):
+        results.append(
+            gates.network_allowance_gate(
+                gates.AllowanceReading(node=gates.FLEET_SUBJECT)
+            )
+        )
+    return results
 
 
 def unevaluated_criteria_gates(seen: set[str]) -> list[GateResult]:

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -42,12 +42,32 @@ Every wired entry has since been read off a running binary. **Nothing in
 map degrades is one plausible entry added from documentation.
 
 MEASURED against livekit-sip 1.10.1 and node_exporter, with a real inbound call
-placed so every counter was populated: all 22 ``livekit-sip`` entries and all 12
+placed so every counter was populated: all 22 ``livekit-sip`` entries and all 21
 ``node-exporter`` entries. Every one resolves, asserted per entry against a
 captured exposition and again in
 ``tests/integration/test_live_node_scrape.py`` against the running exporters.
 
-The last two ``node-exporter`` entries are its own ``process_open_fds`` /
+The nine network and media-port entries were read off the fleet hosts
+themselves, not off documentation, and each is published on ALL FOUR nodes.
+``media_ports_total`` / ``media_ports_in_use`` come from a node-exporter
+textfile collector and carry a ``role`` label that is ``sip`` or ``sfu``; a node
+runs one role, so summing across the label is the node total (a SIP node reads
+10001 total, 0 in use at rest). The five ``node_ethtool_*_allowance_exceeded``
+counters are UNTYPED, one ``device`` label each, and are the hypervisor's
+per-instance shaping counters: bandwidth in, bandwidth out, packets per second,
+conntrack and link-local. ``node_network_receive_bytes_total`` /
+``node_network_transmit_bytes_total`` are the per-device byte counters.
+
+None of the seven device-labelled entries names its device, because the device
+name is not stable across the fleet: it is ``enp39s0`` on the SIP nodes and
+``ens5`` on the SFU nodes, so a ``where`` pin would store NULL for the life of
+the deployment on half of them while ``series_found`` still read high. The two
+byte counters use ``exclude={"device": "lo"}`` instead, which is the only shape
+that both drops loopback and survives a node whose NIC is named differently:
+``lo`` is stable on every Linux host, so the device to LEAVE OUT is nameable
+where the ones to keep are not.
+
+Two ``node-exporter`` entries are its own ``process_open_fds`` /
 ``process_max_fds``, read off a live exporter as 8 and 524287. They were left
 unwired for a while on the reasoning that an exporter's own handles say nothing
 about a service under test, which is true. What made that untenable is that the
@@ -104,7 +124,11 @@ names that could not be found on a live server under any spelling. An unwired
 column is honest; a guessed one is invisible.
 
 node_exporter names come from its filefd / loadavg / cpu / meminfo / sockstat /
-netstat collectors and have been stable since node_exporter 0.18 (current 1.9).
+netstat / netdev / ethtool collectors and have been stable since node_exporter
+0.18 (current 1.9), plus the textfile collector, which is the one source here
+whose content an operator writes rather than node_exporter: ``media_ports_*``
+exists only where that file is being written, and a node without it stores NULL
+rather than 0.
 
 A metric name can still be renamed by a release, which is why an unmatched
 series stores NULL and why every row records ``series_found``: an operator on a
@@ -227,6 +251,12 @@ class _Series:
     # definition (``mode="idle"``). Everything else sums across labels, so a
     # renamed label value cannot silently empty a column.
     where: Mapping[str, str] | None = None
+    # The complement of `where`, for the case where the label values that BELONG
+    # in the total cannot be named but the one that does not can. A sample is
+    # dropped when it matches every pair here. Used for device="lo": the real
+    # NIC name differs per node (enp39s0 / ens5) so pinning it would empty the
+    # column on half the fleet, while loopback is called lo on every Linux host.
+    exclude: Mapping[str, str] | None = None
 
 
 # The metric map. See the module docstring for where these names came from and
@@ -361,6 +391,78 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         # which at 500 concurrent is a likelier wall than CPU.
         _Series("node_sockstat_UDP_inuse", "sockstat_udp_inuse"),
         _Series("node_netstat_Udp_NoPorts", "udp_no_ports_total"),
+        # ---- media port headroom --------------------------------------------
+        # The RTP port range a node was given, and how much of it is currently
+        # taken. Published by a node-exporter textfile collector on all four
+        # fleet nodes, so it is the range the operator actually configured
+        # rather than a default this product assumed: a SIP node reads 10001
+        # total. in_use against total is the headroom that decides how many
+        # concurrent calls the box can carry, and it is a different wall from
+        # udp_no_ports_total (which is the kernel refusing an ephemeral port).
+        #
+        # `role` is sip or sfu and a node runs exactly ONE of them, so summing
+        # across the label is the node total and no `where` is needed. Pinning
+        # role would need two entries and would empty one of them on every node
+        # of the other kind.
+        _Series("media_ports_total", "media_ports_total"),
+        _Series("media_ports_in_use", "media_ports_in_use"),
+        # ---- cloud NIC allowances -------------------------------------------
+        # UNTYPED counters from the ethtool collector, one `device` label each.
+        # These are the hypervisor's per-instance shaping counters: they tick
+        # when the instance exceeded its inbound bandwidth, outbound bandwidth,
+        # packets-per-second, connection-tracking or link-local (DNS/NTP/IMDS)
+        # allowance and traffic was DROPPED for it. That is a ceiling no CPU or
+        # memory chart shows, and at 500 concurrent calls it is a likelier wall
+        # than either.
+        #
+        # Summed across `device` for the same reason the two byte counters
+        # below are: the NIC is enp39s0 on the SIP nodes and ens5 on the SFU
+        # nodes, so a device pin would store NULL for half the fleet.
+        _Series(
+            "node_ethtool_bw_in_allowance_exceeded",
+            "ethtool_bw_in_allowance_exceeded",
+        ),
+        _Series(
+            "node_ethtool_bw_out_allowance_exceeded",
+            "ethtool_bw_out_allowance_exceeded",
+        ),
+        _Series(
+            "node_ethtool_pps_allowance_exceeded",
+            "ethtool_pps_allowance_exceeded",
+        ),
+        _Series(
+            "node_ethtool_conntrack_allowance_exceeded",
+            "ethtool_conntrack_allowance_exceeded",
+        ),
+        _Series(
+            "node_ethtool_linklocal_allowance_exceeded",
+            "ethtool_linklocal_allowance_exceeded",
+        ),
+        # ---- NIC throughput --------------------------------------------------
+        # Cumulative per-device byte counters, read as a rate. Together with the
+        # allowance counters above they answer "was the box near its network
+        # ceiling", which is the question a media fleet fails on before it fails
+        # on CPU.
+        #
+        # EXCLUDED rather than pinned with a `where`, and the distinction is the
+        # point. The real interface is enp39s0 on the SIP nodes and ens5 on the
+        # SFU nodes, so `where={"device": "enp39s0"}` would store NULL forever on
+        # every SFU node while series_found still read high because its siblings
+        # matched. Loopback is `lo` on every Linux host, so naming the ONE device
+        # to leave out is expressible where naming the ones to keep is not. It
+        # has to be left out: lo carries this process's own traffic and a node
+        # talking to itself would inflate the number that is supposed to measure
+        # the wire.
+        _Series(
+            "node_network_receive_bytes_total",
+            "network_receive_bytes_total",
+            exclude={"device": "lo"},
+        ),
+        _Series(
+            "node_network_transmit_bytes_total",
+            "network_transmit_bytes_total",
+            exclude={"device": "lo"},
+        ),
         # ---- this exporter's own process ------------------------------------
         # Wired because the descriptor headroom gate asks every scraped source
         # for this pair, and a gate that is asked but not fed produced seven of
@@ -988,7 +1090,9 @@ class NodeSamplesWorker(AsyncWorker):
         values: dict[str, float | None] = {}
         found = 0
         for series in SERIES.get(target.source, ()):
-            value = sum_series(samples, series.metric, where=series.where)
+            value = sum_series(
+                samples, series.metric, where=series.where, exclude=series.exclude
+            )
             # Absent stays absent: the column is left out entirely, which stores
             # NULL. A 0.0 here would be indistinguishable from a real zero
             # reading and would draw a flat line an operator reads as healthy.

--- a/src/voicegateway/middleware/prometheus_exposition.py
+++ b/src/voicegateway/middleware/prometheus_exposition.py
@@ -221,6 +221,7 @@ def sum_series(
     name: str,
     *,
     where: Mapping[str, str] | None = None,
+    exclude: Mapping[str, str] | None = None,
 ) -> float | None:
     """Sum every sample of ``name`` matching ``where``; None when there are none.
 
@@ -236,6 +237,17 @@ def sum_series(
     a release spelled it differently. ``where`` is used only where the value is
     part of the definition (``mode="idle"``), never to reconstruct a split this
     schema does not store.
+
+    ``exclude`` is the complement, and it exists for the one shape ``where``
+    cannot express: sum EVERY label value except a named one. A sample is
+    skipped when it matches ALL of the pairs given, so ``{"device": "lo"}``
+    drops loopback and keeps whatever the real NIC happens to be called
+    (``enp39s0`` on one node, ``ens5`` on another). Pinning the device instead
+    would empty the column on every host that spells it differently, which is
+    the failure this whole module is written to avoid; ``lo`` is stable on every
+    Linux host, so excluding it is safe where pinning is not. An exclusion that
+    matches nothing changes nothing, and excluding every sample of a series
+    leaves the result None rather than 0.0, exactly as an absent series does.
 
     Summing across BUCKETS is a different operation and is refused. Prometheus
     buckets are cumulative, so ``le=0.1`` is contained in ``le=0.5`` and so on
@@ -256,6 +268,12 @@ def sum_series(
         if sample.name != name:
             continue
         if where and any(sample.labels.get(k) != v for k, v in where.items()):
+            continue
+        # ALL pairs must match to drop a sample, so an exclusion narrows what it
+        # removes as it gains keys. `and exclude` rather than a bare all(): an
+        # empty mapping matches vacuously, and reading that as "exclude
+        # everything" would turn a caller's `exclude={}` into a NULL column.
+        if exclude and all(sample.labels.get(k) == v for k, v in exclude.items()):
             continue
         total = sample.value if total is None else total + sample.value
     return total

--- a/src/voicegateway/models/node_sample_model.py
+++ b/src/voicegateway/models/node_sample_model.py
@@ -280,3 +280,58 @@ class NodeSample(SQLModel, table=True):
     # from node_filefd_maximum rather than scraped directly, but it is still an
     # observation about one scrape, which is what a value column is.
     filefd_maximum_unbounded: int | None = None
+
+    # ---- RTP port headroom -------------------------------------------------
+    # The pair that answers "how close is this node to running out of media
+    # ports", which is the wall a SIP box hits long before CPU does.
+    #
+    # ``media_ports_total`` is a DECLARED config value (the size of the
+    # configured rtp_port range, e.g. 10001), not a measurement. It is stored on
+    # the sample anyway so the ratio is computed against the range that was in
+    # force at that instant rather than against whatever the config says at read
+    # time. A node that publishes in_use without total leaves this NULL, and the
+    # headroom is then UNKNOWN: dividing by a guessed range size would invent a
+    # percentage nobody measured.
+    #
+    # ``media_ports_in_use`` counts UDP sockets bound inside that range, so it is
+    # narrower than sockstat_udp_inuse (which counts every UDP socket on the
+    # host, including signalling and DNS) and is the only one of the two that
+    # can be read as a fraction of the range.
+    media_ports_total: int | None = None
+    media_ports_in_use: int | None = None
+
+    # ---- network headroom --------------------------------------------------
+    # Cloud hosts shape traffic rather than dropping it silently, and the ethtool
+    # allowance counters are where that shaping is admitted. A non-zero DELTA
+    # over a run means the instance was throttled, which presents to a caller as
+    # jitter and loss that no application metric explains.
+    #
+    # Cumulative since driver reset, so only an increase inside the window is
+    # attributable to the run. This is not theoretical: one real SIP node reads
+    # 9613 on bw_in from before the engagement started while its twin reads 0,
+    # so an absolute reading would fail a node for throttling it never suffered
+    # during the test.
+    #
+    # BigInteger on all five: they are unbounded cumulative counters, and an
+    # INT4 that overflows is a 500 on PostgreSQL and a silent wrong number on
+    # SQLite.
+    ethtool_bw_in_allowance_exceeded: int | None = Field(
+        default=None, sa_type=BigInteger
+    )
+    ethtool_bw_out_allowance_exceeded: int | None = Field(
+        default=None, sa_type=BigInteger
+    )
+    ethtool_pps_allowance_exceeded: int | None = Field(default=None, sa_type=BigInteger)
+    ethtool_conntrack_allowance_exceeded: int | None = Field(
+        default=None, sa_type=BigInteger
+    )
+    ethtool_linklocal_allowance_exceeded: int | None = Field(
+        default=None, sa_type=BigInteger
+    )
+
+    # The throughput the allowance counters are the ceiling on. Split by
+    # direction and never summed: one-way audio is invisible in a total, exactly
+    # as with the sip_rtp_packets pair. BigInteger because a busy node passes
+    # 2 GiB within hours.
+    network_receive_bytes_total: int | None = Field(default=None, sa_type=BigInteger)
+    network_transmit_bytes_total: int | None = Field(default=None, sa_type=BigInteger)

--- a/src/voicegateway/repository/node_samples_repository.py
+++ b/src/voicegateway/repository/node_samples_repository.py
@@ -91,6 +91,19 @@ COUNTER_COLUMNS: frozenset[str] = frozenset(
         # about whether any were rejected during THIS window.
         "redis_rejected_connections_total",
         "redis_evicted_keys_total",
+        # Cumulative since DRIVER reset, not since the run started. One live SIP
+        # node carries 9613 on bw_in from before the engagement while its twin
+        # carries 0, so only the delta over the window is attributable; an
+        # absolute would fail a node for throttling it never suffered here.
+        "ethtool_bw_in_allowance_exceeded",
+        "ethtool_bw_out_allowance_exceeded",
+        "ethtool_pps_allowance_exceeded",
+        "ethtool_conntrack_allowance_exceeded",
+        "ethtool_linklocal_allowance_exceeded",
+        # The throughput the allowances cap. Read as a rate; the absolute is
+        # bytes since boot and says nothing about this window.
+        "network_receive_bytes_total",
+        "network_transmit_bytes_total",
     }
 )
 
@@ -138,6 +151,14 @@ GAUGE_COLUMNS: frozenset[str] = frozenset(
         "health_ok",
         "health_status_code",
         "health_timed_out",
+        # Media port headroom. Both are point-in-time: in_use is the count of
+        # UDP sockets bound inside the range right now, and total is the
+        # declared size of that range, republished on every scrape so a ratio is
+        # taken against the range in force at that instant. total NULL means the
+        # headroom is UNKNOWN, never "assume the usual range": a guessed
+        # denominator invents a saturation percentage nobody measured.
+        "media_ports_total",
+        "media_ports_in_use",
     }
 )
 
@@ -217,6 +238,18 @@ _INT_COLUMNS: frozenset[str] = frozenset(
         "health_ok",
         "health_status_code",
         "health_timed_out",
+        # Port counts and byte/event counters. All integral: a fractional port
+        # or a fractional throttling event is not a thing the exposition can
+        # mean, so truncation here loses nothing.
+        "media_ports_total",
+        "media_ports_in_use",
+        "ethtool_bw_in_allowance_exceeded",
+        "ethtool_bw_out_allowance_exceeded",
+        "ethtool_pps_allowance_exceeded",
+        "ethtool_conntrack_allowance_exceeded",
+        "ethtool_linklocal_allowance_exceeded",
+        "network_receive_bytes_total",
+        "network_transmit_bytes_total",
     }
 )
 
@@ -320,6 +353,21 @@ class NodeSampleRow:
     health_timed_out: int | None
     vmstat_oom_kill: int | None
 
+    # Media port and network headroom. media_ports_total is the declared range
+    # size, so NULL here makes the headroom UNKNOWN rather than assumable, and
+    # the ethtool counters are cumulative since driver reset, so a reader must
+    # take a delta over its window rather than the value it is handed.
+    media_ports_total: int | None
+    media_ports_in_use: int | None
+    ethtool_bw_in_allowance_exceeded: int | None
+    ethtool_bw_out_allowance_exceeded: int | None
+    ethtool_pps_allowance_exceeded: int | None
+    ethtool_conntrack_allowance_exceeded: int | None
+    ethtool_linklocal_allowance_exceeded: int | None
+    network_receive_bytes_total: int | None
+    network_transmit_bytes_total: int | None
+
+
 @dataclass(frozen=True)
 class CounterRate:
     """A per-second rate at ``at_ms``, or ``None`` when it is unknowable.
@@ -414,6 +462,19 @@ def _row(sample: NodeSample) -> NodeSampleRow:
         health_status_code=sample.health_status_code,
         health_timed_out=sample.health_timed_out,
         vmstat_oom_kill=sample.vmstat_oom_kill,
+        media_ports_total=sample.media_ports_total,
+        media_ports_in_use=sample.media_ports_in_use,
+        ethtool_bw_in_allowance_exceeded=sample.ethtool_bw_in_allowance_exceeded,
+        ethtool_bw_out_allowance_exceeded=sample.ethtool_bw_out_allowance_exceeded,
+        ethtool_pps_allowance_exceeded=sample.ethtool_pps_allowance_exceeded,
+        ethtool_conntrack_allowance_exceeded=(
+            sample.ethtool_conntrack_allowance_exceeded
+        ),
+        ethtool_linklocal_allowance_exceeded=(
+            sample.ethtool_linklocal_allowance_exceeded
+        ),
+        network_receive_bytes_total=sample.network_receive_bytes_total,
+        network_transmit_bytes_total=sample.network_transmit_bytes_total,
     )
 
 

--- a/src/voicegateway/tests/livekit_diag/test_gates.py
+++ b/src/voicegateway/tests/livekit_diag/test_gates.py
@@ -963,22 +963,53 @@ def test_the_sizing_margin_is_not_this_threshold():
     assert gate.value == pytest.approx(0.20)
 
 
-def test_rtp_ports_and_network_are_emitted_as_not_measured():
-    """The criterion names three resources and nothing scrapes two of them.
+def test_a_caller_that_scraped_nothing_files_three_not_measured_rows():
+    """A caller with no scrape for these files them as unmeasured, not absent.
 
-    Omitting them would show one green row and read as full coverage.
+    WHAT CHANGED. This used to assert TWO rows, ``rtp_ports`` and a single
+    ``network``, on the reasoning that nothing in the system could ever scrape
+    either. Both halves of that became false. RTP ports are now measured from
+    ``media_ports_in_use``/``media_ports_total``, and ``network`` was split into
+    :data:`gates.HEADROOM_NETWORK_IN` and :data:`gates.HEADROOM_NETWORK_OUT`
+    because a cloud instance meters ingress and egress against SEPARATE credit
+    buckets and one row sharing a subject would have to silently pick a
+    direction. So the old two-element assertion is now wrong in its membership
+    AND in its length.
+
+    What this helper still is, and what is still asserted exactly: the fallback
+    a caller uses when it scraped none of them, so an unmeasured resource files
+    a row saying so instead of vanishing. Omitting them would show one green row
+    and read as full coverage of a three-part requirement.
     """
     readings = gates.unscraped_headroom_readings("sfu-1")
     assert [r.resource for r in readings] == [
         gates.HEADROOM_RTP_PORTS,
-        gates.HEADROOM_NETWORK,
+        gates.HEADROOM_NETWORK_IN,
+        gates.HEADROOM_NETWORK_OUT,
     ]
     results = gates.headroom_gates(readings)
-    assert [g.status for g in results] == [gates.UNKNOWN, gates.UNKNOWN]
+    assert [g.status for g in results] == [
+        gates.UNKNOWN,
+        gates.UNKNOWN,
+        gates.UNKNOWN,
+    ]
     for gate in results:
         assert "nothing measures it" in gate.detail
         assert "not spare capacity" in gate.detail
         assert gate.value is None
+    # Every row identifies itself, which is the reason the direction split is
+    # two resources rather than one: two subjects, two answers, no collision.
+    assert [g.subject for g in results] == [
+        "sfu-1/rtp_ports",
+        "sfu-1/network_in",
+        "sfu-1/network_out",
+    ]
+    assert len({g.subject for g in results}) == 3
+    # THE COMPANION. pps is a PERMANENT scope exclusion (no per-instance-type
+    # allowance is published by anyone, so there is no denominator), and it must
+    # never be filed here: an unmeasured-headroom row puts a resource in the
+    # queue of things somebody could fix by wiring an exporter, and nobody can.
+    assert gates.HEADROOM_PPS not in {r.resource for r in readings}
     assert gates.exit_code(gates.verdict(results)) == 1
 
 
@@ -1011,17 +1042,23 @@ def test_no_readings_at_all_is_unknown_not_room_to_spare():
 
 
 def test_one_gate_per_node_and_resource():
+    # FIVE, not four. unscraped_headroom_readings grew a third row when network
+    # split into an inbound and an outbound resource, and one gate per (node,
+    # resource) means the row count follows the resource count exactly.
     results = gates.headroom_gates(
         [_fd("sfu-1", 10, 100), _fd("sfu-2", 95, 100)]
         + gates.unscraped_headroom_readings("sfu-1")
     )
-    assert len(results) == 4
+    assert len(results) == 5
     assert [g.status for g in results] == [
         gates.PASS,
         gates.FAIL,
         gates.UNKNOWN,
         gates.UNKNOWN,
+        gates.UNKNOWN,
     ]
+    # One gate per (node, resource) means no two rows share a subject.
+    assert len({g.subject for g in results}) == len(results)
     assert gates.verdict(results) == gates.FAIL
 
 

--- a/src/voicegateway/tests/loadtest/test_fd_headroom.py
+++ b/src/voicegateway/tests/loadtest/test_fd_headroom.py
@@ -235,8 +235,15 @@ def test_an_aggregate_carrying_no_fd_readings_still_produces_the_gate() -> None:
     """The silent-drop guard.
 
     A caller that builds an aggregate without FD readings must not lose the
-    file-descriptor gate while keeping RTP ports and network. An absent gate
-    reads as a resource nobody had to satisfy; UNKNOWN says nobody measured it.
+    file-descriptor gate. An absent gate reads as a resource nobody had to
+    satisfy; UNKNOWN says nobody measured it.
+
+    WHAT CHANGED. The companion resources this used to be compared against were
+    ``rtp_ports`` and ``network``, which were then emitted on every run because
+    nothing could measure either. Both are measured now, per node, from real
+    columns, so an aggregate carrying no readings for them correctly produces no
+    row for them either. ``pps`` is the resource still emitted unconditionally,
+    so it is the one this is now checked beside.
     """
     agg = aggregation.TestAggregate(
         window=window_of(T0, T0 + 10 * SEC),
@@ -250,15 +257,27 @@ def test_an_aggregate_carrying_no_fd_readings_still_produces_the_gate() -> None:
             gates.NodeUtilisationReading(node="sfu-1", utilisation=0.4, samples=2)
         ],
     )
-    # judge_run, because RTP ports and network are emitted once per run rather
-    # than once per node per test. Every assertion below is unchanged.
+    # judge_run, because the permanent pps exclusion is emitted once per run
+    # rather than once per node per test.
     results = judge.judge_run([HEALTHY], aggregates={HEALTHY["name"]: agg})
     resources = {
         r.subject.split("/")[-1] for r in results if r.subject and "/" in r.subject
     }
-    assert {"file_descriptors", "rtp_ports", "network"} <= resources
+    assert {"file_descriptors", gates.HEADROOM_PPS} <= resources
     [fd_gate] = [r for r in results if r.subject == "sfu-1/file_descriptors"]
     assert fd_gate.status == gates.UNKNOWN
+    # THE COMPANION. The two resources this used to be checked against are not
+    # missing because coverage was dropped: they are measurable now, and nothing
+    # excludes them, so their absence here means "this aggregate carried no
+    # reading" rather than "this system cannot measure it".
+    excluded = judge.excluded_headroom_resources()
+    assert sorted(excluded) == [gates.HEADROOM_PPS]
+    for resource in (
+        gates.HEADROOM_RTP_PORTS,
+        gates.HEADROOM_NETWORK_IN,
+        gates.HEADROOM_NETWORK_OUT,
+    ):
+        assert resource not in excluded, resource
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/loadtest/test_gate_row_identity.py
+++ b/src/voicegateway/tests/loadtest/test_gate_row_identity.py
@@ -78,6 +78,22 @@ def _aggregate() -> _Aggregate:
         )
         for source in SOURCES
     ]
+    # Media ports and throughput, which the fleet's exporters now publish. They
+    # are here because the collision this file is about is a property of a
+    # window that CORRELATED something: a step that measured nothing produces
+    # different rows, so a fixture without them would be checking a shape the
+    # real run does not have. Media ports are per (node, source); bandwidth is
+    # per (node, direction), because the byte counters are the node's.
+    rtp_ports = [
+        gates.HeadroomReading(
+            node=NODE,
+            source=source,
+            resource=gates.HEADROOM_RTP_PORTS,
+            used=340.0,
+            limit=10001.0,
+        )
+        for source in SOURCES
+    ]
     return _Aggregate(
         window=WINDOW,
         peak_cpu_utilisation=0.42,
@@ -86,6 +102,8 @@ def _aggregate() -> _Aggregate:
         cpu_readings=cpu,
         memory_readings=list(cpu),
         fd_readings=fds,
+        rtp_port_readings=rtp_ports,
+        bandwidth_peaks={(NODE, "in"): 480_000_000.0, (NODE, "out"): 505_000_000.0},
     )
 
 
@@ -139,11 +157,19 @@ def test_run_level_rows_carry_no_step() -> None:
 
     Stamping a step on them would claim seven evaluations where there was one,
     which is the same lie in the opposite direction.
+
+    WHAT CHANGED: ``fleet/network`` and ``fleet/rtp_ports`` used to be in this
+    set and are not any more. They were run-level ONLY because nothing could
+    measure them anywhere, which made them a fact about the system rather than
+    about a step. They are measured per node now, so they moved to the per-step
+    half of this file's contract, and the assertions in
+    :func:`test_every_row_in_a_multi_step_run_is_distinguishable` cover them
+    there. ``fleet/pps`` replaces both: its denominator is published by nobody,
+    so it is the one headroom resource that is still a fact about the system.
     """
     run_level = [g for g in _run() if g.step is None]
     assert {g.subject for g in run_level} == {
-        "fleet/network",
-        "fleet/rtp_ports",
+        f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_PPS}",
         # Same shape, added with the dependency criteria: a dependency nobody
         # wired is a fact about the deployment, not about step four of seven.
         "fleet/redis",
@@ -157,6 +183,13 @@ def test_run_level_rows_carry_no_step() -> None:
         "fleet/filefd_allocated",
         "fleet/sockstat_udp_inuse",
     }
+    # THE COMPANION, so the two that left cannot leave silently: they are gone
+    # from the run-level tail because something measures them, and they are
+    # present per step instead.
+    per_step_subjects = {g.subject for g in _run() if g.step is not None}
+    assert f"{NODE}/network_in" in per_step_subjects
+    assert f"{NODE}/network_out" in per_step_subjects
+    assert f"{NODE}/node-exporter/rtp_ports" in per_step_subjects
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/loadtest/test_judge.py
+++ b/src/voicegateway/tests/loadtest/test_judge.py
@@ -59,11 +59,16 @@ def _by_gate(results):
 def test_all_five_criteria_are_judged_even_with_no_measurements() -> None:
     """None of them may silently vanish from a report.
 
-    Asserted against judge_run, which is what builds a report's gate set. RTP
-    ports and network are emitted once per RUN rather than once per node per
-    test: nothing measures either anywhere, so a per-node row said the same
-    thing eighteen times on a three-step ramp. They are still gates, because a
-    written waiver needs something to attach to.
+    Asserted against judge_run, which is what builds a report's gate set.
+
+    WHAT CHANGED. This used to require ``rtp_ports`` and ``network`` in the
+    resource set of a run with no measurements at all, because nothing anywhere
+    could measure either, so both were emitted once per RUN as scope exclusions.
+    Both are measured now (``media_ports_*`` and the network byte counters), so
+    a run that correlated nothing has nothing to say about them and inventing a
+    row would be the fabrication these gates exist to prevent. The one resource
+    still emitted unconditionally is ``pps``, whose denominator is published by
+    nobody.
     """
     results = judge.judge_run([HEALTHY])
     kinds = _by_gate(results)
@@ -74,7 +79,14 @@ def test_all_five_criteria_are_judged_even_with_no_measurements() -> None:
     resources = {
         r.subject.split("/")[-1] for r in results if r.subject and "/" in r.subject
     }
-    assert {"file_descriptors", "rtp_ports", "network"} <= resources
+    assert {"file_descriptors", gates.HEADROOM_PPS} <= resources
+    # THE COMPANION, so the removal cannot silently become a coverage loss: the
+    # two that left this set left it by becoming measurable, and pps did not.
+    excluded = judge.excluded_headroom_resources()
+    assert sorted(excluded) == [gates.HEADROOM_PPS]
+    assert gates.HEADROOM_RTP_PORTS not in excluded
+    assert gates.HEADROOM_NETWORK_IN not in excluded
+    assert gates.HEADROOM_NETWORK_OUT not in excluded
 
 
 def test_an_unmeasured_window_is_unknown_never_pass() -> None:

--- a/src/voicegateway/tests/loadtest/test_pass_path.py
+++ b/src/voicegateway/tests/loadtest/test_pass_path.py
@@ -35,6 +35,7 @@ from typer.testing import CliRunner
 
 from voicegateway.cli._app import app
 from voicegateway.livekit_diag import gates
+from voicegateway.loadtest import judge
 from voicegateway.repository import node_samples_repository as node_samples
 from voicegateway.services.storage_service import StorageService
 
@@ -48,6 +49,28 @@ NODE = "sfu-1"
 SOURCE = "node-exporter"
 CORES = 4.0
 TOTAL_BYTES = 16 * 2**30
+
+# The media-port range this node was configured with, and how much of it the run
+# occupied. Seeded because RTP-port headroom is a MEASUREMENT now: it comes from
+# the media_ports_in_use / media_ports_total pair rather than being emitted as a
+# scope exclusion, which is what it was when this file was written.
+MEDIA_PORTS_TOTAL = 10001.0
+MEDIA_PORTS_IN_USE = 1200.0
+
+# Throughput, as the cumulative byte counters a node_exporter publishes. Read as
+# a RATE over the window, so the value has to be monotonic in absolute time
+# rather than restarting per window: a counter that goes backwards is a reset,
+# and read_counter_rate reports a reset as "cannot say" rather than as a number.
+COUNTER_ORIGIN_S = 1_785_661_200
+RX_BYTES_PER_SECOND = 50_000_000.0
+TX_BYTES_PER_SECOND = 60_000_000.0
+
+# The instance type's PUBLISHED baseline, in bits per second, both directions.
+# Declared rather than scraped, and that is the whole design: the ENA driver
+# reports no link speed, so there is no measurable denominator and an operator
+# writes the published figure down at import. 400 Mbps in and 480 Mbps out
+# against 3.125 Gbps leaves 87% and 85% headroom, comfortably over the 20% floor.
+DECLARED_BASELINE_BPS = 3_125_000_000.0
 
 
 async def _samples(
@@ -65,11 +88,13 @@ async def _samples(
     rows = []
     for index in range(0, (end_ms - start_ms) // 10_000 + 1):
         elapsed = index * 10
+        at_ms = start_ms + elapsed * 1000
+        since_origin = at_ms // 1000 - COUNTER_ORIGIN_S
         rows.append(
             node_samples.NodeSampleInput(
                 node=NODE,
                 source=SOURCE,
-                at_ms=start_ms + elapsed * 1000,
+                at_ms=at_ms,
                 outcome="ok",
                 values={
                     "cpu_seconds_total": 1000.0 + CORES * elapsed,
@@ -81,6 +106,27 @@ async def _samples(
                     # what is left UNKNOWN is only what nothing can scrape.
                     "process_open_fds": 1200.0,
                     "process_max_fds": 524287.0,
+                    # Media ports and network, seeded for the SAME reason and
+                    # this is what changed: both used to be scraped by nothing
+                    # and reported as scope exclusions, so a perfect run could
+                    # never reach PASS. Both are real columns now, so the run
+                    # that demonstrates the acceptance criteria has to carry
+                    # them or it is demonstrating less than it claims.
+                    "media_ports_in_use": MEDIA_PORTS_IN_USE,
+                    "media_ports_total": MEDIA_PORTS_TOTAL,
+                    "network_receive_bytes_total": RX_BYTES_PER_SECOND
+                    * since_origin,
+                    "network_transmit_bytes_total": TX_BYTES_PER_SECOND
+                    * since_origin,
+                    # The hypervisor's five shaping counters, flat at zero: this
+                    # node was never throttled during the window. Flat rather
+                    # than absent, because an unread counter is UNKNOWN and a
+                    # zero DELTA is a measured clean window.
+                    "ethtool_bw_in_allowance_exceeded": 0.0,
+                    "ethtool_bw_out_allowance_exceeded": 0.0,
+                    "ethtool_pps_allowance_exceeded": 0.0,
+                    "ethtool_conntrack_allowance_exceeded": 0.0,
+                    "ethtool_linklocal_allowance_exceeded": 0.0,
                 },
             )
         )
@@ -103,8 +149,15 @@ def _run(
     *,
     plan: Path | None = None,
     waive: Path | None = None,
+    declare_network_baseline: bool = False,
 ):
-    """Seed node samples, import, report. Returns the payload and the exits."""
+    """Seed node samples, import, report. Returns the payload and the exits.
+
+    ``declare_network_baseline`` writes the per-node published link baseline and
+    passes it to the import, which is the only way a bandwidth headroom figure
+    can exist: nothing on the host reports link speed, so an undeclared node
+    reaches the gate as UNKNOWN rather than being divided by a guess.
+    """
     import asyncio
 
     db = tmp_path / "throwaway.db"
@@ -119,6 +172,19 @@ def _run(
     argv = ["loadtest", "import", str(fixture), "--captured", "--config", str(config)]
     if plan is not None:
         argv += ["--plan", str(plan)]
+    if declare_network_baseline:
+        baseline = tmp_path / "network-baseline.json"
+        baseline.write_text(
+            json.dumps(
+                {
+                    NODE: {
+                        "in_bps": DECLARED_BASELINE_BPS,
+                        "out_bps": DECLARED_BASELINE_BPS,
+                    }
+                }
+            )
+        )
+        argv += ["--network-baseline", str(baseline)]
     imported = runner.invoke(app, argv)
 
     out = tmp_path / "out"
@@ -155,8 +221,17 @@ def _gate(payload, name: str):
 @pytest.fixture(scope="module")
 def acceptance(tmp_path_factory):
     tmp = tmp_path_factory.mktemp("acceptance")
-    # One window, the whole run, comfortably inside both ceilings.
-    return _run(tmp, ACCEPTANCE, [(1_785_661_201_000, 1_785_661_320_000, 0.66, 0.61)])
+    # One window, the whole run, comfortably inside both ceilings. The network
+    # baseline is declared, so the bandwidth denominator exists and the two
+    # network gates are judged rather than reported as having nothing to divide
+    # by. That declaration is the operator's job and this is the run that shows
+    # what it buys.
+    return _run(
+        tmp,
+        ACCEPTANCE,
+        [(1_785_661_201_000, 1_785_661_320_000, 0.66, 0.61)],
+        declare_network_baseline=True,
+    )
 
 
 def test_the_fixture_is_shaped_like_a_real_capture() -> None:
@@ -184,28 +259,34 @@ def test_every_measurable_gate_passes(acceptance) -> None:
 def test_the_verdict_is_still_not_pass_and_here_is_why(acceptance) -> None:
     """THE FINDING, and the most important line in this file.
 
-    A verdict of PASS is UNREACHABLE. Two of the three contracted headroom
-    resources, RTP ports and network, are scraped by nothing, so they are
-    emitted as unmeasured on every run; UNKNOWN outranks PASS, so the run's
-    verdict is UNKNOWN however well it went.
+    WHAT CHANGED. The finding used to be that PASS was unreachable because two
+    of the three contracted headroom resources, RTP ports and network, were
+    scraped by NOTHING and therefore reported unmeasured on every run. Both are
+    measured now, from real columns, and on this run both are green. So the old
+    assertion that ``rtp_ports`` and ``network`` are in the UNKNOWN set is false
+    for the best possible reason, and asserting it would now be asserting that
+    the coverage is missing.
 
-    That is honest rather than broken: the criteria require 20% headroom on
-    those resources and nothing demonstrated it. But it means a perfect
-    500-concurrent run still reports UNKNOWN and exits non-zero, which somebody
-    needs to know BEFORE they hand the report over, not after.
+    What survives is the same shape of finding at a smaller size. A verdict of
+    PASS is STILL unreachable on this fixture, and the reasons are now of three
+    kinds, none of them a pass:
 
-    Closing it needs either a scraper for those two, or a written waiver.
+    * ``pps``, which is permanent. No per-instance-type packets-per-second
+      allowance is published by anyone, so there is no denominator. Wiring an
+      exporter does not lift it.
+    * two dependencies nobody configured on this fixture.
+    * four lifecycle criteria whose columns this fixture's samples do not carry.
+
+    That still means a perfect 500-concurrent run reports UNKNOWN and exits
+    non-zero, which somebody needs to know BEFORE they hand the report over.
+    Closing it needs a written waiver, and pps can only ever be closed that way.
     """
     payload = acceptance["payload"]
     assert payload["verdict"]["status"] == gates.UNKNOWN
     unknown = [g for g in payload["gates"] if g["status"] == gates.UNKNOWN]
-    # Four now. rtp_ports and network are unmeasurable by anything; redis and
-    # health_endpoint are unconfigured on this fixture. Different reasons, same
-    # honest status, and none of them is a pass.
     assert {g["subject"].split("/")[-1] for g in unknown} == {
-        # Unmeasurable by anything in the system.
-        "rtp_ports",
-        "network",
+        # PERMANENTLY unmeasurable: the denominator is published by nobody.
+        gates.HEADROOM_PPS,
         # Unconfigured on this fixture: no exporter, no health endpoint.
         "redis",
         "health_endpoint",
@@ -220,30 +301,94 @@ def test_the_verdict_is_still_not_pass_and_here_is_why(acceptance) -> None:
         "filefd_allocated",
         "sockstat_udp_inuse",
     }
-    # File descriptors ARE measurable and pass here, which is what makes the
-    # other two stand out as the gap rather than as more of the same.
-    [fds] = [
+    # THE COMPANION, and the reason the set above got shorter. The three
+    # resources that left it are PASSING measurements on this run, not silent
+    # omissions, and each carries the number that decided it.
+    measured = {
+        g["subject"]: g
+        for g in payload["gates"]
+        if g["gate"] == gates.HEADROOM_GATE and g["status"] == gates.PASS
+    }
+    assert set(measured) == {
+        f"{NODE}/{SOURCE}/file_descriptors",
+        f"{NODE}/{SOURCE}/{gates.HEADROOM_RTP_PORTS}",
+        f"{NODE}/{gates.HEADROOM_NETWORK_IN}",
+        f"{NODE}/{gates.HEADROOM_NETWORK_OUT}",
+    }
+    for subject, gate in measured.items():
+        assert gate["value"] >= gates.MIN_HEADROOM_FRACTION, subject
+    # And the hypervisor never throttled this node, measured as a zero DELTA
+    # rather than assumed from an unread counter.
+    [allowance] = [
+        g for g in payload["gates"] if g["gate"] == gates.NETWORK_ALLOWANCE_GATE
+    ]
+    assert allowance["status"] == gates.PASS
+    assert allowance["value"] == 0.0
+
+
+def test_both_network_directions_are_measured_separately(acceptance) -> None:
+    """Ingress and egress are separate credit buckets, so separate rows.
+
+    This replaces a test that asserted nothing could measure either resource.
+    The stronger claim now available is that they are measured, judged
+    INDEPENDENTLY, and cannot collide: one combined ``network`` row would have
+    had to pick a direction, and whichever it picked is the one nobody asked
+    about. The two values here differ, which is what makes the split non-vacuous.
+    """
+    payload = acceptance["payload"]
+    inbound = [
         g
         for g in payload["gates"]
-        if g["subject"] and g["subject"].endswith("/file_descriptors")
+        if g["subject"] == f"{NODE}/{gates.HEADROOM_NETWORK_IN}"
     ]
-    assert fds["status"] == gates.PASS
+    outbound = [
+        g
+        for g in payload["gates"]
+        if g["subject"] == f"{NODE}/{gates.HEADROOM_NETWORK_OUT}"
+    ]
+    assert len(inbound) == 1
+    assert len(outbound) == 1
+    # 400 Mbps in and 480 Mbps out against the same declared 3.125 Gbps.
+    assert inbound[0]["value"] == pytest.approx(0.872)
+    assert outbound[0]["value"] == pytest.approx(0.8464)
+    assert inbound[0]["value"] != outbound[0]["value"]
+    assert gates.HEADROOM_NETWORK_IN != gates.HEADROOM_NETWORK_OUT
+    # And UNKNOWN really does outrank PASS, which is what makes any remaining
+    # unmeasured criterion decisive for the verdict.
+    assert gates.worst_status([gates.PASS, gates.UNKNOWN]) == gates.UNKNOWN
 
 
-def test_nothing_measures_those_two_resources() -> None:
+def test_pps_is_the_one_resource_nothing_will_ever_measure() -> None:
     """Structural, so it holds beyond this fixture.
 
-    unscraped_headroom_readings emits them unmeasured and no code path anywhere
-    supplies a real reading for either.
+    The old test here asserted that nothing measured RTP ports or network. That
+    is exactly the fact that changed, so it is replaced by the one exclusion
+    that no exporter can lift, with its reason asserted to say the denominator
+    is UNPUBLISHED rather than merely uncollected. A reason phrased as "nothing
+    scrapes it" would read as work somebody could do.
     """
-    readings = gates.unscraped_headroom_readings("sfu-1")
+    excluded = judge.excluded_headroom_resources()
+    assert sorted(excluded) == [gates.HEADROOM_PPS]
+    reason = excluded[gates.HEADROOM_PPS]
+    assert "no denominator" in reason
+    assert "not a gap awaiting work" in reason
+    assert "no per-instance-type PPS allowance is published" in reason
+    # THE COMPANION. The three that used to be here are measurable, and the
+    # unmeasured-reading helper still files them for a caller that scraped
+    # none of them, so an absent scrape is still visible rather than silent.
+    for resource in (
+        gates.HEADROOM_RTP_PORTS,
+        gates.HEADROOM_NETWORK_IN,
+        gates.HEADROOM_NETWORK_OUT,
+    ):
+        assert resource not in excluded, resource
+    readings = gates.unscraped_headroom_readings(NODE)
     assert [r.resource for r in readings] == [
         gates.HEADROOM_RTP_PORTS,
-        gates.HEADROOM_NETWORK,
+        gates.HEADROOM_NETWORK_IN,
+        gates.HEADROOM_NETWORK_OUT,
     ]
     assert all(r.used is None and r.limit is None for r in readings)
-    # And UNKNOWN really does outrank PASS, which is what makes it decisive.
-    assert gates.worst_status([gates.PASS, gates.UNKNOWN]) == gates.UNKNOWN
 
 
 def test_the_establishment_gate_passes(acceptance) -> None:
@@ -403,27 +548,32 @@ def test_a_capacity_figure_requires_breaching_the_ceiling(
 def waived(tmp_path_factory):
     """The acceptance run with every unmeasured criterion declared.
 
-    Four now, not two. This still asserts what it always asserted, that a fully
-    satisfied run reaches a clean verdict; it just declares two dependencies
-    that did not exist when it was written.
+    SEVEN now, not eight, and the one that left is the point. The old map
+    waived ``resource_headroom/fleet/rtp_ports`` and
+    ``resource_headroom/fleet/network``, two fleet-level rows that existed
+    because nothing could measure either resource. RTP ports and network are
+    measured on this run and PASS, so those keys match no gate, and a waiver key
+    matching no gate is REFUSED by design (see
+    :func:`test_a_waiver_naming_no_gate_is_refused`): leaving them in would exit
+    2 and write no report at all.
 
-    The subject is fleet-level because the gate is: nothing measures either on
-    any node, so they are emitted once per run rather than once per node per
-    test. The waiver still attaches to a real gate, which is why they remained
-    gates rather than becoming a note.
+    What replaces them is nothing. A resource that is measured needs no waiver,
+    which is the improvement stated as a diff in this file.
+
+    ``resource_headroom/fleet/pps`` is the one headroom key still here, and it is
+    the only one that can NEVER be retired by wiring an exporter: no
+    per-instance-type PPS allowance is published anywhere, so a written waiver
+    is the only way that criterion is ever closed.
     """
     tmp = tmp_path_factory.mktemp("waived")
     waiver = tmp / "waivers.json"
     waiver.write_text(
         json.dumps(
             {
-                "resource_headroom/fleet/rtp_ports": (
-                    "no RTP-port exporter was funded for this run, agreed in "
-                    "writing before test day"
-                ),
-                "resource_headroom/fleet/network": (
-                    "no network-headroom exporter was funded for this run, "
-                    "agreed in writing before test day"
+                "resource_headroom/fleet/pps": (
+                    "packets-per-second headroom has no published denominator on "
+                    "any instance type, agreed in writing before test day as "
+                    "permanently outside scope"
                 ),
                 # Declared, not silent. The Redis and health-check criteria were
                 # added after this fixture was written, and an unconfigured
@@ -465,6 +615,7 @@ def waived(tmp_path_factory):
         ACCEPTANCE,
         [(1_785_661_201_000, 1_785_661_320_000, 0.66, 0.61)],
         waive=waiver,
+        declare_network_baseline=True,
     )
 
 
@@ -472,7 +623,11 @@ def test_a_waiver_records_the_reason_rather_than_hiding_the_gate(waived) -> None
     """The checklist's requirement: waived in writing, never a silent pass."""
     payload = waived["payload"]
     waived_gates = [g for g in payload["gates"] if g["status"] == gates.WAIVED]
-    assert len(waived_gates) == 8
+    # Seven, down from eight, and every one of them names a real gate: the CLI
+    # exits 2 on a waiver key that matches nothing, so this count is also the
+    # assertion that no key here is stale.
+    assert len(waived_gates) == 7
+    assert waived["exported"].exit_code != 2
     for gate in waived_gates:
         # The property, rather than one phrase: a waiver carries a human reason
         # and that reason is visible in the rendered detail. A waiver a reviewer

--- a/src/voicegateway/tests/loadtest/test_report_shape_end_to_end.py
+++ b/src/voicegateway/tests/loadtest/test_report_shape_end_to_end.py
@@ -97,13 +97,14 @@ def test_the_gate_table_is_materially_smaller(exported) -> None:
     """
     payload = exported["payload"]
     tests = max(1, len(payload["tests"]))
-    # Per test: establishment, node CPU and memory per measured node, and file
-    # descriptors per measured node. Then a FIXED run-level tail that does not
-    # scale with steps: two headroom exclusions, two dependency criteria, one
-    # restart/OOM row, one staleness row and three return-to-baseline rows.
-    # The tail is the point of reporting those once per run rather than per
-    # step, so it is stated as a constant here.
-    assert len(payload["gates"]) <= tests * 6 + 9
+    # Per test: establishment, node CPU and memory per measured node, file
+    # descriptors per measured node, the media-port and bandwidth headroom rows
+    # and the hypervisor allowance row. Then a FIXED run-level tail that does
+    # not scale with steps: the one permanent headroom exclusion (pps), two
+    # dependency criteria, one restart/OOM row, one staleness row and three
+    # return-to-baseline rows. The tail is the point of reporting those once per
+    # run rather than per step, so it is stated as a constant here.
+    assert len(payload["gates"]) <= tests * 6 + 13
 
 
 def test_every_unknown_names_an_attempt_or_a_scope_exclusion(exported) -> None:
@@ -149,13 +150,45 @@ def test_no_gate_grades_a_source_for_a_metric_it_does_not_report(exported) -> No
         assert "livekit-server" not in subject, gate
 
 
-def test_the_two_unmeasurable_resources_appear_once_each(exported) -> None:
+def test_the_unmeasured_resources_appear_once_each(exported) -> None:
+    """WHAT CHANGED: two fleet exclusion rows became one, by measurement.
+
+    This asserted an exact list of ``["fleet/network", "fleet/rtp_ports"]``. Both
+    are measured resources now, per node, so a fleet-level "nothing can measure
+    this" row for either would be a second, contradictory answer to a question
+    the per-node rows already answer. ``pps`` is the only one left, and it is
+    still asserted as an exact list of exactly one element.
+    """
     rows = [
         g["subject"]
         for g in exported["payload"]["gates"]
-        if (g["subject"] or "").endswith(("/rtp_ports", "/network"))
+        if (g["subject"] or "").endswith(
+            ("/rtp_ports", "/network_in", "/network_out", "/pps")
+        )
     ]
-    assert sorted(rows) == ["fleet/network", "fleet/rtp_ports"]
+    # Four rows, and they are two DIFFERENT claims. pps is permanently
+    # unmeasurable: nobody publishes a denominator. The other three are
+    # measurable and appear here only because this capture predates the series
+    # being collected, so their row says the collection was missing rather than
+    # that the system cannot measure them. Collapsing the two would let a
+    # collection regression read as a permanent limit.
+    assert sorted(rows) == [
+        f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_NETWORK_IN}",
+        f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_NETWORK_OUT}",
+        f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_PPS}",
+        f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_RTP_PORTS}",
+    ]
+    # THE COMPANION. Only pps is an EXCLUSION; the other three left that list
+    # because something measures them, which is what makes this an improvement
+    # rather than a loss.
+    excluded = judge.excluded_headroom_resources()
+    assert sorted(excluded) == [gates.HEADROOM_PPS]
+    for resource in (
+        gates.HEADROOM_RTP_PORTS,
+        gates.HEADROOM_NETWORK_IN,
+        gates.HEADROOM_NETWORK_OUT,
+    ):
+        assert resource not in excluded, resource
 
 
 # --------------------------------------------------------------------------
@@ -180,9 +213,18 @@ def test_the_exclusions_sit_above_the_results(exported) -> None:
 # --------------------------------------------------------------------------
 
 
-def test_both_exclusions_are_present_with_reasons(exported) -> None:
+def test_the_exclusion_is_present_with_its_reason(exported) -> None:
+    """WHAT CHANGED: an exact two-key set became an exact one-key set.
+
+    Still exact, and the reason still has to reach the rendered page. The extra
+    assertion is the one the permanent exclusion needs and the derived ones did
+    not: the reason must say the denominator is UNPUBLISHED, not uncollected, or
+    a reader files a permanent boundary as a to-do item.
+    """
     exclusions = exported["payload"]["scope_exclusions"]
-    assert sorted(exclusions) == ["network", "rtp_ports"]
+    assert sorted(exclusions) == [gates.HEADROOM_PPS]
+    assert "no denominator" in exclusions[gates.HEADROOM_PPS]
+    assert "not a gap awaiting work" in exclusions[gates.HEADROOM_PPS]
     for reason in exclusions.values():
         assert run_report._esc(reason) in exported["html"]
 

--- a/src/voicegateway/tests/loadtest/test_scope_exclusions.py
+++ b/src/voicegateway/tests/loadtest/test_scope_exclusions.py
@@ -1,20 +1,37 @@
-"""RTP ports and network as a scope exclusion, not eighteen gate rows.
+"""One scope exclusion, ``pps``, and it is permanent.
 
-Nothing in this system measures either, on any node, in any run. Emitting them
-per node per test told a reader the same two facts eighteen times on a real
-run, above the three-row table they contracted for, and a gate row implies a
-measurement was attempted on that node and failed. Nothing was attempted.
+**WHAT CHANGED, and why every assertion in this file moved.** This file used to
+pin RTP ports and network as the two scope exclusions, on the reasoning that
+nothing in this system could measure either on any node in any run. That is no
+longer true, and it is not true because the coverage improved rather than
+because the standard dropped:
 
-**Collapsing them is only honest while the statement is harder to miss than the
-rows were.** Removing eighteen UNKNOWNs can move a verdict off UNKNOWN, because
-UNKNOWN outranks PASS, so this is the one change that could make a headline read
-better without any underlying result changing. The tests below enforce the
-compensating disclosure rather than trusting it:
+* RTP ports are measured from ``media_ports_in_use`` / ``media_ports_total``.
+* Network is measured from ``network_receive_bytes_total`` /
+  ``network_transmit_bytes_total`` against an operator-DECLARED baseline, and it
+  is TWO resources now (``network_in`` and ``network_out``), because a cloud
+  instance meters each direction against a separate credit bucket.
 
-* both exclusions appear in the payload AND in the rendered HTML, with reasons
-* a PASS verdict still carries both, and says the criterion is not covered
-* the exclusion is DERIVED from nothing being able to measure the resource, so
-  wiring an exporter lifts it automatically rather than needing a second edit
+So the exclusion machinery, which derives an exclusion from nothing publishing
+the columns, lifted both by itself. That is exactly what it was built to do, and
+:func:`test_the_exclusion_follows_from_the_columns_not_from_a_name_list` is the
+test that made it self-healing.
+
+What is left is ``pps``, and it is a PERMANENT exclusion of a different kind.
+There is no per-instance-type packets-per-second allowance published by anyone,
+including AWS, under any API or document: there is a numerator and no
+denominator anywhere at any price. Wiring an exporter does not lift it, so it
+lives in :data:`judge.PERMANENT_HEADROOM_EXCLUSIONS` rather than being derived
+from a column, and its reason has to say the denominator is UNPUBLISHED rather
+than uncollected. Filing it as uncollected would put it in the queue of things
+somebody could fix.
+
+**The compensating disclosure is still enforced, not trusted.** Removing rows
+can move a verdict off UNKNOWN, because UNKNOWN outranks PASS, so a shrinking
+exclusion set is the one change that could make a headline read better without
+any underlying result changing. The tests below therefore assert both halves
+every time: what is no longer excluded is now MEASURED, and what is still
+excluded is still disclosed with its reason in the payload and in the HTML.
 """
 
 from __future__ import annotations
@@ -44,9 +61,30 @@ def _payload(**kw):
 # --------------------------------------------------------------------------
 
 
-def test_both_resources_are_excluded_today() -> None:
+def test_pps_is_the_only_resource_excluded_today() -> None:
+    """Exactly one, and it is the permanent one.
+
+    The old assertion named RTP ports and network. Both are measured now, so
+    this asserts the new exact set AND, in the same breath, that the two that
+    left the set left it by becoming measurable rather than by being dropped.
+    An exclusion set that shrinks for any other reason is a disclosure that
+    shrank.
+    """
     excluded = judge.excluded_headroom_resources()
-    assert sorted(excluded) == [gates.HEADROOM_NETWORK, gates.HEADROOM_RTP_PORTS]
+    assert sorted(excluded) == [gates.HEADROOM_PPS]
+    # It is permanent, not derived: no column anywhere lifts it.
+    assert sorted(judge.PERMANENT_HEADROOM_EXCLUSIONS) == [gates.HEADROOM_PPS]
+    assert gates.HEADROOM_PPS not in judge.HEADROOM_REQUIREMENTS
+
+    # THE COMPANION. The three that stopped being exclusions are not merely
+    # absent from the set: something measures each of them now.
+    for resource in (
+        gates.HEADROOM_RTP_PORTS,
+        gates.HEADROOM_NETWORK_IN,
+        gates.HEADROOM_NETWORK_OUT,
+    ):
+        assert resource not in excluded, resource
+        assert any_source_publishes(*judge.HEADROOM_REQUIREMENTS[resource]), resource
 
 
 def test_file_descriptors_are_not_excluded() -> None:
@@ -69,56 +107,185 @@ def test_the_exclusion_follows_from_the_columns_not_from_a_name_list() -> None:
         assert excluded is not any_source_publishes(*columns), resource
 
 
-def test_each_reason_names_the_column_that_is_missing() -> None:
-    """A reader has to be able to see what would close it."""
+def test_the_derivation_still_bites_when_a_column_is_unpublished(monkeypatch) -> None:
+    """Non-vacuous, now that every derived requirement IS published.
+
+    The loop above once had four resources of which three were excluded, so it
+    exercised both directions on real data. All four are measured today, which
+    would leave the machinery asserted only in its permissive direction: a
+    broken ``excluded_headroom_resources`` that returned the permanent set and
+    nothing else would pass it. So one requirement is pointed at a column no
+    exporter publishes and the exclusion has to come back, with the column named
+    so a reader can see what would close it.
+    """
+    monkeypatch.setitem(
+        judge.HEADROOM_REQUIREMENTS,
+        gates.HEADROOM_RTP_PORTS,
+        ("a_column_no_exporter_publishes",),
+    )
     excluded = judge.excluded_headroom_resources()
-    assert "rtp_port_range_size" in excluded[gates.HEADROOM_RTP_PORTS]
-    assert "network_link_capacity_bytes" in excluded[gates.HEADROOM_NETWORK]
+    assert sorted(excluded) == [gates.HEADROOM_PPS, gates.HEADROOM_RTP_PORTS]
+    assert "a_column_no_exporter_publishes" in excluded[gates.HEADROOM_RTP_PORTS]
+    assert "not evaluated rather than passing" in excluded[gates.HEADROOM_RTP_PORTS]
+
+
+def test_the_permanent_reason_says_unpublished_not_uncollected() -> None:
+    """A reader has to be able to see that nothing would close it.
+
+    The old test asserted that each reason named the COLUMN that was missing,
+    because each exclusion was then a gap an exporter could fill. That is the
+    wrong shape of statement for the one exclusion that is left: pps has no
+    column to name. The denominator is not uncollected, it is UNPUBLISHED, by
+    everyone including AWS, so there is nothing to wire and no work to file.
+    Saying "no exporter publishes it" here would read as a to-do.
+    """
+    reason = judge.excluded_headroom_resources()[gates.HEADROOM_PPS]
+    assert "no denominator" in reason
+    assert "no per-instance-type PPS allowance is published" in reason
+    assert "not a gap awaiting work" in reason
+    # And the honest other half: the EVENT is still detected, so the exclusion
+    # is a boundary on what can be quantified rather than a blind spot.
+    assert "network_allowance" in reason
+    assert gates.NETWORK_ALLOWANCE_GATE in gates.ALL_GATES
+    # A count of allowance events, deliberately NOT a ratio: rendering 9613 as
+    # "961300%" is the misstatement RATIO_GATES exists to prevent.
+    assert gates.NETWORK_ALLOWANCE_GATE not in gates.RATIO_GATES
 
 
 # --------------------------------------------------------------------------
-# They are gone from the gate rows
+# pps is a fleet row; the measurable three are per-node rows again
 # --------------------------------------------------------------------------
 
 
-def test_no_per_node_rows_remain_for_either_resource() -> None:
-    """Per TEST, they are gone entirely. They are a run-level fact."""
+def test_the_measurable_resources_are_per_node_rows_again() -> None:
+    """They stopped being a run-level fact the moment they became measurable.
+
+    The old test asserted the opposite, that no per-node ``rtp_ports`` or
+    ``network`` row may exist anywhere, because nothing could measure either on
+    any node so a per-node row was the same non-fact repeated. Both halves are
+    checked here in the new world, and the pair is the point:
+
+    * a test with NOTHING correlated still fabricates no row, so an absent
+      measurement never turns into an invented one, and
+    * a test whose window carried the readings gets a row PER NODE, which is the
+      whole reason a fleet report exists: at 500 concurrent across six nodes,
+      knowing WHICH node ran out of ports is the actionable content.
+    """
     subjects = [r.subject or "" for r in judge.judge_test(HEALTHY)]
-    assert not [s for s in subjects if s.endswith("/rtp_ports")]
-    assert not [s for s in subjects if s.endswith("/network")]
+    for resource in (
+        gates.HEADROOM_RTP_PORTS,
+        gates.HEADROOM_NETWORK_IN,
+        gates.HEADROOM_NETWORK_OUT,
+    ):
+        assert not [s for s in subjects if s.endswith(f"/{resource}")], resource
+
+    measured = judge.judge_test(
+        HEALTHY,
+        aggregate=_aggregate_with_readings(),
+        network_baselines={"sip-1": {"in_bps": 1_000_000.0, "out_bps": 1_000_000.0}},
+    )
+    by_subject = {r.subject: r for r in measured}
+    assert by_subject["sip-1/node-exporter/rtp_ports"].status == gates.PASS
+    assert by_subject["sip-1/network_in"].status == gates.PASS
+    assert by_subject["sip-1/network_out"].status == gates.PASS
+    # Two directions, two subjects, two answers. One combined "network" row
+    # would have to pick a direction, and the credit buckets are separate.
+    assert by_subject["sip-1/network_in"] != by_subject["sip-1/network_out"]
 
 
-def test_exactly_one_fleet_row_per_resource_survives_a_multi_step_run() -> None:
+def _aggregate_with_readings():
+    """One node whose window carried media ports and throughput in both
+    directions."""
+    from voicegateway.loadtest.aggregation import TestAggregate
+    from voicegateway.repository.node_correlation_repository import window_of
+
+    return TestAggregate(
+        window=window_of(1_785_661_201_000, 1_785_661_260_000),
+        peak_cpu_utilisation=0.4,
+        peak_memory_utilisation=0.4,
+        node_samples_in_window=2,
+        rtp_port_readings=[
+            gates.HeadroomReading(
+                node="sip-1",
+                source="node-exporter",
+                resource=gates.HEADROOM_RTP_PORTS,
+                used=1200.0,
+                limit=10001.0,
+            )
+        ],
+        bandwidth_peaks={("sip-1", "in"): 400_000.0, ("sip-1", "out"): 500_000.0},
+    )
+
+
+def test_exactly_one_fleet_row_for_the_permanent_exclusion_in_a_multi_step_run() -> (
+    None
+):
     """Once per RUN, not once per node per test.
 
-    A three-step ramp across three sources emitted eighteen identical rows. It
-    now emits two, and they stay gates so a written waiver has something to
-    attach to.
+    A three-step ramp across three sources emitted eighteen identical rows. Two
+    of the three resources behind those rows are measured now, so the run-level
+    tail is ONE row, ``fleet/pps``, and it stays a gate so a written waiver has
+    something to attach to. The old assertion looped over rtp_ports and network
+    and demanded a fleet row for each; demanding one now would be demanding an
+    exclusion for a resource that is measured.
     """
     run = [
         {"name": f"ramp-{n}", "attempted_calls": 100, "succeeded_calls": 100}
         for n in (5, 10, 20)
     ]
     results = judge.judge_run(run)
-    for resource in (gates.HEADROOM_RTP_PORTS, gates.HEADROOM_NETWORK):
-        rows = [r for r in results if (r.subject or "").endswith(f"/{resource}")]
-        assert len(rows) == 1, (resource, [r.subject for r in rows])
-        assert rows[0].subject == f"{gates.FLEET_SUBJECT}/{resource}"
-        assert rows[0].status == gates.UNKNOWN
+    rows = [
+        r
+        for r in results
+        if (r.subject or "").endswith(f"/{gates.HEADROOM_PPS}")
+    ]
+    assert len(rows) == 1, [r.subject for r in rows]
+    assert rows[0].subject == f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_PPS}"
+    assert rows[0].status == gates.UNKNOWN
+    # THE COMPANION, and the distinction it turns on. The three that became
+    # measurable DO still get one fleet row here, because this run scraped
+    # nothing and a contracted criterion that emits no row at all reads as one
+    # nobody agreed to. But that row is a different claim from pps: it says the
+    # series were not COLLECTED, not that the quantity is unmeasurable. Only pps
+    # appears in excluded_headroom_resources, and only pps says nobody publishes
+    # a denominator. Collapsing the two would let a collection regression read
+    # as a permanent limit of the system, which is the whole failure mode.
+    excluded = judge.excluded_headroom_resources()
+    for resource in (
+        gates.HEADROOM_RTP_PORTS,
+        gates.HEADROOM_NETWORK_IN,
+        gates.HEADROOM_NETWORK_OUT,
+    ):
+        assert resource not in excluded, resource
+        [row] = [
+            r for r in results if r.subject == f"{gates.FLEET_SUBJECT}/{resource}"
+        ]
+        assert row.status == gates.UNKNOWN
+        assert "gap in what was collected" in row.detail, resource
+        assert "no denominator" not in row.detail, resource
+    # And pps reads the other way round.
+    [pps_row] = [
+        r
+        for r in results
+        if r.subject == f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_PPS}"
+    ]
+    assert "gap in what was collected" not in pps_row.detail
 
 
-def test_they_remain_gates_so_a_waiver_can_attach() -> None:
-    """The reason these are not merely a note.
+def test_it_remains_a_gate_so_a_waiver_can_attach() -> None:
+    """The reason this is not merely a note.
 
     The checklist requires a threshold nobody funded to be recorded as waived,
     in writing, with a reason. An exclusion with no gate has nothing to sign.
+    The old test waived the rtp_ports row; that row is a measurement now, so the
+    only thing left to sign is pps.
     """
-    [rtp] = [
+    [pps] = [
         r
         for r in judge.unmeasurable_headroom_gates()
-        if (r.subject or "").endswith("/rtp_ports")
+        if (r.subject or "").endswith(f"/{gates.HEADROOM_PPS}")
     ]
-    waived = gates.waive(rtp, reason="not funded for this engagement")
+    waived = gates.waive(pps, reason="not funded for this engagement")
     assert waived.status == gates.WAIVED
     assert waived.status != gates.PASS
     assert "not funded" in waived.detail
@@ -135,7 +302,8 @@ def test_the_verdict_does_not_improve_on_its_own() -> None:
 
 
 def test_file_descriptors_still_produce_a_gate() -> None:
-    """Only the two unmeasurable ones left. The measurable one is untouched."""
+    """Only the one unmeasurable resource left. The measurable ones are
+    untouched."""
     results = judge.judge_test(HEALTHY)
     assert [r for r in results if (r.subject or "").endswith("/file_descriptors")]
 
@@ -145,27 +313,41 @@ def test_file_descriptors_still_produce_a_gate() -> None:
 # --------------------------------------------------------------------------
 
 
-def test_both_exclusions_reach_the_payload_with_reasons() -> None:
+def test_the_exclusion_reaches_the_payload_with_its_reason() -> None:
+    """One key now, not two, and the reason carries a different burden.
+
+    The old assertion required every reason to say "not evaluated rather than
+    passing", which is the sentence a DERIVED exclusion needs: it is waiting on
+    an exporter, so the row has to refuse to read as a pass. The permanent one
+    has to carry more than that, because a reader who sees a permanently
+    excluded resource will otherwise file it as work. So the reason is asserted
+    to state that the denominator does not exist and that this is not a gap
+    awaiting work, which is strictly more than the old phrase asserted.
+    """
     payload = _payload()
     exclusions = payload["scope_exclusions"]
-    assert sorted(exclusions) == ["network", "rtp_ports"]
-    for reason in exclusions.values():
-        assert reason.strip()
-        assert "not evaluated rather than passing" in reason
+    assert sorted(exclusions) == [gates.HEADROOM_PPS]
+    reason = exclusions[gates.HEADROOM_PPS]
+    assert reason.strip()
+    assert "no denominator" in reason
+    assert "not a gap awaiting work" in reason
 
 
-def test_both_exclusions_reach_the_rendered_html_with_reasons() -> None:
+def test_the_exclusion_reaches_the_rendered_html_with_its_reason() -> None:
     html = run_report.render_load_html(_payload())
     assert "Not in scope for this report" in html
     for resource, reason in _payload()["scope_exclusions"].items():
         assert run_report._esc(reason) in html, resource
 
 
-def test_a_passing_verdict_still_carries_both_exclusions() -> None:
+def test_a_passing_verdict_still_carries_the_exclusion() -> None:
     """The invariant the whole node turns on.
 
     A PASS is exactly when a reader is most likely to stop reading, and exactly
     when the removed rows would have said the criterion was not fully answered.
+    Two exclusions became one because two resources became measurable, which is
+    the only shrinkage that may ever happen to this banner: the disclosure may
+    shrink only when the coverage grows.
     """
     passing = gates.establishment_gate(
         attempted=1000,
@@ -176,7 +358,7 @@ def test_a_passing_verdict_still_carries_both_exclusions() -> None:
     payload = _payload(gate_results=[passing.as_dict()])
     assert payload["verdict"]["status"] == gates.PASS
 
-    assert sorted(payload["scope_exclusions"]) == ["network", "rtp_ports"]
+    assert sorted(payload["scope_exclusions"]) == [gates.HEADROOM_PPS]
     html = run_report.render_load_html(payload)
     assert "Not in scope for this report" in html
     assert "not fully covered" in html

--- a/src/voicegateway/tests/middleware/test_prometheus_exposition.py
+++ b/src/voicegateway/tests/middleware/test_prometheus_exposition.py
@@ -109,3 +109,112 @@ def test_sum_series_where_filters_on_a_label_value() -> None:
 def test_sum_series_where_matching_nothing_is_none_not_zero() -> None:
     samples = parse_exposition('node_cpu_seconds_total{mode="user"} 5\n')
     assert sum_series(samples, "node_cpu_seconds_total", where={"mode": "idle"}) is None
+
+
+# --------------------------------------------------------------------------
+# exclude: sum every label value EXCEPT a named one
+# --------------------------------------------------------------------------
+#
+# The shape `where` cannot express. A node's real NIC is enp39s0 on one host and
+# ens5 on another, so the devices to KEEP cannot be named; loopback is lo
+# everywhere, so the one to drop can be.
+
+
+def _nic_body() -> str:
+    return (
+        'node_network_receive_bytes_total{device="lo"} 1000\n'
+        'node_network_receive_bytes_total{device="enp39s0"} 40\n'
+        'node_network_receive_bytes_total{device="ens5"} 2\n'
+    )
+
+
+def test_sum_series_exclude_drops_the_matching_series_and_sums_the_rest() -> None:
+    samples = parse_exposition(_nic_body())
+    # Non-vacuous: loopback dominates the unfiltered total, so an exclusion that
+    # did nothing would be visible rather than coincidentally right.
+    assert sum_series(samples, "node_network_receive_bytes_total") == 1042.0
+    assert (
+        sum_series(
+            samples, "node_network_receive_bytes_total", exclude={"device": "lo"}
+        )
+        == 42.0
+    )
+
+
+def test_sum_series_exclude_of_an_absent_label_value_changes_nothing() -> None:
+    """A host whose loopback is spelled differently still gets a real total.
+
+    The counterpart of the pinning failure: an exclusion that matches nothing
+    over-counts by one interface, which is a wrong number. A `where` that
+    matches nothing stores NULL forever, which is a missing column. Excluding is
+    the safer direction, and this pins that it degrades that way.
+    """
+    samples = parse_exposition(_nic_body())
+    assert (
+        sum_series(
+            samples, "node_network_receive_bytes_total", exclude={"device": "lo0"}
+        )
+        == 1042.0
+    )
+
+
+def test_sum_series_exclude_needs_every_pair_to_match() -> None:
+    """ALL pairs, not any: more keys excludes LESS, never more."""
+    samples = parse_exposition(
+        'x{device="lo",kind="virtual"} 5\nx{device="lo",kind="real"} 3\n'
+    )
+    assert sum_series(samples, "x", exclude={"device": "lo"}) is None
+    assert sum_series(samples, "x", exclude={"device": "lo", "kind": "virtual"}) == 3.0
+    # A pair whose key is absent from the sample cannot match, so nothing drops.
+    assert sum_series(samples, "x", exclude={"device": "lo", "nope": "1"}) == 8.0
+
+
+def test_sum_series_exclude_and_where_apply_together() -> None:
+    samples = parse_exposition(
+        'x{device="lo",mode="idle"} 100\n'
+        'x{device="ens5",mode="idle"} 7\n'
+        'x{device="ens5",mode="user"} 500\n'
+    )
+    assert (
+        sum_series(samples, "x", where={"mode": "idle"}, exclude={"device": "lo"})
+        == 7.0
+    )
+
+
+def test_sum_series_exclude_that_removes_everything_is_none_not_zero() -> None:
+    """The absent-is-not-zero rule survives exclusion.
+
+    A node exposing only loopback has not reported zero bytes on the wire; it
+    has reported nothing about the wire at all, and the column must stay NULL so
+    a reader suppresses it rather than drawing a flat healthy line.
+    """
+    samples = parse_exposition('node_network_receive_bytes_total{device="lo"} 900\n')
+    assert (
+        sum_series(
+            samples, "node_network_receive_bytes_total", exclude={"device": "lo"}
+        )
+        is None
+    )
+
+
+def test_sum_series_exclude_leaves_an_absent_series_none() -> None:
+    samples = parse_exposition('node_network_receive_bytes_total{device="lo"} 1\n')
+    assert sum_series(samples, "not_there", exclude={"device": "lo"}) is None
+
+
+def test_sum_series_default_exclude_keeps_every_sample() -> None:
+    """The 51 existing entries pass no exclude, so the default must be inert.
+
+    An empty mapping matches vacuously, so an unguarded `all()` would read it as
+    "drop everything" and turn a whole column NULL.
+    """
+    samples = parse_exposition(_nic_body())
+    unfiltered = sum_series(samples, "node_network_receive_bytes_total")
+    assert (
+        sum_series(samples, "node_network_receive_bytes_total", exclude=None)
+        == unfiltered
+    )
+    assert (
+        sum_series(samples, "node_network_receive_bytes_total", exclude={})
+        == unfiltered
+    )


### PR DESCRIPTION
Two acceptance criteria reported UNKNOWN in every load-test report: network headroom and RTP port headroom. The data existed on the fleet hosts. The collector's series map did not know the metric names, so it discarded them and the gates stayed unmeasurable.

## What is now collected

Nine columns, nine series entries, every name read off the fleet rather than inferred.

| Series | Column | Kind |
|---|---|---|
| `media_ports_total{role}` | `media_ports_total` | gauge |
| `media_ports_in_use{role}` | `media_ports_in_use` | gauge |
| `node_ethtool_{bw_in,bw_out,pps,conntrack,linklocal}_allowance_exceeded{device}` | `ethtool_*_allowance_exceeded` | counter |
| `node_network_{receive,transmit}_bytes_total{device}` | `network_{receive,transmit}_bytes_total` | counter |

**None of the seven device-labelled series keys on the device name.** It is `enp39s0` on SIP nodes and `ens5` on SFU nodes, so pinning one would store NULL forever on half the fleet while `series_found` stayed high. They sum across the label instead.

The two byte counters needed the opposite of a pin: sum every real NIC but drop loopback. No equality matcher can express that, so `sum_series` and `_Series` gained an optional `exclude`. Default `None`, so all 51 pre-existing entries are unchanged in behaviour. Verified live against a running node_exporter: the pair resolves with `lo` excluded.

## Gate 1: RTP port headroom, a real ratio

`min over window of (1 - media_ports_in_use / media_ports_total) >= 0.20`.

This replaces the `sockstat_udp_inuse` approach entirely. That counted every UDP socket in the network namespace, including the SFU's own ICE range, so it was an upper bound rather than a count of media ports.

**The column stays.** `BASELINE_METRICS` still reads it for return-to-baseline, and deleting it would have taken that criterion down with it.

Occupancy is the worst over the window, sampled through the drain as well as the load, because it can peak after the last call ends. The measured shape is roughly 3.4 in-range sockets per call, not one.

`media_ports_total` is a DECLARED configuration value, so a node publishing occupancy without it is UNKNOWN naming which half was missing, rather than divided by a guess.

## Gate 2: network limit events, a binary

`increase(any node_ethtool_*_allowance_exceeded) over the window == 0`. A new count gate, in `ALL_GATES` and deliberately **not** in `RATIO_GATES`.

It reads the DELTA across the window, never the absolute. These are cumulative since driver reset, and one SIP node carries 9613 from before the engagement while its twin reads 0.

**The detail separates the two meanings, because they are different findings:**
- `bw_in`, `bw_out`, `pps` count packets **queued OR dropped** and the hypervisor never separates them, so a non-zero delta is evidence of **shaping, not loss**.
- `conntrack`, `linklocal` count **drops only**, and read as traffic that did not arrive.

## Gate 3: bandwidth headroom against a declared baseline

`peak rate * 8 / declared_baseline_bps <= 0.80`, evaluated **inbound and outbound separately** because the hypervisor keeps separate credit buckets.

There is no measurable link capacity: the ENA driver reports no speed, so `node_network_speed_bytes` yields nothing for the real interface. The denominator is the instance type's published baseline, declared at import via `--network-baseline` and carried in the run notes exactly as the ramp plan is. It is labelled as a comparison against a published **floor**, not a measured ceiling, since the instance can burst above it.

**No instance-type string is ever read to infer a baseline.** An undeclared node is UNKNOWN.

## Permanently out of scope: PPS headroom

The only remaining scope exclusion, and kept apart from the derived ones for a reason: no per-instance-type PPS allowance is published by anyone including AWS, so there is no denominator. It is not a gap awaiting work, and wiring an exporter cannot lift it.

`pps_allowance_exceeded` still feeds gate 2, so PPS saturation is detected as an **event** even though headroom is not quantifiable.

## Two defects found by reading the output, not by a test

**Duplicate blank-subject rows.** `headroom_gates([])` returns one row with no subject at all, and calling it twice on a window that measured neither resource emitted two identical unidentified `resource_headroom` rows per step. That is the same subject collision this codebase has already fixed twice, once by adding the source and once by adding the step. Both calls are guarded now, and a criterion nothing measured is reported once per run.

**Stale report prose.** The limits section still declared RTP-port and network headroom unmeasured, which had become false, and the scope banner counted exclusions against three named resources that are now all measured, rendering "1 of those three are outside what this system measures".

## Verified against the real database

Regenerated `sura-stage2-full` (the fleet run is not on this machine, see below):

| | Before | After |
|---|---|---|
| Rows | 98 | 101 |
| Families | 8 | 9 |
| Scope exclusions | `network`, `rtp_ports` | **`pps` only** |
| Blank subjects | 2 per step | **0** |
| Verdict | FAIL | FAIL |

`rtp_ports`, `network_in` and `network_out` now report once per run as "nothing in this run's scrape carried the series it needs, this is a gap in what was collected rather than a limit of the system" — distinct wording from the permanent `pps` exclusion, and a test pins that the two never collapse.

## Gates

`backend`: ruff clean, mypy clean on 283 files, **3163 passed**, 13 skipped (3164 collected before, count did not decrease). `docs`: PASS, 90 pages. Migration `a1c6e39b7f24` chained off the single head.

## Note on the fleet run

`fleet-100c-1node-10min` is not in this machine's database and its artifacts are on the monitoring host, so it could not be regenerated here. Expect its two `resource_headroom` UNKNOWNs to remain, because that run predates these metrics being collected. The next run is where they resolve.

One integration-marked test, `test_live_node_scrape.py::test_the_host_ceiling_is_the_one_that_gets_refused`, hardcodes `series_found == len(SERIES[node-exporter]) - 1`. Seven of the nine new entries legitimately miss on a non-fleet box. CI excludes integration tests, so this is not blocking, but the assertion should subtract the environment-specific entries rather than a bare 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbound and outbound network headroom reporting for load tests.
  * Added RTP media-port capacity and usage measurements.
  * Added optional per-node network bandwidth baselines through the load-test command line.
  * Added network allowance monitoring to identify shaping or dropped traffic.

* **Bug Fixes**
  * Reports now clearly distinguish measured capacity, unavailable data, and permanently unmeasurable PPS limits.
  * Missing or reset counters are reported as unknown instead of producing misleading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->