### PR TITLE
Give dead-air detection a producer

### DIFF
--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -404,6 +404,7 @@ def attach(
     transcript: bool = True,
     snapshots: bool = False,
     turns: bool = True,
+    dead_air: bool = True,
 ) -> str:
     """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
 
@@ -482,6 +483,19 @@ def attach(
             ``VOICEGW_TURNS=0`` to force it off fleet-wide (the kill-switch wins
             over the argument). LiveKit-only: the Pipecat path accepts the flag
             but has no equivalent speech-boundary events yet.
+        dead_air: watch for silences longer than the threshold (default ON).
+            Writes one row per observed silence, which
+            ``GET /api/sessions/{id}/dead_air`` and the dashboard read back.
+            Driven by the same four speech events as ``turns``, but its own flag
+            because it POLLS: a task per session at one second for the life of
+            the call, where turn capture costs nothing between events. A
+            dead-air row is also an alert rather than a chart cell, so wanting
+            one feature without the other is coherent in both directions.
+            Threshold comes from the project's
+            ``metrics.dead_air_threshold_seconds`` (default 3.0s). Speech is
+            never dead air: while either party is speaking the clock reports
+            now, so a long utterance cannot trip it. Set ``VOICEGW_DEAD_AIR=0``
+            to force it off fleet-wide. LiveKit-only, like ``turns``.
 
     Returns:
         The correlation session id stamped on every captured row.
@@ -504,6 +518,7 @@ def attach(
             transcript=transcript,
             snapshots=snapshots,
             turns=turns,
+            dead_air=dead_air,
         )
     return _attach_livekit(
         session,
@@ -518,6 +533,7 @@ def attach(
         transcript=transcript,
         snapshots=snapshots,
         turns=turns,
+        dead_air=dead_air,
     )
 
 
@@ -545,6 +561,135 @@ def _turns_enabled(param: bool) -> bool:
     if env is not None and env.strip().lower() in ("0", "false", "no", "off"):
         return False
     return param
+
+
+def _dead_air_enabled(param: bool) -> bool:
+    """Whether to watch for dead air. Same shape as turns above.
+
+    Its own flag rather than riding ``turns``, although both are driven by the
+    same four speech events, because this one POLLS: it runs a task per session
+    at ``poll_interval_seconds`` for the life of the call, where turn capture
+    costs nothing between events. A standing per-session cost should be
+    switchable on its own. A dead-air row is also an alert someone acts on
+    rather than a cell on a chart, so wanting one without the other is coherent
+    in both directions.
+    """
+    env = os.environ.get("VOICEGW_DEAD_AIR")
+    if env is not None and env.strip().lower() in ("0", "false", "no", "off"):
+        return False
+    return param
+
+
+_DEFAULT_DEAD_AIR_THRESHOLD_S = 3.0
+_dead_air_threshold_cache: dict[str | None, float] = {}
+
+
+def _dead_air_threshold_s(project: str | None) -> float:
+    """Seconds of silence before a dead-air event fires, for this project.
+
+    ``metrics`` hangs off ProjectConfig, so ``dead_air_threshold_seconds`` is
+    per project, exactly like the two knobs beside it. Same best-effort load and
+    per-project cache as ``_turn_flush_size``.
+    """
+    if project in _dead_air_threshold_cache:
+        return _dead_air_threshold_cache[project]
+    threshold = _DEFAULT_DEAD_AIR_THRESHOLD_S
+    try:
+        from voicegateway.core.config import GatewayConfig
+
+        cfg = GatewayConfig.load(required=False)
+        pcfg = (cfg.projects or {}).get(project) if project else None
+        if pcfg is not None:
+            threshold = float(pcfg.metrics.dead_air_threshold_seconds)
+    except Exception:  # noqa: BLE001 - a bad config must not break attach()
+        logger.debug("attach: reading dead_air_threshold_seconds failed", exc_info=True)
+    if threshold <= 0:
+        threshold = _DEFAULT_DEAD_AIR_THRESHOLD_S
+    _dead_air_threshold_cache[project] = threshold
+    return threshold
+
+
+class _SpeechActivity:
+    """Last-activity clock for dead-air detection, in the detector's own units.
+
+    Returns ``time.monotonic() * 1000``, which is exactly what
+    ``DeadAirDetector._watch`` compares against and what ``TurnTracker._now_ms``
+    already produces, so no conversion and no clock mismatch.
+
+    The part that matters: **while anyone is speaking, activity is now**. A
+    probe that only recorded discrete events would keep reporting the onset
+    timestamp for the whole utterance, so a caller talking for longer than the
+    threshold would trip a dead-air event mid-sentence. Speech is not dead air,
+    and a false alert is worse than a missing one because somebody acts on it.
+
+    Two booleans rather than a counter, so a duplicated event is harmless. That
+    is not hypothetical: LiveKit 1.6 signals onset through
+    ``user_state_changed`` while older builds emit the discrete event, and a
+    build emitting both would leave a counter permanently above zero, which
+    would silently mean dead air could never fire again.
+    """
+
+    def __init__(self) -> None:
+        self._last_ms = self._now_ms()
+        self._caller_speaking = False
+        self._agent_speaking = False
+
+    @staticmethod
+    def _now_ms() -> int:
+        import time
+
+        return int(time.monotonic() * 1000)
+
+    def _touch(self) -> None:
+        self._last_ms = self._now_ms()
+
+    def caller_started(self) -> None:
+        self._caller_speaking = True
+        self._touch()
+
+    def caller_stopped(self) -> None:
+        self._caller_speaking = False
+        self._touch()
+
+    def agent_started(self) -> None:
+        self._agent_speaking = True
+        self._touch()
+
+    def agent_stopped(self) -> None:
+        self._agent_speaking = False
+        self._touch()
+
+    def probe(self, _session_id: str) -> int | None:
+        """The ActivityProbe. Sync by contract, so it only reads memory."""
+        if self._caller_speaking or self._agent_speaking:
+            return self._now_ms()
+        return self._last_ms
+
+
+def _build_dead_air_detector(sink: Sink, project: str | None) -> tuple[Any, Any]:
+    """A detector whose events persist through the sink, and its activity clock.
+
+    Returns ``(detector, activity)``; the caller binds ``activity`` to the same
+    speech events turn capture uses. Without an ``on_event`` the detector falls
+    back to a no-op that logs "dropped (no repository wired)" at debug, which is
+    why ``dead_air_events`` was always empty.
+    """
+    from voicegateway.middleware.dead_air_detector_middleware import (
+        DeadAirDetector,
+        DeadAirEvent,
+    )
+
+    activity = _SpeechActivity()
+
+    async def _on_event(event: DeadAirEvent) -> None:
+        await sink.log_dead_air([event])
+
+    detector = DeadAirDetector(
+        activity_probe=activity.probe,
+        on_event=_on_event,
+        threshold_seconds=_dead_air_threshold_s(project),
+    )
+    return detector, activity
 
 
 _DEFAULT_TURN_FLUSH_SIZE = 25
@@ -596,7 +741,12 @@ def _build_turn_tracker(sink: Sink, project: str | None) -> Any:
     return TurnTracker(flush_callback=_flush, flush_size=_turn_flush_size(project))
 
 
-def _bind_turn_events(session: Any, session_id: str, tracker: Any) -> None:
+def _bind_turn_events(
+    session: Any,
+    session_id: str,
+    tracker: Any,
+    activity: Any = None,
+) -> None:
     """Wire the speech-boundary events onto an AgentSession.
 
     Onset is hooked twice on purpose. LiveKit 1.6 dropped the discrete
