### PR TITLE
Give turn capture a write path, end to end

### DIFF
--- a/src/voicegateway/core/gateway.py
+++ b/src/voicegateway/core/gateway.py
@@ -50,7 +50,7 @@ class Gateway:
         self._storage: StorageService | None
         if enabled:
             db_path = env_db or cost_cfg.get("db_path", DEFAULT_DB_PATH)
-            self._storage = StorageService(db_path)
+            self._storage = StorageService(db_path, config=self._config)
         else:
             self._storage = None
 

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from typing import TYPE_CHECKING, Any
@@ -57,32 +58,86 @@ def reset_components() -> None:
     _active_cost_tracker = None
 
 
-def _emit_user_started(session_id: str, tracker: TurnTracker) -> Any:
-    """Return an event-handler coroutine that forwards user-started events."""
+# Strong refs to in-flight turn-event tasks. asyncio only weak-refs scheduled
+# tasks, so without this a turn write can be collected mid-flight, exactly as
+# _close_tasks below guards the close-time finalize.
+_turn_tasks: set[Any] = set()
 
-    async def _handler(*_args: Any, **_kwargs: Any) -> None:
-        await tracker.on_user_started_speaking(session_id=session_id)
+
+def _schedule_turn_event(coro: Any, what: str) -> None:
+    """Run a tracker coroutine from a SYNCHRONOUS event callback.
+
+    LiveKit does not accept coroutine functions as event handlers. Its
+    ``EventEmitter.on`` raises outright:
+
+        ValueError: Cannot register an async callback with `.on()`.
+        Use `asyncio.create_task` within your synchronous callback instead.
+
+    So every handler here is a plain ``def`` that schedules the await, which is
+    what that message asks for. Registering ``async def`` handlers, as this
+    module used to, raised on any real ``AgentSession``; it survived only
+    because the test doubles accept anything from ``.on()``.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop: a synchronous test rig, or a callback fired off-loop.
+        # Dropping is correct here, and saying so beats a silent no-op.
+        logger.debug("attach: no running loop, dropping turn event %s", what)
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _turn_tasks.add(task)
+    task.add_done_callback(_on_turn_task_done)
+
+
+def _on_turn_task_done(task: Any) -> None:
+    _turn_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning("attach: turn event failed", exc_info=exc)
+
+
+def _emit_user_started(session_id: str, tracker: TurnTracker) -> Any:
+    """Return a sync event handler that forwards user-started events."""
+
+    def _handler(*_args: Any, **_kwargs: Any) -> None:
+        _schedule_turn_event(
+            tracker.on_user_started_speaking(session_id=session_id),
+            "user_started_speaking",
+        )
 
     return _handler
 
 
 def _emit_user_stopped(session_id: str, tracker: TurnTracker) -> Any:
-    async def _handler(*_args: Any, **_kwargs: Any) -> None:
-        await tracker.on_user_stopped_speaking(session_id=session_id)
+    def _handler(*_args: Any, **_kwargs: Any) -> None:
+        _schedule_turn_event(
+            tracker.on_user_stopped_speaking(session_id=session_id),
+            "user_stopped_speaking",
+        )
 
     return _handler
 
 
 def _emit_agent_started(session_id: str, tracker: TurnTracker) -> Any:
-    async def _handler(*_args: Any, **_kwargs: Any) -> None:
-        await tracker.on_agent_audio_first_frame(session_id=session_id)
+    def _handler(*_args: Any, **_kwargs: Any) -> None:
+        _schedule_turn_event(
+            tracker.on_agent_audio_first_frame(session_id=session_id),
+            "agent_started_speaking",
+        )
 
     return _handler
 
 
 def _emit_agent_stopped(session_id: str, tracker: TurnTracker) -> Any:
-    async def _handler(*_args: Any, **_kwargs: Any) -> None:
-        await tracker.on_agent_audio_last_frame(session_id=session_id)
+    def _handler(*_args: Any, **_kwargs: Any) -> None:
+        _schedule_turn_event(
+            tracker.on_agent_audio_last_frame(session_id=session_id),
+            "agent_stopped_speaking",
+        )
 
     return _handler
 
@@ -93,9 +148,13 @@ def _emit_close(
     detector: DeadAirDetector | None,
     cost_tracker: CostTracker | None,
 ) -> Any:
-    """Close handler: flush tracker, stop detector, finalize cost_tracker."""
+    """Close handler: flush tracker, stop detector, finalize cost_tracker.
 
-    async def _handler(*_args: Any, **_kwargs: Any) -> None:
+    Sync wrapper for the same reason as the emitters above: LiveKit refuses a
+    coroutine function at ``.on()``.
+    """
+
+    async def _run() -> None:
         try:
             await tracker.close_session(session_id)
         except Exception:
@@ -122,6 +181,9 @@ def _emit_close(
                     session_id,
                     exc_info=True,
                 )
+
+    def _handler(*_args: Any, **_kwargs: Any) -> None:
+        _schedule_turn_event(_run(), "close")
 
     return _handler
 
@@ -153,17 +215,16 @@ def attach_session(
 
     if tracker is None:
         logger.warning(
-            "attach_session(%s): no TurnTracker registered; "
-            "events will be dropped. Call register_components(...) "
-            "from the Gateway startup path first.",
+            "attach_session(%s): no TurnTracker; turn events will be dropped. "
+            "Pass turn_tracker=..., or use attach(session, turns=True), which "
+            "builds one wired to the sink for you.",
             sid,
         )
         return sid
 
-    agent_session.on("user_started_speaking", _emit_user_started(sid, tracker))
-    agent_session.on("user_stopped_speaking", _emit_user_stopped(sid, tracker))
-    agent_session.on("agent_started_speaking", _emit_agent_started(sid, tracker))
-    agent_session.on("agent_stopped_speaking", _emit_agent_stopped(sid, tracker))
+    # Shared with attach(turns=True) so both paths get the same event set,
+    # including the LiveKit 1.6 onset fallback.
+    _bind_turn_events(agent_session, sid, tracker)
     agent_session.on("close", _emit_close(sid, tracker, detector, ct))
 
     if detector is not None:
@@ -342,6 +403,7 @@ def attach(
     heartbeat: bool = False,
     transcript: bool = True,
     snapshots: bool = False,
+    turns: bool = True,
 ) -> str:
     """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
 
