### PR TITLE
Anchor response_speed_ms to the caller's real stop, not the VAD's notice

### DIFF
--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -738,7 +738,16 @@ def _build_turn_tracker(sink: Sink, project: str | None) -> Any:
     async def _flush(rows: list[TurnRow]) -> None:
         await sink.log_turns(rows)
 
-    return TurnTracker(flush_callback=_flush, flush_size=_turn_flush_size(project))
+    # precise_end_required: on LiveKit the stop event lags the caller's true
+    # stop by the VAD silence window, so a turn whose end was never corrected
+    # from the EOU metric reports no response speed rather than one that is
+    # flatteringly short. See TurnTracker.__init__ and
+    # MetricCapture._caller_end_from_eou.
+    return TurnTracker(
+        flush_callback=_flush,
+        flush_size=_turn_flush_size(project),
+        precise_end_required=True,
+    )
 
 
 def _bind_turn_events(
@@ -1066,6 +1075,28 @@ def _attach_livekit(
     if sink is None:
         sink = _build_default_sink(resolved_collector, resolved_key)
 
+    # Built before MetricCapture, which needs the correction hook below.
+    turn_tracker = (
+        _build_turn_tracker(sink, project) if _turns_enabled(turns) else None
+    )
+
+    def _correct_caller_end(at_ms: int) -> None:
+        """Re-stamp the caller's speech end from the EOU-derived anchor.
+
+        Scheduled, not awaited: this runs from MetricCapture's synchronous
+        metric handler. ``precise=True`` is what lets it overwrite the value the
+        state change already wrote, which is the whole point; a plain
+        first-wins report here would be discarded and nothing would change.
+        """
+        if turn_tracker is None:
+            return
+        _schedule_turn_event(
+            turn_tracker.on_user_stopped_speaking(
+                session_id=session_id, at_ms=at_ms, precise=True
+            ),
+            "caller_end_correction",
+        )
+
     cost_tracker = CostTracker(sink)
     capture = MetricCapture(
         cost_tracker=cost_tracker,
@@ -1077,6 +1108,7 @@ def _attach_livekit(
         room=resolved_room,
         channel=resolved_channel,
         dispatch_name=resolved_dispatch_name,
+        on_caller_end=_correct_caller_end if turn_tracker is not None else None,
     )
     capture.bind(session)
 
@@ -1095,9 +1127,6 @@ def _attach_livekit(
     # Same session_id the RequestRecords above are stamped with. rooms.py joins
     # room -> session_id -> turns, so a tracker keyed on anything else produces
     # turns that exist but never appear in /v1/rooms/{room}/latency.
-    turn_tracker = (
-        _build_turn_tracker(sink, project) if _turns_enabled(turns) else None
-    )
     dead_air_detector, activity = (
         _build_dead_air_detector(sink, project)
         if _dead_air_enabled(dead_air)

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any
 from voicegateway.models.request_model import RequestRecord
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     from voicegateway.middleware.cost_tracker_middleware import CostTracker
     from voicegateway.services.sinks import Sink
@@ -297,6 +297,7 @@ class MetricCapture:
         room: str | None = None,
         channel: str | None = None,
         dispatch_name: str | None = None,
+        on_caller_end: Callable[[int], None] | None = None,
     ) -> None:
         self._cost_tracker = cost_tracker
         self._sink = sink
@@ -307,6 +308,10 @@ class MetricCapture:
         self._room = room
         self._channel = channel
         self._dispatch_name = dispatch_name
+        # Called with the caller's true speech-end, in TurnTracker's monotonic
+        # milliseconds, whenever an EOU metric makes it recoverable. See
+        # _caller_end_from_eou.
+        self._on_caller_end = on_caller_end
         self._pending: set[asyncio.Task[None]] = set()
         # Exception types already reported in full. A sink that cannot write
         # fails on every metric event, and one traceback per event buries the
@@ -481,6 +486,49 @@ class MetricCapture:
             return component_identity(component)
         return "unknown", "unknown"
 
+    def _caller_end_from_eou(self, metric: object, eou: float) -> None:
+        """Recover when the caller ACTUALLY stopped, and report it.
+
+        ``user_state_changed -> listening`` fires only once the VAD has waited
+        out its silence window, so a stop stamped at that event is late by that
+        window (0.55s with Silero's default) and every response speed measured
+        from it is understated by the same amount.
+
+        LiveKit backdates the true stop internally
+        (``on_end_of_speech`` subtracts ``silence_duration`` and
+        ``inference_duration``, then passes it as ``last_speaking_time``), but
+        ``UserStateChangedEvent`` carries only ``old_state``, ``new_state`` and
+        ``created_at``, so it never reaches a subscriber. What does reach us is
+        ``end_of_utterance_delay``, which LiveKit computes as
+        ``max(now - last_speaking_time, 0)``. Subtracting it from the moment the
+        metric was produced recovers the anchor without hardcoding any VAD
+        setting, so it tracks whatever the deployment configured.
+
+        Two things this is careful about:
+
+        ``end_of_utterance_delay`` is published as
+        ``info.metrics.end_of_turn_delay or 0.0``, so ``0.0`` means "could not
+        be measured" far more often than "no delay" (LiveKit returns None for a
+        stale or missing anchor). Treating it as a real zero would quietly
+        re-stamp the biased value and label it corrected, which is worse than
+        leaving it alone. Non-positive is therefore ignored.
+
+        The clocks differ: the metric's ``timestamp`` is ``time.time()`` while
+        TurnTracker works in ``time.monotonic()``. Only the DELTA crosses
+        between them, never an absolute, so the two are never mixed.
+        """
+        if self._on_caller_end is None or eou <= 0:
+            return
+        produced_at = getattr(metric, "timestamp", None)
+        lag = 0.0
+        if isinstance(produced_at, int | float) and produced_at > 0:
+            # How long ago the metric was produced, so handler scheduling does
+            # not get charged to the caller's silence. A wall-clock difference,
+            # not a wall-clock instant.
+            lag = max(0.0, time.time() - float(produced_at))
+        now_ms = int(time.monotonic() * 1000)
+        self._on_caller_end(now_ms - int((lag + eou) * 1000))
+
     def _on_session_metric(self, metric: object, *_a: Any, **_k: Any) -> None:
         metric = getattr(metric, "metrics", metric)
         eou = getattr(metric, "end_of_utterance_delay", None)
@@ -495,6 +543,11 @@ class MetricCapture:
                 provider, model_id = self._agent_component_identity(modality)
                 self._record_metric(metric, modality, provider, model_id)
             return
+        try:
+            self._caller_end_from_eou(metric, float(eou))
+        except Exception:  # noqa: BLE001 - turn timing must not break metering
+            logger.debug("capture: caller-end correction failed", exc_info=True)
+
         record = RequestRecord(
             id=str(uuid.uuid4()),
             timestamp=time.time(),

--- a/src/voicegateway/middleware/turn_tracker_middleware.py
+++ b/src/voicegateway/middleware/turn_tracker_middleware.py
@@ -50,6 +50,9 @@ class _SessionState:
     turn_index: int = 0
     pending_caller_start_ms: int | None = None
     pending_caller_end_ms: int | None = None
+    # Whether pending_caller_end_ms came from a source that knows when the
+    # caller ACTUALLY stopped, rather than when something noticed.
+    caller_end_is_precise: bool = False
     buffered_turns: list[TurnRow] = field(default_factory=list)
 
 
@@ -60,11 +63,28 @@ class TurnTracker(SessionScopedComponent):
         self,
         flush_callback: FlushCallback | None = None,
         flush_size: int = _DEFAULT_FLUSH_SIZE,
+        *,
+        precise_end_required: bool = False,
     ) -> None:
+        """``precise_end_required`` gates ``response_speed_ms`` on a real anchor.
+
+        Set it on transports whose stop event is known to lag the caller's true
+        stop, which is every LiveKit build: ``user_state_changed -> listening``
+        fires only after the VAD has waited out its silence window, so a stop
+        stamped there is late by that window and the response speed derived from
+        it is understated by the same amount. Flatteringly, which is why it
+        would not have been noticed.
+
+        With this set, a turn whose end was never corrected reports
+        ``response_speed_ms = None`` rather than a number half a second too
+        good. Mixing corrected and uncorrected turns in one percentile is worse
+        than a gap: the gap is visible.
+        """
         if flush_size < 1:
             raise ValueError(f"flush_size must be >= 1, got {flush_size}")
         self._flush_callback: FlushCallback = flush_callback or _noop_flush
         self._flush_size = flush_size
+        self._precise_end_required = precise_end_required
         self._sessions: dict[str, _SessionState] = {}
         self._lock = asyncio.Lock()
 
@@ -88,8 +108,15 @@ class TurnTracker(SessionScopedComponent):
         self,
         session_id: str | None = None,
         at_ms: int | None = None,
+        *,
+        precise: bool = False,
     ) -> None:
-        """Record the caller-speech end for the in-flight turn."""
+        """Record the caller-speech end for the in-flight turn.
+
+        ``precise=True`` means ``at_ms`` is when the caller actually stopped,
+        not when a listener noticed. A precise report may overwrite an imprecise
+        one exactly once; nothing overwrites a precise one.
+        """
         sid = self._resolve_session_id(session_id)
         if sid is None:
             return
@@ -98,15 +125,26 @@ class TurnTracker(SessionScopedComponent):
             state = self._sessions.get(sid)
             if state is None or state.pending_caller_start_ms is None:
                 return
-            # First-wins, matching on_user_started_speaking. Two events can
-            # report the same boundary (a discrete ``user_stopped_speaking`` on
-            # one build, the ``user_state_changed`` transition out of
-            # ``speaking`` on another), and both are bound so either kind of
-            # build works. Overwriting would let the later of the two stretch
-            # the caller's speech and shrink the response_speed_ms derived from
-            # it; the first report is the accurate one.
+            # First-wins AMONG EQUALS, matching on_user_started_speaking. Two
+            # events can report the same boundary (a discrete
+            # ``user_stopped_speaking`` on one build, the ``user_state_changed``
+            # transition out of ``speaking`` on another), and both are bound so
+            # either kind of build works. Between two imprecise reports the
+            # first is the accurate one; overwriting would let the later stretch
+            # the caller's speech.
+            #
+            # A precise report is the exception and MUST be able to overwrite,
+            # because the imprecise one always arrives first: the state change
+            # fires when the VAD gives up on more speech, while the corrected
+            # anchor is only recoverable from the end-of-utterance metric that
+            # follows. A plain first-wins guard here silently discards the
+            # correction and leaves every number exactly as wrong as before.
             if state.pending_caller_end_ms is None:
                 state.pending_caller_end_ms = end_ms
+                state.caller_end_is_precise = precise
+            elif precise and not state.caller_end_is_precise:
+                state.pending_caller_end_ms = end_ms
+                state.caller_end_is_precise = True
 
     async def on_agent_audio_first_frame(
         self,
@@ -128,6 +166,11 @@ class TurnTracker(SessionScopedComponent):
             if caller_end is None:
                 caller_end = agent_start
                 response_speed = None
+            elif self._precise_end_required and not state.caller_end_is_precise:
+                # The boundary is still useful for talk time, where the VAD
+                # window is noise. It is not usable as a latency headline, where
+                # that same window is most of the number. Absent, not guessed.
+                response_speed = None
             else:
                 response_speed = max(0, agent_start - caller_end)
             turn = TurnRow(
@@ -142,6 +185,7 @@ class TurnTracker(SessionScopedComponent):
             state.turn_index += 1
             state.pending_caller_start_ms = None
             state.pending_caller_end_ms = None
+            state.caller_end_is_precise = False
             flush_now = len(state.buffered_turns) >= self._flush_size
         if flush_now:
             await self.flush_session(sid)
@@ -207,6 +251,7 @@ class TurnTracker(SessionScopedComponent):
                 state.turn_index += 1
                 state.pending_caller_start_ms = None
                 state.pending_caller_end_ms = None
+                state.caller_end_is_precise = False
         flushed = await self.flush_session(session_id)
         async with self._lock:
             self._sessions.pop(session_id, None)

--- a/src/voicegateway/tests/inference/test_attach_turns.py
+++ b/src/voicegateway/tests/inference/test_attach_turns.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import inspect
+import time
 from typing import Any
 
 import pytest
@@ -74,6 +75,27 @@ class _StateChanged(_Event):
 
     def __init__(self, new_state: str) -> None:
         self.new_state = new_state
+
+
+class _EOU:
+    """An EOUMetrics on ``metrics_collected``.
+
+    Needed for a turn to carry a response speed: the caller's stop is recovered
+    from ``end_of_utterance_delay`` because the state change fires a VAD silence
+    window after the real stop. Turns without it keep their boundaries and
+    report ``response_speed_ms = None`` rather than a flattering number. See
+    test_response_speed_anchor.py.
+    """
+
+    def __init__(self, end_of_utterance_delay: float = 0.3) -> None:
+        self.end_of_utterance_delay = end_of_utterance_delay
+        self.transcription_delay = 0.1
+        self.timestamp = time.time()
+
+
+class _MetricsCollected:
+    def __init__(self, metrics: Any) -> None:
+        self.metrics = metrics
 
 
 async def _drain() -> None:
@@ -163,6 +185,8 @@ async def test_a_turn_reaches_storage(tmp_path) -> None:
     session.emit("user_started_speaking")
     await _drain()
     session.emit("user_stopped_speaking")
+    await _drain()
+    session.emit("metrics_collected", _MetricsCollected(_EOU()))
     await _drain()
     session.emit("agent_started_speaking")
     await _drain()

--- a/src/voicegateway/tests/inference/test_livekit_state_events.py
+++ b/src/voicegateway/tests/inference/test_livekit_state_events.py
@@ -32,6 +32,27 @@ attach_mod = importlib.import_module("voicegateway.inference.session.attach")
 
 # The exact set a 1.5/1.6 AgentSession can emit for speech boundaries.
 _LIVEKIT_SPEECH_EVENTS = ("user_state_changed", "agent_state_changed")
+_LIVEKIT_TURN_EVENTS = (*_LIVEKIT_SPEECH_EVENTS, "metrics_collected")
+
+
+class _EOU:
+    """An EOUMetrics as delivered on ``metrics_collected``.
+
+    Part of the real turn sequence, not scenery: the caller's stop is recovered
+    from ``end_of_utterance_delay``, because the state change fires a VAD
+    silence window late. Without this a turn has boundaries but no response
+    speed. See test_response_speed_anchor.py.
+    """
+
+    def __init__(self, end_of_utterance_delay: float = 0.35) -> None:
+        self.end_of_utterance_delay = end_of_utterance_delay
+        self.transcription_delay = 0.1
+        self.timestamp = __import__("time").time()
+
+
+class _MetricsCollected:
+    def __init__(self, metrics: Any) -> None:
+        self.metrics = metrics
 
 
 class _StrictSession:
@@ -182,6 +203,8 @@ async def test_a_full_turn_from_only_the_real_event_set(tmp_path) -> None:
     await _drain()
     session.emit("user_state_changed", _UserState("speaking", "listening"))
     await _drain()
+    session.emit("metrics_collected", _MetricsCollected(_EOU()))
+    await _drain()
     session.emit("agent_state_changed", _AgentState("thinking", "speaking"))
     await _drain()
     session.emit("agent_state_changed", _AgentState("speaking", "listening"))
@@ -233,6 +256,8 @@ async def test_speaking_to_away_still_counts_as_a_stop(tmp_path) -> None:
     session.emit("user_state_changed", _UserState("listening", "speaking"))
     await _drain()
     session.emit("user_state_changed", _UserState("speaking", "away"))
+    await _drain()
+    session.emit("metrics_collected", _MetricsCollected(_EOU()))
     await _drain()
     session.emit("agent_state_changed", _AgentState("thinking", "speaking"))
     await _drain()
@@ -293,6 +318,8 @@ async def test_two_turns_in_one_session(tmp_path) -> None:
         session.emit("user_state_changed", _UserState("listening", "speaking"))
         await _drain()
         session.emit("user_state_changed", _UserState("speaking", "listening"))
+        await _drain()
+        session.emit("metrics_collected", _MetricsCollected(_EOU()))
         await _drain()
         session.emit("agent_state_changed", _AgentState("thinking", "speaking"))
         await _drain()

--- a/src/voicegateway/tests/inference/test_response_speed_anchor.py
+++ b/src/voicegateway/tests/inference/test_response_speed_anchor.py
@@ -1,0 +1,356 @@
+"""``response_speed_ms`` is measured from when the caller actually stopped.
+
+``user_state_changed -> listening`` does not fire when the caller stops. LiveKit
+raises it only after voice activity has waited out ``min_silence_duration``
+(0.55s with Silero's default), and it backdates the true stop into
+``last_speaking_time``, which ``UserStateChangedEvent`` never publishes: the
+event carries ``old_state``, ``new_state`` and a ``created_at`` stamped at
+delivery.
+
+A stop recorded there is therefore late by the whole silence window, and every
+response speed derived from it is short by the same amount. It biases in the
+flattering direction, which is why it reads as good latency rather than a bug.
+
+What is recoverable is ``EOUMetrics.end_of_utterance_delay``, which LiveKit
+computes as ``max(now - last_speaking_time, 0)``. Subtracting it from the moment
+the metric was produced recovers the anchor without hardcoding any VAD setting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import time
+from typing import Any
+
+import pytest
+
+import voicegateway
+from voicegateway.inference.session.context import reset_session_id
+from voicegateway.middleware.turn_tracker_middleware import TurnRow, TurnTracker
+from voicegateway.services.sinks import LocalSqliteSink
+from voicegateway.services.storage_service import StorageService
+
+attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+
+
+class _Session:
+    def __init__(self) -> None:
+        self._handlers: dict[str, list[Any]] = {}
+        self.stt = None
+        self.llm = None
+        self.tts = None
+        self.current_agent = None
+
+    def on(self, event_name: str, handler: Any) -> None:
+        if inspect.iscoroutinefunction(handler):
+            raise ValueError("Cannot register an async callback with `.on()`.")
+        self._handlers.setdefault(event_name, []).append(handler)
+
+    def emit(self, event_name: str, event: Any) -> None:
+        for handler in list(self._handlers.get(event_name, [])):
+            handler(event)
+
+
+class _UserState:
+    def __init__(self, old_state: str, new_state: str) -> None:
+        self.old_state = old_state
+        self.new_state = new_state
+        self.created_at = 0.0
+
+
+class _AgentState(_UserState):
+    pass
+
+
+class _EOU:
+    """An ``EOUMetrics``, as it reaches ``metrics_collected``.
+
+    ``timestamp`` is ``time.time()`` at emission, matching LiveKit. Note it
+    carries no ``stopped_speaking_at``: LiveKit computes one internally
+    (``_EndOfTurnMetrics``) but never publishes it, which is why the anchor has
+    to be derived rather than read.
+    """
+
+    def __init__(self, end_of_utterance_delay: float) -> None:
+        self.end_of_utterance_delay = end_of_utterance_delay
+        self.transcription_delay = 0.12
+        self.timestamp = time.time()
+
+
+class _MetricsCollected:
+    def __init__(self, metrics: Any) -> None:
+        self.metrics = metrics
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    monkeypatch.delenv("VOICEGW_DB_URL", raising=False)
+    reset_session_id()
+    yield
+    reset_session_id()
+
+
+def _sink(tmp_path: Any) -> LocalSqliteSink:
+    return LocalSqliteSink(StorageService(str(tmp_path / "anchor.db")))
+
+
+async def _drain() -> None:
+    loop = asyncio.get_running_loop()
+
+    def _pending() -> list[Any]:
+        return [
+            t
+            for t in [*attach_mod._turn_tasks, *attach_mod._close_tasks]
+            if not t.done() and t.get_loop() is loop
+        ]
+
+    for _ in range(100):
+        pending = _pending()
+        if not pending:
+            await asyncio.sleep(0)
+            if not _pending():
+                return
+            continue
+        await asyncio.gather(*pending, return_exceptions=True)
+    raise AssertionError("turn event tasks never settled")
+
+
+async def _stored(sink: LocalSqliteSink, session_id: str) -> list[Any]:
+    from voicegateway.repository import turns_repository as turns
+
+    storage = sink._storage
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        return await turns.list_turns_by_session(db, session_id)
+
+
+async def _run_turn(session: Any, *, eou: float | None) -> None:
+    """One caller/agent exchange in the order LiveKit produces it."""
+    session.emit("user_state_changed", _UserState("listening", "speaking"))
+    await _drain()
+    # Fires at stop + silence window, NOT at the stop.
+    session.emit("user_state_changed", _UserState("speaking", "listening"))
+    await _drain()
+    if eou is not None:
+        session.emit("metrics_collected", _MetricsCollected(_EOU(eou)))
+        await _drain()
+    session.emit("agent_state_changed", _AgentState("thinking", "speaking"))
+    await _drain()
+    session.emit("agent_state_changed", _AgentState("speaking", "listening"))
+    await _drain()
+
+
+# --- the correction ------------------------------------------------------
+
+
+async def test_the_anchor_comes_from_the_eou_metric(tmp_path) -> None:
+    """The headline case, and the ordering trap in one.
+
+    The state change writes a stop first; the EOU metric arrives later and must
+    be allowed to replace it. A large delay is used so the corrected number
+    cannot be confused with the uncorrected one: measured from the state change
+    the gap here is a few milliseconds, measured from the true stop it is at
+    least the 0.689s of EOU delay.
+    """
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    await _run_turn(session, eou=0.689)
+    session.emit("close", _UserState("listening", "listening"))
+    await _drain()
+
+    [turn] = await _stored(sink, sid)
+    assert turn.response_speed_ms is not None, (
+        "the EOU correction never landed; the first-wins guard swallowed it"
+    )
+    assert turn.response_speed_ms >= 689, (
+        f"response_speed_ms is {turn.response_speed_ms}, which is smaller than "
+        "the 689ms of end-of-utterance delay it contains. That is the symptom: "
+        "the stop was taken from the state change, not the true anchor"
+    )
+
+
+async def test_response_speed_is_never_less_than_the_eou_it_contains(
+    tmp_path,
+) -> None:
+    """The invariant the consumer used to find this.
+
+    ``end_of_utterance_delay`` is the time from the caller's real stop to the
+    turn commit, and the agent cannot start speaking before the turn commits.
+    So the response speed strictly contains the EOU delay, and any value below
+    it is arithmetically impossible for a correctly anchored measurement.
+    """
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    eou_seconds = 0.42
+    await _run_turn(session, eou=eou_seconds)
+    session.emit("close", _UserState("listening", "listening"))
+    await _drain()
+
+    [turn] = await _stored(sink, sid)
+    assert turn.response_speed_ms is not None
+    assert turn.response_speed_ms >= int(eou_seconds * 1000), (
+        f"{turn.response_speed_ms}ms < {int(eou_seconds * 1000)}ms of contained "
+        "EOU delay"
+    )
+
+
+async def test_without_an_eou_metric_the_speed_is_absent_not_wrong(
+    tmp_path,
+) -> None:
+    """No usable anchor means no number, not a flattering one.
+
+    Reporting the state-change value here would put two populations half a
+    second apart into one percentile, and nothing downstream could tell them
+    apart. The gap is visible; the mixture is not.
+    """
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    await _run_turn(session, eou=None)
+    session.emit("close", _UserState("listening", "listening"))
+    await _drain()
+
+    [turn] = await _stored(sink, sid)
+    assert turn.response_speed_ms is None, (
+        "an uncorrected turn reported a response speed anyway"
+    )
+    # The boundary itself is still recorded: a 0.55s error is noise in talk
+    # time, where it is most of the number in a latency headline.
+    assert turn.caller_speak_end_ms is not None
+
+
+async def test_an_unmeasurable_eou_is_not_treated_as_zero(tmp_path) -> None:
+    """``0.0`` means "could not measure", not "no delay".
+
+    LiveKit publishes ``end_of_utterance_delay=info.metrics.end_of_turn_delay
+    or 0.0`` and returns None for a stale or missing anchor, so zero is the
+    unmeasured case far more often than a real one. Correcting by zero would
+    re-stamp the biased value and label it precise, which is worse than leaving
+    it alone.
+    """
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    await _run_turn(session, eou=0.0)
+    session.emit("close", _UserState("listening", "listening"))
+    await _drain()
+
+    [turn] = await _stored(sink, sid)
+    assert turn.response_speed_ms is None, (
+        "a zero EOU delay was taken as a real measurement and used to 'correct' "
+        "the anchor, which silently keeps the biased value"
+    )
+
+
+async def test_two_turns_each_get_their_own_correction(tmp_path) -> None:
+    """The precise flag has to reset with the turn, or turn 2 refuses its own."""
+    sink = _sink(tmp_path)
+    session = _Session()
+    sid = voicegateway.attach(session, project="p", sink=sink)
+
+    await _run_turn(session, eou=0.30)
+    await _run_turn(session, eou=0.30)
+    session.emit("close", _UserState("listening", "listening"))
+    await _drain()
+
+    rows = await _stored(sink, sid)
+    assert [r.turn_index for r in rows] == [0, 1]
+    for row in rows:
+        assert row.response_speed_ms is not None, (
+            f"turn {row.turn_index} was not corrected; the precise latch did "
+            "not reset between turns"
+        )
+        assert row.response_speed_ms >= 300
+
+
+# --- the tracker's own contract ------------------------------------------
+
+
+async def test_a_precise_report_overwrites_an_imprecise_one() -> None:
+    """The ordering trap, stated directly on the tracker.
+
+    This is the failure mode where everything looks fine: the imprecise value
+    always arrives first, so a plain first-wins guard discards the correction,
+    the tests still pass, and not one number moves.
+    """
+    captured: list[list[TurnRow]] = []
+
+    async def flush(rows: list[TurnRow]) -> None:
+        captured.append(rows)
+
+    tracker = TurnTracker(flush_callback=flush, flush_size=100)
+    await tracker.on_user_started_speaking(session_id="s", at_ms=1000)
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=2000)  # biased
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=1450, precise=True)
+    await tracker.on_agent_audio_first_frame(session_id="s", at_ms=2500)
+    await tracker.close_session("s")
+
+    [turn] = captured[0]
+    assert turn.caller_speak_end_ms == 1450, "the correction was discarded"
+    assert turn.response_speed_ms == 1050
+
+
+async def test_a_second_precise_report_does_not_overwrite() -> None:
+    """Precise is a one-way upgrade, not a free-for-all."""
+    captured: list[list[TurnRow]] = []
+
+    async def flush(rows: list[TurnRow]) -> None:
+        captured.append(rows)
+
+    tracker = TurnTracker(flush_callback=flush, flush_size=100)
+    await tracker.on_user_started_speaking(session_id="s", at_ms=1000)
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=1450, precise=True)
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=1600, precise=True)
+    await tracker.on_agent_audio_first_frame(session_id="s", at_ms=2500)
+    await tracker.close_session("s")
+
+    [turn] = captured[0]
+    assert turn.caller_speak_end_ms == 1450
+
+
+async def test_an_imprecise_report_never_overwrites_a_precise_one() -> None:
+    """Order-independence: the correction can legitimately arrive first."""
+    captured: list[list[TurnRow]] = []
+
+    async def flush(rows: list[TurnRow]) -> None:
+        captured.append(rows)
+
+    tracker = TurnTracker(flush_callback=flush, flush_size=100)
+    await tracker.on_user_started_speaking(session_id="s", at_ms=1000)
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=1450, precise=True)
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=2000)
+    await tracker.on_agent_audio_first_frame(session_id="s", at_ms=2500)
+    await tracker.close_session("s")
+
+    [turn] = captured[0]
+    assert turn.caller_speak_end_ms == 1450
+
+
+async def test_without_the_gate_an_uncorrected_turn_still_reports() -> None:
+    """``precise_end_required`` is opt-in, so other transports are unaffected.
+
+    A framework whose stop event is the real stop should keep getting a number.
+    Only the LiveKit path sets the gate.
+    """
+    captured: list[list[TurnRow]] = []
+
+    async def flush(rows: list[TurnRow]) -> None:
+        captured.append(rows)
+
+    tracker = TurnTracker(flush_callback=flush, flush_size=100)
+    await tracker.on_user_started_speaking(session_id="s", at_ms=1000)
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=1500)
+    await tracker.on_agent_audio_first_frame(session_id="s", at_ms=2000)
+    await tracker.close_session("s")
+
+    [turn] = captured[0]
+    assert turn.response_speed_ms == 500


### PR DESCRIPTION
`response_speed_ms` was understated by the VAD silence window (0.55s with Silero's default). It biased in the flattering direction, so it read as good latency rather than a bug.

## Confirmed against 1.6.8 and 1.6.9, not inferred

```python
# agent_activity.on_end_of_speech
speech_end_time = time.time() - ev.silence_duration - ev.inference_duration
self._session._update_user_state("listening", last_speaking_time=speech_end_time)
```

The handler runs only after voice activity waits out `min_silence_duration`. LiveKit backdates the true stop into `last_speaking_time`, but `_update_user_state` passes it to a **tracing span**, and `UserStateChangedEvent` carries only `old_state`, `new_state` and a `created_at` stamped at delivery. It never reaches a subscriber.

The symptom is arithmetic: `response_speed_ms` came out **smaller than the `eou_ms` for the same turn**, which is impossible for a number that contains it.

## The correction

`EOUMetrics.end_of_utterance_delay` is `max(now - last_speaking_time, 0)`. Subtracting it from when the metric was produced recovers the anchor with no hardcoded VAD setting, so it tracks whatever a deployment configures. `capture.py` already receives that metric and is session-scoped alongside the tracker, so it routes the anchor rather than re-subscribing.

## Two things not in the report, both load-bearing

**`0.0` does not mean "no delay".** LiveKit publishes `end_of_utterance_delay=info.metrics.end_of_turn_delay or 0.0`, and `_compute_end_of_turn_metrics` returns `None` for a stale anchor (`last_speaking_time < speech_start_time`, issue #6093). So zero is the *unmeasured* case far more often than a real one, and correcting by zero would re-stamp the biased value and label it precise. Non-positive is ignored, with a test.

**The clocks differ.** The metric's `timestamp` is `time.time()`; `TurnTracker` works in `time.monotonic()`. Only a delta crosses between them — how long ago the metric was produced, so handler scheduling isn't charged to the caller's silence. Never an absolute.

## Option (b), as recommended

`pending_caller_end_ms` stays first-wins among equals; a precise report may overwrite an imprecise one **exactly once**. That is required, not cosmetic: the imprecise value always arrives first, so a plain first-wins guard discards the correction and not one number moves. There's a dedicated regression test for that failure mode.

**Anchors are not mixed.** `precise_end_required` is set on the LiveKit path, and an uncorrected turn reports `response_speed_ms = None` rather than a value half a second too good. `caller_speak_end_ms` keeps the coarse boundary: the same 0.55s is noise in talk time and most of the number in a latency headline.

**Known cost:** a LiveKit session emitting no EOU metric at all (a realtime model with no STT turn detection) now reports no response speed instead of a biased one. That is the intended trade, and why the flag is opt-in rather than the tracker default.

## Not changed

`caller_speak_start_ms` is anchored on the transition into `speaking`, which fires after `min_speech_duration` (~50ms). Same class of bias, an order of magnitude smaller, and equally unpublished. Left alone with a comment rather than fixed blind.

## Three existing tests are modified — the thing to review

All three asserted a non-null response speed while emitting **no EOU metric**, which no real LiveKit turn does. I added `metrics_collected` to their sequences, which makes them more faithful and keeps every assertion they were written to make. Relaxing them to expect `None` would have deleted the coverage instead.

## Verification

- 8 of 9 new tests fail without the change
- **3408 passed**, up 9 from the 3389 baseline, exactly the tests added
- Two consecutive clean full runs
- `ruff` clean; `mypy` clean on every file touched here
- Pin untouched: `>=1.5,<1.7`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response-speed accuracy by anchoring caller speech-end times to end-of-utterance measurements.
  - Prevented imprecise timestamps from producing misleading response-speed metrics.
  - Allowed precise timing data to correct earlier estimates while preventing later inaccurate updates.
  - Preserved metric collection even if timing callbacks encounter errors.

- **Tests**
  - Added coverage for single-turn, multi-turn, and interrupted conversation timing scenarios.
  - Added validation for missing or zero timing measurements and correction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->