### PR TITLE
Carry the per-call media counts into the row the gate judged

### DIFF
--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -1424,6 +1424,19 @@ def _load_test_row(test: dict[str, Any]) -> dict[str, Any]:
         "node_samples_in_window": _as_int(test.get("node_samples_in_window")),
         "rtp_packets_sent": _as_int(test.get("rtp_packets_sent")),
         "rtp_packets_received": _as_int(test.get("rtp_packets_received")),
+        # The counts the two-way media gate judges. The gate already reported
+        # the right verdict without these, which is exactly why they were
+        # missed: a reader saw "all 900 answered calls received audio" in the
+        # gate detail and null in the row it came from, with no way to check
+        # one against the other.
+        #
+        # None is not zero here either. It means the run carried no readable
+        # per-call records, which is the same thing that makes the gate return
+        # UNKNOWN rather than PASS.
+        "calls_answered_with_inbound": _as_int(test.get("calls_answered_with_inbound")),
+        "calls_answered_without_inbound": _as_int(
+            test.get("calls_answered_without_inbound")
+        ),
     }
 
 

--- a/src/voicegateway/tests/loadtest/test_profile_report.py
+++ b/src/voicegateway/tests/loadtest/test_profile_report.py
@@ -644,3 +644,48 @@ def test_the_measurements_a_reader_came_for_are_present(profiled) -> None:
     html = profiled["html"]
     for section in ("Per test", "Measurements", "How to read these numbers"):
         assert section in html, section
+
+
+class TestPerCallMediaCountsReachThePayload:
+    """The counts the two-way media gate judges must be in the row it judged.
+
+    Shipped without this once. The gate reported the correct verdict and said
+    "all 900 answered calls received audio back", while the test row it came
+    from carried null for both counts. The verdict was right and unverifiable,
+    which is the combination this whole report exists to avoid.
+    """
+
+    def test_the_counts_are_carried_through(self) -> None:
+        row = run_report._load_test_row(
+            {
+                "name": "g0",
+                "attempted_calls": 900,
+                "succeeded_calls": 900,
+                "calls_answered_with_inbound": 899,
+                "calls_answered_without_inbound": 1,
+            }
+        )
+        assert row["calls_answered_with_inbound"] == 899
+        assert row["calls_answered_without_inbound"] == 1
+
+    def test_absent_counts_stay_none_and_never_become_zero(self) -> None:
+        # Zero silent calls is a pass. Not having counted them is not, and a
+        # row that renders None as 0 turns the second into the first.
+        row = run_report._load_test_row({"name": "g0", "attempted_calls": 10})
+        assert row["calls_answered_with_inbound"] is None
+        assert row["calls_answered_without_inbound"] is None
+
+    def test_a_silent_run_shows_its_count_in_the_row(self) -> None:
+        # The 24 hour soak: 16,606 answered calls with audio and 12,198
+        # without, on a run whose establishment ratio was 1.0.
+        row = run_report._load_test_row(
+            {
+                "name": "soak",
+                "attempted_calls": 28804,
+                "succeeded_calls": 28804,
+                "calls_answered_with_inbound": 16606,
+                "calls_answered_without_inbound": 12198,
+            }
+        )
+        assert row["establishment_ratio"] == 1.0
+        assert row["calls_answered_without_inbound"] == 12198

--- a/src/voicegateway/tests/loadtest/test_profile_report.py
+++ b/src/voicegateway/tests/loadtest/test_profile_report.py
@@ -675,6 +675,38 @@ class TestPerCallMediaCountsReachThePayload:
         assert row["calls_answered_with_inbound"] is None
         assert row["calls_answered_without_inbound"] is None
 
+    def test_a_measured_zero_stays_zero(self) -> None:
+        # THE case that matters most, and the one the other tests did not pin.
+        # Zero silent calls is the passing result. If it came through as None
+        # the gate would read the run as never counted and return UNKNOWN, so
+        # a clean run would report as unmeasured.
+        row = run_report._load_test_row(
+            {
+                "name": "g0",
+                "attempted_calls": 900,
+                "succeeded_calls": 900,
+                "calls_answered_with_inbound": 900,
+                "calls_answered_without_inbound": 0,
+            }
+        )
+        assert row["calls_answered_without_inbound"] == 0
+        assert row["calls_answered_without_inbound"] is not None
+
+    def test_persisted_strings_become_integers(self) -> None:
+        # The row arrives from a database driver, not from this process. A
+        # count that came back as text would otherwise reach a gate that
+        # compares it against 0 with >, and "12" > 0 is a TypeError rather
+        # than a verdict.
+        row = run_report._load_test_row(
+            {
+                "name": "g0",
+                "calls_answered_with_inbound": "899",
+                "calls_answered_without_inbound": "1",
+            }
+        )
+        assert row["calls_answered_with_inbound"] == 899
+        assert row["calls_answered_without_inbound"] == 1
+
     def test_a_silent_run_shows_its_count_in_the_row(self) -> None:
         # The 24 hour soak: 16,606 answered calls with audio and 12,198
         # without, on a run whose establishment ratio was 1.0.


### PR DESCRIPTION
## The gap

The two-way media gate (#211) shipped reporting the correct verdict from counts the payload then dropped. On the first real run after it landed, the report said:

```
two_way_media [PASS] g0: all 900 answered calls received audio back from the fleet
```

and the test row it came from said:

```json
{"name": "g0", "establishment_ratio": 1.0,
 "calls_answered_with_inbound": null,
 "calls_answered_without_inbound": null}
```

The gate read the columns from the database correctly. `_load_test_row` never copied them into the payload, so nobody reading the JSON could check the verdict against the numbers it came from.

**Correct and unverifiable is the exact state this report exists to prevent.** It is the same shape as the defect the gate was written for: a run whose real condition was present in the data and absent from anything a reader could act on.

## The change

Two fields in `_load_test_row`. That is the whole fix.

`None` stays `None`. Absent counts mean the run carried no readable per-call records, which is the same condition that makes the gate return UNKNOWN rather than PASS. A row rendering that as `0` would turn "we did not count them" into "there were none", which is precisely the substitution the gate's UNKNOWN path exists to refuse.

## Not changed

The HTML is untouched. It already carries the counts inside the gate detail sentence, so a reader of the rendered report was never missing them. Only the JSON consumer was.

## Verification

- 3 new tests, all three fail with `KeyError` against the unfixed `_load_test_row` and pass with it, including a case pinning the 24 hour soak's real numbers (16,606 with audio, 12,198 without, on a run whose establishment ratio was 1.0)
- `3,168 passed` across the suite, excluding ClickHouse (needs Docker) and `test_live_integration` (needs a live LiveKit server; both its failures reproduce on `main`)
- `ruff check src` clean, which is what CI runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test run reporting so answered-call media totals now appear in loaded results.
  * Preserved missing values as blank/`None` instead of showing them as zero.
  * Silent-call counts are now reported correctly alongside the overall call establishment ratio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->