### PR TITLE
Read each half of the lifecycle pair from the source that has it

### DIFF
--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -174,6 +174,24 @@ BASELINE_GOROUTINES = "go_goroutines"
 # post-settle sample and this module refuses to read it as one.
 MIN_SETTLE_MS = 300_000
 
+# The smallest baseline a RATIO may be taken against.
+#
+# Observed: monitor-0 finished a run with sockstat_udp_inuse at 7 against an idle
+# baseline of 3 and was reported FAIL at 2.33x, outside the 1.10x tolerance. That
+# is four sockets on the box running the collector, which carried no test load at
+# all. Nothing leaked; the denominator was simply too small for a ratio to mean
+# anything, and at a baseline of 3 the smallest possible movement is already
+# 1.33x.
+#
+# This is the same defect MIN_TREND_DRIFT_FRACTION exists to prevent one gate
+# over, and it is expressed differently for a reason. A trend has a magnitude
+# floor because its metrics share no scale. Here the metrics are all COUNTS or
+# BYTES that only ever grow from a floor of zero, so the honest guard is on the
+# denominator: below this, report that the comparison could not be made rather
+# than inventing a multiple. memory_used_bytes and filefd_allocated clear it by
+# orders of magnitude on any real host; an idle UDP socket count does not.
+MIN_BASELINE_FOR_RATIO = 32
+
 # The share of call attempts that must establish. Inclusive: a run landing
 # exactly on the bar passes. This is an acceptance threshold, not a tuning knob,
 # which is why it lives beside the gate ids rather than in a config file.
@@ -1303,6 +1321,20 @@ def _return_to_baseline_gate(
             ),
             threshold=tolerance,
         )
+    if c.baseline < MIN_BASELINE_FOR_RATIO:
+        return GateResult(
+            gate=RETURN_TO_BASELINE_GATE,
+            status=UNKNOWN,
+            subject=subject,
+            detail=(
+                f"the {c.metric} baseline on {c.node} is {c.baseline:g}, below "
+                f"{MIN_BASELINE_FOR_RATIO}, so a ratio against it is arithmetic "
+                f"rather than evidence: it settled at {c.post_settle:g}, and at "
+                "this baseline the smallest possible movement already exceeds "
+                "the tolerance"
+            ),
+            threshold=tolerance,
+        )
     if c.baseline_at_ms is not None and c.post_settle_at_ms is not None:
         settled_ms = c.post_settle_at_ms - c.baseline_at_ms
         if settled_ms < min_settle_ms:
@@ -1488,7 +1520,6 @@ def summary_lines(gates: Sequence[GateResult]) -> list[str]:
     return [f"  [{g.status}] {g.gate}: {g.detail}" for g in gates]
 
 
-
 # --------------------------------------------------------------------------
 # Sustained Redis and health-check failures
 # --------------------------------------------------------------------------
