### PR TITLE
Let scrape targets come from a file, re-read every tick

### DIFF
--- a/src/voicegateway/core/events.py
+++ b/src/voicegateway/core/events.py
@@ -15,6 +15,7 @@ never sets the variable behaves exactly as it did before the worker existed.
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
@@ -31,6 +32,7 @@ from voicegateway.middleware.latency_observations_worker_middleware import (
 )
 from voicegateway.middleware.node_samples_worker_middleware import (
     TARGETS_ENV_VAR,
+    TARGETS_FILE_ENV_VAR,
     NodeSamplesWorker,
     targets_from_env,
 )
@@ -85,8 +87,15 @@ def _build_workers(gateway: Gateway) -> list[Any]:
     # into this code must not start talking to the network on its own. No
     # targets, no worker at all (rather than a worker idling on empty ticks), so
     # the default process has exactly the tasks it had before.
+    # Naming a targets FILE also opts in, and does so even when the file is
+    # empty or absent right now. That is the difference between the two sources:
+    # an env var is everything there will ever be, while a file is whatever the
+    # thing that writes it has got to so far. Refusing to start on an empty file
+    # would mean the collector had to be restarted once the file filled, which is
+    # the restart this whole option exists to remove.
+    targets_file = os.environ.get(TARGETS_FILE_ENV_VAR, "").strip()
     node_targets = targets_from_env()
