### PR TITLE
mock-participant: report job completion, and cancel terminated jobs

### DIFF
--- a/tools/mock-participant/worker.go
+++ b/tools/mock-participant/worker.go
@@ -81,6 +81,11 @@ type Worker struct {
 	// default.
 	StatusInterval time.Duration
 
+	jobsSeen atomic.Int64
+	// jobCancels holds one cancel per in-flight job, keyed by job id, so a
+	// server-initiated termination can actually stop the job it names.
+	jobsMu     sync.Mutex
+	jobCancels map[string]context.CancelFunc
 	conn       *websocket.Conn
 	writeMu    sync.Mutex
 	workerID   string
@@ -254,7 +259,19 @@ func (w *Worker) handle(ctx context.Context, msg *livekit.ServerMessage) error {
 	case *livekit.ServerMessage_Assignment:
 		return w.handleAssignment(ctx, m.Assignment)
 	case *livekit.ServerMessage_Termination:
-		w.logf("job %s terminated by the server", m.Termination.GetJobId())
+		// Logging this is not handling it. Until the job's context is cancelled
+		// the job goroutine runs on, its deferred activeJobs decrement never
+		// fires, and this worker's reported load climbs monotonically. Once that
+		// load crosses the server's dispatch threshold the worker stops being
+		// given work while still looking healthy: registered, connected, silent.
+		id := m.Termination.GetJobId()
+		w.logf("job %s terminated by the server", id)
+		w.jobsMu.Lock()
+		cancelJob := w.jobCancels[id]
+		w.jobsMu.Unlock()
+		if cancelJob != nil {
+			cancelJob()
+		}
 	case *livekit.ServerMessage_Pong:
 		// Nothing to do. Presence is the point.
 	default:
@@ -304,21 +321,47 @@ func (w *Worker) handleAssignment(ctx context.Context, a *livekit.JobAssignment)
 	}
 	w.logf("assigned job %s -> room %q", assignment.JobID, assignment.RoomName)
 	if w.OnAssignment == nil {
-		return nil
+		// Nothing to run, but the server has already registered this job's
+		// terminate topic and will hold it until told the job ended. Say so
+		// rather than leaving it allocated for a job that never started.
+		return w.reportJobEnded(assignment.JobID, nil)
 	}
 	// Off the read loop: a slow join must not stall the connection the next job
 	// arrives on.
+	// The job gets its own context so ServerMessage_Termination can end THIS
+	// job. Without it the only cancel in the process is the process-wide one,
+	// and a terminated job runs until shutdown while still counting against
+	// this worker's reported load.
+	jobCtx, cancelJob := context.WithCancel(ctx)
+	w.jobsMu.Lock()
+	if w.jobCancels == nil {
+		w.jobCancels = make(map[string]context.CancelFunc)
+	}
+	w.jobCancels[assignment.JobID] = cancelJob
+	w.jobsMu.Unlock()
+
 	w.activeJobs.Add(1)
+	w.jobsSeen.Add(1)
 	go func() {
+		var jobErr error
 		defer func() {
+			cancelJob()
+			w.jobsMu.Lock()
+			delete(w.jobCancels, assignment.JobID)
+			w.jobsMu.Unlock()
+			// Before the local bookkeeping, because this is the message the
+			// SERVER is waiting for. See reportJobEnded.
+			if err := w.reportJobEnded(assignment.JobID, jobErr); err != nil {
+				w.logf("job %s: end status not reported: %v", assignment.JobID, err)
+			}
 			w.activeJobs.Add(-1)
 			// Report immediately on the way out rather than waiting for the next
 			// tick, so capacity that has just freed up is visible to the
 			// scheduler now.
 			_ = w.reportStatus()
 		}()
-		if err := w.OnAssignment(ctx, assignment); err != nil {
-			w.logf("job %s failed: %v", assignment.JobID, err)
+		if jobErr = w.OnAssignment(jobCtx, assignment); jobErr != nil {
+			w.logf("job %s failed: %v", assignment.JobID, jobErr)
 		}
 	}()
 	// And immediately on the way in, so a burst of assignments cannot look like
@@ -328,6 +371,46 @@ func (w *Worker) handleAssignment(ctx context.Context, a *livekit.JobAssignment)
 
 // ActiveJobs is how many assignments are currently in flight.
 func (w *Worker) ActiveJobs() int64 { return w.activeJobs.Load() }
+
+// reportJobEnded tells the server that one job is over.
+//
+// THIS IS SERVER-SIDE CLEANUP, NOT BOOKKEEPING, and omitting it leaks memory on
+// the LiveKit node this worker registered with. On accepting an assignment the
+// server calls RegisterJobTerminateTopic for the job (pkg/service/agentservice.go)
+// and holds a psrpc handler plus its bus subscriptions open. It releases them in
+// exactly two places: when the worker disconnects entirely, and when it receives
+// an UpdateJobStatus whose status is SUCCESS or FAILED. A worker that keeps one
+// long-lived connection for a whole load test and never sends this hits neither,
+// so every job it has ever been given stays allocated until the process exits.
+// The same message is what removes the job from the worker's runningJobs map
+// server-side (pkg/agent/worker.go), so that grows without bound too.
+//
+// Measured on the 24 hour soak at 100 concurrent: the SFU holding this worker's
+// registration climbed from 37,364 to 123,662 goroutines over 26,000 calls, about
+// 3.3 per job, while the second SFU carrying identical call load stayed flat at
+// ~19,000. Locally, with all rooms deleted, the same 3.3 per dispatch reproduced
+// against livekit-server 1.13.5 and the stacks were psrpc bus subscription reads.
+//
+// Sent on EVERY exit path including failure, because the server does not care
+// which of SUCCESS or FAILED it gets; it cares that the status is a terminal one.
+// A job that errored and reports nothing leaks exactly as much as one that hung.
+func (w *Worker) reportJobEnded(jobID string, jobErr error) error {
+	status := livekit.JobStatus_JS_SUCCESS
+	detail := ""
+	if jobErr != nil {
+		status = livekit.JobStatus_JS_FAILED
+		detail = jobErr.Error()
+	}
+	return w.send(&livekit.WorkerMessage{
+		Message: &livekit.WorkerMessage_UpdateJob{
+			UpdateJob: &livekit.UpdateJobStatus{
+				JobId:  jobID,
+				Status: status,
+				Error:  detail,
+			},
+		},
+	})
+}
 
 // reportedLoad is the load this worker declares, in 0..1.
 //
@@ -386,7 +469,26 @@ func (w *Worker) reportStatusUntil(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := w.reportStatus(); err != nil {
-				// The read loop owns connection errors; this one just stops.
+				// Returning silently here assumes the read loop will notice
+				// the same failure. It will not always: ReadMessage has no
+				// deadline, so a connection dead only in the write direction
+				// leaves the read loop blocked while this goroutine exits. The
+				// worker then stays registered and receives nothing, because a
+				// worker that stops reporting is drained to zero capacity.
+				//
+				// This was NOT the cause of the load-threshold stall that
+				// prompted the change (that was jobs never being cancelled, see
+				// ServerMessage_Termination above; this path was instrumented
+				// during that investigation and never fired). It is fixed
+				// anyway, because the failure mode it allows is the same one:
+				// silent, permanent, and invisible to every health signal.
+				//
+				// Say what happened, then close the connection so the read loop
+				// fails and the supervisor restarts us. A visible restart beats
+				// a silent zombie.
+				w.logf("STATUS REPORT FAILED after %d jobs (active=%d): %v",
+					w.jobsSeen.Load(), w.activeJobs.Load(), err)
+				_ = w.conn.Close()
 				return
 			}
 		}

--- a/tools/mock-participant/worker_test.go
+++ b/tools/mock-participant/worker_test.go
@@ -516,20 +516,38 @@ func TestTerminationCancelsOnlyTheJobItNames(t *testing.T) {
 		t.Fatalf("write termination: %v", err)
 	}
 
-	waitFor(t, func() bool { mu.Lock(); defer mu.Unlock(); return ended["JOB_A"] })
-	if w.ActiveJobs() != 1 {
-		t.Errorf("ActiveJobs = %d after terminating one of two jobs, want 1", w.ActiveJobs())
-	}
+	// Wait on the end state the deferred cleanup produces, NOT on the marker the
+	// job sets before returning. `ended[JOB_A]` is written inside OnAssignment,
+	// so it goes true a moment BEFORE the status report is sent and before
+	// activeJobs is decremented. Waiting on it and then asserting either of
+	// those races both.
+	waitFor(t, func() bool { return w.ActiveJobs() == 1 && len(jobUpdates(f)) == 1 })
+
 	mu.Lock()
-	if ended["JOB_B"] {
+	endedB := ended["JOB_B"]
+	mu.Unlock()
+	if endedB {
 		t.Error("terminating JOB_A also ended JOB_B")
 	}
-	mu.Unlock()
+	if got := jobUpdates(f)[0]; got.GetJobId() != "JOB_A" {
+		t.Errorf("reported job %q ended, want JOB_A", got.GetJobId())
+	}
 
-	// And only the terminated job was reported ended.
-	got := jobUpdates(f)
-	if len(got) != 1 || got[0].GetJobId() != "JOB_A" {
-		t.Errorf("job updates = %+v, want exactly one for JOB_A", got)
+	// JOB_B's cancel must still be registered and must still work. This also
+	// closes the remaining hole above: had the first termination ended both
+	// jobs, two updates would already exist by now, so the wait could only have
+	// passed by catching a transient one-update state.
+	term2, _ := proto.Marshal(&livekit.ServerMessage{
+		Message: &livekit.ServerMessage_Termination{
+			Termination: &livekit.JobTermination{JobId: "JOB_B"},
+		},
+	})
+	if err := conn.WriteMessage(websocket.BinaryMessage, term2); err != nil {
+		t.Fatalf("write second termination: %v", err)
+	}
+	waitFor(t, func() bool { return w.ActiveJobs() == 0 && len(jobUpdates(f)) == 2 })
+	if got := jobUpdates(f)[1]; got.GetJobId() != "JOB_B" {
+		t.Errorf("second update was for %q, want JOB_B", got.GetJobId())
 	}
 }
 

--- a/tools/mock-participant/worker_test.go
+++ b/tools/mock-participant/worker_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -371,6 +373,202 @@ func TestAnUnparseableFrameDoesNotKillTheWorker(t *testing.T) {
 	}
 	runWorker(t, w)
 	waitFor(t, func() bool { mu.Lock(); defer mu.Unlock(); return seen })
+}
+
+// jobUpdates returns every UpdateJobStatus the worker has sent.
+func jobUpdates(f *fakeServer) []*livekit.UpdateJobStatus {
+	var out []*livekit.UpdateJobStatus
+	for _, m := range f.messages() {
+		if u := m.GetUpdateJob(); u != nil {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+func TestAFinishedJobIsReportedEndedToTheServer(t *testing.T) {
+	// Not cosmetic. livekit-server registers a psrpc terminate topic per assigned
+	// job and releases it only on an UpdateJobStatus carrying a terminal status,
+	// or when the worker disconnects entirely. A load-test worker holds ONE
+	// connection for the whole run, so without this message every job it has ever
+	// been given stays allocated on the node: measured at ~3.3 leaked goroutines
+	// per job, 37k to 124k over a 24 hour soak.
+	f := newFakeServer(t, sendJob("loadtest"))
+	w := newWorker(f)
+	release := make(chan struct{})
+	w.OnAssignment = func(_ context.Context, _ Assignment) error {
+		<-release
+		return nil
+	}
+	runWorker(t, w)
+
+	waitFor(t, func() bool { return w.ActiveJobs() == 1 })
+	if got := jobUpdates(f); len(got) != 0 {
+		t.Fatalf("reported the job ended while it was still running: %+v", got)
+	}
+
+	close(release)
+	waitFor(t, func() bool { return len(jobUpdates(f)) == 1 })
+
+	got := jobUpdates(f)[0]
+	if got.GetJobId() != "JOB_1" {
+		t.Errorf("job id = %q, want JOB_1", got.GetJobId())
+	}
+	if got.GetStatus() != livekit.JobStatus_JS_SUCCESS {
+		t.Errorf("status = %v, want JS_SUCCESS", got.GetStatus())
+	}
+	if got.GetError() != "" {
+		t.Errorf("error = %q, want empty on a clean end", got.GetError())
+	}
+}
+
+func TestAFailedJobIsAlsoReportedEnded(t *testing.T) {
+	// A job that errored leaks exactly as much server-side state as one that
+	// hung, so the report goes out on the failure path too. The server treats
+	// SUCCESS and FAILED identically for cleanup: what matters is that the
+	// status is terminal.
+	f := newFakeServer(t, sendJob("loadtest"))
+	w := newWorker(f)
+	w.OnAssignment = func(_ context.Context, _ Assignment) error {
+		return errors.New("join refused")
+	}
+	runWorker(t, w)
+	waitFor(t, func() bool { return len(jobUpdates(f)) == 1 })
+
+	got := jobUpdates(f)[0]
+	if got.GetStatus() != livekit.JobStatus_JS_FAILED {
+		t.Errorf("status = %v, want JS_FAILED", got.GetStatus())
+	}
+	if !strings.Contains(got.GetError(), "join refused") {
+		t.Errorf("error = %q, want it to carry the reason", got.GetError())
+	}
+}
+
+func TestAJobTerminatedByTheServerIsStillReportedEnded(t *testing.T) {
+	// The server sending Termination does NOT release the job's terminate topic
+	// on its own; it waits for the worker's terminal status. Cancelling the job
+	// without reporting would fix this worker's load accounting and leave the
+	// leak exactly where it was.
+	f := newFakeServer(t, func(conn *websocket.Conn) {
+		sendJob("loadtest")(conn)
+		term, _ := proto.Marshal(&livekit.ServerMessage{
+			Message: &livekit.ServerMessage_Termination{
+				Termination: &livekit.JobTermination{JobId: "JOB_1"},
+			},
+		})
+		_ = conn.WriteMessage(websocket.BinaryMessage, term)
+	})
+	w := newWorker(f)
+	w.OnAssignment = func(ctx context.Context, _ Assignment) error {
+		<-ctx.Done() // what streamTone does: run until the job's context ends
+		return nil
+	}
+	runWorker(t, w)
+
+	waitFor(t, func() bool { return len(jobUpdates(f)) == 1 })
+	if got := jobUpdates(f)[0]; got.GetStatus() != livekit.JobStatus_JS_SUCCESS {
+		t.Errorf("status = %v, want JS_SUCCESS after a server termination", got.GetStatus())
+	}
+	waitFor(t, func() bool { return w.ActiveJobs() == 0 })
+}
+
+func TestTerminationCancelsOnlyTheJobItNames(t *testing.T) {
+	// The cancel map is keyed by job id for a reason. A termination that ended
+	// every in-flight job would drop live calls belonging to other callers, and
+	// on a load-test host that is most of the run. This is the guard on the
+	// keying, which nothing else covers: the other tests all run one job.
+	conns := make(chan *websocket.Conn, 1)
+	f := newFakeServer(t, func(conn *websocket.Conn) {
+		for _, id := range []string{"JOB_A", "JOB_B"} {
+			job := &livekit.Job{Id: id, Room: &livekit.Room{Name: "loadtest"}}
+			assign, _ := proto.Marshal(&livekit.ServerMessage{
+				Message: &livekit.ServerMessage_Assignment{
+					Assignment: &livekit.JobAssignment{Job: job, Token: "t"},
+				},
+			})
+			_ = conn.WriteMessage(websocket.BinaryMessage, assign)
+		}
+		conns <- conn
+	})
+	w := newWorker(f)
+	var mu sync.Mutex
+	ended := map[string]bool{}
+	w.OnAssignment = func(ctx context.Context, a Assignment) error {
+		<-ctx.Done()
+		mu.Lock()
+		defer mu.Unlock()
+		ended[a.JobID] = true
+		return nil
+	}
+	runWorker(t, w)
+
+	// Terminate from the test rather than from the server callback, so the
+	// message provably lands after both jobs are in flight. Sleeping for it
+	// instead would make this pass on a fast machine and flake on a loaded one.
+	waitFor(t, func() bool { return w.ActiveJobs() == 2 })
+	conn := <-conns
+	term, _ := proto.Marshal(&livekit.ServerMessage{
+		Message: &livekit.ServerMessage_Termination{
+			Termination: &livekit.JobTermination{JobId: "JOB_A"},
+		},
+	})
+	if err := conn.WriteMessage(websocket.BinaryMessage, term); err != nil {
+		t.Fatalf("write termination: %v", err)
+	}
+
+	waitFor(t, func() bool { mu.Lock(); defer mu.Unlock(); return ended["JOB_A"] })
+	if w.ActiveJobs() != 1 {
+		t.Errorf("ActiveJobs = %d after terminating one of two jobs, want 1", w.ActiveJobs())
+	}
+	mu.Lock()
+	if ended["JOB_B"] {
+		t.Error("terminating JOB_A also ended JOB_B")
+	}
+	mu.Unlock()
+
+	// And only the terminated job was reported ended.
+	got := jobUpdates(f)
+	if len(got) != 1 || got[0].GetJobId() != "JOB_A" {
+		t.Errorf("job updates = %+v, want exactly one for JOB_A", got)
+	}
+}
+
+func TestEveryJobIsReportedEndedExactlyOnce(t *testing.T) {
+	// The leak is per job, so one missed report per N jobs is still a leak that
+	// grows with the length of the run. Reporting twice would be its own bug:
+	// the second arrives after the server has forgotten the job.
+	const jobs = 25
+	f := newFakeServer(t, func(conn *websocket.Conn) {
+		for i := range jobs {
+			job := &livekit.Job{
+				Id:   fmt.Sprintf("JOB_%d", i),
+				Type: livekit.JobType_JT_ROOM,
+				Room: &livekit.Room{Name: "loadtest"},
+			}
+			assign, _ := proto.Marshal(&livekit.ServerMessage{
+				Message: &livekit.ServerMessage_Assignment{
+					Assignment: &livekit.JobAssignment{Job: job, Token: "t"},
+				},
+			})
+			_ = conn.WriteMessage(websocket.BinaryMessage, assign)
+		}
+	})
+	w := newWorker(f)
+	w.OnAssignment = func(_ context.Context, _ Assignment) error { return nil }
+	runWorker(t, w)
+
+	waitFor(t, func() bool { return len(jobUpdates(f)) >= jobs })
+
+	seen := map[string]int{}
+	for _, u := range jobUpdates(f) {
+		seen[u.GetJobId()]++
+	}
+	for i := range jobs {
+		id := fmt.Sprintf("JOB_%d", i)
+		if seen[id] != 1 {
+			t.Errorf("job %s reported ended %d times, want exactly 1", id, seen[id])
+		}
+	}
 }
 
 func TestRunBeforeConnectIsAnErrorNotAPanic(t *testing.T) {


### PR DESCRIPTION
Two defects in the mock participant. Both are silent, both only show up over hours, and both make a long load test misreport the thing it is measuring.

## 1. The worker never sent `UpdateJobStatus`

Not bookkeeping. It is the message that frees server-side memory.

On accepting an assignment livekit-server calls `RegisterJobTerminateTopic` and holds a psrpc handler plus its bus subscriptions open for that job. It releases them in exactly two places: when the worker disconnects entirely, and when it receives an `UpdateJobStatus` carrying `JS_SUCCESS` or `JS_FAILED`. This worker holds one connection for a whole run, so it hit neither path, and every job it was ever assigned stayed allocated on the node it registered with. The same message is what drops the job from the server's `runningJobs` map, so that grew too.

**On the fleet.** Over a 24 hour soak at 100 concurrent, the SFU holding this worker's registration climbed from 37,364 to 123,662 goroutines across roughly 26,000 calls: **3.3 per job**. The second SFU carried identical call load without the registration and stayed flat at ~19,000. That asymmetry is what identified it.

**On the bench.** livekit-server 1.13.5 built from source, 60 dispatches per round, every room then deleted, 45 seconds to settle, goroutines from `/debug/pprof/goroutine`:

| round | before | after |
| --- | --- | --- |
| baseline | 859 | 863 |
| after 60 jobs | 1,049 (+3.17/job) | 877 (+0.23/job) |
| after 120 jobs | 1,227 (+2.97/job) | 867 (-0.10/job) |
| after 180 jobs | 1,409 (+3.03/job) | 869 (+0.03/job) |

+550 against +6. Three rounds because one round cannot separate a leak from slow teardown, and 25 seconds of settle time reads as a small leak that is not one.

`livekit-agents` sends this message (`_update_job_status` bound to `process_closed`, verified in 1.5.7), so Python agents never show the symptom. Only hand-rolled workers like this one do.

## 2. `ServerMessage_Termination` only logged the job id

Until the job's context is cancelled its goroutine runs on, the deferred `activeJobs` decrement never fires, and reported load climbs monotonically. Once it crosses the server's **0.70** dispatch threshold the worker stops being given work while staying registered, connected and silent: `systemctl` active, fds at idle, nothing in the log. Observed at exactly 141 jobs with `-max-jobs 200`, because 141/200 = 0.705.

**This fix ran on the fleet for every published result but was never committed here.** `main` still carries the pre-fix file. That is how it came to be missing from a downstream copy without anything failing, and it is why this PR adds a test for it.

Cancelling locally does not substitute for reporting. The server waits for the terminal status regardless of which side ended the job, so both changes are needed and neither covers the other.

## Also

`reportStatusUntil` returned silently on a send error, assuming the read loop would notice the same failure. It will not always: `ReadMessage` has no deadline, so a connection dead only in the write direction leaves the read loop blocked while that goroutine exits, and a worker that stops reporting is drained to zero capacity. It now logs the job count and closes the connection so the supervisor restarts it. A visible restart beats a silent zombie.

## Tests

Five new tests. Each was checked against a deliberately broken implementation, not just against a passing one:

- a finished job is reported ended, and not before it finishes
- a failed job is reported ended too, carrying the reason
- a server-terminated job is still reported ended, and its goroutine returns
- every job is reported ended exactly once across 25 jobs
- terminating one of two in-flight jobs leaves the other running

The four status tests time out against a `reportJobEnded` stubbed to a no-op. The keying test times out against a termination handler that cancels nothing. Termination in that test is driven from the test body once both jobs are provably in flight, rather than by sleeping, so it does not pass on a fast machine and flake on a loaded one.

`gofmt`, `go vet`, `go test -race` and `go build` all pass locally, which is the full `go-tools.yml` gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of job cancellation and completion.
  * Job status now reports success or failure accurately, including server-terminated jobs.
  * Prevented jobs without active callbacks from remaining in progress.
  * Improved connection handling when status reporting fails.
* **Tests**
  * Added coverage for successful, failed, cancelled, selective, and concurrent job completion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->