@@ -608,24 +758,70 @@ def _bind_turn_events(session: Any, session_id: str, tracker: Any) -> None:
     First-wins needs no latch here: ``on_user_started_speaking`` only sets
     ``pending_caller_start_ms`` when it is None, so whichever event arrives
     first anchors the turn and the other is a no-op.
+
+    ``activity`` is the optional dead-air clock. It rides these same four events
+    because they are exactly the signal it needs, but it is updated
+    independently of ``tracker`` so the two features stay separately
+    switchable. ``tracker`` may be None when only dead air is on.
+
+    Note the non-speaking branch of ``user_state_changed``: on a build that
+    emits no discrete ``user_stopped_speaking``, that transition is the only
+    signal the caller went quiet, and without it the activity clock would stay
+    "speaking" forever and dead air could never fire.
     """
     on = getattr(session, "on", None)
     if not callable(on):
-        logger.debug("attach: session has no .on(); turn events not bound")
+        logger.debug("attach: session has no .on(); speech events not bound")
         return
 
-    started = _emit_user_started(session_id, tracker)
+    started = _emit_user_started(session_id, tracker) if tracker is not None else None
+    stopped = _emit_user_stopped(session_id, tracker) if tracker is not None else None
+    agent_started = (
+        _emit_agent_started(session_id, tracker) if tracker is not None else None
+    )
+    agent_stopped = (
+        _emit_agent_stopped(session_id, tracker) if tracker is not None else None
+    )
+
+    def _user_started(event: Any = None, *_a: Any, **_k: Any) -> None:
+        if activity is not None:
+            activity.caller_started()
+        if started is not None:
+            started(event)
+
+    def _user_stopped(event: Any = None, *_a: Any, **_k: Any) -> None:
+        if activity is not None:
+            activity.caller_stopped()
+        if stopped is not None:
+            stopped(event)
+
+    def _agent_started(event: Any = None, *_a: Any, **_k: Any) -> None:
+        if activity is not None:
+            activity.agent_started()
+        if agent_started is not None:
+            agent_started(event)
+
+    def _agent_stopped(event: Any = None, *_a: Any, **_k: Any) -> None:
+        if activity is not None:
+            activity.agent_stopped()
+        if agent_stopped is not None:
+            agent_stopped(event)
 
     def _on_state_changed(event: Any = None, *_a: Any, **_k: Any) -> None:
-        if getattr(event, "new_state", None) != "speaking":
+        if getattr(event, "new_state", None) == "speaking":
+            _user_started(event)
             return
-        started(event)
+        # listening / away: the caller stopped. Only the activity clock cares;
+        # the tracker's own stop is driven by user_stopped_speaking, and calling
+        # it here would close turns on an "away" transition.
+        if activity is not None:
+            activity.caller_stopped()
 
-    on("user_started_speaking", started)
+    on("user_started_speaking", _user_started)
     on("user_state_changed", _on_state_changed)
-    on("user_stopped_speaking", _emit_user_stopped(session_id, tracker))
-    on("agent_started_speaking", _emit_agent_started(session_id, tracker))
-    on("agent_stopped_speaking", _emit_agent_stopped(session_id, tracker))
+    on("user_stopped_speaking", _user_stopped)
+    on("agent_started_speaking", _agent_started)
+    on("agent_stopped_speaking", _agent_stopped)
 
 
 def _snapshots_enabled(param: bool) -> bool:
@@ -810,6 +1006,7 @@ def _attach_livekit(
     transcript: bool = True,
     snapshots: bool = False,
     turns: bool = True,
+    dead_air: bool = True,
 ) -> str:
     """LiveKit ``attach()`` body: bind ``MetricCapture`` to an ``AgentSession``."""
     import asyncio
@@ -862,8 +1059,52 @@ def _attach_livekit(
     turn_tracker = (
         _build_turn_tracker(sink, project) if _turns_enabled(turns) else None
     )
-    if turn_tracker is not None:
-        _bind_turn_events(session, session_id, turn_tracker)
+    dead_air_detector, activity = (
+        _build_dead_air_detector(sink, project)
+        if _dead_air_enabled(dead_air)
+        else (None, None)
+    )
+    # One binding for both: the activity clock rides the same four events the
+    # tracker does, and either half may be None.
+    if turn_tracker is not None or activity is not None:
+        _bind_turn_events(session, session_id, turn_tracker, activity)
+    # Expose for tests and for graceful shutdown, as with _vg_capture above.
+    for _attr, _value in (
+        ("_vg_dead_air", dead_air_detector),
+        ("_vg_activity", activity),
+    ):
+        try:
+            setattr(session, _attr, _value)
+        except Exception:  # noqa: BLE001 - real session may forbid attribute set
+            logger.debug("attach: could not stash %s on session", _attr, exc_info=True)
+    if dead_air_detector is not None:
+
+        async def _start_dead_air() -> None:
+            # Warm the store BEFORE the watcher can fire. Otherwise the first
+            # dead-air event is what triggers migrations, from inside the poll
+            # loop, and a "database is locked" there loses that event for good:
+            # the detector sets _already_fired before awaiting the callback, so
+            # it will not re-fire for the same silence. Reproduced, not feared.
+            warm = getattr(sink, "_storage", None)
+            if warm is not None:
+                try:
+                    await warm._ensure_initialized()
+                except Exception:  # noqa: BLE001 - dead air is never load-bearing
+                    logger.debug("attach: storage warm-up failed", exc_info=True)
+            await dead_air_detector.start(session_id)
+
+        # start() spawns the watcher task, so it needs a running loop. attach()
+        # is routinely called from sync setup code; there the watcher simply
+        # does not start, said out loud rather than failing silently.
+        try:
+            task = asyncio.get_running_loop().create_task(_start_dead_air())
+            _close_tasks.add(task)
+            task.add_done_callback(_close_tasks.discard)
+        except RuntimeError:
+            logger.debug(
+                "attach(%s): no running event loop, dead-air watcher not started",
+                session_id,
+            )
 
     async def _finish() -> None:
         # Reconcile cumulative session.usage against the per-call rows, drain
@@ -872,6 +1113,13 @@ def _attach_livekit(
         bump_active(-1)
         await capture.reconcile(session)
         await capture.drain()
+        if dead_air_detector is not None:
+            # Before the flush below, so an event observed in the last poll is
+            # already in the sink's buffer when it drains.
+            try:
+                await dead_air_detector.stop(session_id)
+            except Exception:  # noqa: BLE001 - dead air is never load-bearing
+                logger.debug("attach: dead-air stop on close failed", exc_info=True)
         if turn_tracker is not None:
             # Before sink.flush(): close_session emits the tail turn and pushes
             # everything under the flush-size threshold into the sink, so the
@@ -1055,6 +1303,7 @@ def _attach_pipecat(
     transcript: bool = True,
     snapshots: bool = False,
     turns: bool = True,
+    dead_air: bool = True,
 ) -> str:
     """Register a ``VoiceGatewayObserver`` on a Pipecat ``PipelineTask``.
 