@@ -407,6 +469,19 @@ def attach(
             local sink: a remote collector has no replay tables, so capture is
             skipped there rather than buffering rows nothing can flush.
             LiveKit-only, like transcripts.
+        turns: capture per-turn speech boundaries (default ON). One row per
+            caller/agent exchange: the turn index and the four speech timestamps,
+            from which ``response_speed_ms`` is derived. This is what
+            ``e2e_ms`` and the ``turns`` list on ``/v1/rooms/{room}/latency``
+            are computed from, along with the Conversation tab's response-speed
+            and talk-over columns; all of them read empty without it. On by
+            default because a turn row is six integers and carries no utterance,
+            no prompt and no tool payload, so the disclosure argument that keeps
+            ``snapshots`` off does not apply. Unlike transcripts it works
+            against a remote collector too, via ``POST /v1/ingest/turns``. Set
+            ``VOICEGW_TURNS=0`` to force it off fleet-wide (the kill-switch wins
+            over the argument). LiveKit-only: the Pipecat path accepts the flag
+            but has no equivalent speech-boundary events yet.
 
     Returns:
         The correlation session id stamped on every captured row.
@@ -428,6 +503,7 @@ def attach(
             heartbeat=heartbeat,
             transcript=transcript,
             snapshots=snapshots,
+            turns=turns,
         )
     return _attach_livekit(
         session,
@@ -441,6 +517,7 @@ def attach(
         heartbeat=heartbeat,
         transcript=transcript,
         snapshots=snapshots,
+        turns=turns,
     )
 
 
@@ -451,6 +528,104 @@ def _transcripts_enabled(param: bool) -> bool:
     if env is not None and env.strip().lower() in ("0", "false", "no", "off"):
         return False
     return param
+
+
+def _turns_enabled(param: bool) -> bool:
+    """Whether to capture conversation turns. Same shape as transcripts above.
+
+    DEFAULT ON, like transcripts and unlike snapshots. A turn row is six
+    integers: session id, turn index, and the caller/agent speech boundaries.
+    It carries no utterance, no prompt and no tool payload, so the disclosure
+    argument that makes snapshots opt-in does not apply. It is what
+    ``e2e_ms`` on ``/v1/rooms/{room}/latency`` and the Conversation tab's
+    response-speed and talk-over columns are computed from, and all of them
+    read empty without it.
+    """
+    env = os.environ.get("VOICEGW_TURNS")
+    if env is not None and env.strip().lower() in ("0", "false", "no", "off"):
+        return False
+    return param
+
+
+_DEFAULT_TURN_FLUSH_SIZE = 25
+_turn_flush_size_cache: dict[str | None, int] = {}
+
+
+def _turn_flush_size(project: str | None) -> int:
+    """How many turns TurnTracker buffers before writing through the sink.
+
+    ``metrics`` hangs off ProjectConfig rather than GatewayConfig, so
+    ``turn_buffer_flush_size`` is a per-project knob and needs the project
+    ``attach()`` was called with. Loaded with ``required=False`` because
+    ``attach()`` is library-side and must work with no config file at all;
+    absent one, this is the schema default, which is the same number.
+
+    Cached per project: a busy worker calls ``attach()`` once per session and
+    should not stat the filesystem each time.
+    """
+    if project in _turn_flush_size_cache:
+        return _turn_flush_size_cache[project]
+    size = _DEFAULT_TURN_FLUSH_SIZE
+    try:
+        from voicegateway.core.config import GatewayConfig
+
+        cfg = GatewayConfig.load(required=False)
+        pcfg = (cfg.projects or {}).get(project) if project else None
+        if pcfg is not None:
+            size = int(pcfg.metrics.turn_buffer_flush_size)
+    except Exception:  # noqa: BLE001 - a bad config must not break attach()
+        logger.debug("attach: reading turn_buffer_flush_size failed", exc_info=True)
+    if size < 1:
+        size = _DEFAULT_TURN_FLUSH_SIZE
+    _turn_flush_size_cache[project] = size
+    return size
+
+
+def _build_turn_tracker(sink: Sink, project: str | None) -> Any:
+    """A TurnTracker whose flush writes turns through the sink.
+
+    The flush callback is what was missing: TurnTracker's default is a no-op
+    that logs "turns dropped (no repository wired)" at debug, so every reader of
+    the turns table read empty no matter how the tracker was bound.
+    """
+    from voicegateway.middleware.turn_tracker_middleware import TurnRow, TurnTracker
+
+    async def _flush(rows: list[TurnRow]) -> None:
+        await sink.log_turns(rows)
+
+    return TurnTracker(flush_callback=_flush, flush_size=_turn_flush_size(project))
+
+
+def _bind_turn_events(session: Any, session_id: str, tracker: Any) -> None:
+    """Wire the speech-boundary events onto an AgentSession.
+
+    Onset is hooked twice on purpose. LiveKit 1.6 dropped the discrete
+    ``user_started_speaking`` and signals onset as ``user_state_changed`` ->
+    ``speaking``; older builds emit the discrete event. ``capture.py`` already
+    hooks both for the first-partial latency, and turn capture needs the same
+    treatment or turn starts go uncaptured on 1.6 with a tracker bound.
+
+    First-wins needs no latch here: ``on_user_started_speaking`` only sets
+    ``pending_caller_start_ms`` when it is None, so whichever event arrives
+    first anchors the turn and the other is a no-op.
+    """
+    on = getattr(session, "on", None)
+    if not callable(on):
+        logger.debug("attach: session has no .on(); turn events not bound")
+        return
+
+    started = _emit_user_started(session_id, tracker)
+
+    def _on_state_changed(event: Any = None, *_a: Any, **_k: Any) -> None:
+        if getattr(event, "new_state", None) != "speaking":
+            return
+        started(event)
+
+    on("user_started_speaking", started)
+    on("user_state_changed", _on_state_changed)
+    on("user_stopped_speaking", _emit_user_stopped(session_id, tracker))
+    on("agent_started_speaking", _emit_agent_started(session_id, tracker))
+    on("agent_stopped_speaking", _emit_agent_stopped(session_id, tracker))
 
 
 def _snapshots_enabled(param: bool) -> bool:
@@ -634,6 +809,7 @@ def _attach_livekit(
     heartbeat: bool = False,
     transcript: bool = True,
     snapshots: bool = False,
+    turns: bool = True,
 ) -> str:
     """LiveKit ``attach()`` body: bind ``MetricCapture`` to an ``AgentSession``."""
     import asyncio
@@ -680,6 +856,14 @@ def _attach_livekit(
         if _snapshots_enabled(snapshots)
         else (None, None)
     )
+    # Same session_id the RequestRecords above are stamped with. rooms.py joins
+    # room -> session_id -> turns, so a tracker keyed on anything else produces
+    # turns that exist but never appear in /v1/rooms/{room}/latency.
+    turn_tracker = (
+        _build_turn_tracker(sink, project) if _turns_enabled(turns) else None
+    )
+    if turn_tracker is not None:
+        _bind_turn_events(session, session_id, turn_tracker)
 
     async def _finish() -> None:
         # Reconcile cumulative session.usage against the per-call rows, drain
@@ -688,6 +872,14 @@ def _attach_livekit(
         bump_active(-1)
         await capture.reconcile(session)
         await capture.drain()
+        if turn_tracker is not None:
+            # Before sink.flush(): close_session emits the tail turn and pushes
+            # everything under the flush-size threshold into the sink, so the
+            # flush below is what actually puts them on the wire.
+            try:
+                await turn_tracker.close_session(session_id)
+            except Exception:  # noqa: BLE001 - turns are never load-bearing
+                logger.debug("attach: turn flush on close failed", exc_info=True)
         await sink.flush()
         if snapshot_capture is not None:
             # Final flush of anything still buffered under the flush-size
@@ -862,6 +1054,7 @@ def _attach_pipecat(
     heartbeat: bool = False,
     transcript: bool = True,
     snapshots: bool = False,
+    turns: bool = True,
 ) -> str:
     """Register a ``VoiceGatewayObserver`` on a Pipecat ``PipelineTask``.
 
@@ -869,15 +1062,22 @@ def _attach_pipecat(
     ContextVar, and returns the correlation session id. The observer is the sole
     meter; it finalizes itself on the pipeline ``EndFrame`` (drain + flush).
 
-    ``transcript`` and ``snapshots`` are accepted for signature parity with the
-    LiveKit path but are not captured on Pipecat yet. A Pipecat transcript would
-    come from transcription frames, and snapshots would need the equivalent of
-    LiveKit's ``conversation_item_added`` / ``function_tools_executed``; both are
-    separate hooks. They are no-ops here rather than errors, so the same
-    ``attach(...)`` call works against either framework.
+    ``transcript``, ``snapshots`` and ``turns`` are accepted for signature parity
+    with the LiveKit path but are not captured on Pipecat yet. A Pipecat
+    transcript would come from transcription frames, and snapshots would need the
+    equivalent of LiveKit's ``conversation_item_added`` /
+    ``function_tools_executed``; both are separate hooks. They are no-ops here
+    rather than errors, so the same ``attach(...)`` call works against either
+    framework.
+
+    ``turns`` specifically needs Pipecat speech-boundary events equivalent to
+    LiveKit's user/agent started/stopped, which the observer does not surface
+    today. Accepting it silently is the deliberate choice over raising, but it
+    does mean a Pipecat agent gets no turn rows, so ``e2e_ms`` stays null there.
     """
     _ = transcript  # reserved: Pipecat transcript capture is a future step
     _ = snapshots  # reserved: needs a Pipecat message/tool-call hook
+    _ = turns  # reserved: needs Pipecat speech-boundary events
     from voicegateway.inference.pipecat.observer import VoiceGatewayObserver
 
     resolved_agent_id = agent_id or _default_agent_id()

--- a/src/voicegateway/repository/session_repository.py
+++ b/src/voicegateway/repository/session_repository.py
@@ -151,8 +151,17 @@ async def get_session(session: AsyncSession, session_id: str) -> dict[str, Any] 
     return out
 
 
-async def finalize_session_metrics(session: AsyncSession, session_id: str) -> None:
-    """Recompute and upsert the five aggregate columns on a session row."""
+async def finalize_session_metrics(
+    session: AsyncSession,
+    session_id: str,
+    *,
+    min_overlap_ms: int = turns.DEFAULT_TALK_OVER_MIN_OVERLAP_MS,
+) -> None:
+    """Recompute and upsert the five aggregate columns on a session row.
+
+    ``min_overlap_ms`` reaches ``count_overlap_turns``, which is what makes
+    ``metrics.talk_over_min_overlap_ms`` mean something.
+    """
     session_turns = await turns.list_turns_by_session(session, session_id)
     if not session_turns:
         return
@@ -177,7 +186,9 @@ async def finalize_session_metrics(session: AsyncSession, session_id: str) -> No
     )
 
     pcts = await turns.aggregate_response_speed(session, session_id)
-    overlap_count = await turns.count_overlap_turns(session, session_id)
+    overlap_count = await turns.count_overlap_turns(
+        session, session_id, min_overlap_ms=min_overlap_ms
+    )
     total_turns = len(session_turns)
     talk_over_rate = overlap_count / total_turns if total_turns > 0 else None
 

--- a/src/voicegateway/repository/turns_repository.py
+++ b/src/voicegateway/repository/turns_repository.py
@@ -13,6 +13,11 @@ from voicegateway.middleware.turn_tracker_middleware import TurnRow
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
+# Mirrors MetricsConfig.talk_over_min_overlap_ms. Restated rather than imported
+# so the repository layer does not pull in config; the guard test asserts the
+# two stay equal.
+DEFAULT_TALK_OVER_MIN_OVERLAP_MS = 100
+
 
 _INSERT_TURN = text(
     "INSERT INTO turns ("
@@ -122,8 +127,20 @@ async def aggregate_response_speed(
     }
 
 
-async def count_overlap_turns(session: AsyncSession, session_id: str) -> int:
-    """Return the number of turn pairs that overlap (talk-over events)."""
+async def count_overlap_turns(
+    session: AsyncSession,
+    session_id: str,
+    *,
+    min_overlap_ms: int = DEFAULT_TALK_OVER_MIN_OVERLAP_MS,
+) -> int:
+    """Return the number of turn pairs that overlap (talk-over events).
+
+    ``min_overlap_ms`` is how much the caller must cut into the agent's speech
+    before it counts. Any overlap at all used to count, which made a caller
+    starting a few milliseconds early indistinguishable from one talking over
+    the agent, and is what ``metrics.talk_over_min_overlap_ms`` was declared to
+    control before anything read it.
+    """
     result = await session.execute(
         text(
             "SELECT COUNT(*) FROM turns t1 "
@@ -132,15 +149,17 @@ async def count_overlap_turns(session: AsyncSession, session_id: str) -> int:
             " AND t0.turn_index = t1.turn_index - 1 "
             "WHERE t1.session_id = :session_id "
             "  AND t0.agent_speak_end_ms IS NOT NULL "
-            "  AND t1.caller_speak_start_ms < t0.agent_speak_end_ms"
+            "  AND (t0.agent_speak_end_ms - t1.caller_speak_start_ms) "
+            "      >= :min_overlap_ms"
         ),
-        {"session_id": session_id},
+        {"session_id": session_id, "min_overlap_ms": max(1, min_overlap_ms)},
     )
     row = result.fetchone()
     return int(row[0]) if row is not None else 0
 
 
 __all__ = [
+    "DEFAULT_TALK_OVER_MIN_OVERLAP_MS",
     "aggregate_response_speed",
     "count_overlap_turns",
     "create_turn",

--- a/src/voicegateway/server/api/ingest.py
+++ b/src/voicegateway/server/api/ingest.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.exc import IntegrityError
 
+from voicegateway.middleware.turn_tracker_middleware import TurnRow
 from voicegateway.models.request_model import RequestRecord
 from voicegateway.server.api._deps import get_gateway, require_scope
 
@@ -29,6 +30,8 @@ router = APIRouter()
 _RECORD_FIELDS: frozenset[str] = frozenset(
     f.name for f in dataclasses.fields(RequestRecord)
 )
+
+_TURN_FIELDS: frozenset[str] = frozenset(f.name for f in dataclasses.fields(TurnRow))
 
 
 def _record_from_payload(raw: dict[str, Any]) -> RequestRecord | None:
@@ -168,6 +171,80 @@ async def ingest(
     if rejected:
         logger.warning("ingest: skipped %d malformed record(s)", rejected)
     return {"accepted": accepted, "duplicates": duplicates}
+
+
+def _turn_from_payload(raw: dict[str, Any]) -> TurnRow | None:
+    """Build a TurnRow from a payload dict, ignoring unknown keys.
+
+    Returns None for a malformed row so one bad turn does not reject the batch,
+    matching ``_record_from_payload``.
+    """
+    filtered = {k: v for k, v in raw.items() if k in _TURN_FIELDS}
+    try:
+        return TurnRow(**filtered)
+    except TypeError:
+        return None
+
+
+@router.post("/ingest/turns")
+async def ingest_turns(
+    rows: list[dict[str, Any]],
+    request: Request,
+    _auth: None = Depends(require_scope("write")),
+) -> dict[str, int]:
+    """Persist a batch of conversation turns pushed by a fleet agent.
+
+    Its own route rather than a discriminated record on ``/v1/ingest``. That
+    handler builds a RequestRecord out of every dict it receives and counts
+    anything that fails to build as malformed, so a turn row posted there would
+    be answered ``200`` and silently dropped, which is the exact failure this
+    endpoint exists to end.
+
+    Always SQL, even when ClickHouse is configured for requests: ClickHouse has
+    no turns table, and every reader of turns (``/v1/rooms/{room}/latency``,
+    ``/api/sessions/{id}/turns``, the session aggregates) reads them from SQL.
+    Splitting the write would make those readers empty again.
+    """
+    gateway = get_gateway(request)
+    storage = gateway.storage
+    if storage is None:
+        raise HTTPException(
+            status_code=503,
+            detail="cost tracking storage is disabled on this collector",
+        )
+
+    max_batch = gateway.config.ingest.max_batch_size
+    if len(rows) > max_batch:
+        raise HTTPException(
+            status_code=413,
+            detail=f"batch too large: {len(rows)} turns exceeds max {max_batch}",
+        )
+
+    turns: list[TurnRow] = []
+    rejected = 0
+    for raw in rows:
+        turn = _turn_from_payload(raw)
+        if turn is None:
+            rejected += 1
+            continue
+        turns.append(turn)
+
+    accepted = 0
+    if turns:
+        try:
+            accepted = await storage.log_turns(turns)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ingest/turns: failed to persist %d turn(s)", len(turns), exc_info=True
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="telemetry store temporarily unavailable",
+            ) from exc
+
+    if rejected:
+        logger.warning("ingest/turns: skipped %d malformed turn(s)", rejected)
+    return {"accepted": accepted}
 
 
 __all__ = ["router"]

--- a/src/voicegateway/services/session_service.py
+++ b/src/voicegateway/services/session_service.py
@@ -40,7 +40,31 @@ class SessionService:
 
     async def finalize_metrics(self, session_id: str) -> None:
         async with self._db.session() as s:
-            await repo.finalize_session_metrics(s, session_id)
+            await repo.finalize_session_metrics(
+                s, session_id, min_overlap_ms=await self._talk_over_ms(s, session_id)
+            )
+
+    async def _talk_over_ms(self, s: Any, session_id: str) -> int:
+        """The talk-over threshold for this session's project.
+
+        ``metrics`` hangs off ProjectConfig, not GatewayConfig, so the knob is
+        per project and resolving it needs the session's project. Falls back to
+        the repository default when there is no config, no project on the row,
+        or no matching project block, which is every pre-existing caller.
+        """
+        from voicegateway.repository import turns_repository as turns
+
+        default = turns.DEFAULT_TALK_OVER_MIN_OVERLAP_MS
+        try:
+            projects = getattr(self._db.config, "projects", None) or {}
+            row = await repo.get_session(s, session_id)
+            project = (row or {}).get("project")
+            cfg = projects.get(project) if project else None
+            if cfg is None:
+                return default
+            return int(cfg.metrics.talk_over_min_overlap_ms)
+        except Exception:  # noqa: BLE001 - a config lookup must not fail finalize
+            return default
 
     async def finalize_replay(self, session_id: str) -> None:
         async with self._db.session() as s:

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from voicegateway.middleware.turn_tracker_middleware import TurnRow
     from voicegateway.models.request_model import RequestRecord
     from voicegateway.services.storage_service import StorageService
 
@@ -39,13 +40,20 @@ def _now() -> float:
 
 @runtime_checkable
 class Sink(Protocol):
-    """Narrow write target for request records.
+    """Narrow write target for captured telemetry.
 
-    ``log_request`` persists one record. ``flush`` drains any buffered
-    writes (a no-op for synchronous sinks). ``aclose`` releases resources.
+    ``log_request`` persists one record. ``log_turns`` persists a batch of
+    conversation turns. ``flush`` drains any buffered writes (a no-op for
+    synchronous sinks). ``aclose`` releases resources.
+
+    ``log_turns`` takes a batch rather than one row because TurnTracker already
+    buffers to ``turn_buffer_flush_size`` before calling out, so a per-row
+    method would only unpick batching the caller has already done.
     """
 
     async def log_request(self, record: RequestRecord) -> None: ...
+
+    async def log_turns(self, rows: list[TurnRow]) -> None: ...
 
     async def flush(self) -> None: ...
 
@@ -66,6 +74,9 @@ class LocalSqliteSink:
 
     async def log_request(self, record: RequestRecord) -> None:
         await self._storage.log_request(record)
+
+    async def log_turns(self, rows: list[TurnRow]) -> None:
+        await self._storage.log_turns(rows)
 
     async def flush(self) -> None:
         return None
@@ -135,6 +146,9 @@ class RemoteCollectorSink:
         sleep: Callable[[float], Awaitable[None]] | None = None,
     ) -> None:
         self._ingest_url = _normalize_ingest_url(url)
+        # Turns get their own route off the same base. See _post for why they
+        # cannot share /v1/ingest.
+        self._turns_url = self._ingest_url + "/turns"
         self._headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         self._batch_size = max(1, batch_size)
         self._flush_interval = flush_interval
@@ -149,6 +163,12 @@ class RemoteCollectorSink:
         # ``(seq, payload)`` so an ack can delete exactly those outbox rows.
         self._buffer: list[dict[str, Any]] = []
         self._spooled: list[tuple[int, dict[str, Any]]] = []
+        # Turns batch in memory and are never written to the durable outbox.
+        # The outbox exists so ``voicegw reconcile`` can prove no COST row was
+        # lost; turns are timing metadata that reconcile does not read, and
+        # spooling them would mean a schema change to outbox files already on
+        # disk in deployed agents. Dropped turns are counted and logged.
+        self._turn_buffer: list[dict[str, Any]] = []
         self._flusher: asyncio.Task[None] | None = None
         self._closed = False
         # Durable outbox (opt-in).
@@ -342,6 +362,40 @@ class RemoteCollectorSink:
         if len(self._buffer) >= self._batch_size:
             await self.flush()
 
+    async def log_turns(self, rows: list[TurnRow]) -> None:
+        """Buffer a batch of turns for the collector's ``/v1/ingest/turns``.
+
+        Best-effort by the same rule as ``log_request``: this runs on the
+        agent's hot path at the end of a turn, so it never blocks and never
+        raises. Overflow drops oldest, counted and logged rather than silent.
+        """
+        if not rows:
+            return
+        self._turn_buffer.extend(asdict(row) for row in rows)
+        if len(self._turn_buffer) > self._max_buffer:
+            overflow = len(self._turn_buffer) - self._max_buffer
+            del self._turn_buffer[:overflow]
+            self._dropped += overflow
+            logger.warning(
+                "RemoteCollectorSink turn buffer full; dropped %d oldest turn(s)",
+                overflow,
+            )
+        self._maybe_start_flusher()
+        if len(self._turn_buffer) >= self._batch_size:
+            await self._flush_turns()
+
+    async def _flush_turns(self) -> None:
+        """Drain the turn buffer to the collector. Requeues on failure."""
+        if not self._turn_buffer:
+            return
+        batch = self._turn_buffer
+        self._turn_buffer = []
+        if not await self._post(batch, self._turns_url):
+            # Put them back so the next flush (or aclose) retries. _post has
+            # already exhausted its own retries and logged the reason; the
+            # buffer cap above is what bounds this.
+            self._turn_buffer = batch + self._turn_buffer
+
     def _maybe_start_flusher(self) -> None:
         if not self._flush_interval or self._flusher is not None or self._closed:
             return
@@ -360,6 +414,10 @@ class RemoteCollectorSink:
             pass
 
     async def flush(self) -> None:
+        # Turns drain on every flush, including the spool path. They share the
+        # periodic flusher and aclose with requests, but not the outbox, so this
+        # runs regardless of which request path is taken below.
+        await self._flush_turns()
         if self._spool_path is not None:
             if not self._spooled:
                 return
@@ -381,20 +439,24 @@ class RemoteCollectorSink:
         self._buffer = []
         await self._post(batch)
 
-    async def _post(self, batch: list[dict[str, Any]]) -> bool:
+    async def _post(self, batch: list[dict[str, Any]], url: str | None = None) -> bool:
         """POST a batch; return True on ack (2xx), False if it was not delivered.
 
         The return value drives the durable-spool ack/requeue decision. The
         legacy (no-spool) caller ignores it, preserving best-effort behavior.
+
+        ``url`` defaults to the ingest endpoint. Turns pass their own, because
+        the ingest handler builds a RequestRecord out of every dict it is given
+        and counts anything that fails to build as malformed. A turn row sent
+        there would be answered 200 and dropped.
         """
+        target = url if url is not None else self._ingest_url
         client = self._ensure_client()
         attempt = 0
         while True:
             reason: Any
             try:
-                resp = await client.post(
-                    self._ingest_url, json=batch, headers=self._headers
-                )
+                resp = await client.post(target, json=batch, headers=self._headers)
                 if resp.status_code < 400:
                     return True
                 if resp.status_code == 429:

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -25,12 +26,24 @@ _logger = logging.getLogger(__name__)
 class StorageService:
     """Aggregates per-domain services over one SQLite database."""
 
-    def __init__(self, db_path: str | Path) -> None:
+    def __init__(
+        self, db_path: str | Path, *, config: GatewayConfig | None = None
+    ) -> None:
         # Database.__init__ quiets the noisy aiosqlite/alembic loggers now, so this
         # facade no longer needs its own call.
         self._db_path = Path(db_path).expanduser()
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
-        cfg = GatewayConfig(cost_tracking={"db_path": str(self._db_path)})
+        # ``config`` carries the caller's loaded voicegw.yaml so knobs the
+        # services read (metrics.talk_over_min_overlap_ms) are the user's rather
+        # than built-in defaults. db_path still wins: it is the path this facade
+        # was explicitly opened on, and callers pass it separately.
+        if config is not None:
+            cfg = replace(
+                config,
+                cost_tracking={**config.cost_tracking, "db_path": str(self._db_path)},
+            )
+        else:
+            cfg = GatewayConfig(cost_tracking={"db_path": str(self._db_path)})
         self._conn = Database(cfg)
         self._initialized = False
         # Serialize concurrent _ensure_initialized calls so alembic's
@@ -349,6 +362,25 @@ class StorageService:
                 db, project=project, since=since, warn_threshold=warn_threshold
             )
         return dataclasses.asdict(row)
+
+    # ------------------------------------------------------------------
+    # Turns
+    # ------------------------------------------------------------------
+
+    async def log_turns(self, rows: list[Any]) -> int:
+        """Bulk-write captured turns. Returns the number inserted.
+
+        A passthrough for the same reason as the load-run writes above: the
+        repository owns the insert and the tenant resolution, and a second copy
+        of that here is how the two drift.
+        """
+        from voicegateway.repository import turns_repository as turns
+
+        if not rows:
+            return 0
+        await self._ensure_initialized()
+        async with self._conn.session() as db:
+            return await turns.create_turns_bulk(db, rows)
 
     # ------------------------------------------------------------------
     # Load runs

--- a/src/voicegateway/tests/core/test_metrics_config_is_read.py
+++ b/src/voicegateway/tests/core/test_metrics_config_is_read.py
@@ -1,0 +1,134 @@
+"""``metrics.talk_over_min_overlap_ms`` and ``turn_buffer_flush_size`` are read.
+
+Both were declared in the schema and parsed by the config loader, and neither
+had a consumer. Setting either in ``voicegw.yaml`` validated and did nothing,
+which is worse than not offering the knob: it reads as configured behaviour.
+
+Both hang off ProjectConfig, not GatewayConfig, so both are per project.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import yaml
+
+from voicegateway.core.config import GatewayConfig
+from voicegateway.repository import turns_repository as turns
+from voicegateway.schemas.config_schema import MetricsConfig as SchemaMetrics
+
+
+def _config(tmp_path, *, overlap_ms: int, flush_size: int) -> str:
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(
+        yaml.dump(
+            {
+                "providers": {"openai": {"api_key": "k"}},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "cost_tracking": {"enabled": True},
+                "projects": {
+                    "tuned": {
+                        "name": "Tuned",
+                        "metrics": {
+                            "talk_over_min_overlap_ms": overlap_ms,
+                            "turn_buffer_flush_size": flush_size,
+                        },
+                    }
+                },
+            }
+        )
+    )
+    return str(path)
+
+
+def test_the_repository_default_matches_the_schema_default() -> None:
+    """The repository restates the default rather than importing config.
+
+    Restating is deliberate (the repository layer should not depend on config),
+    but two copies of a number drift, so this is the thing that keeps them one.
+    """
+    assert (
+        turns.DEFAULT_TALK_OVER_MIN_OVERLAP_MS
+        == SchemaMetrics().talk_over_min_overlap_ms
+    )
+
+
+def test_the_flush_size_default_matches_the_schema_default() -> None:
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    assert attach_mod._DEFAULT_TURN_FLUSH_SIZE == SchemaMetrics().turn_buffer_flush_size
+
+
+def test_turn_buffer_flush_size_is_read_from_the_project(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7))
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    attach_mod._turn_flush_size_cache.clear()
+
+    assert attach_mod._turn_flush_size("tuned") == 7
+    # A project with no metrics block, and an unknown project, both fall back.
+    assert attach_mod._turn_flush_size("nope") == attach_mod._DEFAULT_TURN_FLUSH_SIZE
+    attach_mod._turn_flush_size_cache.clear()
+
+
+def test_the_flush_size_reaches_the_tracker(tmp_path, monkeypatch) -> None:
+    """Reading the number is not the same as using it."""
+    monkeypatch.setenv("VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=3))
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    attach_mod._turn_flush_size_cache.clear()
+
+    class _Sink:
+        async def log_turns(self, rows):  # noqa: ANN001, ANN202
+            return None
+
+    tracker = attach_mod._build_turn_tracker(_Sink(), "tuned")
+    assert tracker._flush_size == 3
+    attach_mod._turn_flush_size_cache.clear()
+
+
+def test_the_project_metrics_block_parses(tmp_path) -> None:
+    cfg = GatewayConfig.load(_config(tmp_path, overlap_ms=250, flush_size=7))
+    metrics = cfg.projects["tuned"].metrics
+    assert metrics.talk_over_min_overlap_ms == 250
+    assert metrics.turn_buffer_flush_size == 7
+
+
+async def test_talk_over_threshold_changes_the_overlap_count(tmp_path) -> None:
+    """The knob has to change the answer, not just reach the query.
+
+    Two turns whose overlap is 50ms: counted at the 25ms threshold, not counted
+    at 100ms. Under the old query, which counted any overlap at all, both cases
+    returned 1.
+    """
+    from voicegateway.middleware.turn_tracker_middleware import TurnRow
+    from voicegateway.services.storage_service import StorageService
+
+    storage = StorageService(str(tmp_path / "overlap.db"))
+    await storage._ensure_initialized()
+
+    rows = [
+        TurnRow(
+            session_id="s",
+            turn_index=0,
+            caller_speak_start_ms=0,
+            caller_speak_end_ms=500,
+            agent_speak_start_ms=600,
+            agent_speak_end_ms=1000,
+        ),
+        # Caller starts 50ms before the agent finished: a 50ms overlap.
+        TurnRow(
+            session_id="s",
+            turn_index=1,
+            caller_speak_start_ms=950,
+            caller_speak_end_ms=1500,
+            agent_speak_start_ms=1600,
+            agent_speak_end_ms=2000,
+        ),
+    ]
+    async with storage._conn.session() as db:
+        await turns.create_turns_bulk(db, rows)
+
+    async with storage._conn.session() as db:
+        assert await turns.count_overlap_turns(db, "s", min_overlap_ms=25) == 1
+        assert await turns.count_overlap_turns(db, "s", min_overlap_ms=100) == 0
+
+    await storage.aclose()

--- a/src/voicegateway/tests/inference/test_attach_turns.py
+++ b/src/voicegateway/tests/inference/test_attach_turns.py
@@ -1,0 +1,314 @@
+"""``attach(turns=True)``: the write path from a speech event to a stored turn.
+
+Before this existed, ``turns`` had five readers and no writer. ``create_turn``
+and ``create_turns_bulk`` had no non-test callers, ``TurnTracker`` was built
+only in tests, and its default flush was a no-op that logged "turns dropped (no
+repository wired)" at debug. So ``e2e_ms`` and ``turns`` on
+``/v1/rooms/{room}/latency``, ``/api/sessions/{id}/turns``, and the five
+session-aggregate columns behind the Conversation tab all read empty, with
+nothing anywhere reporting a fault.
+
+These tests walk the whole path rather than asserting on the tracker in
+isolation, because every previous test did the latter and the gap was between
+the parts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+from typing import Any
+
+import pytest
+
+import voicegateway
+from voicegateway.inference.session.context import reset_session_id
+from voicegateway.services.sinks import LocalSqliteSink
+from voicegateway.services.storage_service import StorageService
+
+
+class _Session:
+    """AgentSession double that mirrors ``livekit.rtc.EventEmitter``.
+
+    ``on`` refuses coroutine functions and ``emit`` is synchronous, exactly as
+    the real emitter behaves. A permissive double is what hid the original bug,
+    so this one is deliberately strict: registering an async handler raises
+    here just as it would in production.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, list[Any]] = {}
+        self.stt = None
+        self.llm = None
+        self.tts = None
+        self.current_agent = None
+
+    def on(self, event_name: str, handler: Any) -> None:
+        if inspect.iscoroutinefunction(handler):
+            raise ValueError(
+                "Cannot register an async callback with `.on()`. Use "
+                "`asyncio.create_task` within your synchronous callback instead."
+            )
+        self._handlers.setdefault(event_name, []).append(handler)
+
+    def emit(self, event_name: str, event: Any = None) -> None:
+        # LiveKit always emits with an event payload, and its handlers are
+        # written to take one, so supply a default rather than calling with no
+        # arguments (which no real emit ever does).
+        payload = event if event is not None else _Event()
+        for handler in list(self._handlers.get(event_name, [])):
+            handler(payload)
+
+
+class _Event:
+    """A payload-free event. ``new_state`` is None so the 1.6 onset filter,
+    which only reacts to ``speaking``, correctly ignores it."""
+
+    new_state = None
+    created_at = 0.0
+
+
+class _StateChanged(_Event):
+    """The LiveKit 1.6 onset event, which carries the new state."""
+
+    def __init__(self, new_state: str) -> None:
+        self.new_state = new_state
+
+
+async def _drain() -> None:
+    """Wait for the tasks the sync handlers scheduled, deterministically.
+
+    Handlers are sync and schedule their await via ``asyncio.create_task``, so
+    the effect lands later. Counting event-loop passes is a race: it passed in
+    isolation and failed intermittently under the full suite, where the tracker
+    contends for its lock. ``attach._turn_tasks`` holds a strong ref to every
+    in-flight task, so awaiting that set settles on the actual work rather than
+    on a guess, and raises instead of under-draining silently.
+    """
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    loop = asyncio.get_running_loop()
+
+    def _pending() -> list[Any]:
+        # BOTH task sets. The per-event handlers land in ``_turn_tasks``, but
+        # attach()'s close path schedules ``_finish`` into ``_close_tasks``, and
+        # that is what calls ``turn_tracker.close_session`` and flushes the
+        # buffer. Watching only ``_turn_tasks`` returned before the flush, which
+        # is what made these tests pass alone and fail under the full suite.
+        #
+        # Filtered to this test's loop: both sets are module-global and pytest
+        # gives each test its own loop, so they can still hold tasks created on
+        # an earlier, now-closed loop; awaiting one of those never returns.
+        return [
+            t
+            for t in [*attach_mod._turn_tasks, *attach_mod._close_tasks]
+            if not t.done() and t.get_loop() is loop
+        ]
+
+    for _ in range(100):
+        pending = _pending()
+        if not pending:
+            # One more pass so a task that just finished can schedule follow-on
+            # work (close_session flushes through the sink).
+            await asyncio.sleep(0)
+            if not _pending():
+                return
+            continue
+        await asyncio.gather(*pending, return_exceptions=True)
+    raise AssertionError("turn event tasks never settled")
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    """Give each test its own database AND its own session id.
+
+    Both are shared state that made these tests pass alone and fail
+    intermittently in the full suite:
+
+    - ``resolve_database_url`` gives ``VOICEGW_DB_PATH`` precedence over the
+      path ``StorageService`` was constructed with, so a leftover env var sends
+      every test's writes into one file.
+    - ``get_or_create_session_id`` is a ContextVar that outlives a test, so
+      without a reset every test in this module attaches under the same id.
+
+    Together those two mean test N reads test N-1's turns and counts two.
+    """
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.delenv("VOICEGW_DB_URL", raising=False)
+    reset_session_id()
+    yield
+    reset_session_id()
+
+
+def _sink(tmp_path: Any) -> LocalSqliteSink:
+    return LocalSqliteSink(StorageService(str(tmp_path / "turns.db")))
+
+
+async def _stored_turns(sink: LocalSqliteSink, session_id: str) -> list[Any]:
+    from voicegateway.repository import turns_repository as turns
+
+    storage = sink._storage
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        return await turns.list_turns_by_session(db, session_id)
+
+
+async def test_a_turn_reaches_storage(tmp_path) -> None:
+    """The whole point: speech events in, a row in the turns table out."""
+    sink = _sink(tmp_path)
+    session = _Session()
+
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_started_speaking")
+    await _drain()
+    session.emit("user_stopped_speaking")
+    await _drain()
+    session.emit("agent_started_speaking")
+    await _drain()
+    session.emit("agent_stopped_speaking")
+    await _drain()
+
+    # close_session emits the tail and flushes below the flush-size threshold.
+    capture = session._vg_capture
+    assert capture is not None
+    session.emit("close")
+    await _drain()
+
+    rows = await _stored_turns(sink, sid)
+    assert len(rows) == 1, f"expected one stored turn, got {rows}"
+    turn = rows[0]
+    assert turn.session_id == sid
+    assert turn.turn_index == 0
+    assert turn.agent_speak_start_ms is not None
+    assert turn.agent_speak_end_ms is not None
+    assert turn.response_speed_ms is not None
+    assert turn.response_speed_ms >= 0
+
+
+async def test_livekit_16_onset_starts_a_turn(tmp_path) -> None:
+    """1.6 emits no discrete user_started_speaking; the turn must still start.
+
+    LiveKit 1.6 signals onset as ``user_state_changed`` -> ``speaking``.
+    ``capture.py`` already hooked both for first-partial latency; turn capture
+    did not, so on 1.6 every turn start went uncaptured even with a tracker
+    bound. Only the 1.6 event is emitted here, so a regression to
+    ``user_started_speaking`` alone fails this.
+    """
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_state_changed", _StateChanged("speaking"))
+    await _drain()
+    session.emit("user_stopped_speaking")
+    await _drain()
+    session.emit("agent_started_speaking")
+    await _drain()
+    session.emit("close")
+    await _drain()
+
+    rows = await _stored_turns(sink, sid)
+    assert len(rows) == 1, "the 1.6 onset event did not start a turn"
+
+
+async def test_non_speaking_state_changes_do_not_start_a_turn(tmp_path) -> None:
+    """``user_state_changed`` also fires for listening/away."""
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_state_changed", _StateChanged("listening"))
+    await _drain()
+    session.emit("user_state_changed", _StateChanged("away"))
+    await _drain()
+    session.emit("agent_started_speaking")
+    await _drain()
+    session.emit("close")
+    await _drain()
+
+    assert await _stored_turns(sink, sid) == []
+
+
+async def test_both_onset_events_produce_one_turn(tmp_path) -> None:
+    """A build emitting both must not double-count the turn start.
+
+    First-wins is TurnTracker's own guard (it only sets the pending start when
+    it is None), so this pins the behaviour the dual hook depends on.
+    """
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_state_changed", _StateChanged("speaking"))
+    session.emit("user_started_speaking")
+    await _drain()
+    session.emit("user_stopped_speaking")
+    await _drain()
+    session.emit("agent_started_speaking")
+    await _drain()
+    session.emit("close")
+    await _drain()
+
+    rows = await _stored_turns(sink, sid)
+    assert len(rows) == 1, f"onset fired twice produced {len(rows)} turns"
+
+
+async def test_turns_false_writes_nothing(tmp_path) -> None:
+    """The opt-out has to actually opt out."""
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink, turns=False)
+
+    session.emit("user_started_speaking")
+    await _drain()
+    session.emit("agent_started_speaking")
+    await _drain()
+    session.emit("close")
+    await _drain()
+
+    assert await _stored_turns(sink, sid) == []
+
+
+async def test_env_kill_switch_beats_the_argument(tmp_path, monkeypatch) -> None:
+    """``VOICEGW_TURNS=0`` turns it off fleet-wide, over an explicit True."""
+    monkeypatch.setenv("VOICEGW_TURNS", "0")
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink, turns=True)
+
+    session.emit("user_started_speaking")
+    await _drain()
+    session.emit("agent_started_speaking")
+    await _drain()
+    session.emit("close")
+    await _drain()
+
+    assert await _stored_turns(sink, sid) == []
+
+
+async def test_handlers_are_not_coroutine_functions(tmp_path) -> None:
+    """The regression guard for the bug that made this unusable in production.
+
+    ``EventEmitter.on`` raises ValueError on a coroutine function, so an async
+    handler is not a slow path, it is a crash on any real AgentSession. The
+    strict double above already enforces this during attach; this states it
+    directly so the reason survives a refactor of the double.
+    """
+    # import_module, not ``from ... import attach``: the package __init__ binds
+    # ``attach`` to the FUNCTION, so the plain import would shadow the module.
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    from voicegateway.middleware.turn_tracker_middleware import TurnTracker
+
+    tracker = TurnTracker()
+    for factory in (
+        attach_mod._emit_user_started,
+        attach_mod._emit_user_stopped,
+        attach_mod._emit_agent_started,
+        attach_mod._emit_agent_stopped,
+    ):
+        handler = factory("s", tracker)
+        assert not inspect.iscoroutinefunction(handler), (
+            f"{factory.__name__} returned a coroutine function; "
+            "LiveKit's EventEmitter.on rejects those outright"
+        )

--- a/src/voicegateway/tests/inference/test_metrics_pipeline.py
+++ b/src/voicegateway/tests/inference/test_metrics_pipeline.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
+import inspect
 from typing import Any
 
 import pytest
@@ -17,17 +19,80 @@ from voicegateway.middleware.turn_tracker_middleware import TurnRow, TurnTracker
 
 
 class FakeAgentSession:
-    """Minimal EventEmitter doubling for livekit-agents AgentSession."""
+    """Minimal EventEmitter double for livekit-agents AgentSession.
+
+    Mirrors ``livekit.rtc.EventEmitter`` on the two points that matter:
+    ``emit`` is SYNCHRONOUS, and ``on`` REFUSES a coroutine function with the
+    same ValueError the real one raises.
+
+    This double previously did neither: it was ``async def emit`` awaiting each
+    handler. That is not a contract LiveKit has ever offered, and modelling it
+    is what let ``attach_session`` register ``async def`` handlers for years.
+    Against a real ``AgentSession`` those calls raise:
+
+        ValueError: Cannot register an async callback with `.on()`.
+        Use `asyncio.create_task` within your synchronous callback instead.
+
+    So turn capture could not have worked in production, and no test could see
+    it. Keep this faithful, or the same class of bug walks straight back in.
+    """
 
     def __init__(self) -> None:
         self._handlers: dict[str, list[Any]] = {}
 
     def on(self, event_name: str, handler: Any) -> None:
+        if inspect.iscoroutinefunction(handler):
+            raise ValueError(
+                "Cannot register an async callback with `.on()`. Use "
+                "`asyncio.create_task` within your synchronous callback instead."
+            )
         self._handlers.setdefault(event_name, []).append(handler)
 
-    async def emit(self, event_name: str) -> None:
+    def emit(self, event_name: str, *args: Any) -> None:
         for h in self._handlers.get(event_name, []):
-            await h()
+            h(*args)
+
+
+async def _drain() -> None:
+    """Wait for the tasks the sync handlers scheduled, deterministically.
+
+    Handlers are sync and schedule their await via ``asyncio.create_task``, so
+    the effect lands later. Counting event-loop passes is a race: it passed in
+    isolation and failed intermittently under the full suite, where the tracker
+    contends for its lock. ``attach._turn_tasks`` holds a strong ref to every
+    in-flight task, so awaiting that set settles on the actual work rather than
+    on a guess, and raises instead of under-draining silently.
+    """
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    loop = asyncio.get_running_loop()
+
+    def _pending() -> list[Any]:
+        # BOTH task sets. The per-event handlers land in ``_turn_tasks``, but
+        # attach()'s close path schedules ``_finish`` into ``_close_tasks``, and
+        # that is what calls ``turn_tracker.close_session`` and flushes the
+        # buffer. Watching only ``_turn_tasks`` returned before the flush, which
+        # is what made these tests pass alone and fail under the full suite.
+        #
+        # Filtered to this test's loop: both sets are module-global and pytest
+        # gives each test its own loop, so they can still hold tasks created on
+        # an earlier, now-closed loop; awaiting one of those never returns.
+        return [
+            t
+            for t in [*attach_mod._turn_tasks, *attach_mod._close_tasks]
+            if not t.done() and t.get_loop() is loop
+        ]
+
+    for _ in range(100):
+        pending = _pending()
+        if not pending:
+            # One more pass so a task that just finished can schedule follow-on
+            # work (close_session flushes through the sink).
+            await asyncio.sleep(0)
+            if not _pending():
+                return
+            continue
+        await asyncio.gather(*pending, return_exceptions=True)
+    raise AssertionError("turn event tasks never settled")
 
 
 @pytest.fixture(autouse=True)
@@ -52,11 +117,16 @@ async def test_attach_session_routes_full_turn_to_tracker() -> None:
     assert sid == "test-session"
 
     # Drive a normal turn lifecycle.
-    await agent.emit("user_started_speaking")
-    await agent.emit("user_stopped_speaking")
-    await agent.emit("agent_started_speaking")
-    await agent.emit("agent_stopped_speaking")
-    await agent.emit("close")
+    agent.emit("user_started_speaking")
+    await _drain()
+    agent.emit("user_stopped_speaking")
+    await _drain()
+    agent.emit("agent_started_speaking")
+    await _drain()
+    agent.emit("agent_stopped_speaking")
+    await _drain()
+    agent.emit("close")
+    await _drain()
 
     # `close` fires tracker.close_session(sid) which flushes the buffer.
     assert len(captured) == 1
@@ -108,7 +178,8 @@ async def test_attach_session_starts_dead_air_detector() -> None:
     await asyncio.sleep(0)
     assert started == ["probe-session"]
 
-    await agent.emit("close")
+    agent.emit("close")
+    await _drain()
     assert stopped == ["probe-session"]
 
 
@@ -129,7 +200,8 @@ async def test_attach_session_close_calls_cost_tracker() -> None:
         cost_tracker=_CT(),  # type: ignore[arg-type]
     )
 