-    if node_targets:
+    if targets_file or node_targets:
         workers.append(
             NodeSamplesWorker(
                 storage,
@@ -95,11 +104,18 @@ def _build_workers(gateway: Gateway) -> list[Any]:
         )
         # Logged because the alternative is silence: an operator who typos the
         # variable otherwise cannot tell "not read" from "read and empty".
-        logger.info(
-            "Node scrape enabled: %d target(s) from %s",
-            len(node_targets),
-            TARGETS_ENV_VAR,
-        )
+        if targets_file:
+            logger.info(
+                "Node scrape enabled: targets re-read from %s (%s) every tick",
+                TARGETS_FILE_ENV_VAR,
+                targets_file,
+            )
+        else:
+            logger.info(
+                "Node scrape enabled: %d target(s) from %s",
+                len(node_targets),
+                TARGETS_ENV_VAR,
+            )
     return workers
 
 

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -831,9 +831,7 @@ def parse_targets(raw: str, *, where: str = TARGETS_ENV_VAR) -> list[ScrapeTarge
         # been parsed out yet, so the warning about it is a leak of its own.
         shown = redact_url(item)
         if not sep or not colon or not url.strip() or not node.strip():
-            logger.warning(
-                "%s: ignoring %r; expected 'source:name=url'", where, shown
-            )
+            logger.warning("%s: ignoring %r; expected 'source:name=url'", where, shown)
             continue
         if source not in SOURCES:
             logger.warning(

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -141,6 +141,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import pathlib
 import re
 import time
 import urllib.parse
@@ -205,6 +206,23 @@ OUTCOME_UNPARSEABLE: Final[str] = "unparseable"
 # The same ``name`` on two sources is the point: it is what puts an SFU's own
 # counters and its host's file descriptors on one time axis.
 TARGETS_ENV_VAR: Final[str] = "VOICEGW_NODE_SCRAPE_TARGETS"
+
+# The same entries, read from a FILE instead, and re-read on every tick.
+#
+# An environment variable cannot change inside a running process, so a fleet
+# whose node addresses change means editing a unit file and restarting the
+# collector. Autoscaling changes them routinely: every replacement and every
+# scale-out arrives on an address nobody listed, and the run that follows
+# reports UNKNOWN for that node rather than failing, so it looks complete.
+#
+# With a file, whatever keeps the list current (a timer querying the cloud
+# provider for instances carrying a tag, a config management run, a person) just
+# rewrites it, and the next tick picks it up. This module stays cloud-agnostic:
+# it reads a file, and knows nothing about who wrote it.
+#
+# Entries are separated by commas OR newlines, so a generated file can put one
+# target per line. Same `source:name=url` grammar either way.
+TARGETS_FILE_ENV_VAR: Final[str] = "VOICEGW_NODE_SCRAPE_TARGETS_FILE"
 
 
 @dataclass(frozen=True)
@@ -771,8 +789,38 @@ def targets_from_env(
     dashboard, and a bad env var must not take that process down.
     """
     raw = (environ if environ is not None else os.environ).get(TARGETS_ENV_VAR, "")
+    return parse_targets(raw, where=TARGETS_ENV_VAR)
+
+
+def targets_from_file(path: str | os.PathLike[str]) -> list[ScrapeTarget]:
+    """Parse a targets FILE, returning empty when it cannot be read.
+
+    Never raises. This runs on every tick of a background worker, and a file
+    that is missing, unreadable, or half-written by whatever regenerates it must
+    cost one tick rather than the process. An empty result is already the
+    "nothing to scrape" case the worker handles.
+
+    A partially written file is the interesting one: a writer that truncates and
+    then writes leaves a window where the file is short. That yields fewer
+    targets for one tick, and the next tick recovers, which is why this is read
+    fresh each time rather than cached.
+    """
+    try:
+        raw = pathlib.Path(path).read_text()
+    except (OSError, UnicodeError) as exc:
+        logger.warning("%s: cannot read %s: %s", TARGETS_FILE_ENV_VAR, path, exc)
+        return []
+    return parse_targets(raw, where=str(path))
+
+
+def parse_targets(raw: str, *, where: str = TARGETS_ENV_VAR) -> list[ScrapeTarget]:
+    """Parse ``source:name=url`` entries separated by commas or newlines.
+
+    ``where`` names the source in warnings, so an operator reading the log can
+    tell a bad env var from a bad file.
+    """
     targets: list[ScrapeTarget] = []
-    for entry in raw.split(","):
+    for entry in raw.replace("\n", ",").split(","):
         item = entry.strip()
         if not item:
             continue
@@ -784,13 +832,13 @@ def targets_from_env(
         shown = redact_url(item)
         if not sep or not colon or not url.strip() or not node.strip():
             logger.warning(
-                "%s: ignoring %r; expected 'source:name=url'", TARGETS_ENV_VAR, shown
+                "%s: ignoring %r; expected 'source:name=url'", where, shown
             )
             continue
         if source not in SOURCES:
             logger.warning(
                 "%s: ignoring %r; unknown source %r (known: %s)",
-                TARGETS_ENV_VAR,
+                where,
                 shown,
                 source,
                 ", ".join(SOURCES),
@@ -800,7 +848,7 @@ def targets_from_env(
         if not metrics_url.strip():
             logger.warning(
                 "%s: ignoring %r; no metrics url before %r",
-                TARGETS_ENV_VAR,
+                where,
                 shown,
                 HEALTH_SUFFIX,
             )
@@ -861,7 +909,28 @@ def split_userinfo(url: str) -> tuple[str, tuple[str, str] | None]:
 
 
 async def _default_target_provider() -> list[ScrapeTarget]:
-    """Targets from the environment. Empty (a no-op worker) when unset."""
+    """Targets from the file if one is configured, otherwise the environment.
+
+    Called on EVERY tick, which is what makes the file worth having: an
+    environment variable is fixed for the life of the process, and a file is
+    re-read, so a fleet whose addresses change no longer needs a restart to be
+    seen.
+
+    The file wins when set, including when it currently yields nothing. A file
+    that is empty right now is not the same as no file, because the thing that
+    writes it may not have run yet, and falling back to a stale env var in that
+    window would scrape addresses that have already been replaced.
+    """
+    configured = os.environ.get(TARGETS_FILE_ENV_VAR, "").strip()
+    if configured:
+        targets = targets_from_file(configured)
+        if not targets:
+            logger.debug(
+                "NodeSamplesWorker: %s (%s) yielded no targets this tick",
+                TARGETS_FILE_ENV_VAR,
+                configured,
+            )
+        return targets
     targets = targets_from_env()
     if not targets:
         logger.debug(
@@ -1207,4 +1276,7 @@ __all__ = [
     "redact_url",
     "split_userinfo",
     "targets_from_env",
+    "targets_from_file",
+    "parse_targets",
+    "TARGETS_FILE_ENV_VAR",
 ]

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -923,7 +923,13 @@ async def _default_target_provider() -> list[ScrapeTarget]:
     """
     configured = os.environ.get(TARGETS_FILE_ENV_VAR, "").strip()
     if configured:
-        targets = targets_from_file(configured)
+        # Off the event loop. This provider runs on every tick inside a process
+        # that is also serving the dashboard, and a target list on a network
+        # mount or a FIFO would otherwise stall every HTTP request it is
+        # handling for as long as the read took. A local file costs a fraction
+        # of a millisecond, which is precisely why the pathological case would
+        # never be found in testing.
+        targets = await asyncio.to_thread(targets_from_file, configured)
         if not targets:
             logger.debug(
                 "NodeSamplesWorker: %s (%s) yielded no targets this tick",

--- a/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
+++ b/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
@@ -11,7 +11,6 @@ import asyncio
 import httpx
 import pytest
 
-import voicegateway.middleware.node_samples_worker_middleware as nsw
 from voicegateway.middleware.node_samples_worker_middleware import (
     OUTCOME_HTTP_ERROR,
     OUTCOME_OK,
@@ -25,9 +24,12 @@ from voicegateway.middleware.node_samples_worker_middleware import (
     SOURCE_NODE_EXPORTER,
     SOURCE_REDIS_EXPORTER,
     TARGETS_ENV_VAR,
+    TARGETS_FILE_ENV_VAR,
     NodeSamplesWorker,
     ScrapeTarget,
+    _default_target_provider,
     targets_from_env,
+    targets_from_file,
 )
 from voicegateway.repository import node_samples_repository as repo
 from voicegateway.services.storage_service import StorageService
@@ -548,7 +550,7 @@ class TestTargetsFromFile:
             "node-exporter:sip-1=http://10.0.0.1:9100/metrics,"
             "node-exporter:sip-2=http://10.0.0.2:9100/metrics",
         )
-        targets = nsw.targets_from_file(p)
+        targets = targets_from_file(p)
         assert [t.node for t in targets] == ["sip-1", "sip-2"]
 
     def test_reads_one_target_per_line(self, tmp_path) -> None:
@@ -559,22 +561,22 @@ class TestTargetsFromFile:
             "node-exporter:sip-1=http://10.0.0.1:9100/metrics\n"
             "node-exporter:sip-2=http://10.0.0.2:9100/metrics\n",
         )
-        assert [t.node for t in nsw.targets_from_file(p)] == ["sip-1", "sip-2"]
+        assert [t.node for t in targets_from_file(p)] == ["sip-1", "sip-2"]
 
     def test_a_missing_file_is_empty_not_an_exception(self, tmp_path) -> None:
         # This runs on every tick of a background worker. A file that has not
         # been written yet must cost one tick, never the process.
-        assert nsw.targets_from_file(tmp_path / "nope") == []
+        assert targets_from_file(tmp_path / "nope") == []
 
     def test_a_rewrite_is_seen_without_a_restart(self, tmp_path) -> None:
         # THE reason this exists. Same path, new content, new targets.
         p = self._write(tmp_path, "node-exporter:sip-1=http://10.0.0.1:9100/metrics")
-        assert [t.node for t in nsw.targets_from_file(p)] == ["sip-1"]
+        assert [t.node for t in targets_from_file(p)] == ["sip-1"]
         p.write_text(
             "node-exporter:sip-9=http://10.0.9.9:9100/metrics\n"
             "node-exporter:sip-8=http://10.0.8.8:9100/metrics\n"
         )
-        assert [t.node for t in nsw.targets_from_file(p)] == ["sip-9", "sip-8"]
+        assert [t.node for t in targets_from_file(p)] == ["sip-9", "sip-8"]
 
     def test_one_bad_line_does_not_discard_the_good_ones(self, tmp_path) -> None:
         p = self._write(
@@ -583,7 +585,7 @@ class TestTargetsFromFile:
             "this-is-not-a-target\n"
             "node-exporter:sip-2=http://10.0.0.2:9100/metrics\n",
         )
-        assert [t.node for t in nsw.targets_from_file(p)] == ["sip-1", "sip-2"]
+        assert [t.node for t in targets_from_file(p)] == ["sip-1", "sip-2"]
 
     def test_credentials_are_split_out_of_the_url(self, tmp_path) -> None:
         # Same guarantee the env path already gives: httpx logs the request
@@ -591,7 +593,7 @@ class TestTargetsFromFile:
         p = self._write(
             tmp_path, "node-exporter:sip-1=http://user:pw@10.0.0.1:9100/metrics"
         )
-        target = nsw.targets_from_file(p)[0]
+        target = targets_from_file(p)[0]
         assert target.auth == ("user", "pw")
         assert "pw" not in target.url
 
@@ -603,19 +605,19 @@ class TestTargetsFromFile:
         # in that window would scrape addresses that have already been replaced,
         # which is the failure this option exists to end.
         p = self._write(tmp_path, "")
-        monkeypatch.setenv(nsw.TARGETS_FILE_ENV_VAR, str(p))
+        monkeypatch.setenv(TARGETS_FILE_ENV_VAR, str(p))
         monkeypatch.setenv(
-            nsw.TARGETS_ENV_VAR, "node-exporter:stale=http://10.9.9.9:9100/metrics"
+            TARGETS_ENV_VAR, "node-exporter:stale=http://10.9.9.9:9100/metrics"
         )
-        assert await nsw._default_target_provider() == []
+        assert await _default_target_provider() == []
 
     @pytest.mark.asyncio
     async def test_the_env_is_used_when_no_file_is_configured(
         self, tmp_path, monkeypatch
     ) -> None:
-        monkeypatch.delenv(nsw.TARGETS_FILE_ENV_VAR, raising=False)
+        monkeypatch.delenv(TARGETS_FILE_ENV_VAR, raising=False)
         monkeypatch.setenv(
-            nsw.TARGETS_ENV_VAR, "node-exporter:sip-1=http://10.0.0.1:9100/metrics"
+            TARGETS_ENV_VAR, "node-exporter:sip-1=http://10.0.0.1:9100/metrics"
         )
-        got = await nsw._default_target_provider()
+        got = await _default_target_provider()
         assert [t.node for t in got] == ["sip-1"]

--- a/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
+++ b/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
@@ -11,6 +11,7 @@ import asyncio
 import httpx
 import pytest
 
+import voicegateway.middleware.node_samples_worker_middleware as nsw
 from voicegateway.middleware.node_samples_worker_middleware import (
     OUTCOME_HTTP_ERROR,
     OUTCOME_OK,
@@ -525,3 +526,96 @@ def test_every_mapped_series_names_a_real_value_column() -> None:
         }
         for entry in series:
             assert entry.column in repo.VALUE_COLUMNS, entry
+
+
+class TestTargetsFromFile:
+    """A file source, re-read every tick, so a changing fleet needs no restart.
+
+    The env var cannot change inside a running process. Autoscaling changes node
+    addresses routinely, so every replacement and scale-out arrived on an
+    address nobody had listed, and the report said UNKNOWN for that node rather
+    than failing. Twice in one engagement.
+    """
+
+    def _write(self, tmp_path, text: str):
+        p = tmp_path / "targets"
+        p.write_text(text)
+        return p
+
+    def test_reads_comma_separated_entries(self, tmp_path) -> None:
+        p = self._write(
+            tmp_path,
+            "node-exporter:sip-1=http://10.0.0.1:9100/metrics,"
+            "node-exporter:sip-2=http://10.0.0.2:9100/metrics",
+        )
+        targets = nsw.targets_from_file(p)
+        assert [t.node for t in targets] == ["sip-1", "sip-2"]
+
+    def test_reads_one_target_per_line(self, tmp_path) -> None:
+        # The point of the file: a generator writes a line per instance rather
+        # than assembling one long comma-separated string.
+        p = self._write(
+            tmp_path,
+            "node-exporter:sip-1=http://10.0.0.1:9100/metrics\n"
+            "node-exporter:sip-2=http://10.0.0.2:9100/metrics\n",
+        )
+        assert [t.node for t in nsw.targets_from_file(p)] == ["sip-1", "sip-2"]
+
+    def test_a_missing_file_is_empty_not_an_exception(self, tmp_path) -> None:
+        # This runs on every tick of a background worker. A file that has not
+        # been written yet must cost one tick, never the process.
+        assert nsw.targets_from_file(tmp_path / "nope") == []
+
+    def test_a_rewrite_is_seen_without_a_restart(self, tmp_path) -> None:
+        # THE reason this exists. Same path, new content, new targets.
+        p = self._write(tmp_path, "node-exporter:sip-1=http://10.0.0.1:9100/metrics")
+        assert [t.node for t in nsw.targets_from_file(p)] == ["sip-1"]
+        p.write_text(
+            "node-exporter:sip-9=http://10.0.9.9:9100/metrics\n"
+            "node-exporter:sip-8=http://10.0.8.8:9100/metrics\n"
+        )
+        assert [t.node for t in nsw.targets_from_file(p)] == ["sip-9", "sip-8"]
+
+    def test_one_bad_line_does_not_discard_the_good_ones(self, tmp_path) -> None:
+        p = self._write(
+            tmp_path,
+            "node-exporter:sip-1=http://10.0.0.1:9100/metrics\n"
+            "this-is-not-a-target\n"
+            "node-exporter:sip-2=http://10.0.0.2:9100/metrics\n",
+        )
+        assert [t.node for t in nsw.targets_from_file(p)] == ["sip-1", "sip-2"]
+
+    def test_credentials_are_split_out_of_the_url(self, tmp_path) -> None:
+        # Same guarantee the env path already gives: httpx logs the request
+        # line, so userinfo left in the URL is written to the log every tick.
+        p = self._write(
+            tmp_path, "node-exporter:sip-1=http://user:pw@10.0.0.1:9100/metrics"
+        )
+        target = nsw.targets_from_file(p)[0]
+        assert target.auth == ("user", "pw")
+        assert "pw" not in target.url
+
+    @pytest.mark.asyncio
+    async def test_the_file_wins_over_the_env_even_when_it_is_empty(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # An empty file is not the same as no file. Falling back to the env var
+        # in that window would scrape addresses that have already been replaced,
+        # which is the failure this option exists to end.
+        p = self._write(tmp_path, "")
+        monkeypatch.setenv(nsw.TARGETS_FILE_ENV_VAR, str(p))
+        monkeypatch.setenv(
+            nsw.TARGETS_ENV_VAR, "node-exporter:stale=http://10.9.9.9:9100/metrics"
+        )
+        assert await nsw._default_target_provider() == []
+
+    @pytest.mark.asyncio
+    async def test_the_env_is_used_when_no_file_is_configured(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.delenv(nsw.TARGETS_FILE_ENV_VAR, raising=False)
+        monkeypatch.setenv(
+            nsw.TARGETS_ENV_VAR, "node-exporter:sip-1=http://10.0.0.1:9100/metrics"
+        )
+        got = await nsw._default_target_provider()
+        assert [t.node for t in got] == ["sip-1"]


### PR DESCRIPTION
## The problem

The scrape target list is an environment variable. **An environment variable cannot change inside a running process.**

A fleet behind autoscaling changes its node addresses routinely. Every replacement and every scale-out arrives on an address nobody listed, so that node is scraped by nothing while carrying real calls. It reports no CPU, no memory, no ports.

**And the report does not fail.** It prints UNKNOWN for that node and continues, so a run can finish, look complete, and have had half the fleet unmeasured.

This happened twice in one engagement. Once, four stale addresses were scraped through an entire test. The second time, the fleet came back with four new SIP nodes while the stored list still named two old ones, caught only because someone checked before starting.

## The change

`VOICEGW_NODE_SCRAPE_TARGETS_FILE` names a file carrying the same `source:name=url` entries, separated by commas **or newlines** so a generator can write one target per line.

The worker already calls its target provider on every tick, so nothing there needed changing. **Reading a file instead of an env var is the entire difference** between a list fixed at boot and one that follows the fleet.

## Three decisions worth reviewing

**The file wins when set, including when it currently yields nothing.** An empty file is not the same as no file: whatever writes it may not have run yet, and falling back to a stale env var in that window would scrape addresses that have already been replaced. That is the exact failure being removed, so it must not be the fallback.

**Naming a file opts the worker in even when the file is empty or absent at startup.** Refusing to start would mean a restart once the file filled, which is the restart this exists to remove. The env var keeps its old behaviour: no targets, no worker.

**`targets_from_file` never raises.** It runs on a background tick, so a file that is missing, unreadable, or half-written by its writer costs one tick and recovers on the next. That is also why it is read fresh each time rather than cached.

## Not in this PR

**No AWS.** The module reads a file and knows nothing about who wrote it, so this stays usable off EC2. The discovery half (a timer querying instances by tag and writing the file) belongs to the deployment, and is implemented separately in the engagement repo.

## Verification

- 8 new tests, including that a rewrite of the same path is seen without a restart, that one malformed line does not discard the good ones, that credentials are still split out of the URL, and that an empty file does not fall back to a stale env var
- `3,178 passed` across the suite, excluding ClickHouse (needs Docker) and `test_live_integration` (needs a live LiveKit server; both its failures reproduce on `main`)
- `ruff check src` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring node-scraping targets through a file.
  - Targets can be listed using commas or separate lines.
  - Target files are re-read regularly, so updates take effect without restarting workers.
  - File-based settings take precedence over inline environment configuration, including empty files.
  - Added clearer logging for file-based configuration and invalid or unreadable entries.

- **Bug Fixes**
  - Improved handling of missing, unreadable, and malformed target configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->