@@ -1070,14 +1319,16 @@ def _attach_pipecat(
     rather than errors, so the same ``attach(...)`` call works against either
     framework.
 
-    ``turns`` specifically needs Pipecat speech-boundary events equivalent to
-    LiveKit's user/agent started/stopped, which the observer does not surface
-    today. Accepting it silently is the deliberate choice over raising, but it
-    does mean a Pipecat agent gets no turn rows, so ``e2e_ms`` stays null there.
+    ``turns`` and ``dead_air`` both need Pipecat speech-boundary events
+    equivalent to LiveKit's user/agent started/stopped, which the observer does
+    not surface today. Accepting them silently is the deliberate choice over
+    raising, but it does mean a Pipecat agent gets no turn rows and no dead-air
+    events, so ``e2e_ms`` stays null there and the dead-air view stays empty.
     """
     _ = transcript  # reserved: Pipecat transcript capture is a future step
     _ = snapshots  # reserved: needs a Pipecat message/tool-call hook
     _ = turns  # reserved: needs Pipecat speech-boundary events
+    _ = dead_air  # reserved: same missing events as turns above
     from voicegateway.inference.pipecat.observer import VoiceGatewayObserver
 
     resolved_agent_id = agent_id or _default_agent_id()

--- a/src/voicegateway/server/api/ingest.py
+++ b/src/voicegateway/server/api/ingest.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.exc import IntegrityError
 
+from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
 from voicegateway.middleware.turn_tracker_middleware import TurnRow
 from voicegateway.models.request_model import RequestRecord
 from voicegateway.server.api._deps import get_gateway, require_scope
@@ -32,6 +33,10 @@ _RECORD_FIELDS: frozenset[str] = frozenset(
 )
 
 _TURN_FIELDS: frozenset[str] = frozenset(f.name for f in dataclasses.fields(TurnRow))
+
+_DEAD_AIR_FIELDS: frozenset[str] = frozenset(
+    f.name for f in dataclasses.fields(DeadAirEvent)
+)
 
 
 def _record_from_payload(raw: dict[str, Any]) -> RequestRecord | None:
@@ -244,6 +249,74 @@ async def ingest_turns(
 
     if rejected:
         logger.warning("ingest/turns: skipped %d malformed turn(s)", rejected)
+    return {"accepted": accepted}
+
+
+def _dead_air_from_payload(raw: dict[str, Any]) -> DeadAirEvent | None:
+    """Build a DeadAirEvent from a payload dict, ignoring unknown keys."""
+    filtered = {k: v for k, v in raw.items() if k in _DEAD_AIR_FIELDS}
+    try:
+        return DeadAirEvent(**filtered)
+    except TypeError:
+        return None
+
+
+@router.post("/ingest/dead-air")
+async def ingest_dead_air(
+    events: list[dict[str, Any]],
+    request: Request,
+    _auth: None = Depends(require_scope("write")),
+) -> dict[str, int]:
+    """Persist observed dead-air events pushed by a fleet agent.
+
+    Its own route for the same reason as ``/ingest/turns``: the request handler
+    builds a RequestRecord out of every dict it receives, so anything else sent
+    there is answered ``200`` and dropped.
+
+    Always SQL, even under ClickHouse, because
+    ``GET /api/sessions/{id}/dead_air`` reads them from SQL.
+    """
+    gateway = get_gateway(request)
+    storage = gateway.storage
+    if storage is None:
+        raise HTTPException(
+            status_code=503,
+            detail="cost tracking storage is disabled on this collector",
+        )
+
+    max_batch = gateway.config.ingest.max_batch_size
+    if len(events) > max_batch:
+        raise HTTPException(
+            status_code=413,
+            detail=f"batch too large: {len(events)} events exceeds max {max_batch}",
+        )
+
+    parsed: list[DeadAirEvent] = []
+    rejected = 0
+    for raw in events:
+        event = _dead_air_from_payload(raw)
+        if event is None:
+            rejected += 1
+            continue
+        parsed.append(event)
+
+    accepted = 0
+    if parsed:
+        try:
+            accepted = await storage.log_dead_air(parsed)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ingest/dead-air: failed to persist %d event(s)",
+                len(parsed),
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="telemetry store temporarily unavailable",
+            ) from exc
+
+    if rejected:
+        logger.warning("ingest/dead-air: skipped %d malformed event(s)", rejected)
     return {"accepted": accepted}
 
 

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
     from voicegateway.middleware.turn_tracker_middleware import TurnRow
     from voicegateway.models.request_model import RequestRecord
     from voicegateway.services.storage_service import StorageService
@@ -43,8 +44,9 @@ class Sink(Protocol):
     """Narrow write target for captured telemetry.
 
     ``log_request`` persists one record. ``log_turns`` persists a batch of
-    conversation turns. ``flush`` drains any buffered writes (a no-op for
-    synchronous sinks). ``aclose`` releases resources.
+    conversation turns, ``log_dead_air`` a batch of observed silences. ``flush``
+    drains any buffered writes (a no-op for synchronous sinks). ``aclose``
+    releases resources.
 
     ``log_turns`` takes a batch rather than one row because TurnTracker already
     buffers to ``turn_buffer_flush_size`` before calling out, so a per-row
@@ -54,6 +56,8 @@ class Sink(Protocol):
     async def log_request(self, record: RequestRecord) -> None: ...
 
     async def log_turns(self, rows: list[TurnRow]) -> None: ...
+
+    async def log_dead_air(self, events: list[DeadAirEvent]) -> None: ...
 
     async def flush(self) -> None: ...
 
@@ -77,6 +81,9 @@ class LocalSqliteSink:
 
     async def log_turns(self, rows: list[TurnRow]) -> None:
         await self._storage.log_turns(rows)
+
+    async def log_dead_air(self, events: list[DeadAirEvent]) -> None:
+        await self._storage.log_dead_air(events)
 
     async def flush(self) -> None:
         return None
@@ -149,6 +156,7 @@ class RemoteCollectorSink:
         # Turns get their own route off the same base. See _post for why they
         # cannot share /v1/ingest.
         self._turns_url = self._ingest_url + "/turns"
+        self._dead_air_url = self._ingest_url + "/dead-air"
         self._headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         self._batch_size = max(1, batch_size)
         self._flush_interval = flush_interval
@@ -169,6 +177,9 @@ class RemoteCollectorSink:
         # spooling them would mean a schema change to outbox files already on
         # disk in deployed agents. Dropped turns are counted and logged.
         self._turn_buffer: list[dict[str, Any]] = []
+        # Same reasoning as turns: batched in memory, never in the durable
+        # outbox, which exists to prove cost completeness for reconcile.
+        self._dead_air_buffer: list[dict[str, Any]] = []
         self._flusher: asyncio.Task[None] | None = None
         self._closed = False
         # Durable outbox (opt-in).
@@ -396,6 +407,35 @@ class RemoteCollectorSink:
             # buffer cap above is what bounds this.
             self._turn_buffer = batch + self._turn_buffer
 
+    async def log_dead_air(self, events: list[DeadAirEvent]) -> None:
+        """Buffer observed silences for the collector's ``/v1/ingest/dead-air``.
+
+        Best-effort like the rest of this sink: it runs off the detector's watch
+        loop, so it never blocks and never raises.
+        """
+        if not events:
+            return
+        self._dead_air_buffer.extend(asdict(event) for event in events)
+        if len(self._dead_air_buffer) > self._max_buffer:
+            overflow = len(self._dead_air_buffer) - self._max_buffer
+            del self._dead_air_buffer[:overflow]
+            self._dropped += overflow
+            logger.warning(
+                "RemoteCollectorSink dead-air buffer full; dropped %d oldest", overflow
+            )
+        self._maybe_start_flusher()
+        if len(self._dead_air_buffer) >= self._batch_size:
+            await self._flush_dead_air()
+
+    async def _flush_dead_air(self) -> None:
+        """Drain the dead-air buffer to the collector. Requeues on failure."""
+        if not self._dead_air_buffer:
+            return
+        batch = self._dead_air_buffer
+        self._dead_air_buffer = []
+        if not await self._post(batch, self._dead_air_url):
+            self._dead_air_buffer = batch + self._dead_air_buffer
+
     def _maybe_start_flusher(self) -> None:
         if not self._flush_interval or self._flusher is not None or self._closed:
             return
@@ -418,6 +458,7 @@ class RemoteCollectorSink:
         # periodic flusher and aclose with requests, but not the outbox, so this
         # runs regardless of which request path is taken below.
         await self._flush_turns()
+        await self._flush_dead_air()
         if self._spool_path is not None:
             if not self._spooled:
                 return

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -382,6 +382,24 @@ class StorageService:
         async with self._conn.session() as db:
             return await turns.create_turns_bulk(db, rows)
 
+    async def log_dead_air(self, events: list[Any]) -> int:
+        """Write observed dead-air events. Returns the number inserted.
+
+        Looped rather than bulk-inserted: the repository exposes one insert per
+        event and dead air is rare by construction (one per silence window, and
+        the detector latches so a continuing silence does not re-fire), so a
+        bulk path would be machinery for a batch that is almost always one row.
+        """
+        from voicegateway.repository import dead_air_repository as dead_air
+
+        if not events:
+            return 0
+        await self._ensure_initialized()
+        async with self._conn.session() as db:
+            for event in events:
+                await dead_air.create_event(db, event)
+        return len(events)
+
     # ------------------------------------------------------------------
     # Load runs
     # ------------------------------------------------------------------

--- a/src/voicegateway/tests/core/test_metrics_config_is_read.py
+++ b/src/voicegateway/tests/core/test_metrics_config_is_read.py
@@ -1,10 +1,12 @@
-"""``metrics.talk_over_min_overlap_ms`` and ``turn_buffer_flush_size`` are read.
+"""Every knob in the per-project ``metrics:`` block is read by something.
 
-Both were declared in the schema and parsed by the config loader, and neither
-had a consumer. Setting either in ``voicegw.yaml`` validated and did nothing,
-which is worse than not offering the knob: it reads as configured behaviour.
+All three were declared in the schema and parsed by the config loader, and none
+had a consumer. Setting any of them in ``voicegw.yaml`` validated and did
+nothing, which is worse than not offering the knob: it reads as configured
+behaviour.
 
-Both hang off ProjectConfig, not GatewayConfig, so both are per project.
+All three hang off ProjectConfig, not GatewayConfig, so all three are per
+project.
 """
 
 from __future__ import annotations
@@ -33,6 +35,7 @@ def _config(tmp_path, *, overlap_ms: int, flush_size: int) -> str:
                         "metrics": {
                             "talk_over_min_overlap_ms": overlap_ms,
                             "turn_buffer_flush_size": flush_size,
+                            "dead_air_threshold_seconds": 7.5,
                         },
                     }
                 },
@@ -132,3 +135,47 @@ async def test_talk_over_threshold_changes_the_overlap_count(tmp_path) -> None:
         assert await turns.count_overlap_turns(db, "s", min_overlap_ms=100) == 0
 
     await storage.aclose()
+
+
+def test_the_dead_air_default_matches_the_schema_default() -> None:
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    assert (
+        attach_mod._DEFAULT_DEAD_AIR_THRESHOLD_S
+        == SchemaMetrics().dead_air_threshold_seconds
+    )
+
+
+def test_dead_air_threshold_is_read_from_the_project(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7))
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    attach_mod._dead_air_threshold_cache.clear()
+
+    assert attach_mod._dead_air_threshold_s("tuned") == 7.5
+    assert (
+        attach_mod._dead_air_threshold_s("nope")
+        == attach_mod._DEFAULT_DEAD_AIR_THRESHOLD_S
+    )
+    attach_mod._dead_air_threshold_cache.clear()
+
+
+def test_the_dead_air_threshold_reaches_the_detector(tmp_path, monkeypatch) -> None:
+    """Reading the number is not the same as using it."""
+    monkeypatch.setenv("VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7))
+    attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+    attach_mod._dead_air_threshold_cache.clear()
+
+    class _Sink:
+        async def log_dead_air(self, events):  # noqa: ANN001, ANN202
+            return None
+
+    detector, _activity = attach_mod._build_dead_air_detector(_Sink(), "tuned")
+    assert detector._threshold_ms == 7500
+    attach_mod._dead_air_threshold_cache.clear()
+
+
+def test_the_project_metrics_block_parses_all_three(tmp_path) -> None:
+    cfg = GatewayConfig.load(_config(tmp_path, overlap_ms=250, flush_size=7))
+    metrics = cfg.projects["tuned"].metrics
+    assert metrics.talk_over_min_overlap_ms == 250
+    assert metrics.turn_buffer_flush_size == 7
+    assert metrics.dead_air_threshold_seconds == 7.5

--- a/src/voicegateway/tests/inference/test_attach_dead_air.py
+++ b/src/voicegateway/tests/inference/test_attach_dead_air.py
@@ -1,0 +1,353 @@
+"""``attach(dead_air=True)``: the write path from silence to a stored event.
+
+``DeadAirDetector`` was constructed nowhere outside tests, so ``on_event`` was
+always the no-op that logs "dropped (no repository wired)" at debug,
+``dead_air_events`` was always empty, and ``GET /api/sessions/{id}/dead_air``
+always returned nothing.
+
+The activity probe is the part worth testing hardest. A probe that only recorded
+discrete speech events would report the onset timestamp for a whole utterance,
+so a caller talking for longer than the threshold would trip a dead-air event
+mid-sentence. That is a false alert somebody acts on, which is worse than the
+missing metric this fixes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+from typing import Any
+
+import pytest
+
+import voicegateway
+from voicegateway.inference.session.context import reset_session_id
+from voicegateway.middleware.dead_air_detector_middleware import (
+    DeadAirDetector,
+    DeadAirEvent,
+)
+from voicegateway.services.sinks import LocalSqliteSink
+from voicegateway.services.storage_service import StorageService
+
+attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+
+
+class _Session:
+    """AgentSession double mirroring ``livekit.rtc.EventEmitter``."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, list[Any]] = {}
+        self.stt = None
+        self.llm = None
+        self.tts = None
+        self.current_agent = None
+
+    def on(self, event_name: str, handler: Any) -> None:
+        if inspect.iscoroutinefunction(handler):
+            raise ValueError(
+                "Cannot register an async callback with `.on()`. Use "
+                "`asyncio.create_task` within your synchronous callback instead."
+            )
+        self._handlers.setdefault(event_name, []).append(handler)
+
+    def emit(self, event_name: str, event: Any = None) -> None:
+        payload = event if event is not None else _Event()
+        for handler in list(self._handlers.get(event_name, [])):
+            handler(payload)
+
+
+class _Event:
+    new_state = None
+    created_at = 0.0
+
+
+class _StateChanged(_Event):
+    def __init__(self, new_state: str) -> None:
+        self.new_state = new_state
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    """Own database and own session id, as for the turn tests."""
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.delenv("VOICEGW_DB_URL", raising=False)
+    reset_session_id()
+    yield
+    reset_session_id()
+
+
+def _sink(tmp_path: Any) -> LocalSqliteSink:
+    return LocalSqliteSink(StorageService(str(tmp_path / "dead_air.db")))
+
+
+async def _stored_events(sink: LocalSqliteSink, session_id: str) -> list[Any]:
+    from voicegateway.repository import dead_air_repository as dead_air
+
+    storage = sink._storage
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        return await dead_air.list_events_by_session(db, session_id)
+
+
+# --- the activity probe --------------------------------------------------
+
+
+def test_silence_ages_but_active_speech_does_not() -> None:
+    """The invariant the whole feature rests on.
+
+    While anyone is speaking the probe must report *now*, so the computed
+    silence stays at zero no matter how long the utterance runs. Once they
+    stop, the clock starts ageing from the stop.
+    """
+    activity = attach_mod._SpeechActivity()
+
+    activity.caller_started()
+    first = activity.probe("s")
+    # Simulate the detector polling twice during one long utterance.
+    second = activity.probe("s")
+    assert first is not None and second is not None
+    assert second >= first, "the probe went backwards while speech was active"
+
+    now = attach_mod._SpeechActivity._now_ms()
+    assert now - second < 50, (
+        "probe reported a stale timestamp while the caller was still speaking; "
+        "a long utterance would trip a false dead-air event"
+    )
+
+    activity.caller_stopped()
+    stopped_at = activity.probe("s")
+    assert stopped_at is not None
+    # After the stop the value is pinned, so silence accumulates against it.
+    assert activity.probe("s") == stopped_at
+
+
+def test_agent_speech_also_counts_as_activity() -> None:
+    activity = attach_mod._SpeechActivity()
+    activity.agent_started()
+    pinned = activity.probe("s")
+    assert pinned is not None
+    assert attach_mod._SpeechActivity._now_ms() - pinned < 50
+
+    activity.agent_stopped()
+    assert activity.probe("s") == activity.probe("s")
+
+
+def test_a_duplicated_onset_does_not_wedge_the_clock() -> None:
+    """Booleans, not a counter, and this is why.
+
+    LiveKit 1.6 signals onset through ``user_state_changed`` while older builds
+    emit the discrete event. A build emitting both would leave a counter
+    permanently above zero, and the probe would report "speaking" forever, so
+    dead air could never fire again for that session.
+    """
+    activity = attach_mod._SpeechActivity()
+    activity.caller_started()
+    activity.caller_started()  # the duplicate
+    activity.caller_stopped()
+
+    pinned = activity.probe("s")
+    assert pinned is not None
+    assert activity.probe("s") == pinned, "clock still reports active speech"
+
+
+def test_overlapping_speakers_both_have_to_stop() -> None:
+    """Talk-over: the caller stopping does not mean the line went quiet."""
+    activity = attach_mod._SpeechActivity()
+    activity.caller_started()
+    activity.agent_started()
+    activity.caller_stopped()
+
+    live = activity.probe("s")
+    assert live is not None
+    assert attach_mod._SpeechActivity._now_ms() - live < 50, (
+        "clock froze while the agent was still speaking"
+    )
+
+    activity.agent_stopped()
+    pinned = activity.probe("s")
+    assert activity.probe("s") == pinned
+
+
+# --- the wiring ----------------------------------------------------------
+
+
+async def test_a_dead_air_event_reaches_storage(tmp_path) -> None:
+    """The whole point: an observed silence becomes a stored row.
+
+    Driven through a real DeadAirDetector against the sink-backed on_event that
+    ``attach`` builds, with a short threshold so the test does not sleep for
+    the 3s default.
+    """
+    sink = _sink(tmp_path)
+    # attach() warms the store before starting its watcher; this drives the
+    # detector directly, so it has to do the same. Without it the first write
+    # runs migrations from inside the poll loop and can lose the event to
+    # "database is locked".
+    await sink._storage._ensure_initialized()
+    detector, activity = attach_mod._build_dead_air_detector(sink, None)
+
+    # Rebuild at a test-sized threshold; the callback is what is under test.
+    fast = DeadAirDetector(
+        activity_probe=activity.probe,
+        on_event=detector._on_event,
+        threshold_seconds=0.05,
+        poll_interval_seconds=0.01,
+    )
+
+    activity.caller_started()
+    activity.caller_stopped()
+    await fast.start("sess-dead")
+    try:
+        # Poll to a generous deadline rather than sleeping a fixed slice. The
+        # watcher needs ~6 polls to cross the threshold, and a fixed sleep that
+        # is merely usually long enough is how a suite gets a flaky test.
+        rows: list[Any] = []
+        deadline = asyncio.get_running_loop().time() + 10.0
+        while not rows:
+            if asyncio.get_running_loop().time() > deadline:
+                break
+            await asyncio.sleep(0.02)
+            rows = await _stored_events(sink, "sess-dead")
+    finally:
+        await fast.stop("sess-dead")
+
+    assert len(rows) >= 1, "an observed silence was not persisted"
+    assert rows[0].session_id == "sess-dead"
+    assert rows[0].duration_ms >= 50
+
+
+async def test_no_event_while_speech_continues(tmp_path) -> None:
+    """The false-positive guard, end to end.
+
+    The caller never stops speaking for longer than the threshold, so nothing
+    should fire, however long the watcher runs.
+    """
+    sink = _sink(tmp_path)
+    await sink._storage._ensure_initialized()
+    _, activity = attach_mod._build_dead_air_detector(sink, None)
+
+    async def _on_event(event: DeadAirEvent) -> None:
+        await sink.log_dead_air([event])
+
+    fast = DeadAirDetector(
+        activity_probe=activity.probe,
+        on_event=_on_event,
+        threshold_seconds=0.05,
+        poll_interval_seconds=0.01,
+    )
+
+    activity.caller_started()  # and never stops
+    await fast.start("sess-talking")
+    await asyncio.sleep(0.25)
+    await fast.stop("sess-talking")
+
+    assert await _stored_events(sink, "sess-talking") == [], (
+        "fired a dead-air event while the caller was still speaking"
+    )
+
+
+async def test_attach_binds_the_activity_clock(tmp_path) -> None:
+    """The four speech events have to actually drive the clock."""
+    sink = _sink(tmp_path)
+    session = _Session()
+    voicegateway.attach(session, project="p", sink=sink)
+
+    detector = session._vg_dead_air
+    assert detector is not None, "attach did not build a detector"
+    activity = session._vg_activity
+    assert activity is not None
+
+    session.emit("user_started_speaking")
+    live = activity.probe("x")
+    assert live is not None
+    assert attach_mod._SpeechActivity._now_ms() - live < 50
+
+    session.emit("user_stopped_speaking")
+    pinned = activity.probe("x")
+    assert activity.probe("x") == pinned
+
+
+async def test_the_16_listening_transition_ends_speech(tmp_path) -> None:
+    """On a build with no discrete stop event, ``listening`` is the only signal.
+
+    Without this the clock would stay "speaking" for the rest of the call and
+    dead air could never fire.
+    """
+    sink = _sink(tmp_path)
+    session = _Session()
+    voicegateway.attach(session, project="p", sink=sink)
+    activity = session._vg_activity
+
+    session.emit("user_state_changed", _StateChanged("speaking"))
+    session.emit("user_state_changed", _StateChanged("listening"))
+
+    pinned = activity.probe("x")
+    assert activity.probe("x") == pinned, (
+        "the listening transition did not end the utterance"
+    )
+
+
+async def test_dead_air_false_builds_no_detector(tmp_path) -> None:
+    sink = _sink(tmp_path)
+    session = _Session()
+    voicegateway.attach(session, project="p", sink=sink, dead_air=False)
+    assert getattr(session, "_vg_dead_air", None) is None
+
+
+async def test_env_kill_switch_beats_the_argument(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("VOICEGW_DEAD_AIR", "0")
+    sink = _sink(tmp_path)
+    session = _Session()
+    voicegateway.attach(session, project="p", sink=sink, dead_air=True)
+    assert getattr(session, "_vg_dead_air", None) is None
+
+
+async def test_turns_off_still_gives_dead_air(tmp_path) -> None:
+    """The two flags are independent, which is the reason dead air has its own.
+
+    Turn capture off, dead air on: the events must still be bound, because the
+    activity clock rides them.
+    """
+    sink = _sink(tmp_path)
+    session = _Session()
+    voicegateway.attach(session, project="p", sink=sink, turns=False, dead_air=True)
+
+    activity = session._vg_activity
+    assert activity is not None
+    session.emit("user_started_speaking")
+    live = activity.probe("x")
+    assert live is not None
+    assert attach_mod._SpeechActivity._now_ms() - live < 50
+
+
+async def test_attach_warms_the_store_before_watching(tmp_path) -> None:
+    """The watcher must not be the thing that triggers migrations.
+
+    The detector latches ``_already_fired`` before awaiting its callback, so a
+    "database is locked" on that first write drops the event permanently rather
+    than retrying on the next poll. attach() therefore initialises the store as
+    part of starting the watcher.
+    """
+    sink = _sink(tmp_path)
+    storage = sink._storage
+    assert storage._initialized is False
+
+    session = _Session()
+    voicegateway.attach(session, project="p", sink=sink)
+
+    detector = session._vg_dead_air
+    assert detector is not None
+    try:
+        # Real time, not loop passes: the warm-up runs alembic, which hops
+        # through a thread pool, so yielding N times proves nothing.
+        deadline = asyncio.get_running_loop().time() + 10.0
+        while not storage._initialized:
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError(
+                    "attach started the dead-air watcher without warming the store"
+                )
+            await asyncio.sleep(0.01)
+    finally:
+        for sid in list(detector.active_sessions()):
+            await detector.stop(sid)

--- a/src/voicegateway/tests/server/test_ingest_dead_air_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_dead_air_endpoint.py
@@ -1,0 +1,108 @@
+"""``POST /v1/ingest/dead-air``: the collector-mode half of dead-air capture.
+
+Same shape and same reasoning as ``/v1/ingest/turns``. Its own route because
+``/v1/ingest`` builds a RequestRecord out of every dict it receives and counts
+anything that fails to build as malformed, so an event posted there is answered
+``200`` and dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+
+_CFG: dict[str, Any] = {
+    "providers": {"openai": {"api_key": "k"}},
+    "models": {"stt": {}, "llm": {}, "tts": {}},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+_KEY = "dead-air-test-key"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "dead_air.db"))
+    monkeypatch.setenv("VOICEGW_API_KEY", _KEY)
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.dump(_CFG))
+    app = build_app(
+        Gateway(config_path=str(path)), enable_mcp_sse=False, enable_dashboard=False
+    )
+    with TestClient(app) as c:
+        yield c
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_KEY}"}
+
+
+def _event(session_id: str, *, duration_ms: int = 4200) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "started_at_ms": 10_000,
+        "duration_ms": duration_ms,
+        "threshold_used_ms": 3000,
+    }
+
+
+def test_a_posted_event_is_readable_back(client) -> None:
+    """The round trip. The reader is what was always empty."""
+    posted = client.post(
+        "/v1/ingest/dead-air", json=[_event("s-1")], headers=_auth()
+    )
+    assert posted.status_code == 200, posted.text
+    assert posted.json() == {"accepted": 1}
+
+    read = client.get("/api/sessions/s-1/dead_air", headers=_auth())
+    assert read.status_code == 200, read.text
+    body = read.json()
+    events = body["events"] if isinstance(body, dict) else body
+    assert len(events) == 1
+    assert events[0]["duration_ms"] == 4200
+
+
+def test_a_malformed_event_does_not_reject_the_batch(client) -> None:
+    good = _event("s-2")
+    bad = {"session_id": "s-2"}  # no timings: DeadAirEvent cannot be built
+    resp = client.post("/v1/ingest/dead-air", json=[good, bad], headers=_auth())
+    assert resp.status_code == 200
+    assert resp.json() == {"accepted": 1}
+
+
+def test_unknown_keys_are_ignored(client) -> None:
+    """A newer agent must not 422 against an older collector."""
+    row = _event("s-3")
+    row["some_future_field"] = "whatever"
+    resp = client.post("/v1/ingest/dead-air", json=[row], headers=_auth())
+    assert resp.status_code == 200
+    assert resp.json() == {"accepted": 1}
+
+
+def test_it_requires_auth(client) -> None:
+    resp = client.post("/v1/ingest/dead-air", json=[_event("s-4")])
+    assert resp.status_code == 401
+
+
+def test_the_batch_cap_is_enforced(client) -> None:
+    rows = [_event(f"s-{i}") for i in range(2000)]
+    resp = client.post("/v1/ingest/dead-air", json=rows, headers=_auth())
+    assert resp.status_code == 413
+
+
+def test_events_posted_to_the_request_route_are_not_silently_accepted(client) -> None:
+    """Why this is a separate route rather than a discriminated record."""
+    resp = client.post("/v1/ingest", json=[_event("s-5")], headers=_auth())
+    assert resp.status_code == 200
+    assert resp.json()["accepted"] == 0, (
+        "a dead-air event was accepted as a request record; piggybacking on "
+        "/v1/ingest would be a silent drop"
+    )