-    await agent.emit("close")
+    agent.emit("close")
+    await _drain()
     assert closed == ["cost-session"]
 
 

--- a/src/voicegateway/tests/server/test_ingest_turns_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_turns_endpoint.py
@@ -1,0 +1,167 @@
+"""``POST /v1/ingest/turns``: the collector-mode half of the turn write path.
+
+Binding a tracker alone only fixes the co-located case, where the agent and the
+collector share a database. That is the exact limitation
+``/v1/rooms/{room}/latency`` exists to escape, so a fleet agent needs somewhere
+to push turns to. This is that route.
+
+It is deliberately NOT a discriminated record on ``/v1/ingest``: that handler
+builds a RequestRecord out of every dict it receives and counts anything that
+fails to build as malformed, so a turn posted there is answered ``200`` and
+dropped. The last test here pins that reasoning.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+
+_CFG: dict[str, Any] = {
+    "providers": {"openai": {"api_key": "k"}},
+    "models": {"stt": {}, "llm": {}, "tts": {}},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+_KEY = "turns-test-key"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "turns.db"))
+    monkeypatch.setenv("VOICEGW_API_KEY", _KEY)
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump(_CFG))
+    app = build_app(
+        Gateway(config_path=str(path)), enable_mcp_sse=False, enable_dashboard=False
+    )
+    with TestClient(app) as c:
+        yield c
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_KEY}"}
+
+
+def _turn(session_id: str, index: int, *, start: int = 1000) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "turn_index": index,
+        "caller_speak_start_ms": start,
+        "caller_speak_end_ms": start + 500,
+        "agent_speak_start_ms": start + 900,
+        "agent_speak_end_ms": start + 2000,
+        "response_speed_ms": 400,
+    }
+
+
+def test_a_posted_turn_is_readable_back(client) -> None:
+    """The round trip. Anything less proves only that the route returns 200."""
+    posted = client.post(
+        "/v1/ingest/turns", json=[_turn("s-1", 0)], headers=_auth()
+    )
+    assert posted.status_code == 200, posted.text
+    assert posted.json() == {"accepted": 1}
+
+    read = client.get("/api/sessions/s-1/turns", headers=_auth())
+    assert read.status_code == 200, read.text
+    rows = read.json()
+    body = rows["turns"] if isinstance(rows, dict) else rows
+    assert len(body) == 1
+    assert body[0]["turn_index"] == 0
+    assert body[0]["response_speed_ms"] == 400
+
+
+def test_it_reaches_the_room_latency_endpoint(client) -> None:
+    """The reason the route exists: e2e_ms was always null in collector mode.
+
+    Requests carry the room, turns carry the session id, and rooms.py bridges
+    room -> session_id -> turns. Both halves must be posted for e2e_ms to be
+    anything other than null, so both are posted here.
+    """
+    now = int(time.time())
+    record = {
+        "id": "req-1",
+        "timestamp": now,
+        "project": "p",
+        "modality": "llm",
+        "model_id": "openai/gpt-4o-mini",
+        "provider": "openai",
+        "input_units": 100,
+        "output_units": 50,
+        "pricing_source": "test",
+        "ttfb_ms": 447.0,
+        "status": "success",
+        "session_id": "s-room",
+        "metadata": {"room": "room-1"},
+    }
+    assert client.post("/v1/ingest", json=[record], headers=_auth()).status_code == 200
+    assert (
+        client.post(
+            "/v1/ingest/turns", json=[_turn("s-room", 0)], headers=_auth()
+        ).status_code
+        == 200
+    )
+
+    got = client.get("/v1/rooms/room-1/latency", headers=_auth())
+    assert got.status_code == 200, got.text
+    body = got.json()
+    assert body["turn_count"] == 1, body
+    assert body["e2e_ms"] is not None, "e2e_ms is still null with a turn stored"
+    assert len(body["turns"]) == 1
+
+
+def test_a_malformed_turn_does_not_reject_the_batch(client) -> None:
+    """One bad row must not cost the good ones, matching /v1/ingest."""
+    good = _turn("s-2", 0)
+    bad = {"session_id": "s-2"}  # no boundaries: TurnRow cannot be built
+    resp = client.post("/v1/ingest/turns", json=[good, bad], headers=_auth())
+    assert resp.status_code == 200
+    assert resp.json() == {"accepted": 1}
+
+
+def test_unknown_keys_are_ignored(client) -> None:
+    """A newer agent posting an extra field must not 422 against an older
+    collector, same tolerance ``_record_from_payload`` gives requests."""
+    row = _turn("s-3", 0)
+    row["some_future_field"] = "whatever"
+    resp = client.post("/v1/ingest/turns", json=[row], headers=_auth())
+    assert resp.status_code == 200
+    assert resp.json() == {"accepted": 1}
+
+
+def test_it_requires_auth(client) -> None:
+    """Public by necessity, so it must refuse an unauthenticated write."""
+    resp = client.post("/v1/ingest/turns", json=[_turn("s-4", 0)])
+    assert resp.status_code == 401
+
+
+def test_the_batch_cap_is_enforced(client) -> None:
+    """Same 413 guard as /v1/ingest; an unbounded batch is a memory problem."""
+    rows = [_turn("s-5", i) for i in range(2000)]
+    resp = client.post("/v1/ingest/turns", json=rows, headers=_auth())
+    assert resp.status_code == 413
+
+
+def test_turns_posted_to_the_request_route_are_not_silently_accepted(client) -> None:
+    """Why this is a separate route rather than a discriminated record.
+
+    ``/v1/ingest`` answers 200 and reports how many records it accepted. A turn
+    row sent there builds no RequestRecord, so it is counted as malformed and
+    dropped, and the agent sees success. That silent drop is the whole class of
+    bug this endpoint exists to end, so it is pinned rather than assumed.
+    """
+    resp = client.post("/v1/ingest", json=[_turn("s-6", 0)], headers=_auth())
+    assert resp.status_code == 200
+    assert resp.json()["accepted"] == 0, (
+        "a turn row was accepted as a request record; piggybacking turns on "
+        "/v1/ingest would be a silent drop"
+    )

--- a/src/voicegateway/tests/services/test_sink_log_turns.py
+++ b/src/voicegateway/tests/services/test_sink_log_turns.py
@@ -1,0 +1,180 @@
+"""``Sink.log_turns``: the seam that lets turns leave the agent process.
+
+Binding a TurnTracker only gets turns as far as the sink. Without this the
+RemoteCollectorSink had nowhere to put them, so a collector-mode agent captured
+turns and dropped them, which is the co-located-only limitation
+``/v1/rooms/{room}/latency`` was built to escape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from voicegateway.middleware.turn_tracker_middleware import TurnRow
+from voicegateway.services.sinks import LocalSqliteSink, RemoteCollectorSink
+from voicegateway.services.storage_service import StorageService
+
+
+class _Resp:
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self.headers: dict[str, str] = {}
+
+
+class _Client:
+    """Records every POST so the URL a batch went to can be asserted."""
+
+    def __init__(self, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self.posts: list[tuple[str, Any]] = []
+
+    async def post(self, url: str, json: Any = None, headers: Any = None) -> _Resp:
+        self.posts.append((url, json))
+        return _Resp(self.status_code)
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _turn(index: int, session_id: str = "s-1") -> TurnRow:
+    return TurnRow(
+        session_id=session_id,
+        turn_index=index,
+        caller_speak_start_ms=1000 + index,
+        caller_speak_end_ms=1500 + index,
+        agent_speak_start_ms=1900 + index,
+        agent_speak_end_ms=3000 + index,
+        response_speed_ms=400,
+    )
+
+
+async def test_local_sink_writes_turns_through_storage(tmp_path) -> None:
+    from voicegateway.repository import turns_repository as turns
+
+    storage = StorageService(str(tmp_path / "t.db"))
+    sink = LocalSqliteSink(storage)
+
+    await sink.log_turns([_turn(0), _turn(1)])
+
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        rows = await turns.list_turns_by_session(db, "s-1")
+    assert len(rows) == 2
+    await storage.aclose()
+
+
+async def test_remote_sink_posts_turns_to_their_own_route() -> None:
+    """Not /v1/ingest. That handler would count them malformed and drop them."""
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", batch_size=2, flush_interval=None, client=client
+    )
+
+    await sink.log_turns([_turn(0), _turn(1)])
+
+    assert len(client.posts) == 1
+    url, body = client.posts[0]
+    assert url == "http://collector/v1/ingest/turns"
+    assert [row["turn_index"] for row in body] == [0, 1]
+
+
+async def test_turns_do_not_leave_until_the_batch_fills_or_a_flush() -> None:
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", batch_size=10, flush_interval=None, client=client
+    )
+
+    await sink.log_turns([_turn(0)])
+    assert client.posts == [], "a single turn should still be batching"
+
+    await sink.flush()
+    assert len(client.posts) == 1
+    assert client.posts[0][0].endswith("/v1/ingest/turns")
+
+
+async def test_turns_and_requests_go_to_different_routes() -> None:
+    """One flush, two destinations. Mixing them would drop the turns."""
+    from voicegateway.models.request_model import RequestRecord
+
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", batch_size=50, flush_interval=None, client=client
+    )
+
+    await sink.log_request(
+        RequestRecord(
+            id="r1",
+            timestamp=1.0,
+            modality="llm",
+            model_id="openai/gpt-4o-mini",
+            provider="openai",
+        )
+    )
+    await sink.log_turns([_turn(0)])
+    await sink.flush()
+
+    urls = sorted(url for url, _ in client.posts)
+    assert urls == ["http://collector/v1/ingest", "http://collector/v1/ingest/turns"]
+
+
+async def test_a_failed_turn_post_is_requeued_not_dropped() -> None:
+    """A collector blip must not cost the turns; the next flush retries."""
+    client = _Client(status_code=500)
+    sink = RemoteCollectorSink(
+        "http://collector",
+        "k",
+        batch_size=1,
+        flush_interval=None,
+        max_retries=0,
+        backoff=0,
+        client=client,
+    )
+
+    await sink.log_turns([_turn(0)])
+    assert len(client.posts) == 1  # tried once, failed
+
+    client.status_code = 200
+    await sink.flush()
+    assert len(client.posts) == 2, "the failed batch was not retried"
+    assert client.posts[1][1][0]["turn_index"] == 0
+
+
+async def test_aclose_flushes_pending_turns() -> None:
+    """A graceful shutdown must not silently lose the last partial batch."""
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", batch_size=100, flush_interval=None, client=client
+    )
+
+    await sink.log_turns([_turn(0)])
+    assert client.posts == []
+
+    await sink.aclose()
+    assert len(client.posts) == 1
+    assert client.posts[0][0].endswith("/v1/ingest/turns")
+
+
+async def test_an_empty_batch_makes_no_request() -> None:
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", flush_interval=None, client=client
+    )
+    await sink.log_turns([])
+    await sink.flush()
+    assert client.posts == []
+
+
+async def test_a_full_ingest_url_does_not_double_up_the_turns_path() -> None:
+    """``_normalize_ingest_url`` accepts a base host or a full ingest URL, so
+    the turns route has to be derived from the normalized value, not appended
+    to whatever the user typed."""
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector/v1/ingest",
+        "k",
+        batch_size=1,
+        flush_interval=None,
+        client=client,
+    )
+    await sink.log_turns([_turn(0)])
+    assert client.posts[0][0] == "http://collector/v1/ingest/turns"


