### PR TITLE
Profile by default, judge only when asked

### DIFF
--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -688,15 +688,41 @@ def report(
         help=(
             "JSON mapping gate (or gate/subject) to the reason it was waived in "
             "writing. Records a threshold the run was not held to; never turns "
-            "it into a pass, and the report still exits non-zero."
+            "it into a pass, and the report still exits non-zero. Only "
+            "meaningful with --acceptance."
+        ),
+    ),
+    acceptance: bool = typer.Option(
+        False,
+        "--acceptance",
+        help=(
+            "Judge the run against contracted acceptance thresholds: adds the "
+            "verdict, the per-gate table and a non-zero exit code. Without it "
+            "the report profiles only, showing what was measured and the range "
+            "each figure is read against, and leaves the conclusion to a reader."
         ),
     ),
 ) -> None:
-    """Write one run's report as JSON plus a self-contained HTML file."""
+    """Write one run's profile as JSON plus a self-contained HTML file.
+
+    Two views over ONE set of measurements, never two derivations. The default
+    profiles: it shows what was measured and the reference each figure is
+    usually read against, and stops. ``--acceptance`` adds the verdict, the gate
+    table and the exit code, for the case where somebody contracted thresholds
+    and needs evidence they were met.
+
+    The split is deliberate. A developer reading their own fleet did not sign an
+    acceptance contract and is not served by a FAIL stamped across their run;
+    the same numbers with a reference band teach them where they stand. The
+    gates are not deleted, because an engagement that agreed 99.5% establishment
+    does need a pass or a fail and a pipeline needs an exit code.
+    """
     from voicegateway.livekit_diag.run_report import (
         build_load_payload,
         load_report_filename,
+        profile_filename,
         render_load_html,
+        render_profile_html,
     )
 
     gw = _cli.require_gateway(config)
@@ -754,10 +780,16 @@ def report(
         scope_exclusions=excluded_headroom_resources(),
     )
     out.mkdir(parents=True, exist_ok=True)
-    json_path = out / f"{load_report_filename(run_id).removesuffix('.html')}.json"
-    html_path = out / load_report_filename(run_id)
+    # The JSON is the same payload either way: it is the machine-readable
+    # export, and a consumer of it must not have to know which view a human
+    # asked for. Only the HTML differs.
+    stem = load_report_filename(run_id) if acceptance else profile_filename(run_id)
+    json_path = out / f"{stem.removesuffix('.html')}.json"
+    html_path = out / stem
     json_path.write_text(json.dumps(payload, indent=2) + "\n")
-    html_path.write_text(render_load_html(payload))
+    html_path.write_text(
+        render_load_html(payload) if acceptance else render_profile_html(payload)
+    )
 
     # Read from the payload rather than recomputed, so the console, the exit
     # code, the JSON and the HTML are one derivation rather than four that
