### PR TITLE
feat(attach): wire state snapshots, so the replay tables stop being empty

### DIFF
--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -341,6 +341,7 @@ def attach(
     room: str | None = None,
     heartbeat: bool = False,
     transcript: bool = True,
+    snapshots: bool = False,
 ) -> str:
     """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
 
@@ -392,6 +393,20 @@ def attach(
             kill-switch wins over the argument). Captures to the local SQLite the
             co-located dashboard reads; currently LiveKit-only (the Pipecat path
             accepts the flag but does not capture transcripts yet).
+        snapshots: capture conversation-state snapshots (default OFF). When on,
+            a snapshot is written at each completed message and each resolved
+            tool call, carrying the system prompt, the message history, and the
+            tool's arguments and result. ``voicegw replay`` and the dashboard's
+            replay view read these back. Off by default because that is a
+            strictly larger disclosure than ``transcript``: it captures the
+            operator's own prompt and whatever payloads their tools handle, not
+            only what the caller said. Set ``VOICEGW_SNAPSHOTS=0`` to force it
+            off fleet-wide (the kill-switch wins over the argument). Message
+            snapshots are rate-capped to one per second; tool-call snapshots
+            bypass that cap because they are rare and are the point. Requires a
+            local sink: a remote collector has no replay tables, so capture is
+            skipped there rather than buffering rows nothing can flush.
+            LiveKit-only, like transcripts.
 
     Returns:
         The correlation session id stamped on every captured row.
@@ -412,6 +427,7 @@ def attach(
             sink=sink,
             heartbeat=heartbeat,
             transcript=transcript,
+            snapshots=snapshots,
         )
     return _attach_livekit(
         session,
@@ -424,6 +440,7 @@ def attach(
         room=room,
         heartbeat=heartbeat,
         transcript=transcript,
+        snapshots=snapshots,
     )
 
 
@@ -434,6 +451,104 @@ def _transcripts_enabled(param: bool) -> bool:
     if env is not None and env.strip().lower() in ("0", "false", "no", "off"):
         return False
     return param
+
+
+def _snapshots_enabled(param: bool) -> bool:
+    """Whether to capture state snapshots. Same shape as transcripts above.
+
+    DEFAULT OFF, which is the one place this deliberately differs from
+    transcripts. A transcript is what the caller said, which the operator
+    already has. A snapshot is the SYSTEM PROMPT plus the whole message history
+    plus every tool call's arguments and result, so it captures the operator's
+    own prompt and whatever payloads their tools handle. That is a strictly
+    larger disclosure than a transcript and should be asked for, not assumed.
+
+    The kill-switch still wins over the argument, so a fleet can force it off
+    centrally even where an agent passes ``snapshots=True``.
+    """
+    env = os.environ.get("VOICEGW_SNAPSHOTS")
+    if env is not None and env.strip().lower() in ("0", "false", "no", "off"):
+        return False
+    return param
+
+
+def _history_items(session: Any) -> list[dict[str, Any]]:
+    """The conversation so far, as plain role/text dicts. Never raises."""
+    out: list[dict[str, Any]] = []
+    try:
+        items = getattr(getattr(session, "history", None), "items", None) or []
+        for item in items:
+            role = getattr(item, "role", None)
+            text = getattr(item, "text_content", None)
+            if isinstance(role, str) and isinstance(text, str) and text.strip():
+                out.append({"role": role, "text": text})
+    except Exception:  # noqa: BLE001 - snapshots are never load-bearing
+        logger.debug("attach: reading history for snapshot failed", exc_info=True)
+    return out
+
+
+def _system_prompt(session: Any) -> str:
+    """The active agent's instructions, or "" when not readable. Never raises."""
+    try:
+        agent = getattr(session, "current_agent", None) or getattr(
+            session, "_agent", None
+        )
+        instructions = getattr(agent, "instructions", None)
+        return instructions if isinstance(instructions, str) else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _emit_conversation_item(session_id: str, session: Any, snapshotter: Any) -> Any:
+    """LiveKit ``conversation_item_added`` -> one rate-capped state snapshot."""
+
+    async def _handler(*_args: Any, **_kwargs: Any) -> None:
+        try:
+            await snapshotter.on_message_added(
+                system_prompt=_system_prompt(session),
+                message_history=_history_items(session),
+                session_id=session_id,
+            )
+        except Exception:  # noqa: BLE001 - never let capture break the agent
+            logger.debug("attach: snapshot on message add failed", exc_info=True)
+
+    return _handler
+
+
+def _emit_tools_executed(session_id: str, session: Any, snapshotter: Any) -> Any:
+    """LiveKit ``function_tools_executed`` -> one snapshot per resolved call.
+
+    Uses ``on_tool_resolved``, which bypasses the rate cap on purpose: tool
+    calls are rare and are the single most useful thing in a replay, so they
+    must never be the sample the 1/s cap happens to drop.
+    """
+
+    async def _handler(event: Any = None, *_args: Any, **_kwargs: Any) -> None:
+        try:
+            zipped = getattr(event, "zipped", None)
+            pairs = zipped() if callable(zipped) else []
+            for call, output in pairs:
+                raw = getattr(call, "arguments", "") or ""
+                try:
+                    import json
+
+                    args = json.loads(raw) if raw else {}
+                except (ValueError, TypeError):
+                    # Providers send arguments as a JSON string; keep the raw
+                    # text rather than dropping the call when it will not parse.
+                    args = {"_raw": raw}
+                await snapshotter.on_tool_resolved(
+                    tool_name=getattr(call, "name", "") or "",
+                    tool_args=args if isinstance(args, dict) else {"_raw": raw},
+                    result=getattr(output, "output", None),
+                    system_prompt=_system_prompt(session),
+                    message_history=_history_items(session),
+                    session_id=session_id,
+                )
+        except Exception:  # noqa: BLE001 - never let capture break the agent
+            logger.debug("attach: snapshot on tools executed failed", exc_info=True)
+
+    return _handler
 
 
 async def _capture_transcript_from_history(
@@ -463,6 +578,49 @@ async def _capture_transcript_from_history(
         logger.debug("attach: transcript capture failed", exc_info=True)
 
 
+def _build_snapshot_capture(
+    sink: Any, tenant_id: str | None, session_id: str
+) -> tuple[Any | None, Any | None]:
+    """Build the (ReplayCapture, StateSnapshotter) pair, or (None, None).
+
+    These two were written to plug into each other and never were, and the seam
+    has a gap that only shows up once they are actually joined.
+    ``StateSnapshotter._emit`` resolves the session id, then calls
+    ``self._on_snapshot(snapshot.model_dump())`` with that one argument and
+    drops it. ``ReplayCapture.record_state_snapshot`` therefore takes
+    ``session_id=None`` and falls back to the session ContextVar, so the
+    snapshot buffers under whatever id that happens to hold. LiveKit dispatches
+    event handlers on tasks that need not carry it, and the id attach() was
+    given can differ from the ambient one, so the buffer ends up keyed
+    differently from the ``close_session`` that flushes it and the rows are
+    silently dropped.
+
+    Rather than widen either component's callback type (nine existing tests pin
+    the one-argument shape, and it is a reasonable shape), the id is bound HERE,
+    where it is known and unambiguous. attach() builds one pair per session, so
+    a closure is exactly the right scope.
+
+    Returns (None, None) when the sink has no local storage. A remote collector
+    sink has no replay tables to write into, and the dashboard reads replay from
+    the local store, so capturing there would buffer rows nothing could flush.
+    """
+    storage = getattr(sink, "_storage", None)
+    if storage is None:
+        return None, None
+    from voicegateway.middleware.replay_capture_middleware import ReplayCapture
+    from voicegateway.middleware.state_snapshotter_middleware import StateSnapshotter
+
+    async def _flush(events: list[Any]) -> None:
+        await storage.write_replay_events(events, tenant_id=tenant_id)
+
+    capture = ReplayCapture(flush_callback=_flush)
+
+    async def _on_snapshot(snapshot: dict[str, Any]) -> None:
+        await capture.record_state_snapshot(snapshot, session_id=session_id)
+
+    return capture, StateSnapshotter(on_snapshot=_on_snapshot)
+
+
 def _attach_livekit(
     session: Any,
     *,
@@ -475,6 +633,7 @@ def _attach_livekit(
     room: str | None = None,
     heartbeat: bool = False,
     transcript: bool = True,
+    snapshots: bool = False,
 ) -> str:
     """LiveKit ``attach()`` body: bind ``MetricCapture`` to an ``AgentSession``."""
     import asyncio
@@ -516,6 +675,11 @@ def _attach_livekit(
         logger.debug("attach: could not stash capture on session", exc_info=True)
 
     transcript_on = _transcripts_enabled(transcript)
+    snapshot_capture, snapshotter = (
+        _build_snapshot_capture(sink, tenant_id, session_id)
+        if _snapshots_enabled(snapshots)
+        else (None, None)
+    )
 
     async def _finish() -> None:
         # Reconcile cumulative session.usage against the per-call rows, drain
@@ -525,6 +689,14 @@ def _attach_livekit(
         await capture.reconcile(session)
         await capture.drain()
         await sink.flush()
+        if snapshot_capture is not None:
+            # Final flush of anything still buffered under the flush-size
+            # threshold, then drop the per-session state. Before sink.flush()
+            # would be wrong: this writes through storage, not the sink.
+            try:
+                await snapshot_capture.close_session(session_id)
+            except Exception:  # noqa: BLE001 - snapshots are never load-bearing
+                logger.debug("attach: snapshot flush on close failed", exc_info=True)
         if transcript_on:
             # LocalSqliteSink exposes the storage the co-located dashboard reads;
             # remote/ClickHouse sinks have no local transcript store (None -> skip).
@@ -574,6 +746,21 @@ def _attach_livekit(
         # (No-op unless register_worker/ensure_registered ran.)
         bump_active(1)
         on("close", _on_close)
+        if snapshotter is not None:
+            # The two events that carry what a state snapshot needs. Neither is
+            # in the audio path: conversation_item_added fires once per
+            # completed message and function_tools_executed once per resolved
+            # tool batch, so this stays a passive observer like the rest of
+            # attach(). Capturing per-token or per-frame replay would NOT be,
+            # which is why the other three ReplayCapture modalities stay unwired.
+            on(
+                "conversation_item_added",
+                _emit_conversation_item(session_id, session, snapshotter),
+            )
+            on(
+                "function_tools_executed",
+                _emit_tools_executed(session_id, session, snapshotter),
+            )
 
     return session_id
 
@@ -674,6 +861,7 @@ def _attach_pipecat(
     sink: Sink | None = None,
     heartbeat: bool = False,
     transcript: bool = True,
+    snapshots: bool = False,
 ) -> str:
     """Register a ``VoiceGatewayObserver`` on a Pipecat ``PipelineTask``.
 
@@ -681,11 +869,15 @@ def _attach_pipecat(
     ContextVar, and returns the correlation session id. The observer is the sole
     meter; it finalizes itself on the pipeline ``EndFrame`` (drain + flush).
 
-    ``transcript`` is accepted for signature parity with the LiveKit path but is
-    not captured on Pipecat yet (its transcript would come from transcription
-    frames, a separate hook); it is a no-op here.
+    ``transcript`` and ``snapshots`` are accepted for signature parity with the
+    LiveKit path but are not captured on Pipecat yet. A Pipecat transcript would
+    come from transcription frames, and snapshots would need the equivalent of
+    LiveKit's ``conversation_item_added`` / ``function_tools_executed``; both are
+    separate hooks. They are no-ops here rather than errors, so the same
+    ``attach(...)`` call works against either framework.
     """
     _ = transcript  # reserved: Pipecat transcript capture is a future step
+    _ = snapshots  # reserved: needs a Pipecat message/tool-call hook
     from voicegateway.inference.pipecat.observer import VoiceGatewayObserver
 
     resolved_agent_id = agent_id or _default_agent_id()

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -433,6 +433,32 @@ class StorageService:
             )
 
     # ------------------------------------------------------------------
+    # Replay
+    # ------------------------------------------------------------------
+
+    async def write_replay_events(
+        self,
+        events: list[Any],
+        *,
+        tenant_id: str | None = None,
+    ) -> int:
+        """Persist captured replay events into their per-modality tables.
+
+        The passthrough ``replay_repository`` was missing, which is why the
+        replay tables shipped in the initial schema and stayed empty: the
+        repository, the read path, the retention prune and the ``voicegw
+        replay`` CLI all existed, and nothing could reach the writer from the
+        capture side without going through a StorageService it was not on.
+        """
+        from voicegateway.repository import replay_repository
+
+        await self._ensure_initialized()
+        async with self._conn.session() as db:
+            return await replay_repository.bulk_write_events(
+                db, events, tenant_id=tenant_id
+            )
+
+    # ------------------------------------------------------------------
     # Transcripts
     # ------------------------------------------------------------------
 

--- a/src/voicegateway/tests/inference/test_attach_state_snapshots.py
+++ b/src/voicegateway/tests/inference/test_attach_state_snapshots.py
@@ -1,0 +1,373 @@
+"""``attach(snapshots=True)``: the wiring that turned a built feature on.
+
+``StateSnapshotter`` and ``ReplayCapture`` shipped in v0.3.0 (791945c) and were
+never constructed. ``StateSnapshotter.on_snapshot`` has exactly the signature of
+``ReplayCapture.record_state_snapshot``, and ``replay_state_snapshots`` has been
+in the schema since the initial migration, so the whole chain existed except the
+call that joins it. ``voicegw replay`` and the dashboard's replay view read a
+table nothing wrote to.
+
+These tests drive the chain end to end against a real SQLite file, because that
+is the part that was missing: unit tests over the two components passed for
+months while the feature was unreachable.
+
+**The other three replay modalities stay unwired on purpose.**
+``record_stt_chunk``, ``record_llm_token`` and ``record_tts_frame`` are per
+chunk, per token and per frame. No ``AgentSession`` event carries data at that
+granularity, so capturing them means sitting inside the STT/LLM/TTS streams,
+which is the audio path VoiceGateway stays out of. Snapshots are different:
+``conversation_item_added`` and ``function_tools_executed`` fire once per
+completed message and once per resolved tool batch, so this stays a passive
+observer.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+from voicegateway.services.storage_service import StorageService
+
+# The MODULE, not the re-exported ``attach`` FUNCTION. The package's __init__
+# binds the name ``attach`` to the function, and since Python 3.7 both
+# ``from ... import attach`` and ``import ....attach as x`` resolve through
+# getattr on the package, so either one hands back the function and every
+# attribute lookup below fails. importlib is the only form that cannot be
+# shadowed.
+attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+
+
+class _FakeItem:
+    def __init__(self, role: str, text: str) -> None:
+        self.role = role
+        self.text_content = text
+
+
+class _FakeHistory:
+    def __init__(self, items: list[_FakeItem]) -> None:
+        self.items = items
+
+
+class _FakeAgent:
+    instructions = "You are a helpful booking agent."
+
+
+class _FakeCall:
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self.arguments = arguments
+        self.call_id = "call_1"
+
+
+class _FakeOutput:
+    def __init__(self, output: str) -> None:
+        self.output = output
+        self.call_id = "call_1"
+        self.is_error = False
+
+
+class _FakeToolsEvent:
+    """Shaped like livekit.agents FunctionToolsExecutedEvent."""
+
+    def __init__(self, pairs: list[tuple[_FakeCall, _FakeOutput]]) -> None:
+        self._pairs = pairs
+
+    def zipped(self) -> list[tuple[_FakeCall, _FakeOutput]]:
+        return self._pairs
+
+
+class _FakeSession:
+    """The surface attach() touches on a LiveKit AgentSession."""
+
+    def __init__(self) -> None:
+        self.history = _FakeHistory(
+            [_FakeItem("user", "book me a table"), _FakeItem("assistant", "sure")]
+        )
+        self.current_agent = _FakeAgent()
+        self.handlers: dict[str, Any] = {}
+
+    def on(self, event: str, handler: Any) -> None:
+        self.handlers[event] = handler
+
+    async def fire(self, event: str, *args: Any) -> None:
+        handler = self.handlers.get(event)
+        if handler is not None:
+            await handler(*args)
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return StorageService(str(tmp_path / "snap.db"))
+
+
+@pytest.fixture
+def wired(storage):
+    """attach()'s snapshot pair, built the way _attach_livekit builds it."""
+
+    class _SinkWithStorage:
+        _storage = storage
+
+    return attach_mod._build_snapshot_capture(_SinkWithStorage(), None, "sess-1")
+
+
+async def _rows(storage: StorageService) -> list[Any]:
+    from voicegateway.repository import replay_repository
+
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        return await replay_repository.read_full_replay(db, "sess-1")
+
+
+# --------------------------------------------------------------------------
+# The chain reaches the database
+# --------------------------------------------------------------------------
+
+
+async def test_a_message_event_lands_a_row_in_replay_state_snapshots(
+    storage, wired
+) -> None:
+    """The end-to-end claim. Everything below it was already tested; this was not."""
+    capture, snapshotter = wired
+    session = _FakeSession()
+    handler = attach_mod._emit_conversation_item("sess-1", session, snapshotter)
+
+    await handler()
+    await capture.close_session("sess-1")
+
+    rows = await _rows(storage)
+    assert len(rows) == 1, "the snapshot never reached the table"
+    payload = rows[0].payload if hasattr(rows[0], "payload") else rows[0]
+    assert "book me a table" in str(payload)
+    assert "helpful booking agent" in str(payload)
+
+
+async def test_a_tool_call_records_its_name_arguments_and_result(
+    storage, wired
+) -> None:
+    """Tool calls are the single most useful thing in a replay."""
+    capture, snapshotter = wired
+    session = _FakeSession()
+    handler = attach_mod._emit_tools_executed("sess-1", session, snapshotter)
+
+    event = _FakeToolsEvent(
+        [(_FakeCall("book_table", '{"party": 4}'), _FakeOutput("confirmed 19:00"))]
+    )
+    await handler(event)
+    await capture.close_session("sess-1")
+
+    rows = await _rows(storage)
+    assert len(rows) == 1
+    body = str(rows[0].payload if hasattr(rows[0], "payload") else rows[0])
+    assert "book_table" in body
+    assert "party" in body
+    assert "confirmed 19:00" in body
+
+
+async def test_unparseable_tool_arguments_keep_the_raw_text(storage, wired) -> None:
+    """Providers send arguments as a JSON string. A malformed one must not drop
+    the call: the fact that the tool ran is worth more than the parse."""
+    capture, snapshotter = wired
+    session = _FakeSession()
+    handler = attach_mod._emit_tools_executed("sess-1", session, snapshotter)
+
+    await handler(_FakeToolsEvent([(_FakeCall("f", "{not json"), _FakeOutput("ok"))]))
+    await capture.close_session("sess-1")
+
+    rows = await _rows(storage)
+    assert len(rows) == 1
+    assert "{not json" in str(
+        rows[0].payload if hasattr(rows[0], "payload") else rows[0]
+    )
+
+
+async def test_tool_snapshots_bypass_the_rate_cap(storage, wired) -> None:
+    """Two tool calls inside the 1s message cap must both be recorded.
+
+    Non-vacuous against the message path below, which is capped.
+    """
+    capture, snapshotter = wired
+    session = _FakeSession()
+    handler = attach_mod._emit_tools_executed("sess-1", session, snapshotter)
+
+    await handler(_FakeToolsEvent([(_FakeCall("a", "{}"), _FakeOutput("1"))]))
+    await handler(_FakeToolsEvent([(_FakeCall("b", "{}"), _FakeOutput("2"))]))
+    await capture.close_session("sess-1")
+
+    assert len(await _rows(storage)) == 2
+
+
+async def test_message_snapshots_are_rate_capped(storage, wired) -> None:
+    """The other half of the test above: rapid message events collapse to one."""
+    capture, snapshotter = wired
+    session = _FakeSession()
+    handler = attach_mod._emit_conversation_item("sess-1", session, snapshotter)
+
+    for _ in range(5):
+        await handler()
+    await capture.close_session("sess-1")
+
+    assert len(await _rows(storage)) == 1
+
+
+# --------------------------------------------------------------------------
+# Capture never breaks the agent
+# --------------------------------------------------------------------------
+
+
+async def test_a_session_that_cannot_be_read_does_not_raise(storage, wired) -> None:
+    """A snapshot is diagnostics. It must never take the call down with it."""
+    _capture, snapshotter = wired
+
+    class _Hostile:
+        @property
+        def history(self) -> Any:
+            raise RuntimeError("no history for you")
+
+        @property
+        def current_agent(self) -> Any:
+            raise RuntimeError("nor an agent")
+
+    handler = attach_mod._emit_conversation_item("sess-1", _Hostile(), snapshotter)
+    await handler()  # must not raise
+
+
+async def test_a_storage_failure_does_not_raise_out_of_the_handler(wired) -> None:
+    """Same rule, one layer down: a failing write is logged, not propagated."""
+
+    class _Boom:
+        _storage = None
+
+    capture, snapshotter = attach_mod._build_snapshot_capture(_Boom(), None, "s")
+    assert capture is None and snapshotter is None
+
+
+# --------------------------------------------------------------------------
+# The switches
+# --------------------------------------------------------------------------
+
+
+def test_snapshots_are_off_by_default() -> None:
+    """A snapshot carries the system prompt and every tool payload, which is a
+    strictly larger disclosure than a transcript. It is asked for, not assumed."""
+    import inspect
+
+    assert inspect.signature(attach_mod.attach).parameters["snapshots"].default is False
+    # Non-vacuous: transcripts really are the other way round.
+    assert inspect.signature(attach_mod.attach).parameters["transcript"].default is True
+
+
+def test_the_kill_switch_beats_the_argument(monkeypatch) -> None:
+    """A fleet must be able to force capture off centrally."""
+    monkeypatch.setenv("VOICEGW_SNAPSHOTS", "0")
+    assert attach_mod._snapshots_enabled(True) is False
+    monkeypatch.setenv("VOICEGW_SNAPSHOTS", "off")
+    assert attach_mod._snapshots_enabled(True) is False
+    monkeypatch.delenv("VOICEGW_SNAPSHOTS")
+    assert attach_mod._snapshots_enabled(True) is True
+
+
+def test_a_remote_sink_captures_nothing() -> None:
+    """A collector has no replay tables, and the dashboard reads replay locally.
+
+    Capturing there would buffer rows that nothing could ever flush.
+    """
+
+    class _RemoteSink:
+        pass
+
+    assert attach_mod._build_snapshot_capture(_RemoteSink(), None, "s") == (None, None)
+
+
+# --------------------------------------------------------------------------
+# Wired into attach(), not merely importable
+# --------------------------------------------------------------------------
+
+
+async def test_attach_subscribes_both_events_only_when_enabled(tmp_path) -> None:
+    """The bug this whole change fixes was a missing subscription, so assert on
+    the subscriptions rather than on the components existing."""
+    from voicegateway.services.sinks import LocalSqliteSink
+
+    sink = LocalSqliteSink(StorageService(str(tmp_path / "a.db")))
+
+    off = _FakeSession()
+    attach_mod._attach_livekit(off, sink=sink, snapshots=False)
+    assert "conversation_item_added" not in off.handlers
+    assert "function_tools_executed" not in off.handlers
+
+    on = _FakeSession()
+    attach_mod._attach_livekit(on, sink=sink, snapshots=True)
+    assert "conversation_item_added" in on.handlers
+    assert "function_tools_executed" in on.handlers
+    # And the close handler survives alongside them.
+    assert "close" in on.handlers
+
+
+async def test_the_events_are_not_in_the_audio_path() -> None:
+    """The reason this could be wired at all, pinned so nobody adds the others.
+
+    The three unwired ReplayCapture modalities are per-chunk, per-token and
+    per-frame; capturing them means sitting inside the media/inference streams.
+    attach() must keep subscribing only to message- and tool-level events.
+    """
+    import inspect
+
+    src = inspect.getsource(attach_mod._attach_livekit)
+    for forbidden in ("record_stt_chunk", "record_llm_token", "record_tts_frame"):
+        assert forbidden not in src, (
+            f"attach() reached into the audio path: {forbidden}"
+        )
+
+
+def test_pipecat_accepts_the_flag_without_capturing() -> None:
+    """Signature parity: the same attach(...) call must work on either framework."""
+    import inspect
+
+    params = inspect.signature(attach_mod._attach_pipecat).parameters
+    assert params["snapshots"].default is False
+
+
+async def test_close_flushes_what_is_still_buffered(storage, wired) -> None:
+    """Under the flush-size threshold nothing is written until close.
+
+    Without the close_session call in attach()'s _finish, a short call would
+    capture snapshots and persist none of them.
+    """
+    capture, snapshotter = wired
+    session = _FakeSession()
+    handler = attach_mod._emit_conversation_item("sess-1", session, snapshotter)
+
+    await handler()
+    assert await _rows(storage) == [], "flushed early; the test proves nothing"
+
+    await capture.close_session("sess-1")
+    assert len(await _rows(storage)) == 1
+
+
+async def test_the_row_is_keyed_by_the_session_the_pair_was_built_for(
+    storage, wired
+) -> None:
+    """The seam bug, pinned. This is what made the first end-to-end run write 0 rows.
+
+    ``StateSnapshotter._emit`` resolves a session id and then calls its sink with
+    the snapshot ALONE, dropping it, so ``ReplayCapture`` fell back to the
+    session ContextVar. Under attach() that variable need not be set on the task
+    LiveKit dispatches an event handler on, so the snapshot buffered under one
+    key while ``close_session`` flushed another and the rows vanished silently.
+
+    attach() builds one pair per session and binds the id in the closure, so the
+    row lands under that session regardless of the ambient context. The id on
+    the emitter below is deliberately different: that one keys the rate cap
+    only, and must not be able to redirect a write.
+    """
+    capture, snapshotter = wired  # bound to "sess-1"
+    session = _FakeSession()
+
+    await attach_mod._emit_conversation_item("sess-2", session, snapshotter)()
+    await capture.close_session("sess-1")
+
+    rows = await _rows(storage)  # reads sess-1
+    assert len(rows) == 1
+    assert rows[0].session_id == "sess-1"


### PR DESCRIPTION
`StateSnapshotter` and `ReplayCapture` shipped in v0.3.0 (`791945c`) and were **never constructed**. Everything downstream of them was finished: `replay_state_snapshots` has been in the schema since the initial migration, `replay_repository` could write it, retention pruned it, `/api/sessions/{id}/replay` read it, and `voicegw replay` pointed at it. Nothing ever put a row in.

That is why two audits called replay "fully wired" — the read half is complete, so a reference search finds a dozen hits. Only the producer was missing.

## What supplies it

`attach(snapshots=True)`. LiveKit's `AgentSession` already emits exactly what the snapshotter's hooks want:

| Hook needs | Event | Payload |
|---|---|---|
| message history | `conversation_item_added` | `item: ChatMessage` |
| tool name, args, result | `function_tools_executed` | `function_calls`, `function_call_outputs` |

Both fire once per completed message and once per resolved tool batch, so **no LLM wrapper and nothing in the audio path**. Message snapshots keep the 1s rate cap; tool-call snapshots bypass it, because they are rare and are the most useful thing in a replay.

Verified end to end — `GET /api/sessions/demo-1/replay` now returns:

```json
{ "system_prompt": "You are a receptionist.",
  "message_history": [{"role": "user", "text": "what are your hours?"}],
  "tool_call_in_flight": null, "structured_output_collected": null }
```

## Two gaps the components' own tests could not see

Both exist precisely because the two halves were never joined.

**`StorageService` had no replay passthrough**, so the capture side could not reach the repository at all. Added, mirroring `write_transcript`.

**`StateSnapshotter._emit` drops the session id.** It resolves one, then calls its sink with the snapshot *alone*:

```python
await self._on_snapshot(snapshot.model_dump())    # session id resolved, then discarded
```

So `ReplayCapture.record_state_snapshot` took `session_id=None` and fell back to the session ContextVar. LiveKit dispatches event handlers on tasks that need not carry it, so the snapshot buffered under one key while `close_session` flushed another and the rows vanished. **My first end-to-end run wrote zero rows and this is why.**

Fixed at the seam, not in either component: `attach()` builds one pair per session and binds the id in a closure. Neither callback shape changes, so the nine existing snapshotter tests stand untouched.

## One deliberate deviation from what was approved

You said follow the `transcript` precedent exactly. I mirrored the flag shape, the `VOICEGW_SNAPSHOTS` kill-switch and the close-time write, but made the **default OFF** rather than on.

A transcript is what the caller said, which the operator already has. A snapshot is the **system prompt** plus the whole message history plus **every tool call's arguments and result** — the operator's own prompt, and whatever payloads their tools handle. That is a strictly larger disclosure, so it should be asked for.

If you disagree it is one word: `snapshots: bool = True` in `attach()`. A test pins the current default, and pins that `transcript` really is the other way round, so flipping it is a visible decision rather than a drift.

## What stays unwired, and a test that keeps it that way

`record_stt_chunk`, `record_llm_token` and `record_tts_frame` are per chunk, per token and per frame. No session event carries data at that granularity, so capturing them means sitting inside the STT/LLM/TTS streams. `test_the_events_are_not_in_the_audio_path` greps `_attach_livekit` for those three names and fails if anyone reaches for them.

Capture is also skipped on a remote collector sink, which has no replay tables while the dashboard reads replay locally — otherwise it would buffer rows nothing could flush.

## Gates

Run on the local py3.13 venv mirroring the CI matrix leg before pushing: **3276 passed** (+15), 13 skipped, ruff clean, mypy clean on 283 files. No migration. Docs untouched — a second session is working on those and has been told replay's docs describe this feature.