--- a/src/voicegateway/tests/services/test_sink_log_turns.py
+++ b/src/voicegateway/tests/services/test_sink_log_turns.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
 from voicegateway.middleware.turn_tracker_middleware import TurnRow
 from voicegateway.services.sinks import LocalSqliteSink, RemoteCollectorSink
 from voicegateway.services.storage_service import StorageService
@@ -178,3 +179,105 @@ async def test_a_full_ingest_url_does_not_double_up_the_turns_path() -> None:
     )
     await sink.log_turns([_turn(0)])
     assert client.posts[0][0] == "http://collector/v1/ingest/turns"
+
+
+
+# --- dead air ------------------------------------------------------------
+
+
+def _event(session_id: str = "s-1") -> DeadAirEvent:
+    return DeadAirEvent(
+        session_id=session_id,
+        started_at_ms=10_000,
+        duration_ms=4200,
+        threshold_used_ms=3000,
+    )
+
+
+async def test_local_sink_writes_dead_air_through_storage(tmp_path) -> None:
+    from voicegateway.repository import dead_air_repository as dead_air
+
+    storage = StorageService(str(tmp_path / "da.db"))
+    sink = LocalSqliteSink(storage)
+
+    await sink.log_dead_air([_event()])
+
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        rows = await dead_air.list_events_by_session(db, "s-1")
+    assert len(rows) == 1
+    await storage.aclose()
+
+
+async def test_remote_sink_posts_dead_air_to_its_own_route() -> None:
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", batch_size=1, flush_interval=None, client=client
+    )
+
+    await sink.log_dead_air([_event()])
+
+    assert len(client.posts) == 1
+    url, body = client.posts[0]
+    assert url == "http://collector/v1/ingest/dead-air"
+    assert body[0]["duration_ms"] == 4200
+
+
+async def test_dead_air_and_turns_go_to_different_routes() -> None:
+    """Three destinations off one flush, none of them mixed."""
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", batch_size=50, flush_interval=None, client=client
+    )
+
+    await sink.log_turns([_turn(0)])
+    await sink.log_dead_air([_event()])
+    await sink.flush()
+
+    urls = sorted(url for url, _ in client.posts)
+    assert urls == [
+        "http://collector/v1/ingest/dead-air",
+        "http://collector/v1/ingest/turns",
+    ]
+
+
+async def test_a_failed_dead_air_post_is_requeued_not_dropped() -> None:
+    client = _Client(status_code=500)
+    sink = RemoteCollectorSink(
+        "http://collector",
+        "k",
+        batch_size=1,
+        flush_interval=None,
+        max_retries=0,
+        backoff=0,
+        client=client,
+    )
+
+    await sink.log_dead_air([_event()])
+    assert len(client.posts) == 1
+
+    client.status_code = 200
+    await sink.flush()
+    assert len(client.posts) == 2, "the failed batch was not retried"
+
+
+async def test_aclose_flushes_pending_dead_air() -> None:
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", batch_size=100, flush_interval=None, client=client
+    )
+    await sink.log_dead_air([_event()])
+    assert client.posts == []
+    await sink.aclose()
+    assert len(client.posts) == 1
+    assert client.posts[0][0].endswith("/v1/ingest/dead-air")
+
+
+async def test_an_empty_dead_air_batch_makes_no_request() -> None:
+    client = _Client()
+    sink = RemoteCollectorSink(
+        "http://collector", "k", flush_interval=None, client=client
+    )
+    await sink.log_dead_air([])
+    await sink.flush()
+    assert client.posts == []