### PR DESCRIPTION
Closes the "turn capture has no write path" gap. The `turns` table had five readers and no writer, so `e2e_ms` was always `null`.

## What was wrong

`create_turn` / `create_turns_bulk` had no non-test callers, `TurnTracker` was built only in tests, and its default flush was a no-op logging `"turns dropped (no repository wired)"` at debug. Silently empty as a result: `e2e_ms` and `turns[]` on `/v1/rooms/{room}/latency`, `/api/sessions/{id}/turns`, and the five session-aggregate columns behind the Conversation tab.

## The six steps

| # | Change |
|---|---|
| 1 | `Sink.log_turns(rows)`; `LocalSqliteSink` writes through to `create_turns_bulk` |
| 2 | `RemoteCollectorSink` batches and pushes turns |
| 3 | `POST /v1/ingest/turns` on the collector |
| 4 | `attach(turns=True)` builds the tracker, wired to the sink, under the same session id the request rows carry |
| 5 | LiveKit 1.6 onset fallback (`user_state_changed` -> `speaking`) |
| 6 | Both metrics knobs are actually read |

Two design calls worth review:

**Turns are not spooled to the durable outbox.** That outbox exists so `voicegw reconcile` can prove no *cost* row was lost. Turns are timing metadata reconcile does not read, and spooling them would change the schema of outbox files already on disk in deployed agents.

