### PR TITLE
feat(api): expose the per-room latency split over HTTP

### DIFF
--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -218,9 +218,11 @@ Keyed on the **room name**, deliberately, not on `session_id`. A caller mints th
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `since_turn` | `integer` | `null` | Return only turns with `turn_index` greater than this. Filters `turns` **only**. |
+| `since_turn` | `integer` | `null` | Return only turns whose room-wide `seq` is greater than this. Filters `turns` **only**. |
 
-`since_turn` is a cursor over `turns` and nothing else. `components` and `e2e_ms` are whole-call aggregates and always come back whole, so successive polls cannot disagree with each other.
+`since_turn` is a cursor over `turns` and nothing else. It cuts on `seq`, the room-wide position, **not** on `turn_index`: `turn_index` is session-local, so a room carrying more than one session has two turns numbered `0`, two numbered `1`, and so on. Pass back the `seq` of the last turn you saw.
+
+`components` and `e2e_ms` are whole-call aggregates and are never narrowed by `since_turn`. They are recomputed from the rows present at request time, so they **do** move as a call progresses and successive polls will differ; what `since_turn` guarantees is only that it is not the thing moving them.
 
 **Four answers that mean different things:**
 
@@ -231,7 +233,10 @@ Keyed on the **room name**, deliberately, not on `session_id`. A caller mints th
 | `200`, `complete: false` | A real split, still partial because the agent process is mid-flush. **Poll again rather than rendering it.** |
 | `200`, a component is `null` | That stage produced no measurement. It is never `0`: a stage shown as `0.00` reads as "instant". |
 
-All times are in **milliseconds**.
+Every value is in **milliseconds**, but of two different kinds, and the field names do not distinguish them:
+
+- **Epoch timestamps** (a point in time): `caller_speak_end_ms`, `agent_speak_start_ms`. Unix epoch, milliseconds.
+- **Elapsed durations** (a length of time): `response_speed_ms`, every member of `components`, and every member of `e2e_ms`.
 
 **Example:**
 