### PR DESCRIPTION
Follow-up to #220. `DeadAirDetector` was constructed nowhere outside tests, so `on_event` was always the no-op that logs `"dropped (no repository wired)"`, `dead_air_events` was always empty, and `GET /api/sessions/{id}/dead_air` always returned nothing.

## The probe is the whole difficulty

`DeadAirDetector` fires when `now - last_activity >= threshold`. A probe that only recorded discrete speech events would keep reporting the **onset** timestamp for the whole utterance, so a caller talking for longer than `threshold_seconds` would trip a dead-air event mid-sentence.

Speech is not dead air, and a false alert is worse than the missing metric this fixes, because somebody acts on it.

So `_SpeechActivity` reports **now** while either party is speaking, and only pins the clock once both have stopped.

**Two booleans, not a counter.** LiveKit 1.6 signals onset through `user_state_changed` while older builds emit the discrete event. On a build emitting both, a counter would never return to zero, and dead air could never fire again for that session. The non-speaking branch of `user_state_changed` is load-bearing for the same reason: on a build with no discrete stop event it is the only signal the caller went quiet.

## Its own flag, sharing the events

`attach(dead_air=True)`, default ON, `VOICEGW_DEAD_AIR=0` to force off.

It rides the same four speech events as `turns` but is switchable separately, because it **polls**: one task per session at one second for the life of the call, where turn capture costs nothing between events. `_bind_turn_events` now serves both and either half may be `None`, so `turns=False, dead_air=True` works.