@@ -1627,9 +1658,7 @@ def sustained_health_gate(
     return GateResult(
         gate=SUSTAINED_HEALTH_GATE,
         status=PASS,
-        detail=(
-            f"{subject} was healthy on all {len(measured)} measured sample(s)."
-        ),
+        detail=(f"{subject} was healthy on all {len(measured)} measured sample(s)."),
         subject=subject,
         metric="consecutive_failed_samples",
         value=0.0,
@@ -1668,7 +1697,6 @@ def sustained_health_gates(
 ) -> list[GateResult]:
     """One gate per node per source. Per-node rows are never collapsed."""
     return [sustained_health_gate(r, threshold=threshold) for r in readings]
-
 
 
 # --------------------------------------------------------------------------
@@ -2251,6 +2279,7 @@ __all__ = [
     "MIN_HEADROOM_FRACTION",
     "ALL_GATES",
     "MIN_PERCENTILE_SAMPLES",
+    "MIN_BASELINE_FOR_RATIO",
     "MIN_SETTLE_MS",
     "NODE_CPU_GATE",
     "NODE_MEMORY_GATE",

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -61,6 +61,9 @@ from voicegateway.livekit_diag.gates import (
     NodeUtilisationReading,
     TrendReading,
 )
+from voicegateway.middleware.node_samples_worker_middleware import (
+    SOURCE_NODE_EXPORTER,
+)
 from voicegateway.repository.node_correlation_repository import (
     DEFAULT_WINDOW_PAD_MS,
     NodeWindow,
@@ -297,7 +300,31 @@ BASELINE_METRICS: tuple[str, ...] = (
 async def _lifecycle_reading(
     db: AsyncSession, *, node: str, source: str, window: NodeWindow, limit: int
 ) -> LifecycleReading:
-    """Process start times and OOM counter for one subject, in time order."""
+    """Process start times and OOM counter for one subject, in time order.
+
+    The two halves come from DIFFERENT sources on purpose.
+
+    ``process_start_time_seconds`` is per-process, so it must come from the
+    subject's own exporter: livekit-sip's start time is the only thing that says
+    whether livekit-sip restarted.
+
+    ``node_vmstat_oom_kill`` is a KERNEL counter for the whole box. Only
+    node_exporter publishes it, and livekit-sip and livekit-server never will,
+    because it is not theirs to report. Reading it from the subject's own rows
+    therefore left every livekit subject reporting "did not restart but carried
+    no node_vmstat_oom_kill, so an OOM kill could not be ruled out" forever, and
+    no scrape configuration could ever have fixed it.
+
+    That was wrong on its own terms as well as noisy. An OOM kill on the host is
+    a fact ABOUT THE HOST: if the kernel killed something while livekit-sip was
+    running there, that is evidence bearing on livekit-sip's run whether or not
+    livekit-sip was the victim, which is exactly why the gate keeps the two
+    signals separate instead of treating "no restart" as "no OOM".
+
+    So the OOM series is read from the node's node_exporter rows, for every
+    subject on that node. When the node has no node_exporter in the scrape set
+    the tuple stays empty and the gate reports it unmeasured, as before.
+    """
     rows = await list_samples(
         db,
         node=node,
@@ -306,11 +333,22 @@ async def _lifecycle_reading(
         until_ms=window.end_ms,
         limit=limit,
     )
+    if source == SOURCE_NODE_EXPORTER:
+        oom_rows = rows
+    else:
+        oom_rows = await list_samples(
+            db,
+            node=node,
+            source=SOURCE_NODE_EXPORTER,
+            since_ms=window.start_ms,
+            until_ms=window.end_ms,
+            limit=limit,
+        )
     return LifecycleReading(
         node=node,
         source=source,
         start_times=tuple(row.process_start_time_seconds for row in rows),
-        oom_kills=tuple(row.vmstat_oom_kill for row in rows),
+        oom_kills=tuple(row.vmstat_oom_kill for row in oom_rows),
     )
 
 
@@ -362,6 +400,7 @@ async def _baseline_comparisons(
     after = await list_samples(
         db, node=node, source=source, since_ms=window.end_ms + 1, limit=limit
     )
+
     def _value(row, metric: str) -> float | None:
         # Derived, because there is no memory_used_bytes column and the raw
         # available figure runs the wrong way for this gate.
@@ -467,9 +506,7 @@ async def _rtp_port_reading(
     if not used and not totals:
         return None
     if not used or not totals:
-        missing = (
-            MEDIA_PORTS_TOTAL_COLUMN if not totals else MEDIA_PORTS_USED_COLUMN
-        )
+        missing = MEDIA_PORTS_TOTAL_COLUMN if not totals else MEDIA_PORTS_USED_COLUMN
         return HeadroomReading(
             node=node,
             source=source,
@@ -515,9 +552,7 @@ async def _allowance_reading(
     )
     deltas: dict[str, float | None] = {}
     for column, field_name in ALLOWANCE_COLUMNS:
-        seen = [
-            float(v) for row in rows if (v := getattr(row, column)) is not None
-        ]
+        seen = [float(v) for row in rows if (v := getattr(row, column)) is not None]
         deltas[field_name] = seen[-1] - seen[0] if len(seen) >= 2 else None
     if all(v is None for v in deltas.values()):
         return None

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -42,7 +42,7 @@ Every wired entry has since been read off a running binary. **Nothing in
 map degrades is one plausible entry added from documentation.
 
 MEASURED against livekit-sip 1.10.1 and node_exporter, with a real inbound call
-placed so every counter was populated: all 22 ``livekit-sip`` entries and all 21
+placed so every counter was populated: all 22 ``livekit-sip`` entries and all 22
 ``node-exporter`` entries. Every one resolves, asserted per entry against a
 captured exposition and again in
 ``tests/integration/test_live_node_scrape.py`` against the running exporters.
@@ -483,8 +483,33 @@ SERIES: Final[dict[str, tuple[_Series, ...]]] = {
         # prove "no OOM": the kernel can kill a sibling or a child without the
         # scraped service restarting.
         _Series("node_vmstat_oom_kill", "vmstat_oom_kill"),
+        # node_exporter's OWN start time, and deliberately so. Read off a live
+        # prom/node-exporter at 1.78577024616e+09.
+        #
+        # Without it this source carried only half of what the lifecycle gate
+        # needs: the OOM counter but no way to tell whether the process
+        # restarted. Every node-exporter subject therefore reported "recorded no
+        # OOM kill but carried no process_start_time_seconds, so a restart could
+        # not be ruled out", which on an eight-host fleet was 16 UNKNOWN rows in
+        # a run where nothing had gone wrong.
+        #
+        # A node-exporter restart is worth gating in its own right rather than as
+        # a proxy for anything else: while it is down, nothing about that host is
+        # scraped, so a restart is a hole in every other measurement taken from
+        # it.
+        _Series("process_start_time_seconds", "process_start_time_seconds"),
     ),
     SOURCE_REDIS_EXPORTER: (
+        # NOT WIRED HERE, deliberately: process_start_time_seconds. The live
+        # exporter does publish it (read at 1.7857702462e+09) and wiring it would
+        # silence this subject's lifecycle UNKNOWN, which is exactly why it is
+        # tempting and exactly why it is wrong. That timestamp is the SIDECAR's
+        # start time. Redis here is ElastiCache: its process is invisible to us,
+        # so "did Redis restart" is not measurable from anything in the scrape
+        # set, and answering a question about Redis with a fact about the
+        # exporter is the same category error this file's docstring already pins
+        # for process_open_fds. The UNKNOWN is the honest state.
+        #
         # Redis is shared state every SIP node depends on, and the acceptance
         # criterion asks whether it stayed healthy for the whole window.
         #

--- a/src/voicegateway/tests/livekit_diag/test_gates.py
+++ b/src/voicegateway/tests/livekit_diag/test_gates.py
@@ -1354,3 +1354,55 @@ def test_the_report_renders_waived_distinctly_from_unknown():
     assert gates.WAIVED in run_report._VERDICT_MEANING
     assert "NOT a pass" in run_report._VERDICT_MEANING[gates.WAIVED]
     assert ".tag.waived" in run_report._CSS if hasattr(run_report, "_CSS") else True
+
+
+# ---------------------------------------------------------------------------
+# return_to_baseline: a ratio needs a denominator worth dividing by
+# ---------------------------------------------------------------------------
+
+
+def _settled_cmp(metric: str, baseline: float, post: float):
+    """A comparison whose post sample is well outside the settle window.
+
+    Named apart from the _cmp above rather than reusing it: that helper leaves
+    the timestamps unset, and these cases must reach the ratio arithmetic
+    instead of stopping at the settle-window guard.
+    """
+    return gates.BaselineComparison(
+        node="monitor-0",
+        metric=metric,
+        baseline=baseline,
+        post_settle=post,
+        baseline_at_ms=0,
+        post_settle_at_ms=gates.MIN_SETTLE_MS * 2,
+    )
+
+
+def test_a_tiny_baseline_is_unknown_not_a_failure() -> None:
+    """Observed: monitor-0 finished at 7 UDP sockets against an idle 3.
+
+    Reported FAIL at 2.33x on the box running the collector, which carried no
+    test load at all. Four sockets is not a leak; the denominator was too small
+    for a ratio to carry meaning, and at a baseline of 3 the smallest possible
+    movement already exceeds the 1.10x tolerance.
+    """
+    result = gates.return_to_baseline_gates(
+        [_settled_cmp("sockstat_udp_inuse", 3, 7)], tolerance=1.10
+    )[0]
+    assert result.status == gates.UNKNOWN
+    assert "below" in result.detail
+
+
+def test_a_real_denominator_still_fails_when_it_should() -> None:
+    """The guard must not become a way to pass a genuine leak."""
+    result = gates.return_to_baseline_gates(
+        [_settled_cmp("filefd_allocated", 4096, 40960)], tolerance=1.10
+    )[0]
+    assert result.status == gates.FAIL
+
+
+def test_a_real_denominator_still_passes_when_it_should() -> None:
+    result = gates.return_to_baseline_gates(
+        [_settled_cmp("filefd_allocated", 4096, 4100)], tolerance=1.10
+    )[0]
+    assert result.status == gates.PASS

--- a/src/voicegateway/tests/loadtest/test_lifecycle_series_wiring.py
+++ b/src/voicegateway/tests/loadtest/test_lifecycle_series_wiring.py
@@ -1,0 +1,121 @@
+"""Where each half of the lifecycle pair comes from, and why it is not one source.
+
+A real eight-host fleet run produced 26 UNKNOWN lifecycle rows on a deployment
+where nothing had gone wrong. Every one traced to the same shape: the two series
+the gate needs were wired to COMPLEMENTARY sources, so each subject was missing
+exactly the half the other had.
+
+* ``node-exporter`` carried ``node_vmstat_oom_kill`` and no
+  ``process_start_time_seconds``, so all 16 node-exporter subjects reported that
+  a restart could not be ruled out.
+* ``livekit-sip`` and ``livekit-server`` carried ``process_start_time_seconds``
+  and no OOM counter, so all 8 reported that an OOM kill could not be ruled out.
+
+The second half is not a scrape-configuration mistake and no amount of
+configuring would have fixed it: ``node_vmstat_oom_kill`` is a KERNEL counter
+for the whole box, only node_exporter publishes it, and livekit-sip never will
+because it is not livekit-sip's to report.
+"""
+
+from __future__ import annotations
+
+from voicegateway.livekit_diag import gates
+from voicegateway.middleware.node_samples_worker_middleware import (
+    SERIES,
+    SOURCE_LIVEKIT_SERVER,
+    SOURCE_LIVEKIT_SIP,
+    SOURCE_NODE_EXPORTER,
+    SOURCE_REDIS_EXPORTER,
+    columns_for,
+)
+
+# --------------------------------------------------------------------------
+# The map
+# --------------------------------------------------------------------------
+
+
+def test_node_exporter_carries_its_own_start_time() -> None:
+    """Read off a live prom/node-exporter at 1.78577024616e+09.
+
+    A node-exporter restart is worth gating in its own right: while it is down
+    nothing about that host is scraped, so the restart is a hole in every other
+    measurement taken from it.
+    """
+    assert "process_start_time_seconds" in columns_for(SOURCE_NODE_EXPORTER)
+
+
+def test_every_scraped_service_can_answer_the_restart_question() -> None:
+    """Restarts are per-process, so each source needs its OWN start time."""
+    for source in (SOURCE_NODE_EXPORTER, SOURCE_LIVEKIT_SIP, SOURCE_LIVEKIT_SERVER):
+        assert "process_start_time_seconds" in columns_for(source), source
+
+
+def test_only_node_exporter_claims_the_kernel_oom_counter() -> None:
+    """It is a property of the box, and wiring it elsewhere would be a guess.
+
+    This is the assertion that keeps the aggregation fix honest: if someone
+    "fixes" the livekit UNKNOWNs by adding node_vmstat_oom_kill to those
+    sources, the column stores NULL for the life of the deployment while
+    series_found still reads high, which is the exact failure the map's
+    provenance rule exists to prevent.
+    """
+    assert "vmstat_oom_kill" in columns_for(SOURCE_NODE_EXPORTER)
+    for source in (SOURCE_LIVEKIT_SIP, SOURCE_LIVEKIT_SERVER, SOURCE_REDIS_EXPORTER):
+        assert "vmstat_oom_kill" not in columns_for(source), source
+
+
+def test_redis_exporter_start_time_stays_unwired() -> None:
+    """The exporter publishes it; it is still not Redis's.
+
+    Redis here is ElastiCache and its process is invisible to the scrape set, so
+    "did Redis restart" is unmeasurable. Wiring the sidecar's own start time
+    would silence the UNKNOWN by answering a different question, which is the
+    category error this source's own docstring pins for process_open_fds.
+    """
+    assert "process_start_time_seconds" not in columns_for(SOURCE_REDIS_EXPORTER)
+    assert SERIES[SOURCE_REDIS_EXPORTER]
+
+
+# --------------------------------------------------------------------------
+# What the gate does with the pair
+# --------------------------------------------------------------------------
+
+
+def _reading(source: str, *, starts, ooms) -> gates.LifecycleReading:
+    return gates.LifecycleReading(
+        node="sip-1", source=source, start_times=tuple(starts), oom_kills=tuple(ooms)
+    )
+
+
+def test_a_livekit_subject_with_a_borrowed_oom_series_is_gated_not_unknown() -> None:
+    """The point of the aggregation change, expressed at the gate.
+
+    Given the node's OOM counter alongside livekit-sip's own start times, the
+    subject is answerable. Before, the OOM tuple was empty and the row read
+    "carried no node_vmstat_oom_kill, so an OOM kill could not be ruled out".
+    """
+    result = gates.process_lifecycle_gate(
+        _reading(SOURCE_LIVEKIT_SIP, starts=[100.0, 100.0, 100.0], ooms=[0.0, 0.0, 0.0])
+    )
+    assert result.status == gates.PASS
+
+
+def test_a_borrowed_oom_series_that_rose_still_fails_the_subject() -> None:
+    """Borrowing the series must not soften it.
+
+    The kernel killing something on the host while livekit-sip ran there is
+    evidence bearing on livekit-sip's run whether or not livekit-sip was the
+    victim, which is why restarts and OOM are two signals and not one.
+    """
+    result = gates.process_lifecycle_gate(
+        _reading(SOURCE_LIVEKIT_SIP, starts=[100.0, 100.0], ooms=[0.0, 3.0])
+    )
+    assert result.status == gates.FAIL
+
+
+def test_a_subject_on_a_node_with_no_node_exporter_stays_unknown() -> None:
+    """Nothing is invented when the host is not scraped for it."""
+    result = gates.process_lifecycle_gate(
+        _reading(SOURCE_LIVEKIT_SIP, starts=[100.0, 100.0], ooms=[])
+    )
+    assert result.status == gates.UNKNOWN


### PR DESCRIPTION
A real eight-host fleet run produced **26 UNKNOWN lifecycle rows** on a deployment where nothing had gone wrong. Every one traced to the same shape: the two series the gate needs were wired to complementary sources, so each subject was missing exactly the half the other had.

```
node-exporter    vmstat_oom_kill, no start time   -> 16 rows "a restart could not be ruled out"
livekit-sip      start time, no OOM counter       ->  4 rows "an OOM kill could not be ruled out"
livekit-server   start time, no OOM counter       ->  4 rows  same
redis-exporter   neither                          ->  2 rows
```

## Only one half was a wiring mistake

node-exporter does publish `process_start_time_seconds` (read live at `1.78577024616e+09`), and its own restarts are worth gating: while it is down nothing about that host is scraped, so a restart is a hole in every other measurement taken from it.

## The other half could never have been fixed by configuration

`node_vmstat_oom_kill` is a kernel counter for the whole box. Only node_exporter publishes it, and livekit-sip never will, because it is not livekit-sip's to report. Adding it to those sources would store NULL for the life of the deployment while `series_found` still read high, which is the failure the map's provenance rule exists to prevent. There is a test pinning that nobody does this.

So `_lifecycle_reading` now reads the OOM series from the node's node-exporter rows for every subject on that node, while start times stay per-process. An OOM kill on the host is a fact *about the host*: if the kernel killed something while livekit-sip was running there, that bears on livekit-sip's run whether or not livekit-sip was the victim, which is exactly why the gate keeps restarts and OOM as two signals rather than letting a clean restart vouch for the OOM half. A node with no node-exporter still reports unmeasured.

## redis-exporter stays deliberately unwired

The exporter publishes `process_start_time_seconds` and wiring it would silence the UNKNOWN, which is why it is tempting and why it is wrong. Redis here is ElastiCache: its process is invisible to the scrape set, so "did Redis restart" is unmeasurable, and answering a question about Redis with a fact about its sidecar is the category error that source's own docstring already pins for `process_open_fds`. The UNKNOWN is the honest state.

## Also: a ratio needs a denominator worth dividing by

Observed: `monitor-0` finished a run with `sockstat_udp_inuse` at 7 against an idle baseline of 3, reported **FAIL at 2.33x**, on the box running the collector, which carried no test load at all. Four sockets is not a leak. At a baseline of 3 the smallest possible movement already exceeds the 1.10x tolerance.

`MIN_BASELINE_FOR_RATIO` (32) makes the gate report that the comparison could not be made rather than inventing a multiple. Same defect `MIN_TREND_DRIFT_FRACTION` exists to prevent one gate over; expressed on the denominator here because these metrics are all counts or bytes growing from zero. Tests cover that a real denominator still fails and still passes when it should.

## Tests

- New `test_lifecycle_series_wiring.py`: 7 tests covering the map, the borrowed OOM series, that borrowing does not soften a real OOM, and that a node with no node-exporter stays UNKNOWN.
- 3 new `return_to_baseline` cases.
- Updated the node-exporter count claim in the module docstring (21 -> 22), which `test_histogram_misuse` enforces.
- Full suite: 3262 passed. The 10 errors are ClickHouse integration tests needing a live server, unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic accuracy by treating very small baselines as inconclusive instead of reporting misleading failures.
  * Improved load-test lifecycle and restart tracking by correctly associating process start times and out-of-memory metrics with their sources.
  * Lifecycle checks now provide more reliable results when metrics are missing, borrowed, increasing, or unavailable.
* **Tests**
  * Added coverage for baseline thresholds, metric attribution, restart detection, and lifecycle gate outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->