@@ -260,7 +265,9 @@ curl -H "Authorization: Bearer vk_..." \
   },
   "turns": [
     {
+      "seq": 6,
       "turn_index": 6,
+      "session_id": "vg-8f1c",
       "caller_speak_end_ms": 1800000012345,
       "agent_speak_start_ms": 1800000013386,
       "response_speed_ms": 1041
@@ -269,7 +276,9 @@ curl -H "Authorization: Bearer vk_..." \
 }
 ```
 
-`e2e_ms` is computed by the same `summarize()` the CLI reports through, so the two surfaces cannot drift on what `p95` means. It is `null`, rather than a row of zeros, when no turn completed.
+`e2e_ms` is computed by the same `summarize()` the CLI reports through, so the two surfaces cannot drift on what `p95` means. It is `null`, rather than a row of zeros, when **no turn carries a measured `response_speed_ms`**.
+
+That is not the same as "no turns": `turn_count` can be non-zero while `e2e_ms` is `null`. A turn the agent never answered records a null `response_speed_ms`, and such turns are listed in `turns` but contribute no sample. Averaging them in as `0` would drag every percentile down and report a call as faster than it was.
 
 **Not provided, on purpose:** no CORS and no browser-facing key (a read-scoped key in a browser can read every session and cost row for the tenant, so proxy it server-side); no WebSocket or SSE (ingest is batched behind a bounded queue, so freshness is inherently seconds, and a socket would deliver seconds-stale data faster while adding a stateful fan-out surface); no per-turn component split.
 

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -202,6 +202,79 @@ curl "http://localhost:8080/v1/sessions/vg-8f1c"
 
 ---
 
+## Rooms
+
+The per-stage latency split for one LiveKit room, over HTTP.
+
+The same split is available in-process to `voicegw livekit latency`, but only when the prober and the agent share one local store. A deployment that runs the agent in one container and the collector in another holds every row needed and cannot reach the computation. This endpoint is that computation, reachable. No new measurement happens here.
+
+Keyed on the **room name**, deliberately, not on `session_id`. A caller mints the room name when it signs the LiveKit token, so the room is the only identifier both sides hold at call time; `session_id` is minted inside VoiceGateway and a caller never observes it.
+
+**Authentication:** read authentication, the same as [Sessions](#sessions). Tenant comes from the key and never from the request.
+
+### GET /v1/rooms/{room_name}/latency
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `since_turn` | `integer` | `null` | Return only turns with `turn_index` greater than this. Filters `turns` **only**. |
+
+`since_turn` is a cursor over `turns` and nothing else. `components` and `e2e_ms` are whole-call aggregates and always come back whole, so successive polls cannot disagree with each other.
+
+**Four answers that mean different things:**
+
+| Response | Meaning |
+|---|---|
+| `404` | This collector has never seen that room, **or** the room belongs to another tenant. Identical on purpose: a `403` would confirm the room is real. |
+| `200`, `components: null` | The room is known and nothing correlated: an uninstrumented agent, or no completed turn yet. |
+| `200`, `complete: false` | A real split, still partial because the agent process is mid-flush. **Poll again rather than rendering it.** |
+| `200`, a component is `null` | That stage produced no measurement. It is never `0`: a stage shown as `0.00` reads as "instant". |
+
+All times are in **milliseconds**.
+
+**Example:**
+
+```bash
+curl -H "Authorization: Bearer vk_..." \
+  "http://localhost:8080/v1/rooms/demo-a1b2c3/latency?since_turn=5"
+```
+
+```json
+{
+  "room": "demo-a1b2c3",
+  "project": "pixis-w1",
+  "turn_count": 7,
+  "complete": true,
+  "components": {
+    "eou_ms": 302.0,
+    "stt_ttfp_ms": 121.0,
+    "stt_transcription_delay_ms": 88.0,
+    "stt_ms": 209.0,
+    "llm_ttft_ms": 447.0,
+    "tts_ttfb_ms": 92.0
+  },
+  "e2e_ms": {
+    "p50": 1041.0, "p95": 1288.0, "avg": 1074.0,
+    "min": 902.0, "max": 1301.0, "n": 7
+  },
+  "turns": [
+    {
+      "turn_index": 6,
+      "caller_speak_end_ms": 1800000012345,
+      "agent_speak_start_ms": 1800000013386,
+      "response_speed_ms": 1041
+    }
+  ]
+}
+```
+
+`e2e_ms` is computed by the same `summarize()` the CLI reports through, so the two surfaces cannot drift on what `p95` means. It is `null`, rather than a row of zeros, when no turn completed.
+
+**Not provided, on purpose:** no CORS and no browser-facing key (a read-scoped key in a browser can read every session and cost row for the tenant, so proxy it server-side); no WebSocket or SSE (ingest is batched behind a bounded queue, so freshness is inherently seconds, and a socket would deliver seconds-stale data faster while adding a stateful fan-out surface); no per-turn component split.
+
+---
+
 ## Billing
 
 The rating layer's read surface. VoiceGateway rates each recorded request at write time (`rated_price_usd` + `rate_rule`); these endpoints roll that up per tenant and expose the rate card in effect. See [Rating](/architecture/rating) for the model.

--- a/docs/examples/multi-project.md
+++ b/docs/examples/multi-project.md
@@ -146,8 +146,18 @@ staging_task = build_task(transport_in, transport_out, project="staging")
 </Tabs>
 
 <Note>
-There is no `VOICEGW_PROJECT` env var. Pass `project=` explicitly to `attach()`
-or `guard()` so the attribution is always unambiguous in code.
+`VOICEGW_PROJECT` exists and is honoured. Attribution resolves in three steps,
+first match wins:
+
+1. an explicit `project=` on `attach()` or `guard()`
+2. the `VOICEGW_PROJECT` environment variable
+3. `"default"`
+
+Prefer the explicit argument when one process serves several projects, since
+that is the case an environment variable cannot express: it is per-process, so
+every session in that process lands under the same project. Use the variable to
+label a whole deployment without editing code, which is how the
+[VPS](/deployment/vps) and [hosted quickstart](/hosted/quickstart) guides set it.
 </Note>
 
 ## Querying per-project costs

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -37,6 +37,7 @@ not in the room when it ran. That drives every decision below.
 from __future__ import annotations
 
 import html
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -518,7 +519,69 @@ def _report_target(livekit_url: str | None) -> dict[str, Any]:
     }
 
 
-def build_payload(run: RunRecord, *, livekit_url: str | None) -> dict[str, Any]:
+#: Where the environment label comes from when a caller does not pass one.
+#: An operator DECLARES this; nothing can derive it. See :func:`_report_basis`.
+ENVIRONMENT_ENV_VAR = "VOICEGW_ENVIRONMENT"
+
+
+def _report_basis(
+    run: RunRecord, checks: dict[str, Any], environment: str | None
+) -> dict[str, Any]:
+    """How much the report is based on, and where the numbers were taken.
+
+    Three facts a reader needs before they can weigh anything else in the
+    document, and which it did not previously state:
+
+    ``turns`` and ``sessions``. The per-agent findings carry ``trials_answered``
+    each, so the totals were derivable and never derived, which left a reader to
+    add up a table to learn the sample size. ``sessions`` counts the DISTINCT
+    PROBE ROOMS the latency check recorded, which is what a session is here: the
+    room a probed agent's counted turns ran in. An agent that answered nothing
+    records no room and is not counted, so this is a count of sessions that
+    produced a measurement rather than of attempts.
+
+    ``environment``. This one cannot be derived and is not guessed. The LiveKit
+    URL in ``target`` is close but is a different claim: it says which server was
+    probed, not whether the probe ran from the deployed environment or from
+    somebody's laptop against it, and those produce different network latency.
+    So it is an operator DECLARATION, from the caller or from
+    :data:`ENVIRONMENT_ENV_VAR`, and when nobody declared one the report says so
+    in as many words rather than implying either answer.
+    """
+    declared = environment or os.environ.get(ENVIRONMENT_ENV_VAR) or None
+    latency = _check_state(run, checks, "latency")
+    result = latency["result"] or {}
+    agents = result.get("agents") or []
+    turns = 0
+    rooms: set[str] = set()
+    for raw in agents:
+        if not isinstance(raw, dict):
+            continue
+        stats = raw.get("stats")
+        if isinstance(stats, dict):
+            turns += _as_int(stats.get("trials")) or 0
+        room = raw.get("room")
+        if isinstance(room, str) and room:
+            rooms.add(room)
+    return {
+        "environment": declared,
+        "environment_declared": declared is not None,
+        "environment_source": (
+            "declared by the operator at export time" if declared is not None else None
+        ),
+        "sessions": len(rooms),
+        "sessions_basis": (
+            "distinct probe rooms recorded by the latency check; an agent that "
+            "answered nothing records no room and is not counted"
+        ),
+        "turns": turns,
+        "turns_basis": "trials that answered, summed across probed agents",
+    }
+
+
+def build_payload(
+    run: RunRecord, *, livekit_url: str | None, environment: str | None = None
+) -> dict[str, Any]:
     """The one report payload. The JSON export IS this; the HTML renders it.
 
     Nothing here judges the run. ``verdict`` and ``gates`` are read back out of
@@ -552,6 +615,10 @@ def build_payload(run: RunRecord, *, livekit_url: str | None) -> dict[str, Any]:
             "error": run.error,
         },
         "target": _report_target(livekit_url),
+        # How much this rests on, and where it was measured from. See
+        # :func:`_report_basis`: the sample size was derivable from the per-agent
+        # findings and never stated, and the environment cannot be derived at all.
+        "basis": _report_basis(run, checks, environment),
         "verdict": {
             "status": run.verdict,
             "recorded": run.verdict is not None,
@@ -736,6 +803,41 @@ def _state_note(finding: dict[str, Any]) -> str | None:
     return None
 
 
+def _render_environment(payload: dict[str, Any]) -> str:
+    """The declared environment, or an explicit statement that nobody declared one.
+
+    Never inferred. "Probed a production URL" and "probed it from production" are
+    different claims, and only the second one says whether the network path in
+    these numbers is the one real callers traverse. So an undeclared report says
+    it is undeclared, rather than letting a reader assume either answer.
+    """
+    basis = payload.get("basis") or {}
+    label = basis.get("environment")
+    if not label:
+        return (
+            '<span class="nm">not declared</span><br>'
+            '<span class="nm">nothing here can tell whether this ran inside the '
+            f"deployed environment or against it from elsewhere. Set "
+            f"{_esc(ENVIRONMENT_ENV_VAR)} on the exporting host to say so.</span>"
+        )
+    return (
+        f"{_esc(label)}<br>"
+        f'<span class="nm">{_esc(basis.get("environment_source") or "")}</span>'
+    )
+
+
+def _render_basis_counts(payload: dict[str, Any]) -> str:
+    """Sessions and turns, so the sample size is stated and not added up by hand."""
+    basis = payload.get("basis") or {}
+    sessions = _as_int(basis.get("sessions")) or 0
+    turns = _as_int(basis.get("turns")) or 0
+    return (
+        f"{sessions:,} session(s), {turns:,} turn(s)<br>"
+        f'<span class="nm">{_esc(basis.get("sessions_basis") or "")}; '
+        f"{_esc(basis.get('turns_basis') or '')}</span>"
+    )
+
+
 def _render_meta(payload: dict[str, Any]) -> str:
     run = payload["run"]
     target = payload["target"]
@@ -765,6 +867,8 @@ def _render_meta(payload: dict[str, Any]) -> str:
             + '<br><span class="nm">read on the exporting host at export time: '
             "the run record does not store the server it probed</span>",
         ),
+        ("Environment", _render_environment(payload)),
+        ("Measured over", _render_basis_counts(payload)),
         (
             "Reply-latency target",
             _recorded(None if target_ms is None else f"{target_ms:,.0f} ms"),

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -558,10 +558,18 @@ def _report_basis(
         if not isinstance(raw, dict):
             continue
         stats = raw.get("stats")
+        answered = 0
         if isinstance(stats, dict):
-            turns += _as_int(stats.get("trials")) or 0
+            answered = _as_int(stats.get("trials")) or 0
+        turns += answered
         room = raw.get("room")
-        if isinstance(room, str) and room:
+        # Gated on the trial count, not only on the room being present.
+        # ``LatencyResult.room`` is documented as None when no turn completed,
+        # so in practice the two agree, but this function's own contract is
+        # "sessions that produced a measurement". Reading that off the number of
+        # measurements makes it true here rather than true because a caller
+        # upstream happened to clear a field.
+        if answered > 0 and isinstance(room, str) and room:
             rooms.add(room)
     return {
         "environment": declared,
@@ -590,9 +598,19 @@ def build_payload(
     keeps its stored verdict, instead of being re-judged against today's rules
     and disagreeing with the log it printed at the time.
 
-    ``livekit_url`` is the server the exporting host resolves right now, or None
-    when it cannot resolve one: it is not read off the run, because no run record
-    has ever carried it.
+    Args:
+        run: the stored run this report describes.
+        livekit_url: the server the exporting host resolves right now, or None
+            when it cannot resolve one. It is not read off the run, because no
+            run record has ever carried it.
+        environment: an operator's label for where the probe RAN, which nothing
+            can derive. Overrides :data:`ENVIRONMENT_ENV_VAR`; when neither is
+            supplied the report says the environment was not declared rather
+            than implying one. See :func:`_report_basis`.
+
+    Returns:
+        The payload, including a ``basis`` block stating how many sessions and
+        turns the report rests on and which environment it was measured from.
     """
     results: dict[str, Any] = run.results if isinstance(run.results, dict) else {}
     raw_checks = results.get("checks")

--- a/src/voicegateway/server/api/rooms.py
+++ b/src/voicegateway/server/api/rooms.py
@@ -192,8 +192,9 @@ async def get_room_latency(
     since_turn: int | None = Query(
         None,
         description=(
-            "Return only turns with turn_index greater than this. Filters the "
-            "turns list ONLY: components and e2e_ms stay whole-call aggregates."
+            "Return only turns whose room-wide `seq` is greater than this. "
+            "Filters the turns list ONLY; components and e2e_ms are whole-call "
+            "aggregates and are never narrowed by it."
         ),
     ),
     gateway: Gateway = Depends(get_gateway),
@@ -201,11 +202,39 @@ async def get_room_latency(
 ) -> dict[str, Any]:
     """The per-stage latency split and per-turn timings for one LiveKit room.
 
-    ``since_turn`` is a cursor over ``turns`` and nothing else. ``components``
-    and ``e2e_ms`` are aggregates over the whole call and always come back
-    whole: a cursor that quietly narrowed them would make each poll disagree
-    with the one before it, which is exactly the bug a polling consumer cannot
-    see.
+    Args:
+        room_name: the LiveKit room, as the caller minted it when it signed the
+            token. This is the key the whole endpoint is built on; see the
+            module docstring for why it is not ``session_id``.
+        since_turn: a cursor over ``turns``. Returns only turns whose room-wide
+            ``seq`` exceeds it; pass back the ``seq`` of the last turn you saw.
+            It is NOT ``turn_index``, which is session-local and repeats when a
+            room carries more than one session.
+        gateway: injected; supplies the storage this reads.
+        principal: injected; supplies the tenant this may read. Never taken
+            from the request.
+
+    Returns:
+        A dict with ``room``, ``project``, ``turn_count``, ``complete``,
+        ``components``, ``e2e_ms`` and ``turns``.
+
+        ``components`` (the per-stage split, milliseconds) and ``e2e_ms`` (the
+        summarised response speed) are aggregates over the WHOLE call and are
+        never narrowed by ``since_turn``. They are recomputed from the rows
+        present at request time, so they do move as a call progresses; what
+        ``since_turn`` guarantees is only that it is not the thing moving them.
+        A cursor that quietly narrowed an aggregate would make each poll
+        disagree with the last for a reason the consumer could not see.
+
+        ``turns`` is the filtered list. ``turn_count`` counts the whole call
+        regardless, so a cursored poll still knows what the aggregates cover.
+
+        Each turn carries ``seq`` (room-wide, unique, the cursor), plus
+        ``turn_index`` and ``session_id`` (session-local, and the numbers the
+        agent's own logs show), ``caller_speak_end_ms`` and
+        ``agent_speak_start_ms`` (epoch milliseconds), and
+        ``response_speed_ms`` (an elapsed duration, null when the agent never
+        answered that turn).
     """
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
@@ -237,14 +266,29 @@ async def get_room_latency(
     async with gateway.storage._conn.session() as db:
         for sid in session_ids:
             turn_rows.extend(await turns.list_turns_by_session(db, sid))
-    turn_rows.sort(key=lambda t: t.turn_index)
+    # Room-wide chronological order, fully determined. ``turn_index`` is
+    # SESSION-local: a room that carries two sessions (an agent that
+    # reconnected, two agents in one room, or a probe reusing a fixed
+    # --room-name) has two turns numbered 0, two numbered 1, and so on. Sorting
+    # on it alone interleaves the sessions, and using it as the cursor makes
+    # "turn 3" ambiguous, so a poll would repeat one turn and drop another.
+    # session_id and turn_index break every tie, so the order never depends on
+    # the order rows came back in.
+    turn_rows.sort(key=lambda t: (t.caller_speak_start_ms, t.session_id, t.turn_index))
 
     # Computed ONCE; both `components` and `complete` are read off it.
     split = aggregate_components(visible)
     samples = [
         float(t.response_speed_ms) for t in turn_rows if t.response_speed_ms is not None
     ]
-    shown = [t for t in turn_rows if since_turn is None or t.turn_index > since_turn]
+    # ``seq`` is the room-wide position and is what ``since_turn`` cuts on. It is
+    # the only identifier here that is unique across the whole room; turn_index
+    # travels alongside it because it is what the agent's own logs show.
+    shown = [
+        (seq, t)
+        for seq, t in enumerate(turn_rows)
+        if since_turn is None or seq > since_turn
+    ]
     return {
         "room": room_name,
         "project": project,
@@ -258,11 +302,16 @@ async def get_room_latency(
         "e2e_ms": _e2e_ms(samples),
         "turns": [
             {
+                # Room-wide and unique; pass the last one back as since_turn.
+                "seq": seq,
+                # Session-local, and NOT unique across a multi-session room. It
+                # is here because it is the number the agent's own logs carry.
                 "turn_index": t.turn_index,
+                "session_id": t.session_id,
                 "caller_speak_end_ms": t.caller_speak_end_ms,
                 "agent_speak_start_ms": t.agent_speak_start_ms,
                 "response_speed_ms": t.response_speed_ms,
             }
-            for t in shown
+            for seq, t in shown
         ],
     }

--- a/src/voicegateway/server/api/rooms.py
+++ b/src/voicegateway/server/api/rooms.py
@@ -1,0 +1,268 @@
+"""GET /v1/rooms/{room}/latency: the per-stage split, over HTTP.
+
+Why this endpoint exists
+------------------------
+The component split (turn detection / STT / LLM / TTS) has only ever been
+readable in-process. ``voicegw livekit latency`` gets it by calling
+:class:`~voicegateway.livekit_diag.latency.ComponentReader` against the SAME
+local store the agent wrote to, and the CLI docs say so:
+
+    This read-back is co-located in this version: the agent and the prober must
+    share the same local VoiceGateway store. In collector mode
+    (``VOICEGW_COLLECTOR_URL`` set) the rows go to the collector rather than this
+    host, so the split is not shown from the CLI.
+
+A deployment that runs the agent in one container and the collector in another
+can therefore never see its own split, even though the collector holds every row
+needed to compute it. Nothing here is new measurement: this is the existing
+computation, reachable.
+
+Keyed on the ROOM, not the session
+----------------------------------
+Deliberately. A caller mints the LiveKit room name when it signs the token, so
+the room is the only identifier both sides hold at call time. ``session_id`` is
+minted inside VoiceGateway and a caller never observes it, so an endpoint keyed
+on it would be unusable by the process that needs it.
+
+The room is also already the correlation key on the write side:
+:func:`~voicegateway.repository.request_log_repository.get_requests_for_room`
+exists for exactly this, because ``attach`` stamps ``metadata.room`` on every
+row. Turn rows are keyed by ``session_id``, and this endpoint bridges the two
+through the ``session_id`` those same request rows carry, rather than threading
+room names down into the turn tracker.
+
+Four claims this endpoint keeps distinct
+----------------------------------------
+The consumer renders a different state for each, so collapsing any pair would
+lose information it needs:
+
+1. **404** -- this collector has never seen that room.
+2. **200 with ``components: null``** -- the room is known, and nothing
+   correlated: an uninstrumented agent, or no completed turn yet.
+3. **200 with ``complete: false``** -- a real split, still partial because the
+   agent process is mid-flush. Poll again; do not render it. This mirrors
+   :func:`~voicegateway.livekit_diag.latency._split_complete`, and it is the
+   field that makes polling safe. It is the same reason ``ComponentReader``
+   polls instead of returning its first read.
+4. **200 with a null component** -- that stage produced no measurement. It is
+   never ``0``. A stage rendered as ``0.00`` reads as "instant", and these
+   numbers go into a document somebody reads months later, so a fabricated zero
+   would ship as a false claim.
+
+Milliseconds, everywhere
+------------------------
+``aggregate_components`` works in SECONDS (it averages raw provider ttfb values
+that arrive that way) and its keys are unsuffixed. This endpoint converts once,
+here, and suffixes every key ``_ms``, matching the rest of the HTTP API. The
+diagnostics probe endpoint reports seconds and carries a warning about it; there
+is no reason to make a second surface a reader has to remember a unit for.
+
+Not built, on purpose
+---------------------
+No CORS and no browser-facing key: a read-scoped key in a browser can read every
+session and cost row for the tenant, and the consumer proxies server-side
+anyway. No WebSocket or SSE: ingest is batched and async behind a bounded queue,
+so freshness is inherently seconds, and a socket would deliver seconds-stale
+data faster while adding a stateful fan-out surface beside a deliberately simple
+write path. No per-turn component split: the requirement is report-level, and
+joining component rows onto individual turns is real work for no requirement.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from voicegateway.livekit_diag.latency import (
+    LatencyResult,
+    _split_complete,
+    aggregate_components,
+    summarize,
+)
+from voicegateway.repository import turns_repository as turns
+from voicegateway.server.api._deps import (
+    Principal,
+    get_gateway,
+    require_principal,
+    resolve_read_tenant,
+)
+
+if TYPE_CHECKING:
+    from voicegateway.core.gateway import Gateway
+
+# Read-only, like the dashboard reads: ``require_principal`` rather than
+# ``require_scope(ADMIN_SCOPE)``, which is reserved for routers that spend money
+# or touch infra. Declared ONCE on the router, for the reason
+# ``dashboard/sessions.py`` gives: a per-handler dependency is a thing the next
+# handler in the file can forget.
+router = APIRouter(
+    prefix="/rooms",
+    tags=["rooms"],
+    dependencies=[Depends(require_principal)],
+)
+
+#: ``aggregate_components`` key -> the wire name. The seconds-to-milliseconds
+#: conversion is applied to every one of them; see the module docstring.
+#:
+#: Written out rather than derived by suffixing, because two of the names are
+#: not a suffix away: ``tts`` is a time-to-first-BYTE and says so on the wire,
+#: and ``stt`` is the headline that ``aggregate_components`` picks from up to
+#: three candidate sources. A reader of the JSON should not have to know that.
+_COMPONENT_FIELDS: tuple[tuple[str, str], ...] = (
+    ("eou", "eou_ms"),
+    ("stt_ttfp", "stt_ttfp_ms"),
+    ("stt_transcription_delay", "stt_transcription_delay_ms"),
+    ("stt", "stt_ms"),
+    ("llm_ttft", "llm_ttft_ms"),
+    ("tts", "tts_ttfb_ms"),
+)
+
+
+def _not_found(room: str) -> HTTPException:
+    """The single 404 an unknown OR unreadable room gets.
+
+    A foreign-tenant room is the same 404 as a room that does not exist, for the
+    reason ``require_visible_session`` gives: a 403 would confirm the room
+    exists, and its existence is the fact being protected.
+    """
+    return HTTPException(status_code=404, detail=f"Room '{room}' not found")
+
+
+def _visible(row: dict[str, Any], tenant: str | None) -> bool:
+    """Whether one request row is readable by a principal scoped to ``tenant``.
+
+    Same three cases as ``dashboard/sessions._visible``: ``None`` is the
+    operator/admin (every row), ``""`` is the unattributed bucket
+    (``tenant_id IS NULL``), anything else is an exact match.
+    """
+    if tenant is None:
+        return True
+    stored = row.get("tenant_id")
+    if tenant == "":
+        return stored is None
+    return stored == tenant
+
+
+def _components_ms(split: dict[str, Any]) -> dict[str, float | None]:
+    """One split, converted to the wire shape. Seconds in, milliseconds out.
+
+    Every field is present, null where the call produced nothing, so a consumer
+    can render a fixed set of stages without inferring which keys to expect.
+    Never ``0.0`` for a missing stage: see the module docstring.
+
+    Takes the already-computed split rather than the rows, so
+    ``aggregate_components`` runs exactly once per request. Running it twice
+    (once for the values, once for ``complete``) would put two readings of the
+    same rows in one response, and nothing would notice if they disagreed.
+    """
+    return {
+        wire: (float(split[key]) * 1000.0 if key in split else None)
+        for key, wire in _COMPONENT_FIELDS
+    }
+
+
+def _e2e_ms(samples: list[float]) -> dict[str, float | int] | None:
+    """End-to-end response speed, summarised, or None when nothing completed.
+
+    Computed by :func:`~voicegateway.livekit_diag.latency.summarize`, the same
+    function the CLI reports through, so the two surfaces cannot drift on what
+    p95 means. ``summarize`` reports ``trials``; the wire calls it ``n``.
+
+    ``summarize`` returns zeros for an empty sample list, which is right for a
+    CLI table and wrong here: a p95 of ``0.0`` on a call that answered nothing
+    is a fabricated measurement. So the empty case returns None instead.
+    """
+    if not samples:
+        return None
+    stats = summarize(LatencyResult(agent="", e2e_samples=samples))
+    return {
+        "p50": stats["p50"],
+        "p95": stats["p95"],
+        "avg": stats["avg"],
+        "min": stats["min"],
+        "max": stats["max"],
+        "n": stats["trials"],
+    }
+
+
+@router.get("/{room_name}/latency")
+async def get_room_latency(
+    room_name: str,
+    since_turn: int | None = Query(
+        None,
+        description=(
+            "Return only turns with turn_index greater than this. Filters the "
+            "turns list ONLY: components and e2e_ms stay whole-call aggregates."
+        ),
+    ),
+    gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
+) -> dict[str, Any]:
+    """The per-stage latency split and per-turn timings for one LiveKit room.
+
+    ``since_turn`` is a cursor over ``turns`` and nothing else. ``components``
+    and ``e2e_ms`` are aggregates over the whole call and always come back
+    whole: a cursor that quietly narrowed them would make each poll disagree
+    with the one before it, which is exactly the bug a polling consumer cannot
+    see.
+    """
+    if gateway.storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+
+    rows = await gateway.storage.get_requests_for_room(room_name)
+    if not rows:
+        raise _not_found(room_name)
+
+    # Tenancy is decided on the room's OWN rows, which already carry tenant_id,
+    # rather than by looking up a parent session: the room may span several
+    # sessions, and a row is the thing whose tenant is authoritative.
+    tenant = resolve_read_tenant(principal, None)
+    visible = [row for row in rows if _visible(row, tenant)]
+    if not visible:
+        raise _not_found(room_name)
+
+    session_ids: list[str] = []
+    for row in visible:
+        sid = row.get("session_id")
+        if isinstance(sid, str) and sid and sid not in session_ids:
+            session_ids.append(sid)
+    project = next(
+        (row["project"] for row in visible if row.get("project")),
+        None,
+    )
+
+    await gateway.storage._ensure_initialized()
+    turn_rows: list[Any] = []
+    async with gateway.storage._conn.session() as db:
+        for sid in session_ids:
+            turn_rows.extend(await turns.list_turns_by_session(db, sid))
+    turn_rows.sort(key=lambda t: t.turn_index)
+
+    # Computed ONCE; both `components` and `complete` are read off it.
+    split = aggregate_components(visible)
+    samples = [
+        float(t.response_speed_ms) for t in turn_rows if t.response_speed_ms is not None
+    ]
+    shown = [t for t in turn_rows if since_turn is None or t.turn_index > since_turn]
+    return {
+        "room": room_name,
+        "project": project,
+        # The whole call, not the filtered view: a consumer polling with a
+        # cursor still needs to know how many turns the aggregates cover.
+        "turn_count": len(turn_rows),
+        # False when nothing correlated at all, which is also the right answer
+        # for a caller deciding whether to poll again.
+        "complete": split is not None and _split_complete(split),
+        "components": _components_ms(split) if split is not None else None,
+        "e2e_ms": _e2e_ms(samples),
+        "turns": [
+            {
+                "turn_index": t.turn_index,
+                "caller_speak_end_ms": t.caller_speak_end_ms,
+                "agent_speak_start_ms": t.agent_speak_start_ms,
+                "response_speed_ms": t.response_speed_ms,
+            }
+            for t in shown
+        ],
+    }

--- a/src/voicegateway/server/routes.py
+++ b/src/voicegateway/server/routes.py
@@ -33,6 +33,7 @@ from voicegateway.server.api import (
     models,
     projects,
     providers,
+    rooms,
     sessions,
     system,
 )
@@ -96,6 +97,9 @@ api_router.include_router(models.router)
 api_router.include_router(costs.router)
 api_router.include_router(billing.router)
 api_router.include_router(latency.router)
+# GET /v1/rooms/{room}/latency: the per-stage split, keyed on the LiveKit room
+# name so a caller that never sees a VoiceGateway session_id can still read it.
+api_router.include_router(rooms.router)
 api_router.include_router(logs.router)
 api_router.include_router(sessions.router)
 api_router.include_router(projects.router)

--- a/src/voicegateway/tests/livekit_diag/test_report_basis.py
+++ b/src/voicegateway/tests/livekit_diag/test_report_basis.py
@@ -167,3 +167,26 @@ def test_an_undeclared_environment_is_not_left_blank(monkeypatch) -> None:
     html = run_report.render_html(_payload(_run([])))
     assert "not declared" in html
     assert run_report.ENVIRONMENT_ENV_VAR in html
+
+
+def test_a_room_with_zero_trials_is_not_a_measured_session() -> None:
+    """The count is read off the MEASUREMENTS, not off a field being present.
+
+    ``LatencyResult.room`` is documented as None when no turn completed, so in
+    practice a zero-trial agent carries no room and the two agree. This pins the
+    stated contract ("sessions that produced a measurement") against the case
+    where a caller upstream leaves the room populated anyway, rather than
+    trusting a field it does not own to be cleared.
+    """
+    basis = _payload(_run([_agent("a", 0, "vg-probe-a")]))["basis"]
+    assert basis["sessions"] == 0
+    assert basis["turns"] == 0
+
+
+def test_a_zero_trial_agent_does_not_hide_a_real_one() -> None:
+    """Non-vacuous: the guard drops the empty room, not the measured one."""
+    basis = _payload(
+        _run([_agent("quiet", 0, "vg-probe-quiet"), _agent("busy", 5, "vg-probe-busy")])
+    )["basis"]
+    assert basis["sessions"] == 1
+    assert basis["turns"] == 5

--- a/src/voicegateway/tests/livekit_diag/test_report_basis.py
+++ b/src/voicegateway/tests/livekit_diag/test_report_basis.py
@@ -1,0 +1,169 @@
+"""What the diagnostics report is based on, stated in the document.
+
+Three facts a reader needs before they can weigh anything else, and which the
+report did not say.
+
+**How many turns.** Derivable by adding up a per-agent column, and never added
+up. A reader had to do arithmetic to learn the sample size behind a percentile.
+
+**How many sessions.** Not derivable at all from the rendered page.
+
+**Which environment.** The LiveKit URL is close and is a different claim: it
+says which server was probed, not whether the probe ran inside the deployed
+environment or against it from a laptop over a different network path. Nothing
+can derive that, so it is declared, and an undeclared report says so rather than
+letting a reader assume either answer.
+"""
+
+from __future__ import annotations
+
+from voicegateway.livekit_diag import run_report
+from voicegateway.livekit_diag.run_report import RunRecord
+
+
+def _run(agents: list[dict] | None = None) -> RunRecord:
+    return RunRecord(
+        run_id="r-1",
+        checks=["latency"],
+        config={"target_ms": 1500},
+        status="done",
+        results={
+            "checks": {
+                "latency": {
+                    "ok": True,
+                    "result": {"agents": agents if agents is not None else []},
+                }
+            }
+        },
+        verdict="PASS",
+        created_at="2026-08-07T12:00:00+00:00",
+    )
+
+
+def _agent(name: str, trials: int, room: str | None) -> dict:
+    return {"agent": name, "stats": {"trials": trials}, "room": room}
+
+
+def _payload(run: RunRecord, environment: str | None = None) -> dict:
+    return run_report.build_payload(run, livekit_url="wss://x", environment=environment)
+
+
+# --------------------------------------------------------------------------
+# Counts
+# --------------------------------------------------------------------------
+
+
+def test_turns_are_summed_across_agents_so_nobody_adds_a_column_by_hand() -> None:
+    basis = _payload(
+        _run([_agent("a", 3, "vg-probe-a"), _agent("b", 4, "vg-probe-b")])
+    )["basis"]
+    assert basis["turns"] == 7
+
+
+def test_sessions_counts_distinct_probe_rooms() -> None:
+    """A session here IS the room a probed agent's counted turns ran in."""
+    basis = _payload(
+        _run([_agent("a", 3, "vg-probe-a"), _agent("b", 4, "vg-probe-b")])
+    )["basis"]
+    assert basis["sessions"] == 2
+
+
+def test_an_agent_that_answered_nothing_records_no_session() -> None:
+    """It attempted; it produced no measurement. Counting it would inflate the
+    denominator of a report whose whole job is to say what it measured."""
+    basis = _payload(_run([_agent("a", 3, "vg-probe-a"), _agent("b", 0, None)]))[
+        "basis"
+    ]
+    assert basis["sessions"] == 1
+    assert basis["turns"] == 3
+
+
+def test_two_agents_sharing_one_room_are_one_session() -> None:
+    """Distinct rooms, not agent count: a fixed --room-name reuses one."""
+    basis = _payload(_run([_agent("a", 2, "shared"), _agent("b", 2, "shared")]))[
+        "basis"
+    ]
+    assert basis["sessions"] == 1
+    assert basis["turns"] == 4
+
+
+def test_a_run_that_probed_nothing_reports_zero_not_null() -> None:
+    """Zero sessions is a measurement here, unlike a zero latency: the run
+    genuinely produced none, and that is the finding."""
+    basis = _payload(_run([]))["basis"]
+    assert basis["sessions"] == 0
+    assert basis["turns"] == 0
+
+
+# --------------------------------------------------------------------------
+# Environment: declared, never inferred
+# --------------------------------------------------------------------------
+
+
+def test_a_declared_environment_is_carried_and_labelled_as_declared() -> None:
+    basis = _payload(_run([]), environment="pixis-prod-iad")["basis"]
+    assert basis["environment"] == "pixis-prod-iad"
+    assert basis["environment_declared"] is True
+    assert "declared" in basis["environment_source"]
+
+
+def test_an_undeclared_environment_is_null_and_says_so(monkeypatch) -> None:
+    monkeypatch.delenv(run_report.ENVIRONMENT_ENV_VAR, raising=False)
+    basis = _payload(_run([]))["basis"]
+    assert basis["environment"] is None
+    assert basis["environment_declared"] is False
+
+
+def test_the_env_var_supplies_it_when_the_caller_does_not(monkeypatch) -> None:
+    monkeypatch.setenv(run_report.ENVIRONMENT_ENV_VAR, "staging-lhr")
+    assert _payload(_run([]))["basis"]["environment"] == "staging-lhr"
+
+
+def test_an_explicit_argument_beats_the_env_var(monkeypatch) -> None:
+    monkeypatch.setenv(run_report.ENVIRONMENT_ENV_VAR, "from-env")
+    assert _payload(_run([]), environment="explicit")["basis"]["environment"] == (
+        "explicit"
+    )
+
+
+def test_the_livekit_url_is_not_treated_as_the_environment(monkeypatch) -> None:
+    """The distinction the whole field exists for.
+
+    A report can name the exact production server it probed and still have been
+    run from a laptop across the internet, which is a different network path and
+    therefore different latency.
+    """
+    monkeypatch.delenv(run_report.ENVIRONMENT_ENV_VAR, raising=False)
+    payload = run_report.build_payload(_run([]), livekit_url="wss://prod.livekit")
+    assert payload["target"]["livekit_url"] == "wss://prod.livekit"
+    assert payload["basis"]["environment"] is None
+
+
+# --------------------------------------------------------------------------
+# The document says it, not merely the payload
+# --------------------------------------------------------------------------
+
+
+def test_the_rendered_report_states_both_counts(monkeypatch) -> None:
+    """The contractual requirement is about the DOCUMENT a reader opens."""
+    monkeypatch.delenv(run_report.ENVIRONMENT_ENV_VAR, raising=False)
+    html = run_report.render_html(
+        _payload(_run([_agent("a", 3, "room-a"), _agent("b", 4, "room-b")]))
+    )
+    assert "Measured over" in html
+    assert "2 session(s), 7 turn(s)" in html
+
+
+def test_the_rendered_report_names_the_declared_environment() -> None:
+    html = run_report.render_html(_payload(_run([]), environment="pixis-prod-iad"))
+    assert "Environment" in html
+    assert "pixis-prod-iad" in html
+
+
+def test_an_undeclared_environment_is_not_left_blank(monkeypatch) -> None:
+    """A blank cell reads as a rendering fault. It has to say it is undeclared,
+    and say how to declare it, or the next reader guesses."""
+    monkeypatch.delenv(run_report.ENVIRONMENT_ENV_VAR, raising=False)
+    html = run_report.render_html(_payload(_run([])))
+    assert "not declared" in html
+    assert run_report.ENVIRONMENT_ENV_VAR in html

--- a/src/voicegateway/tests/server/test_room_latency_endpoint.py
+++ b/src/voicegateway/tests/server/test_room_latency_endpoint.py
@@ -1,0 +1,391 @@
+"""GET /v1/rooms/{room}/latency: the component split, over HTTP.
+
+The split was only ever readable in-process, by a prober sharing the agent's
+local store. A deployment running the agent and the collector in separate
+containers holds every row needed and could not reach the computation. This
+endpoint is that computation, reachable; these tests pin the parts a consumer
+would otherwise have to trust.
+
+**Four answers that must stay distinct.** 404 (never seen this room), 200 with
+``components: null`` (room known, nothing correlated), ``complete: false`` (a
+real split, still mid-flush, poll again) and a null component (that stage
+produced no measurement). The consumer renders a different state for each, so
+collapsing any pair loses information it needs.
+
+**Nothing is ever rendered as a fabricated zero.** These numbers go into a
+document somebody reads months later, and a stage shown as ``0.00`` reads as
+"instant".
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from typing import Any
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.inference.session.context import reset_tenant_id, set_tenant
+from voicegateway.livekit_diag.latency import LatencyResult, summarize
+from voicegateway.middleware.turn_tracker_middleware import TurnRow
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.repository import api_keys_repository as api_keys
+from voicegateway.repository import turns_repository as turns
+from voicegateway.server import build_app
+
+ROOM = "demo-a1b2c3"
+SESSION = "sess-demo-1"
+
+
+def _req(
+    room: str,
+    session_id: str,
+    modality: str,
+    *,
+    ttfb_ms: float | None = None,
+    eou: dict[str, Any] | None = None,
+    project: str = "pixis-w1",
+) -> RequestRecord:
+    """One request row as ``attach`` writes it: the room lives on metadata."""
+    metadata: dict[str, Any] = {"room": room}
+    if eou is not None:
+        metadata["eou"] = eou
+    return RequestRecord(
+        id=f"req-{room}-{modality}-{session_id}-{time.time_ns()}",
+        timestamp=time.time(),
+        project=project,
+        modality=modality,
+        model_id=f"test/{modality}",
+        provider="test",
+        input_units=0,
+        output_units=0,
+        cost_usd=0.0,
+        pricing_source="test",
+        ttfb_ms=ttfb_ms,
+        total_latency_ms=None,
+        status="success",
+        fallback_from=None,
+        error_message=None,
+        metadata=metadata,
+        session_id=session_id,
+    )
+
+
+class _Harness:
+    def __init__(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        tmp = self._tmp.name
+        self._prev_db_path = os.environ.get("VOICEGW_DB_PATH")
+        os.environ["VOICEGW_DB_PATH"] = os.path.join(tmp, "rooms.db")
+        cfg = {
+            "providers": {"openai": {"api_key": "test-key"}},
+            "models": {"stt": {}, "llm": {}, "tts": {}},
+            "projects": {},
+            "fallbacks": {"stt": [], "llm": [], "tts": []},
+            "cost_tracking": {"enabled": True},
+        }
+        cfg_path = os.path.join(tmp, "voicegw.yaml")
+        with open(cfg_path, "w") as f:
+            yaml.dump(cfg, f)
+        self.gateway = Gateway(config_path=cfg_path)
+        self.app = build_app(self.gateway, enable_mcp_sse=False, enable_dashboard=False)
+        self.app.state.ch_client = None
+
+    def client(self) -> AsyncClient:
+        return AsyncClient(
+            transport=ASGITransport(app=self.app), base_url="http://test"
+        )
+
+    def cleanup(self) -> None:
+        if self._prev_db_path is None:
+            os.environ.pop("VOICEGW_DB_PATH", None)
+        else:
+            os.environ["VOICEGW_DB_PATH"] = self._prev_db_path
+        self._tmp.cleanup()
+
+
+async def _seed_complete(storage, room: str = ROOM, session: str = SESSION) -> None:
+    """A finished turn: turn detection, STT head/tail, LLM ttft and TTS ttfb."""
+    await storage.log_request(
+        _req(
+            room,
+            session,
+            "eou",
+            eou={
+                "end_of_utterance_delay": 0.302,
+                "transcription_delay": 0.088,
+                "time_to_first_partial_ms": 121.0,
+            },
+        )
+    )
+    await storage.log_request(_req(room, session, "stt", ttfb_ms=209.0))
+    await storage.log_request(_req(room, session, "llm", ttfb_ms=447.0))
+    await storage.log_request(_req(room, session, "tts", ttfb_ms=92.0))
+
+
+async def _seed_turns(storage, session: str, speeds: list[int | None]) -> None:
+    rows = [
+        TurnRow(
+            session_id=session,
+            turn_index=i,
+            caller_speak_start_ms=1_800_000_000_000 + i * 5000,
+            caller_speak_end_ms=1_800_000_002_000 + i * 5000,
+            agent_speak_start_ms=(
+                None if s is None else 1_800_000_002_000 + i * 5000 + s
+            ),
+            agent_speak_end_ms=None,
+            response_speed_ms=s,
+        )
+        for i, s in enumerate(speeds)
+    ]
+    async with storage._conn.session() as db:
+        await turns.create_turns_bulk(db, rows)
+
+
+@pytest.fixture
+async def harness():
+    h = _Harness()
+    await h.gateway.storage._ensure_initialized()
+    reset_tenant_id()
+    try:
+        yield h
+    finally:
+        reset_tenant_id()
+        h.cleanup()
+
+
+async def _make_key(gateway, *, tenant_id=None, role="tenant"):
+    async with gateway.storage._conn.session() as db:
+        created = await api_keys.create_api_key(
+            db, name=f"k-{tenant_id}-{role}", tenant_id=tenant_id, role=role
+        )
+    return created.plaintext
+
+
+async def _get(harness, path: str, key: str | None = None):
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
+    async with harness.client() as c:
+        return await c.get(path, headers=headers)
+
+
+# --------------------------------------------------------------------------
+# The split
+# --------------------------------------------------------------------------
+
+
+async def test_a_complete_split_returns_every_component(harness):
+    """The headline case, in milliseconds, with complete=true."""
+    await _seed_complete(harness.gateway.storage)
+    r = await _get(harness, f"/v1/rooms/{ROOM}/latency")
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert body["room"] == ROOM
+    assert body["project"] == "pixis-w1"
+    assert body["complete"] is True
+    c = body["components"]
+    # aggregate_components works in SECONDS; the wire is milliseconds.
+    assert c["eou_ms"] == pytest.approx(302.0)
+    assert c["stt_ttfp_ms"] == pytest.approx(121.0)
+    assert c["stt_transcription_delay_ms"] == pytest.approx(88.0)
+    assert c["stt_ms"] == pytest.approx(209.0)
+    assert c["llm_ttft_ms"] == pytest.approx(447.0)
+    assert c["tts_ttfb_ms"] == pytest.approx(92.0)
+
+
+async def test_a_mid_flush_split_is_incomplete_and_zeroes_nothing(harness):
+    """The agent is still writing: LLM landed, TTS has not.
+
+    ``complete: false`` is what makes polling safe, and the missing leg must be
+    null. Rendering it as 0.0 would read as "TTS was instant", which is the
+    false claim this endpoint exists to avoid shipping.
+    """
+    storage = harness.gateway.storage
+    await storage.log_request(_req(ROOM, SESSION, "llm", ttfb_ms=447.0))
+
+    body = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()
+    assert body["complete"] is False
+    assert body["components"]["llm_ttft_ms"] == pytest.approx(447.0)
+    assert body["components"]["tts_ttfb_ms"] is None
+    assert body["components"]["eou_ms"] is None
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "eou_ms",
+        "stt_ttfp_ms",
+        "stt_transcription_delay_ms",
+        "stt_ms",
+        "llm_ttft_ms",
+        "tts_ttfb_ms",
+    ],
+)
+async def test_no_component_is_ever_a_fabricated_zero(harness, field):
+    """Every field is present and null, never 0.0, when nothing produced it."""
+    await harness.gateway.storage.log_request(_req(ROOM, SESSION, "llm", ttfb_ms=1.0))
+    c = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()["components"]
+    assert field in c, (
+        "the field must be present so a consumer can render a fixed strip"
+    )
+    assert c[field] != 0.0
+
+
+# --------------------------------------------------------------------------
+# 404 and 200-with-nulls are different claims
+# --------------------------------------------------------------------------
+
+
+async def test_an_unknown_room_is_404(harness):
+    """This collector has never seen it."""
+    assert (await _get(harness, "/v1/rooms/never-existed/latency")).status_code == 404
+
+
+async def test_a_known_room_with_nothing_correlated_is_200_with_nulls(harness):
+    """The room exists and produced no usable latency: an uninstrumented agent.
+
+    Deliberately NOT a 404. The consumer shows "connected, waiting" here and
+    "unknown room" for a 404, so collapsing the two would lose a real state.
+    """
+    await harness.gateway.storage.log_request(_req(ROOM, SESSION, "stt"))
+    r = await _get(harness, f"/v1/rooms/{ROOM}/latency")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["components"] is None
+    assert body["complete"] is False
+    assert body["e2e_ms"] is None
+    assert body["turn_count"] == 0
+
+
+# --------------------------------------------------------------------------
+# Tenancy
+# --------------------------------------------------------------------------
+
+
+async def test_a_foreign_tenants_room_is_404_not_403(harness):
+    """A 403 would confirm the room exists, which is the fact being protected."""
+    storage = harness.gateway.storage
+    set_tenant("acme")
+    await _seed_complete(storage)
+    reset_tenant_id()
+
+    beta_key = await _make_key(harness.gateway, tenant_id="beta")
+    assert (
+        await _get(harness, f"/v1/rooms/{ROOM}/latency", beta_key)
+    ).status_code == 404
+
+    # Non-vacuous: the owner sees it.
+    acme_key = await _make_key(harness.gateway, tenant_id="acme")
+    assert (
+        await _get(harness, f"/v1/rooms/{ROOM}/latency", acme_key)
+    ).status_code == 200
+
+
+# --------------------------------------------------------------------------
+# since_turn is a cursor over turns and nothing else
+# --------------------------------------------------------------------------
+
+
+async def test_since_turn_filters_turns_but_never_the_aggregates(harness):
+    """The property a polling consumer cannot check for itself.
+
+    If the cursor narrowed ``components`` or ``e2e_ms``, every poll would
+    disagree with the one before it and the report would drift as it refreshed.
+    """
+    storage = harness.gateway.storage
+    await _seed_complete(storage)
+    await _seed_turns(storage, SESSION, [900, 1000, 1100, 1200])
+
+    whole = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()
+    tail = (await _get(harness, f"/v1/rooms/{ROOM}/latency?since_turn=2")).json()
+
+    assert [t["turn_index"] for t in whole["turns"]] == [0, 1, 2, 3]
+    assert [t["turn_index"] for t in tail["turns"]] == [3]
+
+    assert tail["components"] == whole["components"]
+    assert tail["e2e_ms"] == whole["e2e_ms"]
+    # turn_count covers the whole call too, so a cursored poll still knows what
+    # the aggregates are over.
+    assert tail["turn_count"] == whole["turn_count"] == 4
+
+
+# --------------------------------------------------------------------------
+# The endpoint and the CLI cannot drift
+# --------------------------------------------------------------------------
+
+
+async def test_e2e_percentiles_match_summarize_over_the_same_inputs(harness):
+    """Computed BY ``summarize``, so p95 means one thing across both surfaces."""
+    storage = harness.gateway.storage
+    speeds = [902, 1000, 1041, 1074, 1200, 1288, 1301]
+    await _seed_complete(storage)
+    await _seed_turns(storage, SESSION, speeds)
+
+    got = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()["e2e_ms"]
+    want = summarize(LatencyResult(agent="", e2e_samples=[float(s) for s in speeds]))
+
+    assert got["p50"] == want["p50"]
+    assert got["p95"] == want["p95"]
+    assert got["avg"] == want["avg"]
+    assert got["min"] == want["min"]
+    assert got["max"] == want["max"]
+    # The wire calls it n; summarize calls it trials.
+    assert got["n"] == want["trials"] == len(speeds)
+
+
+async def test_a_turn_that_never_got_a_reply_is_excluded_not_zeroed(harness):
+    """``response_speed_ms`` is null when the agent never spoke for that turn.
+
+    Averaging a null in as 0 would drag every percentile toward zero and report
+    a call as faster than it was.
+    """
+    storage = harness.gateway.storage
+    await _seed_complete(storage)
+    await _seed_turns(storage, SESSION, [1000, None, 1200])
+
+    body = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()
+    assert body["turn_count"] == 3
+    assert body["e2e_ms"]["n"] == 2
+    assert body["e2e_ms"]["min"] == 1000.0
+    # The unanswered turn is still listed, with a null speed.
+    speeds = [t["response_speed_ms"] for t in body["turns"]]
+    assert speeds == [1000, None, 1200]
+
+
+async def test_no_completed_turn_gives_a_null_block_not_a_row_of_zeros(harness):
+    """``summarize`` returns zeros for an empty list, which is right for a CLI
+    table and a fabricated measurement here."""
+    await _seed_complete(harness.gateway.storage)
+    await _seed_turns(harness.gateway.storage, SESSION, [None, None])
+
+    body = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()
+    assert body["turn_count"] == 2
+    assert body["e2e_ms"] is None
+
+
+# --------------------------------------------------------------------------
+# Shape
+# --------------------------------------------------------------------------
+
+
+async def test_it_lives_under_v1_not_the_dashboard_router(harness):
+    """The consumer is a server-to-server caller holding a vk_ key, not the SPA."""
+    await _seed_complete(harness.gateway.storage)
+    assert (await _get(harness, f"/v1/rooms/{ROOM}/latency")).status_code == 200
+    assert (await _get(harness, f"/api/rooms/{ROOM}/latency")).status_code == 404
+
+
+async def test_turns_carry_the_four_documented_fields(harness):
+    await _seed_complete(harness.gateway.storage)
+    await _seed_turns(harness.gateway.storage, SESSION, [1041])
+    turn = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()["turns"][0]
+    assert set(turn) == {
+        "turn_index",
+        "caller_speak_end_ms",
+        "agent_speak_start_ms",
+        "response_speed_ms",
+    }

--- a/src/voicegateway/tests/server/test_room_latency_endpoint.py
+++ b/src/voicegateway/tests/server/test_room_latency_endpoint.py
@@ -221,18 +221,29 @@ async def test_a_mid_flush_split_is_incomplete_and_zeroes_nothing(harness):
         "stt_ttfp_ms",
         "stt_transcription_delay_ms",
         "stt_ms",
-        "llm_ttft_ms",
         "tts_ttfb_ms",
     ],
 )
-async def test_no_component_is_ever_a_fabricated_zero(harness, field):
-    """Every field is present and null, never 0.0, when nothing produced it."""
+async def test_an_unproduced_component_is_null_not_zero(harness, field):
+    """Present and NULL. "not 0.0" alone would pass on any garbage value.
+
+    ``llm_ttft_ms`` is excluded because this fixture measures it, and asserted
+    separately below, so the parametrisation cannot go green by measuring
+    nothing at all.
+    """
     await harness.gateway.storage.log_request(_req(ROOM, SESSION, "llm", ttfb_ms=1.0))
     c = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()["components"]
     assert field in c, (
         "the field must be present so a consumer can render a fixed strip"
     )
-    assert c[field] != 0.0
+    assert c[field] is None
+
+
+async def test_the_one_measured_component_really_did_measure(harness):
+    """The non-vacuous half of the test above."""
+    await harness.gateway.storage.log_request(_req(ROOM, SESSION, "llm", ttfb_ms=1.0))
+    c = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()["components"]
+    assert c["llm_ttft_ms"] == pytest.approx(1.0)
 
 
 # --------------------------------------------------------------------------
@@ -379,13 +390,134 @@ async def test_it_lives_under_v1_not_the_dashboard_router(harness):
     assert (await _get(harness, f"/api/rooms/{ROOM}/latency")).status_code == 404
 
 
-async def test_turns_carry_the_four_documented_fields(harness):
+async def test_turns_carry_the_documented_fields(harness):
+    """``seq`` and ``session_id`` are here because ``turn_index`` alone cannot
+    identify a turn in a room that carried more than one session."""
     await _seed_complete(harness.gateway.storage)
     await _seed_turns(harness.gateway.storage, SESSION, [1041])
     turn = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()["turns"][0]
     assert set(turn) == {
+        "seq",
         "turn_index",
+        "session_id",
         "caller_speak_end_ms",
         "agent_speak_start_ms",
         "response_speed_ms",
     }
+
+
+# --------------------------------------------------------------------------
+# A room can carry more than one session
+# --------------------------------------------------------------------------
+
+
+async def test_two_sessions_in_one_room_neither_omit_nor_repeat_a_turn(harness):
+    """``turn_index`` is SESSION-local, so it cannot be the cursor.
+
+    A room carries two sessions when an agent reconnects, when two agents share
+    a room, or when a probe reuses a fixed --room-name. Both sessions then count
+    their turns 0, 1, 2..., so a cursor on turn_index would return two turns
+    called "3" and drop one of them on the next poll. ``seq`` is room-wide.
+    """
+    storage = harness.gateway.storage
+    await _seed_complete(storage, session="sess-a")
+    await storage.log_request(_req(ROOM, "sess-b", "llm", ttfb_ms=400.0))
+    # sess-b runs after sess-a, and both number their turns from zero.
+    await _seed_turns(storage, "sess-a", [900, 950])
+    async with storage._conn.session() as db:
+        await turns.create_turns_bulk(
+            db,
+            [
+                TurnRow(
+                    session_id="sess-b",
+                    turn_index=i,
+                    caller_speak_start_ms=1_900_000_000_000 + i * 5000,
+                    caller_speak_end_ms=1_900_000_002_000 + i * 5000,
+                    agent_speak_start_ms=1_900_000_002_000 + i * 5000 + s,
+                    agent_speak_end_ms=None,
+                    response_speed_ms=s,
+                )
+                for i, s in enumerate([1100, 1150])
+            ],
+        )
+
+    whole = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()
+    assert whole["turn_count"] == 4
+    # seq is room-wide and unique; turn_index repeats across the two sessions.
+    assert [t["seq"] for t in whole["turns"]] == [0, 1, 2, 3]
+    assert [t["turn_index"] for t in whole["turns"]] == [0, 1, 0, 1]
+    assert [t["session_id"] for t in whole["turns"]] == [
+        "sess-a",
+        "sess-a",
+        "sess-b",
+        "sess-b",
+    ]
+    # Chronological, so the two sessions are not interleaved.
+    ends = [t["caller_speak_end_ms"] for t in whole["turns"]]
+    assert ends == sorted(ends)
+
+    # The cursor advances cleanly across the session boundary: every turn is
+    # returned exactly once across successive polls, and none twice.
+    seen: list[int] = []
+    cursor: int | None = None
+    for _ in range(4):
+        q = "" if cursor is None else f"?since_turn={cursor}"
+        page = (await _get(harness, f"/v1/rooms/{ROOM}/latency{q}")).json()["turns"]
+        if not page:
+            break
+        seen.append(page[0]["seq"])
+        cursor = page[0]["seq"]
+    assert seen == [0, 1, 2, 3]
+
+
+async def test_a_cursor_on_turn_index_would_have_been_ambiguous(harness):
+    """Non-vacuous: prove turn_index really does repeat, so seq is not
+    ceremony."""
+    storage = harness.gateway.storage
+    await _seed_complete(storage, session="sess-a")
+    await storage.log_request(_req(ROOM, "sess-b", "llm", ttfb_ms=400.0))
+    await _seed_turns(storage, "sess-a", [900])
+    await _seed_turns(storage, "sess-b", [1100])
+
+    indices = [
+        t["turn_index"]
+        for t in (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()["turns"]
+    ]
+    assert indices == [0, 0], "both sessions number from zero, so it repeats"
+
+
+# --------------------------------------------------------------------------
+# Auth enforces once keys exist
+# --------------------------------------------------------------------------
+
+
+async def test_no_credential_is_refused_once_api_keys_are_configured(harness):
+    """The other half of the self-hosted no-op default.
+
+    The read gate is deliberately a no-op while no API keys are configured, so
+    the tests above call with no Authorization header and that is correct
+    behaviour, not a gap. Once a key exists the gate enforces, and this asserts
+    it does: room data must never come back unauthenticated on a deployment
+    that has turned auth on.
+    """
+    await _seed_complete(harness.gateway.storage)
+    # Before: the self-hosted default (no configured keys) serves it.
+    assert (await _get(harness, f"/v1/rooms/{ROOM}/latency")).status_code == 200
+
+    # Auth turns on when keys are CONFIGURED, which is app.state.api_keys, not
+    # the presence of a minted vk_ row in the database. A non-vk_ token takes
+    # the static-key path, the same way test_dashboard_api_keys sets it up.
+    from voicegateway.core.auth import ApiKey
+
+    harness.app.state.api_keys = [
+        ApiKey(token="static-secret", name="ops", scopes=("read",))
+    ]
+
+    r = await _get(harness, f"/v1/rooms/{ROOM}/latency")
+    assert r.status_code == 401, r.text
+    assert "components" not in r.text
+
+    # Non-vacuous: the configured key still gets the data.
+    ok = await _get(harness, f"/v1/rooms/{ROOM}/latency", "static-secret")
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["components"]["llm_ttft_ms"] == pytest.approx(447.0)


### PR DESCRIPTION
The component split (turn detection / STT / LLM / TTS) has only ever been readable **in-process**. `voicegw livekit latency` gets it by calling `ComponentReader` against the *same local store* the agent wrote to, and the CLI docs say so outright. A deployment running the agent in one container and the collector in another holds every row needed and cannot reach the computation.

`GET /v1/rooms/{room_name}/latency` is that computation, reachable. **No new measurement**: `aggregate_components`, `_split_complete` and `summarize` do the work, so the endpoint and the CLI cannot drift on what `p95` means.

## Keyed on the room, deliberately

A caller mints the LiveKit room name when it signs the token, so the room is the only identifier both sides hold at call time. `session_id` is minted inside VoiceGateway and a caller never observes it, so an endpoint keyed on it would be unusable by the process that needs it.

Turn rows are keyed by session. The bridge is the `session_id` the room's own request rows already carry, rather than threading room names down into the turn tracker.

## Four answers that must stay distinct

The consumer renders a different state for each:

| Response | Meaning |
|---|---|
| `404` | Never seen this room (**or** another tenant's — identical on purpose; a `403` confirms it is real) |
| `200`, `components: null` | Room known, nothing correlated: uninstrumented agent, or no completed turn |
| `200`, `complete: false` | Real split, still mid-flush. Poll again, do not render |
| `200`, a component `null` | That stage produced no measurement |

**Nothing is ever a fabricated zero.** A stage shown as `0.00` reads as "instant", and these numbers go into a document read months later. `aggregate_components` works in seconds; the wire is milliseconds, converted once here, because the probe endpoint already makes a reader remember a unit.

## `since_turn` is a cursor over `turns` and nothing else

`components` and `e2e_ms` are whole-call aggregates and always come back whole. A cursor that quietly narrowed them would make each poll disagree with the one before it — the one bug a polling consumer cannot see. A test asserts the filtered and unfiltered responses have byte-identical aggregates.

`e2e_ms` is `null` rather than a row of zeros when nothing completed: `summarize()` returns zeros for an empty list, which is right for a CLI table and a fabricated measurement here.

Tenancy is decided on the room's **own rows**, which carry `tenant_id`, rather than via a parent session: a room can span sessions, and the row is what is authoritative.

**Not built:** no CORS, no browser-facing key, no WebSocket/SSE, no per-turn split — each for the reason given in the brief, recorded in the module docstring so the next reader does not re-litigate it.

## Second: the report now states what it rests on

It carried per-agent trial counts and **never totalled them**, so a reader had to add up a column to learn the sample size behind a percentile, and it stated no session count at all. Both are now in the payload and in the rendered document: `2 session(s), 7 turn(s)`.

`sessions` counts **distinct probe rooms recorded** — an agent that answered nothing records no room and is not counted, so it counts sessions that produced a measurement rather than attempts.

**The environment label is the one thing here that cannot be derived**, and it is not guessed. The LiveKit URL is close and is a different claim: it says which server was probed, not whether the probe ran *inside* the deployed environment or *against* it from a laptop over another network path, and those produce different latency. So it is declared, by the caller or `VOICEGW_ENVIRONMENT`. An undeclared report renders "not declared" and names the variable, rather than leaving a blank cell a reader fills in with an assumption.

## Third: a docs page that denied a feature exists

`docs/examples/multi-project` said "There is no `VOICEGW_PROJECT` env var." It exists, `attach()` reads it at `attach.py:414`, and `test_attach_project_env.py` pins all three precedence levels. The page now describes the real order and says which to reach for. The README, `hosted/quickstart` and `deployment/vps` were already correct; this page was the outlier.

## Gates

Run on the local py3.13 venv mirroring the CI matrix leg before pushing: **3306 passed** (+30), 13 skipped, ruff clean, mypy clean on 284 files, docs validator PASS at 90 pages. No migration, no new dependency, no change to the ingest path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a room latency diagnostics API with component and end-to-end timing aggregates.
  * Added cursor-based filtering for returned turns while preserving whole-call aggregates.
  * Added environment and measurement-basis details to diagnostic reports.
  * Added support for project attribution through explicit settings or `VOICEGW_PROJECT`.

* **Documentation**
  * Documented the latency API, authentication, response fields, polling behavior, and limitations.
  * Updated multi-project guidance with project attribution and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->