@@ -766,13 +798,29 @@ def report(
     counts: dict[str, int] = {}
     for gate in results:
         counts[gate.status] = counts.get(gate.status, 0) + 1
-    breakdown = ", ".join(f"{n} {status}" for status, n in sorted(counts.items()))
-    console.print(f"\nVerdict: [bold]{run_verdict}[/bold]  ({breakdown})")
-    if run_verdict == "UNKNOWN":
-        _cli.warn(
-            "UNKNOWN is not a pass. At least one acceptance criterion could not "
-            "be evaluated; the run did not demonstrate it, it failed to measure it."
+    if acceptance:
+        breakdown = ", ".join(f"{n} {status}" for status, n in sorted(counts.items()))
+        console.print(f"\nVerdict: [bold]{run_verdict}[/bold]  ({breakdown})")
+        if run_verdict == "UNKNOWN":
+            _cli.warn(
+                "UNKNOWN is not a pass. At least one acceptance criterion could "
+                "not be evaluated; the run did not demonstrate it, it failed to "
+                "measure it."
+            )
+    else:
+        # No verdict on the console either. A profile that prints PASS to the
+        # terminal while the document refuses to is two products disagreeing.
+        measured = sum(1 for g in results if g.value is not None)
+        console.print(
+            f"\nProfiled {measured} measurement(s) across {len(tests)} test(s)."
         )
+        missing = len(results) - measured
+        if missing:
+            _cli.warn(
+                f"{missing} measurement(s) were not collected in this run. The "
+                'report lists them under "Not collected in this run", each with '
+                "what to change so the next run carries them."
+            )
 
     if capacity.get("calls_per_node") is None:
         _cli.warn(f"No capacity table: {capacity['reason']}")
@@ -816,6 +864,13 @@ def report(
     # run failed to measure something, which is not the same as demonstrating
     # it). One non-zero code on purpose, so an existing `if [ $? -eq 1 ]` keeps
     # catching every kind of failure.
-    code = exit_code(run_verdict)
-    if code != 0:
-        raise typer.Exit(code)
+    #
+    # Only under --acceptance. A profile makes no claim to judge, so exiting
+    # non-zero on it would be a verdict delivered through the exit status while
+    # the document carefully refuses to give one. A developer profiling their
+    # own fleet gets 0 and a document; a pipeline that contracted thresholds
+    # asks for --acceptance and gets the code.
+    if acceptance:
+        code = exit_code(run_verdict)
+        if code != 0:
+            raise typer.Exit(code)

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -1944,3 +1944,766 @@ def _render_appendix(payload: dict[str, Any]) -> str:
         "configuration are referenced by name rather than reproduced here: they "
         "are the work of whoever authored them.</p>" + "".join(sections)
     )
+
+
+# ---------------------------------------------------------------------------
+# Profile view: what was measured, and the range each number is read against
+# ---------------------------------------------------------------------------
+#
+# A second RENDERING of the load payload, not a second payload. It takes exactly
+# what :func:`build_load_payload` produces, so the two views cannot disagree
+# about a number: there is one set of figures and two ways of presenting them.
+#
+# The difference is what each view is FOR. The acceptance view exists because a
+# client engagement contracted thresholds, so it grades every gate and prints a
+# verdict. This one exists because VoiceGateway is a profiler: its default
+# output shows what it measured and the range each number is read against, and
+# then stops. No verdict, no status word, no exit code. A human reads it and
+# decides, because the person accountable for the deployment is the one holding
+# the context a threshold cannot carry.
+#
+# That is why the status field is never rendered here, not even as a colour. A
+# report that grades has to be right about the threshold; a report that measures
+# only has to be right about the measurement, and the second claim is the one
+# this system can actually stand behind.
+
+#: What ``kind`` a consumer matches on to tell this VIEW from the acceptance
+#: view of the same run. The payload's own ``kind`` is unchanged and still says
+#: ``voicegateway.loadtest.run_report``: this is a rendering of that payload,
+#: not a new schema, and the footer prints both so a reader holding the HTML can
+#: tell which document they have.
+PROFILE_KIND = "voicegateway.loadtest.profile_report"
+
+#: Resources that can never be measured by anybody, so their gate rows are
+#: DROPPED from this document entirely rather than listed as not collected.
+#:
+#: A "not collected" row is a promise that somebody could collect it. Nobody
+#: publishes a per-instance-type packets-per-second allowance, under any API or
+#: at any price, so a row saying "unknown" for PPS headroom is an item on a
+#: checklist that can never be ticked. It is noise in a document whose whole job
+#: is to separate what was measured from what was not.
+#:
+#: THE SOURCE OF TRUTH IS :data:`voicegateway.loadtest.judge.
+#: PERMANENT_HEADROOM_EXCLUSIONS`, whose keys are exactly these names and whose
+#: reasoning lives on :data:`gates.HEADROOM_PPS`. It is named here from the
+#: gates constant rather than imported from judge for two reasons, either of
+#: which alone would be enough. This module's docstring promises it touches no
+#: storage, and importing judge pulls in the repository layer through
+#: ``loadtest.aggregation``. And it would make ``livekit_diag`` depend on
+#: ``loadtest``, which already depends on ``livekit_diag.gates``, so the first
+#: loadtest module to import a renderer closes the loop. Naming the shared
+#: ``gates`` constant keeps a rename from silently breaking the match, and a
+#: test can assert this set equals judge's keys without either module importing
+#: the other.
+PROFILE_PERMANENTLY_UNMEASURABLE: frozenset[str] = frozenset({gates.HEADROOM_PPS})
+
+#: Where each measurement is filed, grouped by WHAT THE NUMBER TEACHES rather
+#: than by which gate family produced it. A reader asking "did the boxes have
+#: room" does not care that file descriptors arrive through the headroom gate
+#: and CPU through its own; they care that both describe one node's limits.
+#:
+#: Keys are profile keys, not gate ids. Headroom is one gate id covering several
+#: resources that belong in different groups (file descriptors are a node limit,
+#: RTP ports are a media limit), so a headroom row is keyed
+#: ``resource_headroom/<resource>``. Everything else is keyed by gate id.
+#:
+#: Declared as a mapping so a new gate has to be CLASSIFIED rather than falling
+#: through into whichever branch a renderer happens to reach. Anything unknown
+#: renders under :data:`PROFILE_UNGROUPED_GROUP` where somebody will see it,
+#: which is the point: a measurement that quietly vanishes from a profiler is
+#: worse than one filed under the wrong heading.
+PROFILE_GROUPS: dict[str, tuple[str, ...]] = {
+    "Node resources": (
+        gates.NODE_CPU_GATE,
+        gates.NODE_MEMORY_GATE,
+        f"{gates.HEADROOM_GATE}/{gates.HEADROOM_FILE_DESCRIPTORS}",
+    ),
+    "Media and network": (
+        f"{gates.HEADROOM_GATE}/{gates.HEADROOM_RTP_PORTS}",
+        f"{gates.HEADROOM_GATE}/{gates.HEADROOM_NETWORK_IN}",
+        f"{gates.HEADROOM_GATE}/{gates.HEADROOM_NETWORK_OUT}",
+        gates.NETWORK_ALLOWANCE_GATE,
+    ),
+    "Stability over time": (
+        gates.PROCESS_LIFECYCLE_GATE,
+        gates.RESOURCE_TREND_GATE,
+        gates.RETURN_TO_BASELINE_GATE,
+    ),
+    "Call handling": (
+        gates.ESTABLISHMENT_GATE,
+        gates.SUSTAINED_HEALTH_GATE,
+    ),
+}
+
+#: Where an unclassified measurement lands. Deliberately visible and
+#: deliberately unflattering to read: it is a prompt to classify the gate, not a
+#: permanent home.
+PROFILE_UNGROUPED_GROUP = "Not yet classified"
+
+_CLASSIFIED_GATE_IDS: frozenset[str] = frozenset(
+    key.split("/", 1)[0] for keys in PROFILE_GROUPS.values() for key in keys
+)
+
+#: Gate ids :data:`PROFILE_GROUPS` does not place, computed rather than written
+#: down so it cannot drift from the mapping above.
+#:
+#: Today it is the four DIAGNOSTICS gates: agents, reply latency and the two SFU
+#: gates. A load payload never carries them, because a load run is an external
+#: generator placing calls and not this host probing an SFU, so leaving them
+#: unclassified is the accurate statement rather than an omission. They are
+#: named here so a test can pin the list and a fifth entry appearing is a
+#: question somebody has to answer.
+PROFILE_UNCLASSIFIED_GATES: frozenset[str] = frozenset(
+    gates.ALL_GATES - _CLASSIFIED_GATE_IDS
+)
+
+#: One human name and one "what it means" sentence per measurement, keyed the
+#: same way as :data:`PROFILE_GROUPS`.
+#:
+#: The name is what the number IS, in the words somebody reading a capacity
+#: report already uses. The sentence is what it teaches, and it carries the
+#: caveat that changes how the figure should be read: which denominator it is a
+#: fraction of, whether that denominator was measured or declared, and whether
+#: it is a fraction at all.
+_PROFILE_MEASUREMENTS: dict[str, tuple[str, str]] = {
+    gates.NODE_CPU_GATE: (
+        "Peak node CPU",
+        "How close the busiest node came to using all of its CPU while the test "
+        "ran. The worst node over the window, not a fleet average.",
+    ),
+    gates.NODE_MEMORY_GATE: (
+        "Peak node memory",
+        "How close the busiest node came to using all of its memory while the "
+        "test ran. The worst node over the window, not a fleet average.",
+    ),
+    f"{gates.HEADROOM_GATE}/{gates.HEADROOM_FILE_DESCRIPTORS}": (
+        "File-descriptor headroom",
+        "The share of the process file-descriptor limit that stayed unused. "
+        "Both halves are real counters, so this fraction is measured end to end.",
+    ),
+    f"{gates.HEADROOM_GATE}/{gates.HEADROOM_RTP_PORTS}": (
+        "RTP media-port headroom",
+        "The share of the media port range that stayed free. The range size is "
+        "declared configuration rather than a measurement, so a node that "
+        "publishes occupancy without it reports nothing rather than a guess.",
+    ),
+    f"{gates.HEADROOM_GATE}/{gates.HEADROOM_NETWORK_IN}": (
+        "Inbound network headroom",
+        "Observed inbound throughput against the instance type's DECLARED "
+        "baseline. The instance can burst above that baseline, so this reads "
+        "high rather than low.",
+    ),
+    f"{gates.HEADROOM_GATE}/{gates.HEADROOM_NETWORK_OUT}": (
+        "Outbound network headroom",
+        "Observed outbound throughput against the instance type's DECLARED "
+        "baseline. Judged apart from inbound because the hypervisor meters the "
+        "two against separate credit buckets.",
+    ),
+    gates.HEADROOM_GATE: (
+        "Resource headroom",
+        "Headroom on a limited resource, with no resource named on the row: "
+        "read the recorded detail beside it to find out which one.",
+    ),
+    gates.NETWORK_ALLOWANCE_GATE: (
+        "Hypervisor allowance events",
+        "How many times the hypervisor recorded an allowance as exceeded during "
+        "the window. A count of throttling EVENTS, not a fraction of a limit: "
+        "the limit itself is unpublished.",
+    ),
+    gates.PROCESS_LIFECYCLE_GATE: (
+        "Restarts and OOM kills",
+        "Processes that restarted, and kernel OOM kills, across the window. "
+        "Either one means something died and came back while the test ran.",
+    ),
+    gates.RESOURCE_TREND_GATE: (
+        "Resource drift",
+        "How far a resource moved between the middle and the last third of the "
+        "steady-state window, in that resource's own units.",
+    ),
+    gates.RETURN_TO_BASELINE_GATE: (
+        "Return to baseline",
+        "Where a resource settled after teardown, as a multiple of its own idle "
+        "baseline from before the run. 1.0 is exactly back to where it started.",
+    ),
+    gates.ESTABLISHMENT_GATE: (
+        "Calls established",
+        "The share of call attempts that reached an established call, counted "
+        "from the generator's own records over one network path.",
+    ),
+    gates.SUSTAINED_HEALTH_GATE: (
+        "Consecutive failed health samples",
+        "The longest unbroken run of failed dependency or health-check samples. "
+        "A count of samples, so consecutive rather than cumulative.",
+    ),
+}
+
+#: How a not-collected row is filed, and what to do about it. Ordered: the first
+#: marker that appears in the gate's recorded detail wins.
+#:
+#: Classified from the DETAIL because that is the only cause the payload
+#: carries. The gate records why it could not evaluate in prose and nowhere as a
+#: code, so this matches on the phrases those gates actually write. It is
+#: fragile by construction, which is why the fallback below is a named cause
+#: rather than a silent bucket, and why every row prints its own detail verbatim
+#: underneath: a misfiled row is visible to the reader, not hidden by the
+#: heading it landed under.
+#:
+#: Grouped by cause rather than by gate so the section reads as a setup
+#: checklist. Twelve rows saying "not measured" are one action when they share a
+#: cause, and a reader who has to derive that themselves does not.
+_PROFILE_CAUSES: tuple[tuple[tuple[str, ...], str, str], ...] = (
+    (
+        (
+            "no scrape target",
+            "nothing in the scrape set publishes",
+            "outside scope for this report",
+        ),
+        "Nothing was configured to answer it",
+        "No source in the scrape set can produce this at all, so it was never "
+        "asked. Wire the exporter or endpoint the detail names and run again. "
+        "Until then the measurement does not exist, which is not the same as it "
+        "coming back clean.",
+    ),
+    (
+        ("usable sample",),
+        "The window carried too few samples",
+        "A trend is computed over thirds of the steady-state window and each "
+        f"third needs at least {gates.MIN_TREND_SAMPLES} usable samples. Run for "
+        "longer, or sample more often. Too short to tell is not flat.",
+    ),
+    (
+        (),
+        "The series was not in this run's scrape",
+        "These are collectable and simply were not in the scrape correlated to "
+        "this window: the exporter or the series was wired after the run was "
+        "captured, or nothing was scraped for the window at all. Re-run against "
+        "the current scrape configuration and they fill in.",
+    ),
+)
+
+
+def _headroom_resource(gate: dict[str, Any]) -> str | None:
+    """Which resource a headroom gate is about, from whichever field survived.
+
+    ``metric`` is ``<resource>_headroom`` and is the reliable source, but it is
+    None on every gate that could not evaluate, which is most of the rows this
+    view has to file. The subject is built as ``<node>[/<source>]/<resource>``,
+    so the last segment is the resource on both the measured and the unmeasured
+    row.
+
+    Nothing is validated against a list of known resources on purpose. A
+    resource this build has never heard of must reach
+    :data:`PROFILE_UNGROUPED_GROUP` and be seen, and a whitelist would instead
+    fold it back into the bare headroom key where it looks classified.
+    """
+    metric = gate.get("metric")
+    if isinstance(metric, str) and metric.endswith("_headroom"):
+        return metric[: -len("_headroom")] or None
+    subject = gate.get("subject")
+    if isinstance(subject, str) and "/" in subject:
+        return subject.rsplit("/", 1)[1] or None
+    return None
+
+
+def _profile_key(gate: dict[str, Any]) -> str:
+    """The key a gate is grouped and named by. See :data:`PROFILE_GROUPS`."""
+    gate_id = str(gate.get("gate") or "")
+    if gate_id != gates.HEADROOM_GATE:
+        return gate_id
+    resource = _headroom_resource(gate)
+    return f"{gate_id}/{resource}" if resource else gate_id
+
+
+def _profile_name(key: str) -> tuple[str, str]:
+    """The human name and the "what it means" sentence for one key.
+
+    A key with no entry falls back to the key itself rather than to a blank, and
+    says out loud that this build does not know what it is. An unnamed row is
+    still a measurement somebody took, and dropping it because the renderer has
+    no label for it would be the renderer deciding what counts.
+    """
+    named = _PROFILE_MEASUREMENTS.get(key)
+    if named is not None:
+        return named
+    return (
+        key.replace("_", " ").replace("/", ": "),
+        "This build carries no description for this measurement, so read the "
+        "recorded detail beside it rather than inferring what it means.",
+    )
+
+
+def _profile_cause(detail: str) -> tuple[str, str]:
+    """Why nothing was recorded, and what closes the gap. See
+    :data:`_PROFILE_CAUSES`."""
+    lowered = detail.lower()
+    for markers, title, remedy in _PROFILE_CAUSES:
+        if any(marker in lowered for marker in markers):
+            return title, remedy
+    return _PROFILE_CAUSES[-1][1], _PROFILE_CAUSES[-1][2]
+
+
+def _profile_rows(
+    payload: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split the payload's gates into measured, not-collected and dropped rows.
+
+    Order is the payload's own order throughout, which is the order the run
+    executed in. Re-sorting would break the correspondence with the per-test
+    table above it, and a reader matching a row to a step should not have to
+    hold two orderings in their head.
+
+    Permanently unmeasurable resources are dropped here rather than filtered at
+    render time, so no downstream count includes a row nobody will ever see.
+    """
+    measured: list[dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
+    dropped: list[dict[str, Any]] = []
+    for gate in payload.get("gates") or []:
+        if not isinstance(gate, dict):
+            continue
+        key = _profile_key(gate)
+        name, meaning = _profile_name(key)
+        detail = str(gate.get("detail") or "")
+        row = {
+            "key": key,
+            "gate": str(gate.get("gate") or ""),
+            "name": name,
+            "meaning": meaning,
+            "subject": gate.get("subject"),
+            "step": gate.get("step"),
+            "value": _as_float(gate.get("value")),
+            "threshold": _as_float(gate.get("threshold")),
+            "detail": detail,
+        }
+        resource = (
+            _headroom_resource(gate) if row["gate"] == gates.HEADROOM_GATE else None
+        )
+        if resource in PROFILE_PERMANENTLY_UNMEASURABLE:
+            dropped.append(row)
+        elif row["value"] is None:
+            missing.append(row)
+        else:
+            measured.append(row)
+    return measured, missing, dropped
+
+
+def _profile_subject(row: dict[str, Any]) -> str:
+    """Which node, source and step a row belongs to.
+
+    The step is part of a row's identity and not decoration, for the same reason
+    it is on the gate table: a seven-step run otherwise renders seven rows with
+    identical subjects and nothing to tell them apart. Suppressed where it
+    merely repeats the subject, which is the establishment row, whose subject IS
+    the step.
+    """
+    subject, step = row.get("subject"), row.get("step")
+    cell = _recorded(subject)
+    if step and step != subject:
+        cell += f'<div class="why">{_esc(step)}</div>'
+    return cell
+
+
+def _profile_band(value: float, threshold: float) -> str:
+    """The reference band: a track, a neutral fill, and a tick at the reference.
+
+    THE FILL IS ONE NEUTRAL COLOUR FOR ITS WHOLE LENGTH, on both sides of the
+    tick, and that is the single most important line in this function. Colouring
+    a bar by which side of a line it lands on is a verdict wearing a chart's
+    clothes: it grades the number before the reader has read it, in the one view
+    that exists to stop doing exactly that. The tick says where the reference
+    sits; whether landing past it is fine is the reader's call, and this
+    document does not have the context to make it for them.
+
+    CSS only. No SVG and no image: three test suites scan the output for those
+    markers, because this file has to render from disk with no network, and a
+    chart library is what somebody reaches for the first time a bar is wanted.
+    """
+    fill = max(0.0, min(100.0, value * 100.0))
+    tick = max(0.0, min(100.0, threshold * 100.0))
+    return (
+        '<div class="band">'
+        f'<div class="band-fill" style="width:{_esc(f"{fill:.1f}")}%"></div>'
+        f'<div class="band-tick" style="left:{_esc(f"{tick:.1f}")}%"></div>'
+        "</div>"
+    )
+
+
+def _profile_reference(row: dict[str, Any]) -> str:
+    """The range a value is read against: a band where one exists, else words.
+
+    A band is drawn ONLY for a gate in :data:`gates.RATIO_GATES` whose value and
+    reference both fall inside 0..1. There the full scale is exactly 1.0, and
+    1.0 is a real thing: the limit the fraction was taken against. The bar's
+    length then means what a reader assumes it means.
+
+    Everything else gets the figure and no bar, and this is the decision the
+    alternative was worse than. Scaling a count against
+    ``max(value, threshold) * 1.25`` would put a fill on the page whose
+    denominator this renderer invented, so its width would mean "some share of a
+    number nobody measured". A reader reads a bar as a fraction of something
+    real. Restarts, OOM kills, allowance events and consecutive failed samples
+    have no maximum, and neither does a return-to-baseline ratio, which is a
+    multiple of a baseline and runs past 1 by design. So no bar is drawn for any
+    of them. It is the same reasoning that drops the PPS rows entirely: where
+    there is no denominator, the honest rendering is the numerator alone.
+    """
+    value, threshold = row["value"], row["threshold"]
+    if threshold is None:
+        return (
+            '<span class="nm">no reference recorded: this run carried no value '
+            "to read the figure against</span>"
+        )
+    reference = _gate_number(threshold, row["gate"])
+    if (
+        row["gate"] in gates.RATIO_GATES
+        and value is not None
+        and 0.0 <= value <= 1.0
+        and 0.0 <= threshold <= 1.0
+    ):
+        return (
+            _profile_band(value, threshold) + '<div class="band-scale"><span>0%</span>'
+            f"<span>reference {reference}</span><span>100%</span></div>"
+        )
+    return (
+        f"reference {reference}"
+        '<div class="why">No bar: this figure is a count, or a multiple of a '
+        "baseline, so there is no full scale to draw it against.</div>"
+    )
+
+
+def _render_profile_measurements(measured: list[dict[str, Any]]) -> str:
+    """Everything this run put a number on, grouped by what the number teaches."""
+    if not measured:
+        return (
+            "<h2>Measurements</h2>"
+            '<div class="note">This run put a number on nothing. Every gate it '
+            "evaluated recorded an absence, and those are listed below with the "
+            "reason each one gives. Read that section as the whole result: there "
+            "is no measured half hiding behind it.</div>"
+        )
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in measured:
+        title = next(
+            (t for t, keys in PROFILE_GROUPS.items() if row["key"] in keys),
+            PROFILE_UNGROUPED_GROUP,
+        )
+        grouped.setdefault(title, []).append(row)
+    out = [
+        "<h2>Measurements</h2>"
+        "<p>Every figure this run recorded, with the range it is read against. "
+        "The reference is the value the number is compared to; nothing here says "
+        "whether landing on either side of it is acceptable, because that "
+        "depends on what the deployment is for.</p>"
+    ]
+    # PROFILE_GROUPS order first, then anything unclassified, so a new gate
+    # surfaces at the bottom of the section instead of shuffling the groups a
+    # reader knows.
+    order = [t for t in PROFILE_GROUPS if t in grouped]
+    order += [t for t in grouped if t not in PROFILE_GROUPS]
+    for title in order:
+        body = "".join(
+            f"<tr><td class='mono'>{_profile_subject(row)}</td>"
+            f"<td>{_esc(row['name'])}"
+            f"<div class='why'>{_esc(row['meaning'])}</div></td>"
+            f"<td class='num'>{_gate_number(row['value'], row['gate'])}</td>"
+            f"<td>{_profile_reference(row)}</td></tr>"
+            for row in grouped[title]
+        )
+        out.append(
+            f"<h3>{_esc(title)}</h3>"
+            "<table><thead><tr><th>Subject</th><th>Measurement</th>"
+            "<th class='num'>Value</th><th>Read against</th></tr></thead>"
+            f"<tbody>{body}</tbody></table>"
+        )
+    if PROFILE_UNGROUPED_GROUP in grouped:
+        out.append(
+            '<div class="note">The measurements above are real and this build '
+            "does not know where to file them. They are shown rather than "
+            "dropped: a profiler that silently loses a number it took is worse "
+            "than one that admits it has no heading for it.</div>"
+        )
+    return "".join(out)
+
+
+def _render_profile_not_collected(
+    payload: dict[str, Any],
+    missing: list[dict[str, Any]],
+    dropped: list[dict[str, Any]],
+) -> str:
+    """The setup checklist: what produced no number, grouped by why.
+
+    Rows for permanently unmeasurable resources are absent from this list on
+    purpose, and a single sentence names them when any were dropped. The list
+    itself is a queue of work somebody can do, and an item nobody can ever do
+    turns it into a queue that never empties. Naming them once keeps the
+    disclosure from shrinking silently, which is the failure mode of collapsing
+    rows into a summary.
+    """
+    run_limits = payload.get("run_limitations") or []
+    out = ["<h2>Not collected in this run</h2>"]
+    if not missing and not run_limits:
+        out.append(
+            "<p>Every gate this run evaluated produced a number, and every "
+            "number is in the section above.</p>"
+        )
+    else:
+        out.append(
+            "<p>These produced no number. They are grouped by cause so the "
+            "section reads as a list of things to fix rather than as a list of "
+            "gaps, and each row carries what the run itself recorded, verbatim. "
+            "An absence is never a zero and never a pass: nothing was compared "
+            "against anything.</p>"
+        )
+    if dropped:
+        names = sorted(
+            {str(r["subject"] or r["key"]).rsplit("/", 1)[-1] for r in dropped}
+        )
+        out.append(
+            f"<p class='sub'>{len(dropped)} row(s) covering "
+            f"{_esc(', '.join(names))} are absent from this list entirely, not "
+            "filed as uncollected: no allowance for them is published by "
+            "anybody, so there is no denominator to divide by and no run will "
+            "ever fill them in.</p>"
+        )
+    grouped: dict[str, tuple[str, list[dict[str, Any]]]] = {}
+    for row in missing:
+        title, remedy = _profile_cause(row["detail"])
+        grouped.setdefault(title, (remedy, []))[1].append(row)
+    for _markers, title, _remedy in _PROFILE_CAUSES:
+        entry = grouped.get(title)
+        if entry is None:
+            continue
+        remedy, rows = entry
+        body = "".join(
+            f"<tr><td class='mono'>{_profile_subject(row)}</td>"
+            f"<td>{_esc(row['name'])}</td>"
+            f"<td>{_esc(row['detail'])}</td></tr>"
+            for row in rows
+        )
+        out.append(
+            f"<h3>{_esc(title)}</h3><p class='sub'>{_esc(remedy)}</p>"
+            "<table><thead><tr><th>Subject</th><th>Measurement</th>"
+            "<th>What the run recorded</th></tr></thead>"
+            f"<tbody>{body}</tbody></table>"
+        )
+    if run_limits:
+        entries = "".join(f"<li>{_esc(item)}</li>" for item in run_limits)
+        out.append(
+            "<h3>From this run's own artifacts</h3>"
+            "<p class='sub'>Gaps in the files this report was built from, rather "
+            "than in the fleet it describes. A later run can close them.</p>"
+            f"<ul>{entries}</ul>"
+        )
+    return "".join(out)
+
+
+def _render_profile_method(payload: dict[str, Any]) -> str:
+    """How to read the figures above, including the reasons they read low or high.
+
+    The structural limits are :data:`_LOAD_REPORT_LIMITS`, reused through the
+    payload rather than restated: a second copy of that list is a second list
+    that goes stale, and the version a client reads would be the stale one. What
+    is added here is the reading rules a profile view needs and a gated view
+    does not, because a gated view hands the reader a verdict and this one hands
+    them the numbers.
+    """
+    structural = "".join(f"<li>{_esc(item)}</li>" for item in payload["not_measured"])
+    method = [
+        "There is no verdict in this document, and that is deliberate. It "
+        "reports what was measured and the range each number is read against, "
+        "then stops. Whether a figure is acceptable depends on what the "
+        "deployment is for, and the person accountable for it holds context "
+        "this file cannot carry.",
+        "A reference bar is ONE neutral colour for its whole length, on both "
+        "sides of the tick. It is never coloured by which side the value lands "
+        "on, because a bar that changes colour at a line has graded the number "
+        "before the reader read it.",
+        "A bar is drawn only where a real full scale exists: a fraction of a "
+        "limit, where 100% is the limit itself. A count has no maximum, so a "
+        "count is shown as a figure with its reference beside it and no bar.",
+        "A gap is NULL, and renders as absent. Nothing unmeasured is shown as "
+        "0, because zero and unmeasured support opposite conclusions and the "
+        "difference cannot be recovered once it is lost.",
+        f"Below {gates.MIN_PERCENTILE_SAMPLES} samples a peak is the max of N "
+        "rather than a percentile. A percentile computed from a handful of "
+        "samples is the maximum wearing a more confident label.",
+    ]
+    items = "".join(f"<li>{_esc(item)}</li>" for item in method)
+    return (
+        "<h2>How to read these numbers</h2>"
+        f"<ul>{items}</ul>"
+        "<h3>What this report structurally does not measure</h3>"
+        "<p>These are limits of the system, not of this run. A later run does "
+        "not close them.</p>"
+        f"<ul>{structural}</ul>"
+    )
+
+
+def _render_profile_identity(payload: dict[str, Any]) -> str:
+    """Which run this is, as a plain definition list.
+
+    No bordered box. The acceptance view boxes its metadata because it sits
+    beside a verdict panel and needs to hold its own against it; here the
+    metadata is the second thing on the page and a border around it only says
+    "this part is separate", which is not true.
+
+    Provenance is the FIRST row, ahead of the identifiers. A reader who stops
+    after one line should have read whether these numbers describe anything
+    real.
+    """
+    run = payload.get("run") or {}
+    started, ended = _utc(run.get("started_at_ms")), _utc(run.get("ended_at_ms"))
+    if started and ended:
+        window = f"{_esc(started)} to {_esc(ended)}"
+    elif started:
+        window = f"{_esc(started)}, end not recorded"
+    elif ended:
+        window = f"start not recorded, ended {_esc(ended)}"
+    else:
+        window = '<span class="nm">not recorded</span>'
+    checksum = run.get("artifact_sha256")
+    rows = [
+        (
+            "Data provenance",
+            f"{_esc(payload.get('data_provenance'))}"
+            f'<div class="why">{_esc(payload.get("provenance_basis") or "")}</div>',
+        ),
+        ("Run id", f'<span class="mono">{_esc(run.get("id"))}</span>'),
+        ("Label", _recorded(run.get("label"))),
+        ("Project", _recorded(run.get("project"))),
+        ("Run window (UTC)", window),
+        (
+            "Artifact checksum",
+            f'<span class="mono">{_esc(str(checksum)[:16])}</span>'
+            if checksum
+            else '<span class="nm">no artifact checksum</span>',
+        ),
+        (
+            "Generator",
+            _recorded(run.get("tool"))
+            + (f" {_esc(run.get('tool_version'))}" if run.get("tool_version") else ""),
+        ),
+        ("Report generated", _esc(payload["generated_at"])),
+        (
+            "Generated by",
+            f"voicegateway {_esc(payload['generator']['version'])}"
+            f" &middot; payload schema v{payload['schema_version']}",
+        ),
+    ]
+    body = "".join(f"<dt>{label}</dt><dd>{value}</dd>" for label, value in rows)
+    return f'<div class="ident"><dl>{body}</dl></div>'
+
+
+#: Appended to :data:`_REPORT_CSS`, never merged into it. That sheet is shared
+#: with the diagnostics and acceptance documents and several suites pin what it
+#: renders, so a class added for this view belongs in its own constant where it
+#: cannot change either of those.
+#:
+#: Carries the print rules the load sheet never had. A capacity report is
+#: printed and filed, and without a repeating table head a page-two row is a
+#: line of numbers with no column names above it, which is worse than useless
+#: because it is still readable.
+_PROFILE_CSS = """
+.ident dl { display: grid; grid-template-columns: 200px 1fr; gap: 5px 18px;
+            margin: 14px 0 6px; font-size: 13px; }
+.ident dt { color: #5b6472; }
+.ident dd { margin: 0; }
+.why { color: #5b6472; font-size: 12px; margin: 2px 0 0; line-height: 1.4; }
+.band { position: relative; height: 12px; min-width: 130px; margin: 4px 0 5px;
+        background: #edeff3; border: 1px solid #dfe2e7; border-radius: 3px; }
+/* ONE neutral fill, both sides of the tick. Colouring it by which side the
+   value lands on would grade the number, which is the whole thing this view
+   exists to remove. See _profile_band. */
+.band-fill { position: absolute; top: 0; bottom: 0; left: 0; background: #9aa3b0;
+             border-radius: 2px; }
+.band-tick { position: absolute; top: -3px; bottom: -3px; width: 2px;
+             margin-left: -1px; background: #16181d; }
+.band-scale { display: flex; justify-content: space-between; gap: 10px;
+              font-size: 11px; color: #5b6472; }
+@page { margin: 16mm 14mm; }
+@media print {
+  thead { display: table-header-group; }
+  tr { break-inside: avoid; }
+  h2, h3 { break-after: avoid; }
+}
+"""
+
+
+def profile_filename(run_id: Any) -> str:
+    """A filename that cannot smuggle anything into a header. See
+    :func:`report_filename`.
+
+    A different stem from :func:`load_report_filename` on purpose. The two
+    documents describe the same run and say different things about it, so they
+    have to be able to sit in one directory without one overwriting the other,
+    and somebody holding a file should be able to tell which view it is without
+    opening it.
+    """
+    safe = re.sub(r"[^A-Za-z0-9_-]", "", str(run_id))[:32] or "run"
+    return f"voicegateway-profile-{safe}.html"
+
+
+def render_profile_html(payload: dict[str, Any]) -> str:
+    """Render a load payload as the PROFILE view: measurements, no judgement.
+
+    Takes exactly what :func:`build_load_payload` produces, which is the whole
+    point of the signature. The acceptance view and this one read one payload,
+    so they cannot disagree about a number: only about how much of it they show.
+
+    What this deliberately does NOT render, in a document that has every input
+    needed to render all three. There is no verdict block, no status word on any
+    row, and no gate table. Those are the acceptance view, and it still exists
+    for the engagement that contracted thresholds. Reproducing them here as
+    well, in the profiler's default output, would make the threshold the headline
+    of every run, including the many where nobody agreed to one.
+
+    The measurement rows are derived FROM ``payload["gates"]`` rather than from
+    the findings, because a gate row already carries the four things a profile
+    row needs: what it is about, the number, the reference, and what the run
+    recorded about it. Deriving them separately would be a second path to the
+    same figures, and two paths is how the two views start to disagree.
+
+    SYNCHRONOUS, and self-contained on the same hard terms as
+    :func:`render_load_html`: no script, no link, no image, no SVG, no external
+    font, no url() and no absolute URL anywhere in the output. This file is
+    opened from disk, possibly offline, possibly years later.
+    """
+    measured, missing, dropped = _profile_rows(payload)
+    run_id = _esc((payload.get("run") or {}).get("id"))
+    body = "".join(
+        [
+            "<h1>Load-test profile</h1>",
+            # Not in the section order this view was specified with, and kept
+            # anyway: the stamp is the element that stops a fixture-built file
+            # being mistaken for a measurement, and it renders nothing at all
+            # when the run was measured. Dropping a disclosure because a layout
+            # list did not mention it is how disclosures disappear.
+            _render_stamp(payload),
+            _render_profile_identity(payload),
+            # Reused verbatim from the acceptance view rather than reimplemented.
+            # These two sections carry no status and no verdict, so they are
+            # already the profile rendering of those numbers, and a second
+            # implementation would be a second set of figures to keep in step.
+            _render_load_tests(payload),
+            _render_profile_measurements(measured),
+            _render_capacity(payload),
+            _render_profile_not_collected(payload, missing, dropped),
+            _render_profile_method(payload),
+            "<footer>Generated by voicegateway "
+            f"{_esc(payload['generator']['version'])} on "
+            f"{_esc(payload['generated_at'])} &middot; "
+            f"{_esc(PROFILE_KIND)}, rendered from payload schema v"
+            f"{payload['schema_version']} ({_esc(payload.get('kind'))}). This is "
+            "the profile view: it reports what was measured and stops. This file "
+            "is self-contained: it loads nothing over the network and reads the "
+            "same offline.</footer>",
+        ]
+    )
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        f"<title>Load-test profile {run_id}</title>"
+        f"<style>{_REPORT_CSS}{_LOAD_REPORT_CSS}{_PROFILE_CSS}</style></head>"
+        f"<body>{body}</body></html>\n"
+    )

--- a/src/voicegateway/tests/cli/test_calls_cli.py
+++ b/src/voicegateway/tests/cli/test_calls_cli.py
@@ -27,13 +27,24 @@ def test_fmt_started_short_and_passthrough() -> None:
     assert _fmt_started("not-a-date") == "not-a-date"  # unparseable -> first 16 chars
 
 
-def _rec(session_id: str, modality: str, model_id: str, provider: str,
-         cost: float, ts: float) -> RequestRecord:
+def _rec(
+    session_id: str, modality: str, model_id: str, provider: str, cost: float, ts: float
+) -> RequestRecord:
     return RequestRecord(
-        id=f"{session_id}-{modality}-{ts}", timestamp=ts, project="default",
-        modality=modality, model_id=model_id, provider=provider,
-        input_units=1, output_units=0, cost_usd=cost, pricing_source="test",
-        ttfb_ms=None, total_latency_ms=100.0, status="success", session_id=session_id,
+        id=f"{session_id}-{modality}-{ts}",
+        timestamp=ts,
+        project="default",
+        modality=modality,
+        model_id=model_id,
+        provider=provider,
+        input_units=1,
+        output_units=0,
+        cost_usd=cost,
+        pricing_source="test",
+        ttfb_ms=None,
+        total_latency_ms=100.0,
+        status="success",
+        session_id=session_id,
     )
 
 
@@ -41,12 +52,16 @@ def _seed(tmp_path, monkeypatch) -> str:
     db = tmp_path / "calls.db"
     monkeypatch.setenv("VOICEGW_DB_PATH", str(db))
     cfg = tmp_path / "voicegw.yaml"
-    cfg.write_text(yaml.dump({
-        "providers": {"openai": {"api_key": "x"}},
-        "models": {"stt": {}, "llm": {}, "tts": {}},
-        "projects": {},
-        "cost_tracking": {"enabled": True},
-    }))
+    cfg.write_text(
+        yaml.dump(
+            {
+                "providers": {"openai": {"api_key": "x"}},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "cost_tracking": {"enabled": True},
+            }
+        )
+    )
     gw = Gateway(config_path=str(cfg))
 
     async def seed() -> None:
@@ -57,7 +72,9 @@ def _seed(tmp_path, monkeypatch) -> str:
             ("tts", "cartesia/sonic-3", "cartesia", 0.010),
         ]
         for i, (mod, model, prov, cost) in enumerate(turn):
-            await gw.storage.log_request(_rec("call-001", mod, model, prov, cost, 1_700_000 + i))
+            await gw.storage.log_request(
+                _rec("call-001", mod, model, prov, cost, 1_700_000 + i)
+            )
 
     asyncio.run(seed())
     return str(cfg)

--- a/src/voicegateway/tests/cli/test_daemon_linux.py
+++ b/src/voicegateway/tests/cli/test_daemon_linux.py
@@ -72,8 +72,7 @@ def test_render_unit_threads_config_path(backend):
     cp = configparser.ConfigParser(strict=False, interpolation=None)
     cp.read_string(rendered)
     assert cp.get("Service", "ExecStart") == (
-        '/usr/local/bin/voicegw serve -c "'
-        '/home/me/.config/voicegateway/voicegw.yaml"'
+        '/usr/local/bin/voicegw serve -c "/home/me/.config/voicegateway/voicegw.yaml"'
     )
 
 

--- a/src/voicegateway/tests/cli/test_daemon_windows.py
+++ b/src/voicegateway/tests/cli/test_daemon_windows.py
@@ -69,7 +69,9 @@ def test_install_uses_schtasks_first(backend, fake_subprocess, monkeypatch):
     assert _powershell_calls(fake_subprocess) == []
 
 
-def test_install_threads_config_path_into_task_run(backend, fake_subprocess, monkeypatch):
+def test_install_threads_config_path_into_task_run(
+    backend, fake_subprocess, monkeypatch
+):
     """A config path becomes ``serve -c "<path>"`` in the schtasks /TR value."""
     monkeypatch.setattr(
         "voicegateway.cli.daemon.windows_daemon.shutil.which",

--- a/src/voicegateway/tests/cli/test_loadtest_end_to_end.py
+++ b/src/voicegateway/tests/cli/test_loadtest_end_to_end.py
@@ -94,6 +94,7 @@ def _report(run: dict, *extra: str):
         [
             "loadtest",
             "report",
+            "--acceptance",
             "ramp-500",
             "--config",
             run["config"],

--- a/src/voicegateway/tests/cli/test_loadtest_exit_code.py
+++ b/src/voicegateway/tests/cli/test_loadtest_exit_code.py
@@ -62,6 +62,7 @@ def _report(workspace: dict, *extra: str):
         [
             "loadtest",
             "report",
+            "--acceptance",
             "ramp-500",
             "--config",
             workspace["config"],

--- a/src/voicegateway/tests/core/test_config.py
+++ b/src/voicegateway/tests/core/test_config.py
@@ -67,9 +67,7 @@ def test_livekit_block_is_accepted(tmp_path):
     """
     path = tmp_path / "voicegw.yaml"
     with open(path, "w") as f:
-        yaml.dump(
-            {"livekit": {"url": "wss://x", "api_key": "k", "api_secret": "s"}}, f
-        )
+        yaml.dump({"livekit": {"url": "wss://x", "api_key": "k", "api_secret": "s"}}, f)
     # Must not raise ConfigError.
     GatewayConfig.load(str(path))
 

--- a/src/voicegateway/tests/fixtures/loadtest/make_synthetic.py
+++ b/src/voicegateway/tests/fixtures/loadtest/make_synthetic.py
@@ -32,9 +32,9 @@ from __future__ import annotations
 import pathlib
 
 HERE = pathlib.Path(__file__).resolve().parent
-HEADER = (HERE / "capture-01" / "gossipper_2958087_stats.log").read_text().splitlines()[
-    0
-]
+HEADER = (
+    (HERE / "capture-01" / "gossipper_2958087_stats.log").read_text().splitlines()[0]
+)
 COLUMNS = HEADER.split(",")
 
 # 2026-08-02T09:00:00Z, a round instant so the windows are easy to reason about.
@@ -134,7 +134,10 @@ def main() -> None:
     for index, target in enumerate((100, 150, 200, 250)):
         established = target * 30
         _stat_file(
-            HERE / "saturation-ramp" / f"ramp-{target}" / f"gossipper_{5000 + index}_stats.log",
+            HERE
+            / "saturation-ramp"
+            / f"ramp-{target}"
+            / f"gossipper_{5000 + index}_stats.log",
             # Steps run back to back, 90s apart, so their windows do not overlap
             # and each correlates to its own node samples.
             start_ms=BASE_MS + index * 90_000,

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -926,14 +926,20 @@ async def test_time_to_first_partial_latched_onto_eou_row():
     capture.bind(session)
 
     session.emit("user_started_speaking", _SpeakingEvent(100.0))
-    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.3))
-    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.5))
+    session.emit(
+        "user_input_transcribed", _Transcript(is_final=False, created_at=100.3)
+    )
+    session.emit(
+        "user_input_transcribed", _Transcript(is_final=False, created_at=100.5)
+    )
     session.emit("user_input_transcribed", _Transcript(is_final=True, created_at=100.9))
     session.emit("metrics_collected", _TurnEOU())
     await capture.drain()
 
     eou = next(r for r in sink.records if r.modality == "eou")
-    assert eou.metadata["eou"]["time_to_first_partial_ms"] == pytest.approx(300.0)  # first interim only
+    assert eou.metadata["eou"]["time_to_first_partial_ms"] == pytest.approx(
+        300.0
+    )  # first interim only
     assert eou.metadata["eou"]["end_of_utterance_delay"] == 0.5
 
 
@@ -959,7 +965,9 @@ async def test_first_partial_latch_resets_between_turns():
     capture.bind(session)
 
     session.emit("user_started_speaking", _SpeakingEvent(100.0))
-    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.3))
+    session.emit(
+        "user_input_transcribed", _Transcript(is_final=False, created_at=100.3)
+    )
     session.emit("metrics_collected", _TurnEOU())
     session.emit("user_started_speaking", _SpeakingEvent(200.0))  # turn 2: no interim
     session.emit("metrics_collected", _TurnEOU())
@@ -993,7 +1001,9 @@ async def test_time_to_first_partial_via_user_state_changed():
     capture.bind(session)
 
     session.emit("user_state_changed", _UserStateChanged("speaking", 100.0))
-    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.28))
+    session.emit(
+        "user_input_transcribed", _Transcript(is_final=False, created_at=100.28)
+    )
     session.emit("user_input_transcribed", _Transcript(is_final=True, created_at=100.9))
     session.emit("metrics_collected", _TurnEOU())
     await capture.drain()
@@ -1009,7 +1019,9 @@ async def test_non_speaking_user_state_change_does_not_anchor_onset():
     capture.bind(session)
 
     session.emit("user_state_changed", _UserStateChanged("listening", 50.0))
-    session.emit("user_input_transcribed", _Transcript(is_final=False, created_at=100.28))
+    session.emit(
+        "user_input_transcribed", _Transcript(is_final=False, created_at=100.28)
+    )
     session.emit("metrics_collected", _TurnEOU())
     await capture.drain()
 

--- a/src/voicegateway/tests/livekit_diag/test_admin.py
+++ b/src/voicegateway/tests/livekit_diag/test_admin.py
@@ -14,15 +14,21 @@ STD = 0
 
 class _Rooms:
     async def list_rooms(self, _req):
-        return SimpleNamespace(rooms=[SimpleNamespace(name="r1"), SimpleNamespace(name="r2")])
+        return SimpleNamespace(
+            rooms=[SimpleNamespace(name="r1"), SimpleNamespace(name="r2")]
+        )
 
     async def list_participants(self, req):
         table = {
             "r1": [
-                SimpleNamespace(identity="agent-x", name="realty", kind=AGENT, joined_at=100),
+                SimpleNamespace(
+                    identity="agent-x", name="realty", kind=AGENT, joined_at=100
+                ),
                 SimpleNamespace(identity="human-1", name="", kind=STD, joined_at=100),
             ],
-            "r2": [SimpleNamespace(identity="human-2", name="", kind=STD, joined_at=100)],
+            "r2": [
+                SimpleNamespace(identity="human-2", name="", kind=STD, joined_at=100)
+            ],
         }
         return SimpleNamespace(participants=table[req.room])
 

--- a/src/voicegateway/tests/livekit_diag/test_client.py
+++ b/src/voicegateway/tests/livekit_diag/test_client.py
@@ -9,11 +9,11 @@ def _pcm(amplitude: int, samples: int = 160) -> bytes:
 
 def test_reply_detector_ignores_silence_then_fires_on_speech():
     d = ReplyDetector(threshold=0.02, min_frames=2)
-    d.feed(_pcm(0), t=0.0)          # silence
-    d.feed(_pcm(50), t=0.1)         # tiny blip, below min_frames
+    d.feed(_pcm(0), t=0.0)  # silence
+    d.feed(_pcm(50), t=0.1)  # tiny blip, below min_frames
     assert d.first_reply_at is None
-    d.feed(_pcm(8000), t=0.2)       # loud
-    d.feed(_pcm(8000), t=0.3)       # loud, 2 in a row -> fires at first loud
+    d.feed(_pcm(8000), t=0.2)  # loud
+    d.feed(_pcm(8000), t=0.3)  # loud, 2 in a row -> fires at first loud
     assert d.first_reply_at == 0.2
 
 

--- a/src/voicegateway/tests/livekit_diag/test_config.py
+++ b/src/voicegateway/tests/livekit_diag/test_config.py
@@ -41,7 +41,9 @@ def test_config_home_fallback(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     home_cfg = tmp_path / ".config" / "voicegateway" / "voicegw.yaml"
     home_cfg.parent.mkdir(parents=True)
-    home_cfg.write_text("livekit:\n  url: wss://home\n  api_key: hk\n  api_secret: hs\n")
+    home_cfg.write_text(
+        "livekit:\n  url: wss://home\n  api_key: hk\n  api_secret: hs\n"
+    )
     c = resolve_creds(None, None, None)
     assert c.url == "wss://home" and c.api_key == "hk" and c.api_secret == "hs"
 

--- a/src/voicegateway/tests/livekit_diag/test_gates.py
+++ b/src/voicegateway/tests/livekit_diag/test_gates.py
@@ -431,7 +431,9 @@ def test_a_step_from_an_older_run_without_a_sample_count_is_not_mislabelled():
     assert quiet.value is None
 
     # A legacy step with no rtt key at all is not a 0.0 either.
-    no_rtt = gates.sfu_capacity_gate([{"clients": 2, "quality": "Excellent"}], 50.0, None)
+    no_rtt = gates.sfu_capacity_gate(
+        [{"clients": 2, "quality": "Excellent"}], 50.0, None
+    )
     assert no_rtt.status == gates.UNKNOWN
 
 

--- a/src/voicegateway/tests/livekit_diag/test_live_integration.py
+++ b/src/voicegateway/tests/livekit_diag/test_live_integration.py
@@ -152,7 +152,10 @@ async def test_latency_probe_runs_end_to_end_without_a_real_agent(creds):
     """
     admin = _admin(creds)
     runner = ProbeRunner(
-        admin, lambda u, t: SyntheticClient(u, t), UtteranceSource(_WAV), ComponentReader()
+        admin,
+        lambda u, t: SyntheticClient(u, t),
+        UtteranceSource(_WAV),
+        ComponentReader(),
     )
     try:
         result = await runner.probe(

--- a/src/voicegateway/tests/livekit_diag/test_probe_agent.py
+++ b/src/voicegateway/tests/livekit_diag/test_probe_agent.py
@@ -355,10 +355,16 @@ async def test_probe_surfaces_the_models_it_ran(monkeypatch) -> None:
     _patch(monkeypatch)
     room = "vg-probe-a-ab12cd34"
     rows = [
-        {"modality": "stt", "model_id": "livekit/deepgram/nova-3",
-         "metadata": {"room": room}},
-        {"modality": "llm", "model_id": "livekit/google/gemma-4-31b-it",
-         "metadata": {"room": room}},
+        {
+            "modality": "stt",
+            "model_id": "livekit/deepgram/nova-3",
+            "metadata": {"room": room},
+        },
+        {
+            "modality": "llm",
+            "model_id": "livekit/google/gemma-4-31b-it",
+            "metadata": {"room": room},
+        },
         # No TTS row: that leg's model stays None, not a guess.
     ]
     out = await service.probe_agent(

--- a/src/voicegateway/tests/livekit_diag/test_service.py
+++ b/src/voicegateway/tests/livekit_diag/test_service.py
@@ -489,7 +489,9 @@ async def test_the_run_report_still_renders_after_the_payload_change(monkeypatch
         created_at="2026-07-31T12:00:00+00:00",
     )
 
-    finding = run_report.build_payload(run, livekit_url="wss://x")["findings"]["latency"]
+    finding = run_report.build_payload(run, livekit_url="wss://x")["findings"][
+        "latency"
+    ]
     assert [a["agent"] for a in finding["agents"]] == list(_PROBED)
     assert [a["measured"] for a in finding["agents"]] == [True, False, False]
     # Unmeasured stays null, never zero, for both no-reply agents.
@@ -500,6 +502,7 @@ async def test_the_run_report_still_renders_after_the_payload_change(monkeypatch
     )
     assert "reception" in document and "checkout-voice" in document
     assert "no trial produced a reply" in document
+
 
 # What rtt_ms IS travels with it: a tier that measured nothing says so
 # ---------------------------------------------------------------------------
@@ -559,21 +562,21 @@ async def test_a_measured_smallest_tier_still_passes_through_the_payload(monkeyp
     monkeypatch.setattr(probes, "_diag_cache", _fake_diag(SfuProbe=_MixedSfuProbe))
     out = await probes.RealProbes().sfu(_CREDS, True, probes.clamp_config({}))
 
-    gate = gates.sfu_capacity_gate(
-        out["ramp"], out["target_rtt_ms"], out["resource"]
-    )
+    gate = gates.sfu_capacity_gate(out["ramp"], out["target_rtt_ms"], out["resource"])
     assert gate.status == gates.PASS  # 12.0ms of 2 real round-trips, budget 50ms
 
 
-async def test_a_ramp_that_measured_nothing_does_not_pass_the_capacity_gate(monkeypatch):
+async def test_a_ramp_that_measured_nothing_does_not_pass_the_capacity_gate(
+    monkeypatch,
+):
     """End to end: the probe's own payload, fed to the gate that reads it."""
-    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(SfuProbe=_AllTimedOutSfuProbe))
+    monkeypatch.setattr(
+        probes, "_diag_cache", _fake_diag(SfuProbe=_AllTimedOutSfuProbe)
+    )
     out = await probes.RealProbes().sfu(_CREDS, True, probes.clamp_config({}))
 
     assert [s["rtt_stat"] for s in out["ramp"]] == ["not_measured", "not_measured"]
-    gate = gates.sfu_capacity_gate(
-        out["ramp"], out["target_rtt_ms"], out["resource"]
-    )
+    gate = gates.sfu_capacity_gate(out["ramp"], out["target_rtt_ms"], out["resource"])
     assert gate.status == gates.UNKNOWN
     assert gates.exit_code(gates.verdict([gate])) == 1
 
@@ -625,9 +628,7 @@ async def test_a_measured_baseline_still_passes_the_quality_gate(monkeypatch):
 
 async def test_an_excellent_baseline_that_measured_nothing_does_not_pass(monkeypatch):
     """End to end: the probe's own payload, fed to the gate that reads it."""
-    monkeypatch.setattr(
-        probes, "_diag_cache", _fake_diag(SfuProbe=_SilentPingSfuProbe)
-    )
+    monkeypatch.setattr(probes, "_diag_cache", _fake_diag(SfuProbe=_SilentPingSfuProbe))
     out = await probes.RealProbes().sfu(_CREDS, False, probes.clamp_config({}))
 
     assert out["baseline"]["quality"] == "Excellent"  # the SDK really said this

--- a/src/voicegateway/tests/livekit_diag/test_sfu.py
+++ b/src/voicegateway/tests/livekit_diag/test_sfu.py
@@ -29,7 +29,9 @@ def test_find_knee_at_first_threshold_break():
         RampStep(25, 9.0, 0.1, "Good", 25),
         RampStep(50, 22.0, 1.4, "Poor", 50),
     ]