**A separate route, not a discriminated record on `/v1/ingest`.** That handler builds a `RequestRecord` out of every dict and counts anything that fails to build as malformed, so a turn posted there is answered `200` and dropped. Pinned by a test.

**The knobs are per project.** `metrics` hangs off `ProjectConfig`, not `GatewayConfig`. `talk_over_min_overlap_ms` now reaches `count_overlap_turns`, whose query counted *any* overlap before, making a caller who started a few milliseconds early indistinguishable from one talking over the agent.

## A seventh problem, and the reason none of this could have worked

Every handler was `async def`, and LiveKit refuses those:

```
ValueError: Cannot register an async callback with `.on()`.
Use `asyncio.create_task` within your synchronous callback instead.
```

So `attach_session(..., turn_tracker=...)` raised against any real `AgentSession`. It survived because the test double was `async def emit` awaiting each handler, a contract LiveKit has never offered.

Handlers are now sync and schedule the await, tasks are strong-ref'd so a write cannot be collected mid-flight, and the double mirrors the real emitter. **That double is the one edit to an existing test here** — it was asserting against a fiction, and the corrected version would have caught this.

## Verified against a running container

```
BEFORE:  "turn_count": 0, "e2e_ms": null, "turns": []
AFTER:   "turn_count": 2, "e2e_ms": {"p50":400.0,...,"n":2}, turns populated
```

