### PR TITLE
Drive turn boundaries from the state events LiveKit actually emits

### DIFF
--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -749,25 +749,42 @@ def _bind_turn_events(
 ) -> None:
     """Wire the speech-boundary events onto an AgentSession.
 
-    Onset is hooked twice on purpose. LiveKit 1.6 dropped the discrete
-    ``user_started_speaking`` and signals onset as ``user_state_changed`` ->
-    ``speaking``; older builds emit the discrete event. ``capture.py`` already
-    hooks both for the first-partial latency, and turn capture needs the same
-    treatment or turn starts go uncaptured on 1.6 with a tracker bound.
+    **Every boundary is driven by a state-change event, because the discrete
+    ones do not exist.** ``user_started_speaking``, ``user_stopped_speaking``,
+    ``agent_started_speaking`` and ``agent_stopped_speaking`` are absent from
+    ``EventTypes`` in livekit-agents 1.5.7 AND 1.6.9, and the names appear
+    nowhere in the package on either. This is not a 1.6 regression; nothing in
+    the supported ``>=1.5,<1.7`` range has ever emitted them.
 
-    First-wins needs no latch here: ``on_user_started_speaking`` only sets
-    ``pending_caller_start_ms`` when it is None, so whichever event arrives
-    first anchors the turn and the other is a no-op.
+    Turn capture previously bridged only the caller's ONSET, which is why the
+    table came back empty rather than partially filled: a turn is closed by
+    ``on_agent_audio_first_frame``, so with no agent-start signal no turn ever
+    closed and nothing was ever buffered.
 
-    ``activity`` is the optional dead-air clock. It rides these same four events
-    because they are exactly the signal it needs, but it is updated
-    independently of ``tracker`` so the two features stay separately
-    switchable. ``tracker`` may be None when only dead air is on.
+    What LiveKit does emit is ``user_state_changed`` and
+    ``agent_state_changed``, each carrying ``old_state`` and ``new_state``:
 
-    Note the non-speaking branch of ``user_state_changed``: on a build that
-    emits no discrete ``user_stopped_speaking``, that transition is the only
-    signal the caller went quiet, and without it the activity clock would stay
-    "speaking" forever and dead air could never fire.
+    - ``UserState``  = speaking | listening | away
+    - ``AgentState`` = initializing | idle | listening | thinking | speaking
+
+    So a boundary is a transition INTO or OUT OF ``speaking``. Stops guard on
+    ``old_state == "speaking"`` rather than on a specific destination: the
+    caller can go speaking -> away as well as speaking -> listening, and both
+    are the same event (they stopped talking), while listening -> away is not a
+    stop at all because no speech was in flight. Keying on the origin gets all
+    three right; keying on the destination drops the away case.
+
+    The four discrete names stay bound. They cost nothing on LiveKit, where they
+    never fire, and they are the path for any other framework or future build
+    that does emit them. Double-binding is safe because every tracker entry
+    point is first-wins: ``on_user_started_speaking`` and
+    ``on_user_stopped_speaking`` only set their field when it is None,
+    ``on_agent_audio_first_frame`` returns early once the turn is closed, and
+    ``on_agent_audio_last_frame`` only fills an unset end.
+
+    ``activity`` is the optional dead-air clock, updated independently of
+    ``tracker`` so the two features stay separately switchable. ``tracker`` may
+    be None when only dead air is on.
     """
     on = getattr(session, "on", None)
     if not callable(on):