## A bug found by running it, not reading it

The first dead-air event was what triggered alembic migrations, from inside the poll loop, and that raced to `database is locked`.

Losing it is **permanent, not transient**: the detector sets `_already_fired` *before* awaiting the callback, so it will not re-fire for the same silence. `attach` now warms the store as part of starting the watcher.

## Collector mode

Same treatment as turns: `Sink.log_dead_air`, a buffer that never touches the durable outbox (that outbox exists so `reconcile` can prove no *cost* row was lost), and `POST /v1/ingest/dead-air`. A separate route because `/v1/ingest` builds a `RequestRecord` out of every dict, so an event posted there is answered `200` and dropped.

## Third and last dead knob

`dead_air_threshold_seconds` now sizes the detector, joining `turn_buffer_flush_size` and `talk_over_min_overlap_ms` from #220. All three hang off `ProjectConfig`, so all three are per project. The `metrics:` block no longer contains anything that silently does nothing.

## Verified against a real container

```
BEFORE:  {"session_id":"sess-D","events":[]}
AFTER:   duration_ms 4200 reads back, 401 without a key,
         same event posted to /v1/ingest still reports accepted: 0
```

## Tests

**3389 passed**, up 28 from the 3361 baseline, exactly the tests added. Two consecutive clean full runs.

The timing-sensitive test polls to a deadline rather than sleeping a fixed slice, because a sleep that is merely *usually* long enough is exactly how the #220 tests flaked.

`ruff check src` and `mypy<2` clean.

## Docs

Needs a pass: the `dead_air` flag, `POST /v1/ingest/dead-air`, and `dead_air_threshold_seconds`. Pipecat accepts the flag for parity but has no equivalent speech-boundary events, so its dead-air view stays empty; worth stating rather than implying parity.
