### PR TITLE
fix(doctor): a slow provider API crashed the command instead of timing out

### DIFF
--- a/src/voicegateway/tests/cli/test_doctor.py
+++ b/src/voicegateway/tests/cli/test_doctor.py
@@ -30,6 +30,35 @@ def temp_config(tmp_path):
     return cfg
 
 
+@pytest.fixture(autouse=True)
+def no_provider_network(monkeypatch):
+    """No test in this file may dial a provider's API. Autouse, so none can.
+
+    ``temp_config`` configures ``providers.openai``, which makes the doctor's
+    "Provider key valid" check run for real: it builds the OpenAI provider and
+    calls ``health_check``, which issues a live HTTPS GET to
+    ``api.openai.com/v1/models`` carrying the fake ``sk-test`` key.
+
+    That made two tests here depend on the public internet. When the request
+    answered quickly they passed in 0.4s; when it did not, the 5s validation
+    deadline fired and the test failed. Measured on an untouched tree: three
+    failures in thirty runs, and the same rate in CI on a different network.
+
+    ``all_pass`` already stubbed this for the tests that use it, which is why
+    only the two tests WITHOUT ``all_pass`` ever flaked. Making it autouse
+    closes the hole for every test in the file, including ones added later.
+    ``all_pass`` still installs its own "ok" stub over the top; this is the
+    floor, not a replacement.
+    """
+
+    async def _no_network(provider, key):
+        return "skipped", "provider validation stubbed: tests never dial out"
+
+    monkeypatch.setattr(
+        "voicegateway.utils.cli.doctor._validate_provider_key", _no_network
+    )
+
+
 @pytest.fixture
 def all_pass(monkeypatch):
     """Stub the slow / OS-side calls so all 10 checks return ok or skip."""

--- a/src/voicegateway/tests/cli/test_doctor_validation.py
+++ b/src/voicegateway/tests/cli/test_doctor_validation.py
@@ -111,3 +111,63 @@ async def test_validate_skipped_when_plugin_not_installed(monkeypatch):
     status, message = await _validate_provider_key("openai", "sk-test")
     assert status == "skipped"
     assert "plugin not installed" in (message or "")
+
+
+async def test_a_timeout_during_the_provider_s_own_cleanup_is_still_a_timeout(
+    monkeypatch,
+):
+    """The real shape of the flake, which the hang test above does not reach.
+
+    ``test_validate_returns_timeout_when_health_check_hangs`` cancels a bare
+    ``Event().wait()``. Nothing runs after the cancellation there, so
+    ``wait_for`` converts it to TimeoutError and all is well.
+
+    The real provider cancels inside ``async with httpx.AsyncClient()``, whose
+    ``__aexit__`` awaits again to drain the connection pool. The cancellation is
+    therefore delivered a SECOND time, during cleanup, and escapes ``wait_for``'s
+    conversion as a bare CancelledError. CancelledError derives from
+    BaseException, not Exception, so every ``except Exception`` between here and
+    the CLI misses it and ``voicegw doctor`` dies with a traceback on a slow
+    network instead of reporting the timeout it already has a branch for.
+
+    This fake reproduces that shape with no network and no httpx.
+    """
+    import asyncio as _aio
+
+    class _AwaitsDuringCleanup:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            # The httpx.AsyncClient.aclose() equivalent. Draining the pool runs
+            # under anyio's own cancel scope, which cancels this task a SECOND
+            # time. That extra cancel is the whole mechanism: asyncio.timeout
+            # only rewrites CancelledError into TimeoutError while
+            # `task.uncancel() <= self._cancelling`, so one unaccounted cancel
+            # defeats the conversion and the raw CancelledError escapes.
+            _aio.current_task().cancel()
+            await _aio.sleep(0)
+            return False
+
+    class _FakeProvider:
+        async def health_check(self):
+            try:
+                async with _AwaitsDuringCleanup():
+                    await _aio.Event().wait()
+            except Exception:
+                # Exactly what the real provider does, and exactly why it does
+                # not help: CancelledError is not an Exception.
+                return False
+            return True
+
+    monkeypatch.setattr(
+        "voicegateway.core.registry._PROVIDER_REGISTRY", {"openai": object}
+    )
+    monkeypatch.setattr(
+        "voicegateway.core.registry.create_provider", lambda name, cfg: _FakeProvider()
+    )
+    monkeypatch.setattr("voicegateway.utils.cli.doctor.VALIDATION_TIMEOUT_S", 0.05)
+
+    status, message = await _validate_provider_key("openai", "sk-test")
+    assert status == "timeout"
+    assert message is None

--- a/src/voicegateway/utils/cli/doctor.py
+++ b/src/voicegateway/utils/cli/doctor.py
@@ -230,6 +230,29 @@ async def _validate_provider_key(provider: str, api_key: str) -> tuple[str, str 
         )
     except TimeoutError:
         return "timeout", None
