### PR TITLE
Document turn capture and dead-air detection

### DIFF
--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -1165,3 +1165,37 @@ curl -X POST http://localhost:8080/v1/ingest \
   -H "Content-Type: application/json" \
   -d '[{"id":"...", "timestamp":1752460800.0, "modality":"stt", "provider":"deepgram", "model":"nova-3", "cost_usd":0.0021}]'
 ```
+
+### POST /v1/ingest/turns
+
+Push a batch of conversation turns. Same bearer auth and batch cap as `/v1/ingest`, returns `{"accepted": n}`.
+
+Each object needs `session_id`, `turn_index`, `caller_speak_start_ms`, and `caller_speak_end_ms`. `agent_speak_start_ms`, `agent_speak_end_ms`, and `response_speed_ms` are optional. Unknown keys are ignored, and one malformed row does not reject the batch.
+
+```bash
+curl -X POST http://localhost:8080/v1/ingest/turns \
+  -H "Authorization: Bearer vk_..." \
+  -H "Content-Type: application/json" \
+  -d '[{"session_id":"vg-123","turn_index":0,"caller_speak_start_ms":1000,"caller_speak_end_ms":2400,"agent_speak_start_ms":2847,"response_speed_ms":447}]'
+```
+
+<Note>
+A separate route rather than a record type on `/v1/ingest`. That handler builds a `RequestRecord` from every object it receives and counts anything that fails to build as malformed, so a turn posted there is answered `200` and silently dropped.
+
+Turns are always written to SQL, even where ClickHouse is configured for requests: ClickHouse has no turns table, and every reader of turns (`/v1/rooms/{room}/latency`, `/api/sessions/{id}/turns`, the session aggregates) reads from SQL.
+</Note>
+
+### POST /v1/ingest/dead-air
+
+Push a batch of dead-air events. Same bearer auth and batch cap, returns `{"accepted": n}`.
+
+Each object needs `session_id`, `started_at_ms`, `duration_ms`, and `threshold_used_ms`. Unknown keys are ignored, and one malformed row does not reject the batch.
+
+```bash
+curl -X POST http://localhost:8080/v1/ingest/dead-air \
+  -H "Authorization: Bearer vk_..." \
+  -H "Content-Type: application/json" \
+  -d '[{"session_id":"vg-123","started_at_ms":1752460800000,"duration_ms":4200,"threshold_used_ms":3000}]'
+```
+
+A separate route for the same reason as `/v1/ingest/turns`.

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -24,7 +24,7 @@ These variables configure the agent-side remote sink that pushes telemetry to Vo
 | Variable | Purpose |
 |---|---|
 | `VOICEGW_COLLECTOR_URL` | Base URL of the collector, e.g. `https://collect.voicegateway.dev`. The engine appends `/v1/ingest` (a full `.../v1/ingest` URL is also accepted). |
-| `VOICEGW_API_KEY` | Virtual API key (`vk_...`) that authenticates the agent to the collector |
+| `VOICEGW_API_KEY` | Two roles, depending on which side sets it. **On an agent**, the key it presents to the collector, normally a virtual key (`vk_...`). **On a collector**, a static wildcard ingest key it will accept. A collector value starting with `vk_` routes to virtual-key lookup in the database instead, so every request fails with `{"detail":"Invalid virtual key"}`: generate a collector key with `openssl rand -hex 32`. |
 | `VOICEGW_PROJECT` | Default project name for `attach()` calls. Resolution order: `project=` argument, then this env var, then `"default"`. |
 
 Set all three in the agent's environment. `attach()` reads them automatically. The `project=` argument in your `attach(target, project="...")` call always takes precedence over `VOICEGW_PROJECT`. See [Hosted quickstart](/hosted/quickstart) for the full setup flow.