Also confirmed: `/api/sessions/{id}/turns` populated, `401` without a key, and a turn posted to `/v1/ingest` still reports `accepted: 0`.

## Defaults

`turns=True` with a `VOICEGW_TURNS=0` kill switch, matching `transcript`. A turn row is six integers with no utterance, prompt or tool payload, so the disclosure argument that keeps `snapshots` opt-in does not apply.

Pipecat accepts the flag for parity but has no equivalent speech-boundary events, so `e2e_ms` stays null there. Stated in the docstring rather than silently implied.

## Tests

**3361 passed**, up 28 from the 3333 baseline, exactly the tests added here. Two consecutive clean full runs.

That second run matters: the first version of these tests was flaky. They drained a fixed number of event-loop passes, and `attach()`'s close path schedules its flush into `_close_tasks` rather than `_turn_tasks`, so the drain returned before the write landed. They now wait on both sets, scoped to the running loop, and fail loudly instead of under-draining.

`ruff check src` and `mypy<2` clean.

## Docs

Needs a docs pass: the `turns` flag on `attach()`, the new ingest route, and the two knobs that now do something. Also worth fixing while there: `docs/configuration/environment-variables.md` says `VOICEGW_API_KEY` is a "Virtual API key (`vk_...`)", which is correct agent-side but wrong for a collector, where a `vk_` prefix routes to virtual-key lookup and 401s every request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic conversation turn tracking during session attachment, enabled by default with opt-out controls.
  - Captured turns can be buffered, stored locally, or forwarded to a remote collector.
  - Added authenticated batch ingestion for conversation turns.
  - Added configurable project-level buffer sizes and talk-over detection thresholds.

- **Bug Fixes**
  - Improved handling of speech onset events to prevent duplicate turns.
  - Added reliable retry and shutdown flushing for remotely submitted turn data.
  - Preserved session finalization when configuration lookup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->