@@ -807,18 +824,40 @@ def _bind_turn_events(
         if agent_stopped is not None:
             agent_stopped(event)
 
-    def _on_state_changed(event: Any = None, *_a: Any, **_k: Any) -> None:
-        if getattr(event, "new_state", None) == "speaking":
+    def _on_user_state_changed(event: Any = None, *_a: Any, **_k: Any) -> None:
+        old = getattr(event, "old_state", None)
+        new = getattr(event, "new_state", None)
+        if new == "speaking":
             _user_started(event)
             return
-        # listening / away: the caller stopped. Only the activity clock cares;
-        # the tracker's own stop is driven by user_stopped_speaking, and calling
-        # it here would close turns on an "away" transition.
-        if activity is not None:
-            activity.caller_stopped()
+        if old == "speaking":
+            # Out of speaking, to listening OR away: the caller stopped talking.
+            # An earlier version routed this to the activity clock only, on the
+            # worry that it would close a turn on an "away" transition. It does
+            # not: on_user_stopped_speaking records the caller's speech END, and
+            # the turn is closed by on_agent_audio_first_frame. Withholding it
+            # left response_speed_ms measured from the wrong instant.
+            _user_stopped(event)
 
+    def _on_agent_state_changed(event: Any = None, *_a: Any, **_k: Any) -> None:
+        old = getattr(event, "old_state", None)
+        new = getattr(event, "new_state", None)
+        if new == "speaking":
+            # The boundary that closes a turn. Without it nothing is ever
+            # buffered, which is why the table was empty and not merely partial.
+            _agent_started(event)
+            return
+        if old == "speaking":
+            # speaking -> idle/listening/thinking are all the agent finishing.
+            _agent_stopped(event)
+
+    # State changes: the only ones LiveKit actually emits.
+    on("user_state_changed", _on_user_state_changed)
+    on("agent_state_changed", _on_agent_state_changed)
+    # Discrete events: absent from LiveKit in the supported range, kept for
+    # other frameworks and any build that does emit them. Harmless when they
+    # never fire, and safe alongside the above because the tracker is first-wins.
     on("user_started_speaking", _user_started)
-    on("user_state_changed", _on_state_changed)
     on("user_stopped_speaking", _user_stopped)
     on("agent_started_speaking", _agent_started)
     on("agent_stopped_speaking", _agent_stopped)

--- a/src/voicegateway/middleware/turn_tracker_middleware.py
+++ b/src/voicegateway/middleware/turn_tracker_middleware.py
@@ -98,7 +98,15 @@ class TurnTracker(SessionScopedComponent):
             state = self._sessions.get(sid)
             if state is None or state.pending_caller_start_ms is None:
                 return
-            state.pending_caller_end_ms = end_ms
+            # First-wins, matching on_user_started_speaking. Two events can
+            # report the same boundary (a discrete ``user_stopped_speaking`` on
+            # one build, the ``user_state_changed`` transition out of
+            # ``speaking`` on another), and both are bound so either kind of
+            # build works. Overwriting would let the later of the two stretch
+            # the caller's speech and shrink the response_speed_ms derived from
+            # it; the first report is the accurate one.
+            if state.pending_caller_end_ms is None:
+                state.pending_caller_end_ms = end_ms
 
     async def on_agent_audio_first_frame(
         self,

--- a/src/voicegateway/tests/inference/test_livekit_state_events.py
+++ b/src/voicegateway/tests/inference/test_livekit_state_events.py
@@ -1,0 +1,324 @@
+"""Turn capture driven by the events LiveKit actually emits.
+
+The four discrete speech events this code bound for years
+(``user_started_speaking``, ``user_stopped_speaking``,
+``agent_started_speaking``, ``agent_stopped_speaking``) are absent from
+``EventTypes`` in livekit-agents 1.5.7 and 1.6.9 alike, and the names appear
+nowhere in the package on either version. Nothing in the supported
+``>=1.5,<1.7`` range has ever emitted them, so the handlers were never invoked
+and the ``turns`` table stayed empty.
+
+Every existing test drove those discrete names against a permissive double, so
+they proved the handlers work and never that LiveKit calls them. These drive the
+real event set instead, which is the only thing that distinguishes a working
+build from the one that shipped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+from typing import Any
+
+import pytest
+
+import voicegateway
+from voicegateway.inference.session.context import reset_session_id
+from voicegateway.services.sinks import LocalSqliteSink
+from voicegateway.services.storage_service import StorageService
+
+attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+
+# The exact set a 1.5/1.6 AgentSession can emit for speech boundaries.
+_LIVEKIT_SPEECH_EVENTS = ("user_state_changed", "agent_state_changed")
+
+
+class _StrictSession:
+    """AgentSession double that refuses events LiveKit does not define.
+
+    A permissive double is what let this bug survive: it accepted
+    ``user_started_speaking`` happily, so the tests passed while production
+    never fired a single handler. This one only accepts names present in the
+    installed ``livekit.agents`` ``EventTypes``, so a test cannot rely on an
+    event the library will not send.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, list[Any]] = {}
+        self.stt = None
+        self.llm = None
+        self.tts = None
+        self.current_agent = None
+
+    def on(self, event_name: str, handler: Any) -> None:
+        if inspect.iscoroutinefunction(handler):
+            raise ValueError("Cannot register an async callback with `.on()`.")
+        self._handlers.setdefault(event_name, []).append(handler)
+
+    def emit(self, event_name: str, event: Any) -> None:
+        if event_name not in _live_event_types():
+            raise AssertionError(
+                f"{event_name!r} is not in livekit's EventTypes; a test driving "
+                "it proves nothing about a real AgentSession"
+            )
+        for handler in list(self._handlers.get(event_name, [])):
+            handler(event)
+
+
+def _live_event_types() -> frozenset[str]:
+    from livekit.agents.voice.events import EventTypes
+
+    return frozenset(EventTypes.__args__)  # type: ignore[attr-defined]
+
+
+class _UserState:
+    """``UserStateChangedEvent``: old_state/new_state over speaking|listening|away."""
+
+    def __init__(self, old_state: str, new_state: str) -> None:
+        self.old_state = old_state
+        self.new_state = new_state
+        self.created_at = 0.0
+
+
+class _AgentState:
+    """``AgentStateChangedEvent``: adds initializing|idle|thinking."""
+
+    def __init__(self, old_state: str, new_state: str) -> None:
+        self.old_state = old_state
+        self.new_state = new_state
+        self.created_at = 0.0
+
+
+async def _drain() -> None:
+    """Settle the tasks the sync handlers scheduled."""
+    loop = asyncio.get_running_loop()
+
+    def _pending() -> list[Any]:
+        return [
+            t
+            for t in [*attach_mod._turn_tasks, *attach_mod._close_tasks]
+            if not t.done() and t.get_loop() is loop
+        ]
+
+    for _ in range(100):
+        pending = _pending()
+        if not pending:
+            await asyncio.sleep(0)
+            if not _pending():
+                return
+            continue
+        await asyncio.gather(*pending, return_exceptions=True)
+    raise AssertionError("turn event tasks never settled")
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.delenv("VOICEGW_DB_URL", raising=False)
+    reset_session_id()
+    yield
+    reset_session_id()
+
+
+def _sink(tmp_path: Any) -> LocalSqliteSink:
+    return LocalSqliteSink(StorageService(str(tmp_path / "state.db")))
+
+
+async def _stored_turns(sink: LocalSqliteSink, session_id: str) -> list[Any]:
+    from voicegateway.repository import turns_repository as turns
+
+    storage = sink._storage
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        return await turns.list_turns_by_session(db, session_id)
+
+
+# --- the library contract ------------------------------------------------
+
+
+def test_livekit_does_not_define_the_discrete_speech_events() -> None:
+    """Pins the reason this fix exists.
+
+    If a future LiveKit reintroduces them, this fails and whoever sees it can
+    simplify the bindings on purpose rather than discovering the overlap by
+    accident.
+    """
+    defined = _live_event_types()
+    for name in (
+        "user_started_speaking",
+        "user_stopped_speaking",
+        "agent_started_speaking",
+        "agent_stopped_speaking",
+    ):
+        assert name not in defined, (
+            f"{name} is now a real LiveKit event; the discrete bindings in "
+            "_bind_turn_events are no longer dead weight and the dual-binding "
+            "comment needs revisiting"
+        )
+
+
+def test_the_state_events_we_depend_on_exist() -> None:
+    """The other half: a rename upstream must break loudly, not silently."""
+    defined = _live_event_types()
+    for name in _LIVEKIT_SPEECH_EVENTS:
+        assert name in defined, f"{name} disappeared from livekit's EventTypes"
+
+
+# --- the fix -------------------------------------------------------------
+
+
+async def test_a_full_turn_from_only_the_real_event_set(tmp_path) -> None:
+    """The failing case: nothing but 1.6 events, and a complete turn out.
+
+    The strict double refuses the discrete names, so this cannot pass by
+    accidentally exercising the legacy path.
+    """
+    sink = _sink(tmp_path)
+    session = _StrictSession()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_state_changed", _UserState("listening", "speaking"))
+    await _drain()
+    session.emit("user_state_changed", _UserState("speaking", "listening"))
+    await _drain()
+    session.emit("agent_state_changed", _AgentState("thinking", "speaking"))
+    await _drain()
+    session.emit("agent_state_changed", _AgentState("speaking", "listening"))
+    await _drain()
+    session.emit("close", _UserState("listening", "listening"))
+    await _drain()
+
+    rows = await _stored_turns(sink, sid)
+    assert len(rows) == 1, f"expected one turn from the real event set, got {rows}"
+    turn = rows[0]
+    assert turn.turn_index == 0
+    assert turn.caller_speak_start_ms is not None
+    assert turn.caller_speak_end_ms is not None
+    assert turn.agent_speak_start_ms is not None, "no agent start: the turn never closed"
+    assert turn.agent_speak_end_ms is not None
+    assert turn.response_speed_ms is not None
+    assert turn.response_speed_ms >= 0
+
+
+async def test_the_agent_start_is_what_closes_the_turn(tmp_path) -> None:
+    """Without the agent_state_changed bridge the table is empty, not partial.
+
+    A turn is buffered by on_agent_audio_first_frame, so a run with caller
+    boundaries but no agent start must produce nothing at all. That is exactly
+    the reported symptom.
+    """
+    sink = _sink(tmp_path)
+    session = _StrictSession()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_state_changed", _UserState("listening", "speaking"))
+    await _drain()
+    session.emit("user_state_changed", _UserState("speaking", "listening"))
+    await _drain()
+
+    assert await _stored_turns(sink, sid) == []
+
+
+async def test_speaking_to_away_still_counts_as_a_stop(tmp_path) -> None:
+    """Guarding on the destination would drop this; guarding on origin does not.
+
+    The caller can go speaking -> away without passing through listening, and
+    that is still them finishing an utterance.
+    """
+    sink = _sink(tmp_path)
+    session = _StrictSession()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_state_changed", _UserState("listening", "speaking"))
+    await _drain()
+    session.emit("user_state_changed", _UserState("speaking", "away"))
+    await _drain()
+    session.emit("agent_state_changed", _AgentState("thinking", "speaking"))
+    await _drain()
+    session.emit("close", _UserState("away", "away"))
+    await _drain()
+
+    rows = await _stored_turns(sink, sid)
+    assert len(rows) == 1
+    assert rows[0].response_speed_ms is not None, (
+        "the speaking -> away transition did not record the caller's stop, so "
+        "response_speed_ms was measured from the wrong instant"
+    )
+
+
+async def test_an_away_transition_that_is_not_a_stop_opens_nothing(tmp_path) -> None:
+    """listening -> away is not speech ending; no turn should exist."""
+    sink = _sink(tmp_path)
+    session = _StrictSession()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_state_changed", _UserState("listening", "away"))
+    await _drain()
+    session.emit("agent_state_changed", _AgentState("idle", "listening"))
+    await _drain()
+    session.emit("close", _UserState("away", "away"))
+    await _drain()
+
+    assert await _stored_turns(sink, sid) == []
+
+
+async def test_agent_thinking_is_not_an_agent_boundary(tmp_path) -> None:
+    """Only transitions into and out of ``speaking`` are boundaries.
+
+    ``AgentState`` has initializing/idle/listening/thinking too, and treating
+    any of them as a start would close turns that never had agent audio.
+    """
+    sink = _sink(tmp_path)
+    session = _StrictSession()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    session.emit("user_state_changed", _UserState("listening", "speaking"))
+    await _drain()
+    session.emit("user_state_changed", _UserState("speaking", "listening"))
+    await _drain()
+    session.emit("agent_state_changed", _AgentState("listening", "thinking"))
+    await _drain()
+
+    assert await _stored_turns(sink, sid) == [], "thinking closed a turn"
+
+
+async def test_two_turns_in_one_session(tmp_path) -> None:
+    """turn_index has to advance across a real back-and-forth."""
+    sink = _sink(tmp_path)
+    session = _StrictSession()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    for _ in range(2):
+        session.emit("user_state_changed", _UserState("listening", "speaking"))
+        await _drain()
+        session.emit("user_state_changed", _UserState("speaking", "listening"))
+        await _drain()
+        session.emit("agent_state_changed", _AgentState("thinking", "speaking"))
+        await _drain()
+        session.emit("agent_state_changed", _AgentState("speaking", "listening"))
+        await _drain()
+
+    session.emit("close", _UserState("listening", "listening"))
+    await _drain()
+
+    rows = await _stored_turns(sink, sid)
+    assert [r.turn_index for r in rows] == [0, 1]
+
+
+async def test_the_dead_air_clock_follows_the_state_events(tmp_path) -> None:
+    """Dead air rides the same bridges, so it must work on the real set too."""
+    sink = _sink(tmp_path)
+    session = _StrictSession()
+    voicegateway.attach(session, project="p", sink=sink)
+    activity = session._vg_activity
+    assert activity is not None
+
+    session.emit("user_state_changed", _UserState("listening", "speaking"))
+    live = activity.probe("x")
+    assert live is not None
+    assert attach_mod._SpeechActivity._now_ms() - live < 50
+
+    session.emit("user_state_changed", _UserState("speaking", "listening"))
+    pinned = activity.probe("x")
+    assert activity.probe("x") == pinned, "clock still reports active speech"

--- a/src/voicegateway/tests/middleware/test_turn_tracker_middleware.py
+++ b/src/voicegateway/tests/middleware/test_turn_tracker_middleware.py
@@ -155,3 +155,29 @@ async def test_active_sessions_lists_in_flight() -> None:
 
     await tracker.close_session("s1")
     assert tracker.active_sessions() == []
+
+
+async def test_first_user_stopped_wins() -> None:
+    """The caller's speech END latches, mirroring the start.
+
+    Both a discrete ``user_stopped_speaking`` and the ``user_state_changed``
+    transition out of ``speaking`` are bound, so on a build emitting both this
+    is reported twice. Overwriting would let the later report stretch the
+    caller's speech and shrink the ``response_speed_ms`` derived from it.
+    """
+    captured: list[list[TurnRow]] = []
+
+    async def flush(rows: list[TurnRow]) -> None:
+        captured.append(rows)
+
+    tracker = TurnTracker(flush_callback=flush, flush_size=100)
+    await tracker.on_user_started_speaking(session_id="s1", at_ms=1000)
+    await tracker.on_user_stopped_speaking(session_id="s1", at_ms=1500)
+    await tracker.on_user_stopped_speaking(session_id="s1", at_ms=1900)
+    await tracker.on_agent_audio_first_frame(session_id="s1", at_ms=2000)
+    await tracker.close_session("s1")
+
+    [turn] = captured[0]
+    assert turn.caller_speak_end_ms == 1500, "a later stop overwrote the first"
+    # Measured from the first stop, not the second.
+    assert turn.response_speed_ms == 500


### PR DESCRIPTION
Turn capture produced no rows, so `turns` stayed empty and `e2e_ms` on `/v1/rooms/{room}/latency` was always `null`, with the four stage components populating normally beside it.

## It is not a 1.6 regression

I installed **1.6.9** to check rather than infer, and also read the version this repo pins and tests against.

| | 1.5.7 (installed) | 1.6.9 |
|---|---|---|
| `user_started_speaking` in `EventTypes` | absent | absent |
| `user_stopped_speaking` | absent | absent |
| `agent_started_speaking` | absent | absent |
| `agent_stopped_speaking` | absent | absent |

On 1.6.9 those names appear **nowhere in the `livekit/agents` package at all**. Nothing in the supported `>=1.5,<1.7` range has ever emitted them, so this never worked on any version, including the one CI runs.

## Why the table was empty rather than partial

#220 bridged the caller's **onset** through `user_state_changed`. But a turn is buffered by `on_agent_audio_first_frame`, so with no agent-start signal no turn ever closed and nothing was written.

## The fix

LiveKit emits `user_state_changed` and `agent_state_changed`, each carrying `old_state` and `new_state`:

```
UserState  = speaking | listening | away
AgentState = initializing | idle | listening | thinking | speaking
```

A boundary is a transition into or out of `speaking`. Both are now bridged.

**Stops guard on `old_state == "speaking"`, not on a destination.** The suggested guard was `new_state == "listening"`, which drops `speaking -> away`: the caller can go away without passing through listening, and that is still them finishing an utterance. `listening -> away` is correctly not a stop, because no speech was in flight. Keying on the origin gets all three right; there is a test for each.

The old comment claiming a stop here would "close turns on an away transition" was wrong. `on_user_stopped_speaking` records the caller's speech **end**; the turn is closed by `on_agent_audio_first_frame`. Withholding it left `response_speed_ms` measured from the wrong instant.

## Idempotency, verified rather than assumed

The discrete names stay bound for other frameworks. That is safe only if every entry point is first-wins:

| Entry point | Was it? |
|---|---|
| `on_user_started_speaking` | already latched |
| `on_agent_audio_first_frame` | returns early once closed |
| `on_agent_audio_last_frame` | already latched |
| `on_user_stopped_speaking` | **overwrote** — now latches |

Without that latch a later duplicate could stretch the caller's speech and shrink the `response_speed_ms` derived from it.

## The tests are the other half

Every existing test drove the discrete names against a permissive double, so they proved the handlers work and never that LiveKit calls them. Same shape as the async-handler bug in #220: a double more forgiving than reality.

The new ones use a **strict double that refuses any event name absent from the installed `EventTypes`**, so a test cannot lean on an event the library will not send. Plus two contract tests on the library itself:

- the discrete four are absent — if a future LiveKit brings them back this fails, and the bindings can be simplified deliberately rather than overlapping by accident
- the two state events still exist — an upstream rename breaks loudly

Three new behavioural tests fail without this change. The negative and contract ones pass either way, by design.

Pin untouched: `>=1.5,<1.7` already covers 1.6.9.

## Verification

**3399 passed**, up 10 from the 3389 baseline, exactly the tests added. Two consecutive clean full runs. `ruff` and `mypy<2` clean.

## Docs

No new surface, so probably nothing to change. One caveat worth a line if the turns page implies it: on Pipecat this is still unwired, so `e2e_ms` stays null there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech detection across caller and agent speaking-state transitions.
  * More reliably closes conversation turns when the agent begins speaking.
  * Prevented duplicate caller stop events from affecting response-time measurements.
  * Improved dead-air tracking and turn persistence across multiple exchanges.

* **Tests**
  * Added coverage for speech transitions, turn boundaries, multi-turn conversations, and duplicate event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->