-    assert find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) == 25  # last good before break
+    assert (
+        find_knee(steps, target_rtt_ms=20.0, max_loss=1.0) == 25
+    )  # last good before break
 
 
 def test_find_knee_none_when_all_healthy():

--- a/src/voicegateway/tests/loadtest/test_capture_end_to_end.py
+++ b/src/voicegateway/tests/loadtest/test_capture_end_to_end.py
@@ -65,7 +65,19 @@ def reported(tmp_path_factory):
     out = tmp / "out"
     exported = runner.invoke(
         app,
-        ["loadtest", "report", RUN_ID, "--config", str(config), "--out", str(out)],
+        # --acceptance: this file asserts the exit code and the gate rows,
+        # which are the acceptance view. The default report profiles and
+        # deliberately carries neither.
+        [
+            "loadtest",
+            "report",
+            "--acceptance",
+            RUN_ID,
+            "--config",
+            str(config),
+            "--out",
+            str(out),
+        ],
     )
     payload = json.loads(
         next(p for p in out.iterdir() if p.suffix == ".json").read_text()

--- a/src/voicegateway/tests/loadtest/test_dashboard.py
+++ b/src/voicegateway/tests/loadtest/test_dashboard.py
@@ -129,9 +129,7 @@ def test_the_four_known_gaps_are_all_present_as_notes() -> None:
 
 def test_redis_is_measured_rather_than_a_note() -> None:
     """The other half of the change above, so the gap cannot quietly return."""
-    measured = " ".join(
-        p.get("title", "") for p in _panels_by_type("timeseries")
-    )
+    measured = " ".join(p.get("title", "") for p in _panels_by_type("timeseries"))
     assert "Redis" in measured
 
 

--- a/src/voicegateway/tests/loadtest/test_pass_path.py
+++ b/src/voicegateway/tests/loadtest/test_pass_path.py
@@ -114,10 +114,8 @@ async def _samples(
                     # them or it is demonstrating less than it claims.
                     "media_ports_in_use": MEDIA_PORTS_IN_USE,
                     "media_ports_total": MEDIA_PORTS_TOTAL,
-                    "network_receive_bytes_total": RX_BYTES_PER_SECOND
-                    * since_origin,
-                    "network_transmit_bytes_total": TX_BYTES_PER_SECOND
-                    * since_origin,
+                    "network_receive_bytes_total": RX_BYTES_PER_SECOND * since_origin,
+                    "network_transmit_bytes_total": TX_BYTES_PER_SECOND * since_origin,
                     # The hypervisor's five shaping counters, flat at zero: this
                     # node was never throttled during the window. Flat rather
                     # than absent, because an unread counter is UNKNOWN and a
@@ -191,6 +189,7 @@ def _run(
     report_argv = [
         "loadtest",
         "report",
+        "--acceptance",
         fixture.name,
         "--config",
         str(config),

--- a/src/voicegateway/tests/loadtest/test_profile_report.py
+++ b/src/voicegateway/tests/loadtest/test_profile_report.py
@@ -1,0 +1,305 @@
+"""The profile view: measurements and reference bands, and no verdict at all.
+
+VoiceGateway profiles. Its default report shows what it measured and the range
+each figure is usually read against, and stops. A human reads and decides.
+
+The gate machinery is not deleted, it moves behind ``--acceptance``, because an
+engagement that contracted 99.5% establishment does need a pass or a fail and a
+pipeline needs an exit code. Two views over ONE set of measurements, so they can
+never disagree about a number.
+
+**Three properties this file exists to hold.**
+
+*No judgement leaks into the default view.* Not a verdict block, not a status
+tag, not a coloured bar, not an exit code, and not a line on the console. A
+profile that prints PASS to the terminal while the document refuses to is two
+products disagreeing.
+
+*A quantity nobody can measure does not appear at all.* PPS headroom has no
+published denominator, so a row reading "unknown" for it is noise rather than
+disclosure. It is dropped, not reported.
+
+*A quantity that IS measurable but was not collected is still named.* On the
+real seven-step run, 46 of the 47 old UNKNOWN rows were this rather than a limit
+of the tool. Rendering them blank would say there was nothing to report, which
+is a worse lie than a verdict.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from voicegateway.cli._app import app
+from voicegateway.livekit_diag import gates, run_report
+from voicegateway.loadtest import judge
+
+runner = CliRunner()
+
+CAPTURE = (
+    Path(__file__).resolve().parent.parent / "fixtures" / "loadtest" / "capture-01"
+)
+
+# Imported from the suites that own them, so self-containment cannot drift here
+# while this file looks like it enforces it.
+from voicegateway.tests.cli.test_livekit_report_cli import (  # noqa: E402
+    _EXTERNAL_MARKERS as CLI_MARKERS,
+)
+from voicegateway.tests.server.test_diagnostics_report import (  # noqa: E402
+    _EXTERNAL_MARKERS as SERVER_MARKERS,
+)
+
+
+def _config(tmp: Path) -> Path:
+    config = tmp / "voicegw.yaml"
+    config.write_text(
+        yaml.dump(
+            {"cost_tracking": {"enabled": True, "db_path": str(tmp / "throwaway.db")}}
+        )
+    )
+    return config
+
+
+@pytest.fixture(scope="module")
+def profiled(tmp_path_factory):
+    """The real capture, exported through the DEFAULT report path."""
+    tmp = tmp_path_factory.mktemp("profile")
+    monkey = pytest.MonkeyPatch()
+    monkey.delenv("VOICEGW_DB_PATH", raising=False)
+    config = _config(tmp)
+    assert (
+        runner.invoke(
+            app,
+            ["loadtest", "import", str(CAPTURE), "--captured", "--config", str(config)],
+        ).exit_code
+        == 0
+    )
+    out = tmp / "out"
+    result = runner.invoke(
+        app,
+        [
+            "loadtest",
+            "report",
+            "capture-01",
+            "--config",
+            str(config),
+            "--out",
+            str(out),
+        ],
+    )
+    html = next(p for p in out.iterdir() if p.suffix == ".html")
+    payload = json.loads(
+        next(p for p in out.iterdir() if p.suffix == ".json").read_text()
+    )
+    monkey.undo()
+    return {
+        "result": result,
+        "html": html.read_text(),
+        "name": html.name,
+        "payload": payload,
+    }
+
+
+# --------------------------------------------------------------------------
+# No judgement, anywhere
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "marker",
+    ['class="verdict', 'class="tag', "<h2>Gates</h2>", "Not in scope for this report"],
+)
+def test_no_judgement_survives_into_the_document(profiled, marker) -> None:
+    assert marker not in profiled["html"], marker
+
+
+@pytest.mark.parametrize("word", [gates.PASS, gates.FAIL, gates.UNKNOWN, gates.WAIVED])
+def test_no_status_word_appears(profiled, word) -> None:
+    """Not even in prose. A profile that says FAIL anywhere has judged."""
+    assert word not in profiled["html"], word
+
+
+def test_the_cli_exits_zero_on_a_run_that_would_fail(profiled) -> None:
+    """The capture is a FAILED run: every call timed out.
+
+    Under --acceptance it exits non-zero, and a separate suite pins that. Here
+    it must exit 0, because a profile makes no claim to judge and delivering a
+    verdict through the exit status while the document refuses to give one is
+    the same contradiction wearing a different hat.
+    """
+    assert profiled["result"].exit_code == 0, profiled["result"].output
+
+
+def test_the_console_names_no_verdict(profiled) -> None:
+    out = profiled["result"].output
+    assert "Verdict" not in out
+    assert "Profiled" in out
+
+
+# --------------------------------------------------------------------------
+# What cannot be measured is absent, not reported as unknown
+# --------------------------------------------------------------------------
+
+
+def test_the_permanently_unmeasurable_resource_is_gone(profiled) -> None:
+    """PPS headroom has no denominator anywhere, so it is not a row.
+
+    Distinct from every other absence in this document: wiring an exporter
+    cannot lift it, so listing it would put a permanent fact in a section a
+    reader scans for things to fix.
+    """
+    assert "pps headroom" not in profiled["html"].lower()
+    assert "fleet/pps" not in profiled["html"]
+
+
+def test_that_set_is_the_judge_module_source_of_truth() -> None:
+    """Named from the shared gate constant, never a second hand-written list.
+
+    The renderer does not import judge (that would close a package loop between
+    livekit_diag and loadtest), so this asserts the equality a shared import
+    would otherwise have guaranteed.
+    """
+    assert run_report.PROFILE_PERMANENTLY_UNMEASURABLE == frozenset(
+        judge.PERMANENT_HEADROOM_EXCLUSIONS
+    )
+
+
+def test_the_pps_counter_still_reaches_the_page(profiled) -> None:
+    """Non-vacuous, and the distinction that makes the deletion honest.
+
+    PPS headroom is unmeasurable. The pps allowance COUNTER is measured, and it
+    is one of the five that fire on shaping, so the allowance row still names
+    it. Deleting the word everywhere would have lost a real measurement.
+    """
+    assert "allowance" in profiled["html"].lower()
+
+
+# --------------------------------------------------------------------------
+# What was not collected is still named, with a remedy
+# --------------------------------------------------------------------------
+
+
+def test_uncollected_measurements_are_listed(profiled) -> None:
+    assert "Not collected in this run" in profiled["html"]
+
+
+def test_every_uncollected_row_says_why(profiled) -> None:
+    """A blank would read as nothing to report. 46 of 47 on the real run were
+    this, so the section carries most of what a reader can act on."""
+    html = profiled["html"]
+    section = html[html.index("Not collected in this run") :]
+    section = section[: section.index("<h2")] if "<h2" in section else section
+    assert "not measured" in section.lower() or "no scrape" in section.lower()
+
+
+# --------------------------------------------------------------------------
+# The reference band never becomes a verdict
+# --------------------------------------------------------------------------
+
+
+def test_the_band_fill_is_one_neutral_colour() -> None:
+    """THE central rule of this view, asserted against the stylesheet.
+
+    Colouring the fill by which side of the tick it lands on is a verdict
+    wearing a chart's clothes: it grades the number before the reader has read
+    it, in the one view that exists to stop doing that. So no status colour may
+    appear in a band rule.
+    """
+    css = run_report._PROFILE_CSS
+    band = css[css.index(".band") :]
+    for status_colour in ("#1f7a44", "#a32020", "#a86a00", "#6a4ca8"):
+        assert status_colour not in band.split(".band-tick")[0], status_colour
+
+
+def test_the_band_renders_the_value_and_the_reference_separately() -> None:
+    """The fill is the number, the tick is the reference. Two facts, two marks."""
+    html = run_report._profile_band(0.838, 0.70)
+    assert "83.8%" in html and "70.0%" in html
+    assert "band-fill" in html and "band-tick" in html
+
+
+def test_a_band_is_only_drawn_where_the_denominator_is_real() -> None:
+    """A count has no natural maximum, so a bar for it would imply one.
+
+    Same reasoning as dropping the PPS rows: where there is no denominator, the
+    honest rendering is the numerator alone.
+    """
+    ratio = run_report._profile_reference(
+        {"gate": gates.NODE_CPU_GATE, "value": 0.838, "threshold": 0.70}
+    )
+    count = run_report._profile_reference(
+        {"gate": gates.SUSTAINED_HEALTH_GATE, "value": 2.0, "threshold": 3.0}
+    )
+    assert "band-fill" in ratio, "a 0..1 ratio has a real full scale"
+    assert "band-fill" not in count, "a count has no maximum and must not imply one"
+
+
+def test_return_to_baseline_gets_no_band_though_it_is_a_ratio_gate() -> None:
+    """The subtle case. It is in RATIO_GATES but is a MULTIPLE of a baseline,
+    with a 1.10 threshold, so it runs past 1.0 by design and has no full scale."""
+    assert gates.RETURN_TO_BASELINE_GATE in gates.RATIO_GATES
+    rendered = run_report._profile_reference(
+        {"gate": gates.RETURN_TO_BASELINE_GATE, "value": 0.82, "threshold": 1.10}
+    )
+    assert "band-fill" not in rendered
+
+
+# --------------------------------------------------------------------------
+# Classification, so a new gate cannot vanish
+# --------------------------------------------------------------------------
+
+
+def test_every_load_gate_is_classified() -> None:
+    """A gate nobody grouped would silently drop out of the document.
+
+    The four unclassified ids are the diagnostics-probe gates, which a load
+    payload never carries; asserting them explicitly keeps that a decision.
+    """
+    assert run_report.PROFILE_UNCLASSIFIED_GATES == {
+        gates.AGENTS_GATE,
+        gates.LATENCY_GATE,
+        gates.SFU_CAPACITY_GATE,
+        gates.SFU_QUALITY_GATE,
+    }
+
+
+def test_the_groups_do_not_overlap() -> None:
+    seen: set[str] = set()
+    for keys in run_report.PROFILE_GROUPS.values():
+        for key in keys:
+            assert key not in seen, key
+            seen.add(key)
+
+
+# --------------------------------------------------------------------------
+# Still a self-contained document
+# --------------------------------------------------------------------------
+
+
+def test_the_html_is_self_contained(profiled) -> None:
+    for marker in set(CLI_MARKERS) | set(SERVER_MARKERS):
+        assert marker not in profiled["html"], marker
+
+
+def test_it_writes_a_distinct_filename(profiled) -> None:
+    """Both views can sit in one directory without one overwriting the other."""
+    assert profiled["name"] == run_report.profile_filename("capture-01")
+    assert profiled["name"] != run_report.load_report_filename("capture-01")
+
+
+def test_the_json_is_the_same_payload_either_way(profiled) -> None:
+    """The machine-readable export must not depend on which view a human asked
+    for, so it still carries the gates and the verdict."""
+    assert profiled["payload"]["gates"]
+    assert profiled["payload"]["verdict"]["status"]
+
+
+def test_the_measurements_a_reader_came_for_are_present(profiled) -> None:
+    """Non-vacuous: removing judgement must not have removed the numbers."""
+    html = profiled["html"]
+    for section in ("Per test", "Measurements", "How to read these numbers"):
+        assert section in html, section

--- a/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
+++ b/src/voicegateway/tests/loadtest/test_report_against_real_capture.py
@@ -63,6 +63,7 @@ def exported(tmp_path_factory):
         [
             "loadtest",
             "report",
+            "--acceptance",
             "capture-01",
             "--config",
             str(config),

--- a/src/voicegateway/tests/loadtest/test_report_identity_and_limits.py
+++ b/src/voicegateway/tests/loadtest/test_report_identity_and_limits.py
@@ -68,6 +68,7 @@ def exported(tmp_path_factory):
         [
             "loadtest",
             "report",
+            "--acceptance",
             "capture-01",
             "--config",
             str(config),

--- a/src/voicegateway/tests/loadtest/test_report_shape_end_to_end.py
+++ b/src/voicegateway/tests/loadtest/test_report_shape_end_to_end.py
@@ -65,6 +65,7 @@ def exported(tmp_path_factory):
         [
             "loadtest",
             "report",
+            "--acceptance",
             "capture-01",
             "--config",
             str(config),

--- a/src/voicegateway/tests/loadtest/test_scope_exclusions.py
+++ b/src/voicegateway/tests/loadtest/test_scope_exclusions.py
@@ -234,11 +234,7 @@ def test_exactly_one_fleet_row_for_the_permanent_exclusion_in_a_multi_step_run()
         for n in (5, 10, 20)
     ]
     results = judge.judge_run(run)
-    rows = [
-        r
-        for r in results
-        if (r.subject or "").endswith(f"/{gates.HEADROOM_PPS}")
-    ]
+    rows = [r for r in results if (r.subject or "").endswith(f"/{gates.HEADROOM_PPS}")]
     assert len(rows) == 1, [r.subject for r in rows]
     assert rows[0].subject == f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_PPS}"
     assert rows[0].status == gates.UNKNOWN
@@ -257,17 +253,13 @@ def test_exactly_one_fleet_row_for_the_permanent_exclusion_in_a_multi_step_run()
         gates.HEADROOM_NETWORK_OUT,
     ):
         assert resource not in excluded, resource
-        [row] = [
-            r for r in results if r.subject == f"{gates.FLEET_SUBJECT}/{resource}"
-        ]
+        [row] = [r for r in results if r.subject == f"{gates.FLEET_SUBJECT}/{resource}"]
         assert row.status == gates.UNKNOWN
         assert "gap in what was collected" in row.detail, resource
         assert "no denominator" not in row.detail, resource
     # And pps reads the other way round.
     [pps_row] = [
-        r
-        for r in results
-        if r.subject == f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_PPS}"
+        r for r in results if r.subject == f"{gates.FLEET_SUBJECT}/{gates.HEADROOM_PPS}"
     ]
     assert "gap in what was collected" not in pps_row.detail
 

--- a/src/voicegateway/tests/models/test_call_models.py
+++ b/src/voicegateway/tests/models/test_call_models.py
@@ -109,8 +109,7 @@ def test_sessions_gains_nullable_correlation_columns() -> None:
             "LiveKit room, and there is no backfill by design"
         )
     indexed = {
-        tuple(col.name for col in index.columns)
-        for index in Session.__table__.indexes
+        tuple(col.name for col in index.columns) for index in Session.__table__.indexes
     }
     # Indexed so the sessions<->calls correlation rate is cheap to measure.
     assert ("room_name",) in indexed

--- a/src/voicegateway/tests/repository/test_calls_answer_latency.py
+++ b/src/voicegateway/tests/repository/test_calls_answer_latency.py
@@ -270,9 +270,7 @@ async def test_the_first_sip_leg_to_join_is_the_caller(db: AsyncSession) -> None
     """A transfer or SIP REFER adds a second SIP leg; the caller rang first."""
     call_id = await repo.upsert_call(db, origin="webhook", room_sid="RM_transfer")
     await _caller_joined(db, call_id)
-    await _caller_joined(
-        db, call_id, _CALLER_JOINED_MS + 20_000, sid="PA_transferee"
-    )
+    await _caller_joined(db, call_id, _CALLER_JOINED_MS + 20_000, sid="PA_transferee")
     await _agent_published(db, call_id)
     assert await _latency(db, call_id) == (_ANSWER_MS, "webhook_proxy")
 
@@ -323,7 +321,7 @@ async def test_the_source_names_the_weaker_of_the_two_clocks(db: AsyncSession) -
 async def test_an_unstamped_writer_is_treated_as_webhook_precision(
     db: AsyncSession,
 ) -> None:
-    """"The writer did not say" must under-claim, never over-claim."""
+    """ "The writer did not say" must under-claim, never over-claim."""
     call_id = await repo.upsert_call(db, origin="agent", room_sid="RM_unstamped")
     await _caller_joined(db, call_id, source="agent")
     await _agent_published(db, call_id, source=None)
@@ -484,7 +482,10 @@ async def test_a_reported_value_and_its_source_travel_together(
 ) -> None:
     with pytest.raises(ValueError, match="both the value and its source"):
         await repo.upsert_call(
-            db, origin="loadgen", attempt_id="att-half", **kwargs  # type: ignore[arg-type]
+            db,
+            origin="loadgen",
+            attempt_id="att-half",
+            **kwargs,  # type: ignore[arg-type]
         )
 
 

--- a/src/voicegateway/tests/repository/test_calls_repository.py
+++ b/src/voicegateway/tests/repository/test_calls_repository.py
@@ -299,7 +299,7 @@ async def test_only_sip_attributes_are_persisted(db: AsyncSession) -> None:
 async def test_no_sip_attributes_stores_null_not_empty_object(
     db: AsyncSession,
 ) -> None:
-    """"{}" would read as "we looked and there were none"; NULL is honest."""
+    """ "{}" would read as "we looked and there were none"; NULL is honest."""
     call_id = await repo.upsert_call(db, origin="webhook", room_sid="RM_noattrs")
     await repo.upsert_call_leg(
         db, call_id=call_id, participant_sid="PA_web", attributes={"app.x": 1}

--- a/src/voicegateway/tests/repository/test_diagnostics_runs_repository.py
+++ b/src/voicegateway/tests/repository/test_diagnostics_runs_repository.py
@@ -104,7 +104,7 @@ async def test_state_transitions_overwrite_the_same_row(db: AsyncSession) -> Non
 async def test_no_results_stays_null_and_is_not_an_empty_dict(
     db: AsyncSession,
 ) -> None:
-    """"No results were recorded" is a different claim from "{}"."""
+    """ "No results were recorded" is a different claim from "{}"."""
     await repo.upsert_run(
         db,
         run_id="r1",

--- a/src/voicegateway/tests/repository/test_node_correlation.py
+++ b/src/voicegateway/tests/repository/test_node_correlation.py
@@ -98,7 +98,7 @@ async def _call_row(
 async def test_window_for_call_reports_both_the_requested_and_padded_bounds(
     db: AsyncSession,
 ) -> None:
-    """"Within 15 s of this call" is a weaker claim than "during this call".
+    """ "Within 15 s of this call" is a weaker claim than "during this call".
 
     Both bounds are carried so a renderer can tell which one it is holding.
     """
@@ -574,7 +574,7 @@ async def test_a_truncated_read_says_so(db: AsyncSession) -> None:
 async def test_the_ramp_window_surfaces_file_descriptor_saturation(
     db: AsyncSession,
 ) -> None:
-    """"The knee at 25 clients CORRELATED WITH filefd_allocated hitting
+    """ "The knee at 25 clients CORRELATED WITH filefd_allocated hitting
     filefd_maximum on one host."
 
     One host walks into its fd ceiling during the ramp step; a second host is not

--- a/src/voicegateway/tests/server/test_agent_filter_api.py
+++ b/src/voicegateway/tests/server/test_agent_filter_api.py
@@ -97,5 +97,3 @@ async def test_api_agents_index(gateway):
     assert by_id["agent-x"]["request_count"] == 2
     assert "p95_latency_ms" in by_id["agent-x"]
     assert "unattributed" in body
-
-

--- a/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
+++ b/src/voicegateway/tests/server/test_agents_endpoint_rollup.py
@@ -138,9 +138,7 @@ async def _insert_worker(gw: Gateway, **cols) -> None:
     keys = ", ".join(cols)
     vals = ", ".join(f":{k}" for k in cols)
     async with gw.storage._conn.session() as db:
-        await db.execute(
-            text(f"INSERT INTO workers ({keys}) VALUES ({vals})"), cols
-        )
+        await db.execute(text(f"INSERT INTO workers ({keys}) VALUES ({vals})"), cols)
         await db.commit()
 
 
@@ -194,26 +192,41 @@ async def test_list_memory_pct_null_when_no_worker(tmp_path, monkeypatch) -> Non
 async def test_list_attaches_last_seen_model_cascade(tmp_path, monkeypatch) -> None:
     gw = _gateway(tmp_path, monkeypatch)
     await _insert_obs(
-        gw, agent_id="cascade-agent", request_count=3, total_cost_usd=0.0,
-        error_count=0, last_seen=1000.0, window_start="ws", window_end="we",
+        gw,
+        agent_id="cascade-agent",
+        request_count=3,
+        total_cost_usd=0.0,
+        error_count=0,
+        last_seen=1000.0,
+        window_start="ws",
+        window_end="we",
     )
     # two llm requests: the later timestamp wins
-    for i, (mod, model, ts) in enumerate([
-        ("stt", "deepgram/nova-3", 100.0),
-        ("llm", "openai/gpt-4o-mini", 100.0),
-        ("llm", "openai/gpt-4o", 200.0),
-        ("tts", "cartesia/sonic", 100.0),
-    ]):
-        await gw.storage.log_request(RequestRecord(
-            id=f"r{i}", timestamp=ts, modality=mod, model_id=model,
-            provider=model.split("/")[0], project="default", agent_id="cascade-agent",
-        ))
+    for i, (mod, model, ts) in enumerate(
+        [
+            ("stt", "deepgram/nova-3", 100.0),
+            ("llm", "openai/gpt-4o-mini", 100.0),
+            ("llm", "openai/gpt-4o", 200.0),
+            ("tts", "cartesia/sonic", 100.0),
+        ]
+    ):
+        await gw.storage.log_request(
+            RequestRecord(
+                id=f"r{i}",
+                timestamp=ts,
+                modality=mod,
+                model_id=model,
+                provider=model.split("/")[0],
+                project="default",
+                agent_id="cascade-agent",
+            )
+        )
     async with _client(gw) as c:
         data = (await c.get("/api/agents")).json()
     entry = next(x for x in data["agents"] if x["agent_id"] == "cascade-agent")
     assert entry["models"] == {
         "stt": "deepgram/nova-3",
-        "llm": "openai/gpt-4o",   # last-seen (ts 200 > 100)
+        "llm": "openai/gpt-4o",  # last-seen (ts 200 > 100)
         "tts": "cartesia/sonic",
     }
 
@@ -251,7 +264,9 @@ async def test_list_includes_registered_worker_without_telemetry(tmp_path, monke
     assert entry["agent_name"] == "idle-bot"
 
 
-async def test_list_registered_agent_gets_status_and_fresher_last_seen(tmp_path, monkeypatch):
+async def test_list_registered_agent_gets_status_and_fresher_last_seen(
+    tmp_path, monkeypatch
+):
     gw = _gateway(tmp_path, monkeypatch)
     now = time.time()
     await _insert_obs(
@@ -290,12 +305,22 @@ async def test_list_dedups_same_agent_id_across_tenants_keeping_freshest(
     now = time.time()
     # The full-fleet read (tenant_id=None) returns both tenant rows for one id.
     await _insert_worker(
-        gw, agent_id="dup", agent_name="dup", project="default",
-        tenant_id=None, status="idle", last_seen=now - 10,
+        gw,
+        agent_id="dup",
+        agent_name="dup",
+        project="default",
+        tenant_id=None,
+        status="idle",
+        last_seen=now - 10,
     )
     await _insert_worker(
-        gw, agent_id="dup", agent_name="dup", project="default",
-        tenant_id="t1", status="busy", last_seen=now,
+        gw,
+        agent_id="dup",
+        agent_name="dup",
+        project="default",
+        tenant_id="t1",
+        status="busy",
+        last_seen=now,
     )
     async with _client(gw) as c:
         data = (await c.get("/api/agents")).json()
@@ -327,8 +352,12 @@ async def test_list_skips_offline_roster_only_worker(tmp_path, monkeypatch):
     # A registered worker gone offline (ancient heartbeat) with no telemetry:
     # read_roster derives 'offline', and it must not clutter the fleet index.
     await _insert_worker(
-        gw, agent_id="dead", agent_name="dead", project="default",
-        status="idle", last_seen=1000.0,
+        gw,
+        agent_id="dead",
+        agent_name="dead",
+        project="default",
+        status="idle",
+        last_seen=1000.0,
     )
     async with _client(gw) as c:
         data = (await c.get("/api/agents")).json()
@@ -339,21 +368,36 @@ async def test_list_includes_avg_ttfb_latency_stack(tmp_path, monkeypatch):
     gw = _gateway(tmp_path, monkeypatch)
     now = time.time()
     await _insert_obs(
-        gw, agent_id="lat-agent", request_count=4, total_cost_usd=0.0,
-        error_count=0, last_seen=now, window_start="ws", window_end="we",
+        gw,
+        agent_id="lat-agent",
+        request_count=4,
+        total_cost_usd=0.0,
+        error_count=0,
+        last_seen=now,
+        window_start="ws",
+        window_end="we",
     )
     # STT avg = 100, LLM = 200, TTS = 50 (first-byte per modality).
-    for i, (mod, model, ttfb) in enumerate([
-        ("stt", "deepgram/nova-3", 80.0),
-        ("stt", "deepgram/nova-3", 120.0),
-        ("llm", "openai/gpt-4o", 200.0),
-        ("tts", "cartesia/sonic", 50.0),
-    ]):
-        await gw.storage.log_request(RequestRecord(
-            id=f"r{i}", timestamp=now, modality=mod, model_id=model,
-            provider=model.split("/")[0], project="default", agent_id="lat-agent",
-            ttfb_ms=ttfb,
-        ))
+    for i, (mod, model, ttfb) in enumerate(
+        [
+            ("stt", "deepgram/nova-3", 80.0),
+            ("stt", "deepgram/nova-3", 120.0),
+            ("llm", "openai/gpt-4o", 200.0),
+            ("tts", "cartesia/sonic", 50.0),
+        ]
+    ):
+        await gw.storage.log_request(
+            RequestRecord(
+                id=f"r{i}",
+                timestamp=now,
+                modality=mod,
+                model_id=model,
+                provider=model.split("/")[0],
+                project="default",
+                agent_id="lat-agent",
+                ttfb_ms=ttfb,
+            )
+        )
     async with _client(gw) as c:
         data = (await c.get("/api/agents")).json()
     entry = next(x for x in data["agents"] if x["agent_id"] == "lat-agent")
@@ -366,19 +410,41 @@ async def test_list_latency_stack_is_windowed_to_24h(tmp_path, monkeypatch):
     gw = _gateway(tmp_path, monkeypatch)
     now = time.time()
     await _insert_obs(
-        gw, agent_id="win-agent", request_count=2, total_cost_usd=0.0,
-        error_count=0, last_seen=now, window_start="ws", window_end="we",
+        gw,
+        agent_id="win-agent",
+        request_count=2,
+        total_cost_usd=0.0,
+        error_count=0,
+        last_seen=now,
+        window_start="ws",
+        window_end="we",
     )
     # An ancient STT call (26h ago) must not drag the average; only the recent
     # one counts.
-    await gw.storage.log_request(RequestRecord(
-        id="old", timestamp=now - 93600, modality="stt", model_id="deepgram/nova-3",
-        provider="deepgram", project="default", agent_id="win-agent", ttfb_ms=999.0,
-    ))
-    await gw.storage.log_request(RequestRecord(
-        id="new", timestamp=now, modality="stt", model_id="deepgram/nova-3",
-        provider="deepgram", project="default", agent_id="win-agent", ttfb_ms=100.0,
-    ))
+    await gw.storage.log_request(
+        RequestRecord(
+            id="old",
+            timestamp=now - 93600,
+            modality="stt",
+            model_id="deepgram/nova-3",
+            provider="deepgram",
+            project="default",
+            agent_id="win-agent",
+            ttfb_ms=999.0,
+        )
+    )
+    await gw.storage.log_request(
+        RequestRecord(
+            id="new",
+            timestamp=now,
+            modality="stt",
+            model_id="deepgram/nova-3",
+            provider="deepgram",
+            project="default",
+            agent_id="win-agent",
+            ttfb_ms=100.0,
+        )
+    )
     async with _client(gw) as c:
         data = (await c.get("/api/agents")).json()
     entry = next(x for x in data["agents"] if x["agent_id"] == "win-agent")
@@ -389,8 +455,12 @@ async def test_list_latency_stack_null_for_roster_only_worker(tmp_path, monkeypa
     gw = _gateway(tmp_path, monkeypatch)
     now = time.time()
     await _insert_worker(
-        gw, agent_id="idle-lat", agent_name="idle-lat", project="default",
-        status="idle", last_seen=now,
+        gw,
+        agent_id="idle-lat",
+        agent_name="idle-lat",
+        project="default",
+        status="idle",
+        last_seen=now,
     )
     async with _client(gw) as c:
         data = (await c.get("/api/agents")).json()
@@ -403,8 +473,12 @@ async def test_list_q_filter_covers_roster_only_workers(tmp_path, monkeypatch):
     now = time.time()
     for name in ("alpha", "beta"):
         await _insert_worker(
-            gw, agent_id=name, agent_name=name, project="default",
-            status="idle", last_seen=now,
+            gw,
+            agent_id=name,
+            agent_name=name,
+            project="default",
+            status="idle",
+            last_seen=now,
         )
     async with _client(gw) as c:
         data = (await c.get("/api/agents?q=alph")).json()

--- a/src/voicegateway/tests/server/test_agents_memory.py
+++ b/src/voicegateway/tests/server/test_agents_memory.py
@@ -30,16 +30,26 @@ def gateway(tmp_path, monkeypatch):
 async def test_roster_returns_memory_and_pct(gateway):
     await gateway.storage._ensure_initialized()
     presence = {
-        "agent_id": "a1", "agent_name": "bot", "project": "default",
-        "tenant_id": None, "region": None, "version": "0", "host": "h",
-        "active_sessions": 0, "status": "idle", "started_at": 1000.0,
-        "memory_rss_bytes": 268_435_456, "memory_total_bytes": 536_870_912,
+        "agent_id": "a1",
+        "agent_name": "bot",
+        "project": "default",
+        "tenant_id": None,
+        "region": None,
+        "version": "0",
+        "host": "h",
+        "active_sessions": 0,
+        "status": "idle",
+        "started_at": 1000.0,
+        "memory_rss_bytes": 268_435_456,
+        "memory_total_bytes": 536_870_912,
         "ts": 9_999_999_999.0,
     }
     async with gateway.storage._conn.session() as db:
         await repo.upsert_heartbeat(db, presence)
 
-    client = AsyncClient(transport=ASGITransport(app=build_app(gateway)), base_url="http://t")
+    client = AsyncClient(
+        transport=ASGITransport(app=build_app(gateway)), base_url="http://t"
+    )
     async with client as c:
         resp = await c.get("/v1/agents")
     assert resp.status_code == 200

--- a/src/voicegateway/tests/server/test_billing_api.py
+++ b/src/voicegateway/tests/server/test_billing_api.py
@@ -154,6 +154,7 @@ async def test_rate_card_models_lists_price_and_override(gateway) -> None:
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
         from voicegateway.repository import request_log_repository as rlr
+
         await rlr.log_request(
             db,
             RequestRecord(

--- a/src/voicegateway/tests/server/test_call_observations_endpoint.py
+++ b/src/voicegateway/tests/server/test_call_observations_endpoint.py
@@ -291,9 +291,7 @@ async def test_kill_switch_disables_the_whole_path(gateway, monkeypatch):
     assert await _calls(gateway) == []
 
 
-async def test_kill_switch_set_to_a_falsy_word_leaves_the_path_on(
-    gateway, monkeypatch
-):
+async def test_kill_switch_set_to_a_falsy_word_leaves_the_path_on(gateway, monkeypatch):
     monkeypatch.setenv("VG_DISABLE_CALL_OBSERVATIONS", "0")
 
     resp = await _post(gateway, _observation())
@@ -327,9 +325,7 @@ async def test_auth_is_required_when_api_keys_are_configured(tmp_path, monkeypat
     ).status_code == 401
     assert await _calls(gw) == []
 
-    ok = await _post(
-        gw, _observation(), {"Authorization": "Bearer sk-configured"}
-    )
+    ok = await _post(gw, _observation(), {"Authorization": "Bearer sk-configured"})
     assert ok.status_code == 202
     await _await_flushed(1)
     assert len(await _calls(gw)) == 1
@@ -341,9 +337,7 @@ async def test_a_key_without_the_write_scope_is_refused(tmp_path, monkeypatch):
         tmp_path,
         {
             "auth": {
-                "api_keys": [
-                    {"name": "reader", "token": "sk-read", "scopes": ["read"]}
-                ]
+                "api_keys": [{"name": "reader", "token": "sk-read", "scopes": ["read"]}]
             }
         },
     )

--- a/src/voicegateway/tests/server/test_calls_endpoint.py
+++ b/src/voicegateway/tests/server/test_calls_endpoint.py
@@ -259,9 +259,7 @@ async def test_unobserved_fields_stay_null(client, gateway):
     call_id = await gateway.storage.upsert_call(
         origin="loadgen", attempt_id="attempt-1"
     )
-    await gateway.storage.upsert_call_leg(
-        call_id=call_id, participant_sid="PA_bare"
-    )
+    await gateway.storage.upsert_call_leg(call_id=call_id, participant_sid="PA_bare")
 
     (call,) = (await client.get(_URL)).json()["calls"]
 
@@ -466,7 +464,7 @@ async def test_a_key_with_no_tenant_reads_the_unattributed_bucket(client, gatewa
 
 
 async def test_storage_disabled_returns_503_not_an_empty_list(tmp_path, monkeypatch):
-    """"No call has been recorded" and "this deployment records nothing" are
+    """ "No call has been recorded" and "this deployment records nothing" are
     different facts."""
     monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
     config = _write_config(tmp_path, {"cost_tracking": {"enabled": False}})

--- a/src/voicegateway/tests/server/test_correlation_endpoint.py
+++ b/src/voicegateway/tests/server/test_correlation_endpoint.py
@@ -299,7 +299,7 @@ async def test_a_tenant_key_is_refused_rather_than_shown_the_whole_deployment(
 
 
 async def test_storage_disabled_returns_503_not_an_unknown_rate(tmp_path, monkeypatch):
-    """"Nothing has correlated yet" and "this deployment records nothing" are
+    """ "Nothing has correlated yet" and "this deployment records nothing" are
     different facts."""
     monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
     config = _write_config(tmp_path, {"cost_tracking": {"enabled": False}})

--- a/src/voicegateway/tests/server/test_dashboard_api_keys.py
+++ b/src/voicegateway/tests/server/test_dashboard_api_keys.py
@@ -107,9 +107,7 @@ def test_list_api_keys_filters_revoked_when_include_revoked_false(client) -> Non
     client.post(f"/api/api_keys/{created_id}/revoke")
 
     with_revoked = client.get("/api/api_keys?include_revoked=true").json()["keys"]
-    without_revoked = client.get("/api/api_keys?include_revoked=false").json()[
-        "keys"
-    ]
+    without_revoked = client.get("/api/api_keys?include_revoked=false").json()["keys"]
 
     assert any(k["id"] == created_id for k in with_revoked)
     assert all(k["id"] != created_id for k in without_revoked)

--- a/src/voicegateway/tests/server/test_ingest_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_endpoint.py
@@ -57,9 +57,7 @@ def _payload(rid: str, agent_id: str = "agent-1") -> dict:
 async def test_ingest_accepts_batch_and_stamps_tenant(gateway):
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(
-            db, name="bot", tenant_id="acme"
-        )
+        created = await api_keys.create_api_key(db, name="bot", tenant_id="acme")
 
     client = await _client(gateway)
     async with client as c:

--- a/src/voicegateway/tests/server/test_livekit_webhook_burst.py
+++ b/src/voicegateway/tests/server/test_livekit_webhook_burst.py
@@ -254,7 +254,9 @@ async def test_dashboard_reads_survive_a_concurrent_burst(gateway):
         stop.set()
         await reader
 
-    _report(f"dashboard reads during a {len(burst)}-event burst", read_latencies_ms, wall_s)
+    _report(
+        f"dashboard reads during a {len(burst)}-event burst", read_latencies_ms, wall_s
+    )
 
     assert read_statuses == {200}
     # The loop was never starved: reads kept completing throughout the burst.

--- a/src/voicegateway/tests/server/test_livekit_webhook_endpoint.py
+++ b/src/voicegateway/tests/server/test_livekit_webhook_endpoint.py
@@ -101,7 +101,9 @@ async def _send(gw: Gateway, event: WebhookEvent):
     return await _post(gw, body, _sign(body))
 
 
-def _room(sid: str = "RM_test", name: str = "call-1", created_ms: int = 1_800_000_000_000):
+def _room(
+    sid: str = "RM_test", name: str = "call-1", created_ms: int = 1_800_000_000_000
+):
     return lkm.Room(sid=sid, name=name, creation_time_ms=created_ms)
 
 
@@ -137,7 +139,9 @@ async def _calls(gw: Gateway) -> list[dict]:
 
 async def test_request_with_no_signature_is_rejected_and_writes_nothing(gateway):
     """No Authorization header at all: the public internet gets nothing."""
-    resp = await _post(gateway, _body(WebhookEvent(event="room_started", room=_room())), None)
+    resp = await _post(
+        gateway, _body(WebhookEvent(event="room_started", room=_room())), None
+    )
 
     assert resp.status_code == 401
     assert await _calls(gateway) == []
@@ -214,7 +218,9 @@ async def test_rejection_does_not_echo_the_body_or_the_reason(gateway):
     assert "hash" not in resp.text.lower()
 
 
-async def test_credentials_from_the_config_file_verify(tmp_path, monkeypatch, no_livekit_env):
+async def test_credentials_from_the_config_file_verify(
+    tmp_path, monkeypatch, no_livekit_env
+):
     """An operator who configured LiveKit in voicegw.yaml, not the env.
 
     ``VOICEGW_CONFIG`` is how the daemon publishes the config it was served
@@ -222,7 +228,8 @@ async def test_credentials_from_the_config_file_verify(tmp_path, monkeypatch, no
     """
     monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "webhook-yaml.db"))
     config = _write_config(
-        tmp_path, {"livekit": {"url": "wss://x", "api_key": _KEY, "api_secret": _SECRET}}
+        tmp_path,
+        {"livekit": {"url": "wss://x", "api_key": _KEY, "api_secret": _SECRET}},
     )
     monkeypatch.setenv("VOICEGW_CONFIG", config)
     gw = Gateway(config_path=config)

--- a/src/voicegateway/tests/server/test_metrics_diag_gates.py
+++ b/src/voicegateway/tests/server/test_metrics_diag_gates.py
@@ -49,9 +49,7 @@ async def _seed_run(
 ) -> None:
     """Store one diagnostics run exactly as the dashboard endpoint stores it."""
     results = (
-        None
-        if gates is None
-        else {"checks": {}, "gates": gates, "verdict": verdict}
+        None if gates is None else {"checks": {}, "gates": gates, "verdict": verdict}
     )
     await gateway.storage.upsert_diagnostics_run(
         run_id=run_id,
@@ -151,8 +149,12 @@ async def test_repeated_gate_ids_are_counted_not_duplicated(client, gateway) -> 
     )
     text = (await client.get("/v1/metrics")).text
 
-    assert 'voicegw_diag_gate_status{gate="agent_reply_latency",status="PASS"} 2' in text
-    assert 'voicegw_diag_gate_status{gate="agent_reply_latency",status="WARN"} 1' in text
+    assert (
+        'voicegw_diag_gate_status{gate="agent_reply_latency",status="PASS"} 2' in text
+    )
+    assert (
+        'voicegw_diag_gate_status{gate="agent_reply_latency",status="WARN"} 1' in text
+    )
 
     lines = _diag_lines(text)
     label_sets = [ln.rsplit(" ", 1)[0] for ln in lines]

--- a/src/voicegateway/tests/server/test_nodes_endpoint.py
+++ b/src/voicegateway/tests/server/test_nodes_endpoint.py
@@ -326,7 +326,9 @@ async def test_an_unmeasured_series_is_null_and_says_so_never_zero(client, gatew
         filefd_allocated=1_024.0,
     )
 
-    node = (await client.get(_URL)).json()["calls"][0]["correlation"]["nodes_sampled"][0]
+    node = (await client.get(_URL)).json()["calls"][0]["correlation"]["nodes_sampled"][
+        0
+    ]
 
     assert node["gauges"]["load1"]["latest"] == pytest.approx(0.75)
     assert node["gauges"]["rooms"]["samples"] == 0
@@ -513,7 +515,10 @@ async def test_an_empty_node_samples_table_is_not_an_error(client, gateway):
     """The state every operator starts in, and the one before the scrape worker
     is wired or a target is configured."""
     await _call(
-        gateway.storage, attempt_id="fresh", started_at_ms=_T0, ended_at_ms=_T0 + _MINUTE
+        gateway.storage,
+        attempt_id="fresh",
+        started_at_ms=_T0,
+        ended_at_ms=_T0 + _MINUTE,
     )
 
     resp = await client.get(_URL)
@@ -525,9 +530,7 @@ async def test_an_empty_node_samples_table_is_not_an_error(client, gateway):
     assert body["calls"][0]["correlation"]["nodes_sampled"] == []
 
 
-async def test_the_stored_row_count_separates_unscraped_from_unsampled(
-    client, gateway
-):
+async def test_the_stored_row_count_separates_unscraped_from_unsampled(client, gateway):
     """`no_samples` on one window does not say whether anything is scraped at
     all, so the row count is published beside it."""
     await _call(
@@ -612,7 +615,7 @@ async def test_a_tenant_key_is_refused_rather_than_shown_the_whole_fleet(
 async def test_storage_disabled_returns_503_not_an_empty_correlation(
     tmp_path, monkeypatch
 ):
-    """"Nothing was scraped" and "this deployment records nothing" are different
+    """ "Nothing was scraped" and "this deployment records nothing" are different
     facts."""
     monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
     config = _write_config(tmp_path, {"cost_tracking": {"enabled": False}})

--- a/src/voicegateway/tests/server/test_server_api.py
+++ b/src/voicegateway/tests/server/test_server_api.py
@@ -221,7 +221,11 @@ async def test_overview_rooms_grouped_and_cost_annotated(client, gateway, monkey
                 {"timestamp": now, "cost_usd": 0.01, "total_latency_ms": 100.0},
                 {"timestamp": now, "cost_usd": 0.02, "total_latency_ms": 300.0},
                 # A stale row outside the 24h window: the SQL `since` bound drops it.
-                {"timestamp": now - 200_000, "cost_usd": 5.0, "total_latency_ms": 900.0},
+                {
+                    "timestamp": now - 200_000,
+                    "cost_usd": 5.0,
+                    "total_latency_ms": 900.0,
+                },
             ]
         }.get(room, [])
         # Mirror the repository's `since` semantics so this test exercises that

--- a/src/voicegateway/tests/services/test_retention_calls.py
+++ b/src/voicegateway/tests/services/test_retention_calls.py
@@ -397,7 +397,9 @@ async def _request_session_id(storage, request_id: str) -> str | None:
 
 
 async def test_pruned_session_nulls_the_request_pointer(storage) -> None:
-    await _seed_session(storage, "s-req-doomed", "acme", call_id=None, ended_days_ago=10)
+    await _seed_session(
+        storage, "s-req-doomed", "acme", call_id=None, ended_days_ago=10
+    )
     await _seed_request(storage, "r-keeps", "acme", session_id="s-req-doomed")
 
     await RetentionWorker(storage, retention_provider=_provider("acme", 5)).tick_now()
@@ -426,7 +428,9 @@ async def test_other_sessions_projects_and_tenants_keep_their_pointers(storage) 
 
     await _seed_request(storage, "r-doomed", "acme", session_id="s-doomed", tenant="t1")
     await _seed_request(storage, "r-alive", "acme", session_id="s-alive", tenant="t2")
-    await _seed_request(storage, "r-foreign", "other", session_id="s-foreign", tenant="t3")
+    await _seed_request(
+        storage, "r-foreign", "other", session_id="s-foreign", tenant="t3"
+    )
     await _seed_request(storage, "r-none", "acme", session_id=None, tenant="t2")
     # A request in another project (and another tenant) pointing at the doomed
     # session: the row itself is out of this tick's scope and must survive, but

--- a/src/voicegateway/tests/storage/test_migration_agent_probe_results.py
+++ b/src/voicegateway/tests/storage/test_migration_agent_probe_results.py
@@ -56,7 +56,9 @@ async def test_migration_creates_agent_probe_results(tmp_path: Path) -> None:
             f"agent_probe_results.result_json is {cols['result_json'][0]}; the "
             "migration declares sa.Text() and the model must agree"
         )
-        assert cols["result_json"][1] == 1, "a cached row without a payload is not a cache hit"
+        assert cols["result_json"][1] == 1, (
+            "a cached row without a payload is not a cache hit"
+        )
         # Epoch seconds the probe ran, so the UI can say "measured Ns ago". A row
         # with no timestamp could not be aged, so it is NOT NULL.
         assert cols["created_at"][0] == "FLOAT"

--- a/src/voicegateway/tests/storage/test_migration_calls.py
+++ b/src/voicegateway/tests/storage/test_migration_calls.py
@@ -127,9 +127,7 @@ async def test_migration_matches_the_model(tmp_path: Path, table: str) -> None:
     db, migrated = await _migrated_engine(tmp_path)
     declared = create_engine(f"sqlite:///{tmp_path / 'declared.db'}")
     try:
-        SQLModel.metadata.create_all(
-            declared, tables=[SQLModel.metadata.tables[table]]
-        )
+        SQLModel.metadata.create_all(declared, tables=[SQLModel.metadata.tables[table]])
         assert _columns(migrated, table) == _columns(declared, table)
     finally:
         declared.dispose()

--- a/src/voicegateway/tests/storage/test_migration_diagnostics_runs.py
+++ b/src/voicegateway/tests/storage/test_migration_diagnostics_runs.py
@@ -55,7 +55,9 @@ async def test_migration_creates_diagnostics_runs(tmp_path: Path) -> None:
                 f"diagnostics_runs.{column} is {cols[column][0]}; it must stay a "
                 "string so the payload is not re-derived through epoch time"
             )
-        assert cols["created_at"][1] == 1, "created_at must be NOT NULL: every run has an age"
+        assert cols["created_at"][1] == 1, (
+            "created_at must be NOT NULL: every run has an age"
+        )
         assert cols["started_at"][1] == 0, "a queued run has not started"
         assert cols["ended_at"][1] == 0, "a running run has not ended"
         # NULL results means "nothing was recorded", not "{}".

--- a/src/voicegateway/tests/test_framework_neutral.py
+++ b/src/voicegateway/tests/test_framework_neutral.py
@@ -151,5 +151,3 @@ def test_require_extra_missing_raises_with_hint() -> None:
         assert "pip install voicegateway[definitely_not_a_framework]" in str(exc)
     else:  # pragma: no cover - require_extra must raise for a missing extra
         raise AssertionError("require_extra did not raise for a missing extra")
-
-

--- a/src/voicegateway/tests/test_schema_guards.py
+++ b/src/voicegateway/tests/test_schema_guards.py
@@ -47,7 +47,11 @@ def _table_backed_classes(path: Path) -> list[str]:
         if not isinstance(node, ast.ClassDef):
             continue
         for kw in node.keywords:
-            if kw.arg == "table" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+            if (
+                kw.arg == "table"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+            ):
                 found.append(node.name)
     return found
 


### PR DESCRIPTION
VoiceGateway is a profiler. Its report opened with a verdict, stamped PASS or FAIL on every row and exited non-zero, because that is what a client engagement asked for. A developer reading their own fleet did not sign that contract and is not served by a FAIL across their run.

Two views over **one** set of measurements, never two derivations. The default profiles. `--acceptance` adds the verdict, the gate table and the exit code.

| | default | `--acceptance` |
|---|---|---|
| Verdict block | no | yes |
| Status tags | no | yes |
| Gate table | no | yes |
| Reference bands | 36 | 0 |
| Exit code on a failing run | **0** | **1** |
| JSON payload | identical | identical |

## What cannot be measured is absent, not reported as unknown

Nobody publishes a per-instance-type PPS allowance, so PPS headroom has no denominator. A row saying "unknown" for it is noise in a section a reader scans for things to fix, so it is dropped entirely.

The pps allowance **counter** is still measured and still named in the allowance row. That is the distinction that makes the deletion honest rather than lossy: deleting the word everywhere would have lost a real measurement.

## What is measurable but was not collected is still named

With what to change so the next run carries it. On the real seven-step run, **46 of the 47 UNKNOWN rows were this**, not a limit of the tool. Rendering them blank would say there was nothing to report, which is a worse lie than a verdict.

Grouped by cause: nothing configured to answer it, the series was wired after the run, the window carried too few samples.

## The reference band never becomes a verdict

CSS only, no SVG and no image, because three suites scan the output for those markers and a chart library is what somebody reaches for the first time a bar is wanted.

**The fill is one neutral colour on both sides of the tick.** Colouring a bar by which side of a line it lands on is a verdict wearing a chart's clothes, in the one view that exists to stop doing that.

A band is drawn only where the full scale is real: a 0..1 ratio against the limit the fraction was taken against. Counts have no maximum, and `return_to_baseline` is a multiple of a baseline that runs past 1 by design, so both get the figure and no bar. Scaling those against `max(value, threshold) * 1.25` would give the fill a width meaning "some share of a number nobody measured".

## Blast radius kept small on purpose

`render_load_html` and `build_load_payload` are **untouched**, so every test pinning the acceptance view still pins it. Eight test files now request `--acceptance` because they assert on the verdict, the gate rows or the exit code.

One design note worth a reviewer's eye: the profile renderer does **not** import `judge`, because that would close a package loop (`livekit_diag` to `loadtest` to `livekit_diag.gates`). It names the permanently-unmeasurable set from the shared `gates.HEADROOM_PPS` constant instead, and a test asserts equality with `judge.PERMANENT_HEADROOM_EXCLUSIONS` so the two cannot drift.

## Gates

`backend`: ruff clean, mypy clean on 283 files, **3188 passed**, 13 skipped (3163 before, +25 new). `docs`: PASS, 90 pages. No migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a non-judgmental load-test profile report showing measurement counts, missing data, resource classifications, and neutral reference bands.
  * Added an optional acceptance mode that displays verdicts and returns failure exit codes for non-passing results.
  * Profile and acceptance reports now use distinct filenames and HTML presentations while sharing the same JSON data.

* **Tests**
  * Expanded coverage for report contents, classifications, output formats, filenames, and acceptance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->