--- a/docs/configuration/voicegw-yaml.md
+++ b/docs/configuration/voicegw-yaml.md
@@ -157,6 +157,27 @@ default_project: customer-support
 
 `budget_action` is one of `warn`, `throttle`, or `block`. Project-level `providers` override the top-level block for that project. See [Projects](/configuration/projects).
 
+### `projects.<id>.metrics`
+
+Conversation-metric tuning, per project rather than global:
+
+```yaml
+projects:
+  customer-support:
+    metrics:
+      turn_buffer_flush_size: 25
+      talk_over_min_overlap_ms: 100
+      dead_air_threshold_seconds: 3.0
+```
+
+| Key | Default | Effect |
+|---|---|---|
+| `turn_buffer_flush_size` | `25` | Turn rows buffered before the tracker writes. See [Turns and transcripts](/guide/turns). |
+| `talk_over_min_overlap_ms` | `100` | Minimum caller/agent speech overlap counted as a talk-over. Changes a published rate, not just a threshold: the query previously counted any overlap at all, so figures either side of this are not comparable. |
+| `dead_air_threshold_seconds` | `3.0` | Silence, in seconds, before a dead-air event is written. Aggressive for a slow LLM; raise it if thinking time fires events. See [Dead air](/guide/dead-air). |
+
+The dead-air poll interval is a constructor argument, not a config key.
+
 ---
 
 ## `fallbacks`