+    except asyncio.CancelledError:
+        # ALSO a timeout, and the reason `voicegw doctor` used to die with a
+        # traceback on a slow network.
+        #
+        # ``wait_for`` normally rewrites the cancellation it delivers into
+        # TimeoutError. It only does so while ``task.uncancel() <=
+        # self._cancelling``, so one cancel it did not account for defeats the
+        # conversion and the raw CancelledError comes out instead. The provider
+        # supplies that extra cancel by construction: ``health_check`` runs
+        # inside ``async with httpx.AsyncClient()``, and draining that pool on
+        # the way out awaits again under anyio's own cancel scope.
+        #
+        # Nothing between here and the CLI catches it, because CancelledError
+        # derives from BaseException and every handler on the path is
+        # ``except Exception``. So the whole command crashed, at a rate set by
+        # how fast api.openai.com happened to answer.
+        #
+        # Swallowing a cancellation is normally wrong: it hides a caller who
+        # wanted to stop us. It is right HERE because this coroutine is only
+        # ever driven by ``asyncio.run`` from synchronous CLI code (see the
+        # caller above), so there is no caller above capable of cancelling it.
+        # The only possible source is the deadline we set ourselves.
+        return "timeout", None
     except Exception as exc:  # noqa: BLE001
         return "failed", f"{type(exc).__name__}: {exc}"
 


### PR DESCRIPTION
`voicegw doctor` validates a configured provider key by calling `health_check`, which issues a **live HTTPS GET to `api.openai.com/v1/models`** under a 5-second deadline. When that call did not answer in time, the command died with an unhandled `CancelledError` traceback instead of reporting the timeout it already has a branch for.

## Why the timeout did not become a TimeoutError

`asyncio.wait_for` rewrites the cancellation it delivers into `TimeoutError`, but only while `task.uncancel() <= self._cancelling`. The provider supplies an extra, unaccounted cancel by construction:

```python
async with httpx.AsyncClient() as client:   # draining this pool on the way out
    resp = await client.get(...)             # awaits again under anyio's own
                                             # cancel scope -> a second cancel
```

One cancel it did not account for defeats the conversion, so the raw `CancelledError` comes out. Nothing on the path to the CLI catches it, because `CancelledError` derives from `BaseException` while every handler between here and the command is `except Exception` — including the provider's own `except Exception: return False`.

Swallowing a cancellation is usually wrong. It is right here, and the comment says why: this coroutine is only ever driven by `asyncio.run` from synchronous CLI code, so the only thing that can cancel it is the deadline it set itself.

## The same defect was flaking CI

Two tests in `test_doctor.py` drove that path against the real internet: `temp_config` configures `providers.openai`, so the check ran for real with the fake `sk-test` key.

`all_pass` already stubbed provider validation, which is exactly why only the two tests **without** it ever failed. The timings tell the rest:

| Run | Result | Duration |
|---|---|---|
| 1 | failed | 5.49s |
| 2 | passed | 0.38s |
| 3 | failed | 5.33s |
| 4 | passed | 0.31s |
| 5 | passed | 0.46s |

Every failure lands on the 5.0s deadline; every pass returns in under half a second. The discriminator was simply whether `api.openai.com` answered quickly.

Measured on an untouched tree: **3 failures in 30 runs**, and a similar rate in CI on a different network. The stub is now `autouse`, so no test in that file can dial out, including ones added later. `all_pass` still installs its own "ok" stub over the top; this is the floor, not a replacement.

## The regression test fails on the unfixed tree

The existing `test_validate_returns_timeout_when_health_check_hangs` cancels a bare `Event().wait()`. Nothing runs after the cancellation there, so the conversion works and it passes either way — it cannot catch this.

The new test reproduces the real shape with no network and no httpx: a fake whose async cleanup cancels the task a second time, the way anyio's cancel scope does inside `httpx.AsyncClient.aclose()`. It raises `CancelledError` on current `main` and passes with the fix.

## Verification

Run on a local py3.13 venv built to mirror the CI matrix leg exactly (`uv venv --seed --python 3.13`, same install line), so this was proven before reaching CI rather than after:

- Previously flaky test: **0 failures in 40 runs** (was 3 in 30)
- `test_doctor.py`: 21 passed in **0.49s**, down from an intermittent 5s stall
- Full leg: **3261 passed**, 13 skipped, ruff clean, mypy clean on 283 files
- Slowest test in the entire suite is now **2.01s**, so nothing is parked on a network timeout

## User-visible effect

`voicegw doctor` on a slow or firewalled network now prints the timeout row it was always meant to. Before, it exited with a traceback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider health-check timeout handling so interrupted cleanup no longer causes the CLI to exit with a traceback.
  * Provider validation now consistently reports timed-out checks when cancellation occurs during cleanup.

* **Tests**
  * Added regression coverage for repeated cancellation during provider health-check cleanup.
  * Updated CLI tests to avoid external provider network requests, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->