--- a/docs/guide/attach.md
+++ b/docs/guide/attach.md
@@ -27,6 +27,8 @@ voicegateway.attach(
     heartbeat: bool = False,          # register + heartbeat this process in the fleet roster
     transcript: bool = True,          # capture the call transcript (LiveKit only for now)
     snapshots: bool = False,          # capture conversation-state snapshots for replay (opt-in)
+    turns: bool = True,               # capture per-exchange turn timing (LiveKit only)
+    dead_air: bool = True,            # watch for silence longer than the threshold (LiveKit only)
 ) -> str                              # correlation session id stamped on every row
 ```
 
@@ -135,13 +137,15 @@ same async context inherits it too, with no argument needed.
 **Tenant** attribution is opt-in: pass `tenant_id=` when one deployment
 serves several customers. See [Tenant attribution](/guide/multi-tenant-quickstart).
 
-## room, heartbeat, transcript, snapshots (LiveKit)
+## room, heartbeat, transcript, snapshots, turns, dead_air (LiveKit)
 
 | Param | Behavior |
 |---|---|
 | `room` | LiveKit room name stamped on each row, so `voicegw livekit latency` can read the STT/LLM/TTS split back by room. Auto-resolved from the running job context. |
 | `heartbeat=True` | Registers this process in the fleet roster and heartbeats its presence (the dashboard's Fleet/Agents view). Best for single-process agents where `attach()` is the sole writer. In LiveKit's per-call subprocess model (`agent dev`), call `register_worker(agent_id, local=True)` at your `__main__` boot instead, and skip `heartbeat=True` there, because the subprocess would become a second writer of the same roster row. |
 | `transcript=True` (default) | On close, user/agent turns are read from the framework's conversation history and written to local storage for the Calls page. `transcript=False` disables it per attach; `VOICEGW_TRANSCRIPTS=0` kills it fleet-wide (the env var wins over the argument). Pipecat accepts the flag but does not capture transcripts yet. |
+| `turns=True` (default) | Captures one row per caller/agent exchange: turn index and four speech timestamps, from which `response_speed_ms` is derived. `VOICEGW_TURNS=0` kills it fleet-wide. Pipecat accepts the flag and captures nothing. See [Turns and transcripts](/guide/turns). |
+| `dead_air=True` (default) | Runs a per-session watchdog that writes an event when neither party speaks for longer than the threshold. `VOICEGW_DEAD_AIR=0` kills it fleet-wide. A separate flag from `turns` because it polls once a second for the life of the call. See [Dead air](/guide/dead-air). |
 | `snapshots=True` | Captures conversation-state snapshots for [session replay](/cli/replay). **Off by default**, the one place this differs from `transcript`. `VOICEGW_SNAPSHOTS=0` kills it fleet-wide and beats the argument. Pipecat accepts the flag and does not capture yet. |
 
 <Warning>

--- a/docs/guide/dead-air.md
+++ b/docs/guide/dead-air.md
@@ -2,13 +2,13 @@
 title: Dead air
 description: What counts as a dead-air event, the default threshold, and where detected events surface.
 ---
-Dead air is silence on a call that outlasts a threshold: no activity from the caller or the agent, as the wired probe reports it, for longer than expected. VoiceGateway's `DeadAirDetector` is a per-session watchdog that polls for it and fires an event when it crosses that threshold, written only if a callback is wired to catch it.
+Dead air is silence on a call that outlasts a threshold: neither the caller nor the agent speaking for longer than expected. `attach()` runs a per-session watchdog that polls for it and writes one event per silence stretch.
 
 ## What counts as dead air
 
 `DeadAirDetector` polls once a second (`poll_interval_seconds`, default `1.0`) and asks an `activity_probe` callback for the session's last-known activity timestamp. If the gap since that timestamp is at least `threshold_seconds` (default `3.0`), it emits one `DeadAirEvent` and latches so it won't fire again until activity resumes and the gap re-crosses the threshold: one event per silence stretch, not one per poll (`src/voicegateway/middleware/dead_air_detector_middleware.py:17-18,43-124`).
 
-What counts as "activity" is entirely up to whatever supplies the probe: the detector itself has no notion of speech, VAD, or audio frames.
+The probe `attach()` supplies is driven by the same four speech-boundary events that feed [turn capture](/guide/turns). While either party is speaking the clock reports now, so **a long utterance cannot trip a dead-air event**. That is a guarantee of the wiring, not a tuning artifact.
 
 An event row carries:
 
@@ -19,17 +19,36 @@ An event row carries:
 | `duration_ms` | How long the silence had run when it crossed threshold. |
 | `threshold_used_ms` | The threshold in effect for this detector, in milliseconds. |
 
-Rows land in `dead_air_events` (`session_id`, `started_at_ms`, `duration_ms`, `threshold_used_ms`, `created_at`, `tenant_id`) via `create_event`; `list_events_by_session` reads them oldest-first and `count_events_by_filter` counts by session or time window (`src/voicegateway/models/dead_air_event_model.py`, `src/voicegateway/repository/dead_air_repository.py`). Without a callback wired, a fired event is dropped and only logged at debug (`dead_air_detector_middleware.py:35-40`).
+Rows land in `dead_air_events` and are read back oldest-first by session, or counted by session or time window.
 
-## Is the threshold configurable?
+## Turning it on
 
-In code, yes: `threshold_seconds` and `poll_interval_seconds` are constructor arguments on `DeadAirDetector` (both must be `> 0`). In `voicegw.yaml`, there's a `dead_air_threshold_seconds` key under `projects.<id>.metrics` that parses and validates (default `3.0`, same as the code default). Nothing in the codebase reads it back to configure a running detector, though, so setting it in YAML today has no effect (`src/voicegateway/schemas/config_schema.py:43-47`, `src/voicegateway/core/config.py:56-61,236-244`).
+On by default:
 
-## When the detector doesn't start
+```python
+voicegateway.attach(session, project="my-agent")                 # dead air watched
+voicegateway.attach(session, project="my-agent", dead_air=False) # not watched
+```
 
-Starting a session's watcher is scheduled with `loop.create_task(...)`, which requires a running asyncio event loop at the moment the session is wired up. When there isn't one (synchronous code, a sync test rig), the auto-start is skipped outright: nothing crashes, but no watcher runs for that session, and the skip is logged once at debug: *"no running event loop, skipping DeadAirDetector auto-start. Call detector.start(sid) explicitly."* The caller has to start it by hand in that case (`src/voicegateway/inference/session/attach.py:169-187`).
+`VOICEGW_DEAD_AIR=0` forces it off fleet-wide and beats the argument.
 
-Binding a live session to `DeadAirDetector` at all is a lower-level integration point than [`attach()`](/guide/attach)/[`guard()`](/guide/guard): `attach()`'s own metric path never touches `dead_air_events`, so dead-air capture is opt-in, not automatic.
+It is a separate flag from `turns` even though both ride the same speech events, because dead air **polls**: one task per session, once a second, for the life of the call. That is a standing per-session cost, so it is switchable on its own.
+
+<Warning>
+LiveKit only. Pipecat accepts `dead_air=` for signature parity but has no equivalent speech-boundary events, so its dead-air view stays empty.
+</Warning>
+
+Events can also be pushed directly with `POST /v1/ingest/dead-air`; see the [HTTP API](/api/http-api).
+
+## Tuning the threshold
+
+`dead_air_threshold_seconds` under `projects.<id>.metrics` in `voicegw.yaml`, default `3.0`, per project rather than global. Three seconds is aggressive for an agent with a slow LLM: raise it if normal thinking time is firing events.
+
+The one-second poll interval is a constructor argument with no config key.
+
+## When the watcher doesn't start
+
+The watcher is scheduled with `loop.create_task(...)`, which needs a running asyncio event loop when the session is wired up. Without one (synchronous code, a sync test rig) the auto-start is skipped: nothing crashes, no watcher runs, and the skip is logged once at debug.
 
 ## Where you see it
 

--- a/docs/guide/turns.md
+++ b/docs/guide/turns.md
@@ -2,7 +2,7 @@
 title: Turns and transcripts
 description: What VoiceGateway records per caller-agent exchange, how that differs from the call transcript, and where both surface.
 ---
-A **turn** is one caller-agent exchange: the caller speaks, the caller stops, the agent responds. VoiceGateway can capture the timing of that exchange in a `turns` table, separate from the call **transcript** (the text of what was said) in `transcript_turns`. The two are captured by different code paths and are not row-aligned.
+A **turn** is one caller-agent exchange: the caller speaks, the caller stops, the agent responds. VoiceGateway captures the timing of that exchange in a `turns` table, separate from the call **transcript** (the text of what was said) in `transcript_turns`. The two are captured by different code paths and are not row-aligned.
 
 ## What a turn is
 
@@ -30,9 +30,40 @@ The transcript is a separate capture: at session close, [`attach()`](/guide/atta
 
 Because a `TurnRow` measures speech timing and a transcript row carries text from the framework's own history, nothing joins them 1:1: a session can have a transcript with no turns, or turns with no transcript, depending on what's wired up.
 
-## Is it on by default?
+## Turning it on
 
-Transcript capture is: `attach()` turns it on unless you opt out. Turn capture is not: nothing in `attach()`'s metric path writes to `turns`, and there's no `voicegw.yaml` switch for it either. A `metrics:` block does exist under `projects.<id>` (`turn_buffer_flush_size`, `talk_over_min_overlap_ms`) and validates, but nothing in the codebase currently reads it back at runtime (`src/voicegateway/schemas/config_schema.py:43-47`). Populating `turns` requires binding a `TurnTracker` (`voicegateway.middleware.turn_tracker_middleware`) to the live session yourself, a lower-level integration point than [`attach()`](/guide/attach)/[`guard()`](/guide/guard) and outside the scope of this page.
+On by default, like the transcript:
+
+```python
+voicegateway.attach(session, project="my-agent")            # turns captured
+voicegateway.attach(session, project="my-agent", turns=False)  # not captured
+```
+
+`VOICEGW_TURNS=0` forces it off fleet-wide and beats the argument, the same shape as
+`VOICEGW_TRANSCRIPTS`. It defaults on because a turn row is four timestamps and an index:
+no utterance, no prompt, no tool payload, so it is not the disclosure that
+[`snapshots`](/cli/replay) is.
+
+<Warning>
+LiveKit only. Pipecat accepts `turns=` for signature parity but has no equivalent
+speech-boundary events, so no rows are written there and `e2e_ms` stays null.
+</Warning>
+
+### Two knobs, per project
+
+Both live under `projects.<id>.metrics` in `voicegw.yaml`, not at the top level:
+
+| Key | Default | Effect |
+|---|---|---|
+| `turn_buffer_flush_size` | `25` | Rows buffered before the tracker writes |
+| `talk_over_min_overlap_ms` | `100` | Minimum caller/agent overlap counted as a talk-over |
+
+`talk_over_min_overlap_ms` changes a published number rather than just a threshold: the
+query used to count any overlap at all, so talk-over rates measured before and after are
+not comparable.
+
+Feeding turns from outside a LiveKit session is possible too. `POST /v1/ingest/turns`
+takes a batch directly; see the [HTTP API](/api/http-api).
 
 ## Where you see it
 


### PR DESCRIPTION
#220 and #221 gave the `turns` and `dead_air_events` tables a write path. The docs described the world before them, and after they merged those descriptions became actively wrong.

Verified against `35bed51` before writing, rather than against the PR descriptions: `DeadAirDetector` is constructed at `attach.py:687`, both flags exist and default on, both kill switches are read, both ingest routes are mounted, and all three `metrics` knobs now have consumers.

## What main said that is no longer true

- **`turns.md`** said turn capture "is not" on by default, that no `voicegw.yaml` switch existed, that the metrics knobs were read by nothing, and that populating `turns` meant binding a `TurnTracker` yourself. All four are now false.
- **`dead-air.md`** said an event is written "only if a callback is wired", implying the reader wires it. `attach()` wires it.

## Also fixed, independently

`environment-variables.md` documented only the agent-side role of `VOICEGW_API_KEY`. On a collector it registers a static wildcard ingest key, and a `vk_` value routes to virtual-key lookup, so every request fails with `{"detail":"Invalid virtual key"}`. Someone hit exactly this. The Railway page already warned about it, so the two pages contradicted each other. The table now names both roles.

## Written

| | |
|---|---|
| `attach(turns=True)` | default on, `VOICEGW_TURNS=0` kills it |
| `attach(dead_air=True)` | default on, `VOICEGW_DEAD_AIR=0` kills it |
| `POST /v1/ingest/turns` | and why it is a separate route |
| `POST /v1/ingest/dead-air` | same |
| `projects.<id>.metrics` | all three knobs, in the yaml reference |

Three things worth calling out because a reader cannot infer them:

**Why `dead_air` is a separate flag from `turns`** when both ride the same four speech events: dead air polls, one task per session at one second for the life of the call. That is a standing per-session cost and deserves its own switch.

**A long utterance cannot trip a dead-air event.** While either party speaks the activity clock reports now. That is a guarantee of the wiring, not a tuning artifact, and it is the first thing anyone reasoning about false positives will ask.

**`talk_over_min_overlap_ms` changes a published number**, not just a threshold. The query previously counted any overlap at all, so talk-over rates measured either side of #220 are not comparable.

Both flags are LiveKit-only. Pipecat accepts them for signature parity and captures nothing, stated as a limitation on both pages rather than glossed.

## Not documented

The dead-air poll interval, which is a constructor argument with no config key. Documenting it as configurable would be wrong.

## Gates

Validator passes at 79 pages. All five changed pages render under `mint dev` with no MDX errors, which is the check that matters here: two defects on the previous PR were invisible in Markdown and only showed in a browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added HTTP API documentation for batch ingestion of conversation turns and dead-air events.
  - Clarified API key roles, virtual-key routing, failure responses, and collector-key generation.
  - Documented project-level metrics settings for turn buffering, overlap detection, and dead-air thresholds.
  - Updated attachment, turn-capture, and dead-air guides with automatic behavior, configuration options, supported integrations, and querying details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->