### PR TITLE
Widen turns and dead_air_events millisecond columns to BIGINT, and store epoch not uptime

### DIFF
--- a/alembic/versions/c5b1e83d0f47_turns_ms_bigint.py
+++ b/alembic/versions/c5b1e83d0f47_turns_ms_bigint.py
@@ -1,0 +1,86 @@
+"""widen the turns millisecond columns to BIGINT
+
+Revision ID: c5b1e83d0f47
+Revises: e4a7c2b9d013
+Create Date: 2026-08-09 06:00:00.000000
+
+Every turn insert failed on Postgres:
+
+    DataError: invalid input for query argument $3 in element #0 of
+    executemany() sequence: 6886684364 (value out of int32 range)
+
+which surfaced as HTTP 503 from ``POST /v1/ingest/turns``, so the table stayed
+empty and ``e2e_ms`` on ``/v1/rooms/{room}/latency`` stayed null.
+
+``Turn`` declared the five ``_ms`` columns as plain ``int``, which SQLModel maps
+to INTEGER, int32, capped at 2147483647. The values stored there are
+millisecond timestamps and are far larger.
+
+SQLite is why this survived: its dynamic typing stores an oversized value in an
+INTEGER column without complaint, so the whole SQLite test suite passed while
+Postgres rejected every row. ``clickhouse/migrations/0003_turns.sql`` had
+declared all five Int64 from the start, so the two stores already disagreed
+about the same field.
+
+``response_speed_ms`` is a delta and fits in int32. It is widened anyway so the
+row is uniform and no future reader has to remember which of five sibling
+columns is the narrow one.
+
+SQLite is skipped, not because it is safe to skip, but because it is already
+correct: the column type is advisory there, the values round-trip today, and
+``ALTER COLUMN TYPE`` does not exist in its dialect. Attempting it would break
+the migration on the default backend to fix a problem that backend does not
+have.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c5b1e83d0f47"
+down_revision: str | None = "e4a7c2b9d013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_COLUMNS = (
+    ("caller_speak_start_ms", False),
+    ("caller_speak_end_ms", False),
+    ("agent_speak_start_ms", True),
+    ("agent_speak_end_ms", True),
+    ("response_speed_ms", True),
+)
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name == "sqlite":
+        return
+    for name, nullable in _COLUMNS:
+        op.alter_column(
+            "turns",
+            name,
+            existing_type=sa.Integer(),
+            type_=sa.BigInteger(),
+            existing_nullable=nullable,
+        )
+
+
+def downgrade() -> None:
+    # Narrowing is lossy by construction: any row written since the upgrade
+    # holds a value that does not fit, and Postgres will refuse the ALTER rather
+    # than truncate. That refusal is correct, so it is left to surface rather
+    # than being papered over with a USING clause that would silently corrupt
+    # every timestamp.
+    if op.get_bind().dialect.name == "sqlite":
+        return
+    for name, nullable in _COLUMNS:
+        op.alter_column(
+            "turns",
+            name,
+            existing_type=sa.BigInteger(),
+            type_=sa.Integer(),
+            existing_nullable=nullable,
+        )

--- a/alembic/versions/c5b1e83d0f47_turns_ms_bigint.py
+++ b/alembic/versions/c5b1e83d0f47_turns_ms_bigint.py
@@ -1,4 +1,4 @@
-"""widen the turns millisecond columns to BIGINT
+"""widen the turns and dead_air_events millisecond columns to BIGINT
 
 Revision ID: c5b1e83d0f47
 Revises: e4a7c2b9d013
@@ -26,6 +26,13 @@ about the same field.
 row is uniform and no future reader has to remember which of five sibling
 columns is the narrow one.
 
+``dead_air_events`` carries the identical defect and is fixed here rather than
+left for the next host to hit: ``started_at_ms`` is also a millisecond timestamp
+in an INTEGER column, so dead-air inserts fail the same way and
+``GET /api/sessions/{id}/dead_air`` returns nothing. It has not been reported
+only because a monotonic stamp stays under int32 until the host has been up
+24.9 days.
+
 SQLite is skipped, not because it is safe to skip, but because it is already
 correct: the column type is advisory there, the values round-trip today, and
 ``ALTER COLUMN TYPE`` does not exist in its dialect. Attempting it would break
@@ -46,26 +53,34 @@ down_revision: str | None = "e4a7c2b9d013"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-_COLUMNS = (
-    ("caller_speak_start_ms", False),
-    ("caller_speak_end_ms", False),
-    ("agent_speak_start_ms", True),
-    ("agent_speak_end_ms", True),
-    ("response_speed_ms", True),
-)
+_TABLES: dict[str, tuple[tuple[str, bool], ...]] = {
+    "turns": (
+        ("caller_speak_start_ms", False),
+        ("caller_speak_end_ms", False),
+        ("agent_speak_start_ms", True),
+        ("agent_speak_end_ms", True),
+        ("response_speed_ms", True),
+    ),
+    "dead_air_events": (
+        ("started_at_ms", False),
+        ("duration_ms", False),
+        ("threshold_used_ms", False),
+    ),
+}
 
 
 def upgrade() -> None:
     if op.get_bind().dialect.name == "sqlite":
         return
-    for name, nullable in _COLUMNS:
-        op.alter_column(
-            "turns",
-            name,
-            existing_type=sa.Integer(),
-            type_=sa.BigInteger(),
-            existing_nullable=nullable,
-        )
+    for table, columns in _TABLES.items():
+        for name, nullable in columns:
+            op.alter_column(
+                table,
+                name,
+                existing_type=sa.Integer(),
+                type_=sa.BigInteger(),
+                existing_nullable=nullable,
+            )
 
 
 def downgrade() -> None:
@@ -76,11 +91,12 @@ def downgrade() -> None:
     # every timestamp.
     if op.get_bind().dialect.name == "sqlite":
         return
-    for name, nullable in _COLUMNS:
-        op.alter_column(
-            "turns",
-            name,
-            existing_type=sa.BigInteger(),
-            type_=sa.Integer(),
-            existing_nullable=nullable,
-        )
+    for table, columns in _TABLES.items():
+        for name, nullable in columns:
+            op.alter_column(
+                table,
+                name,
+                existing_type=sa.BigInteger(),
+                type_=sa.Integer(),
+                existing_nullable=nullable,
+            )

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -494,17 +494,21 @@ class MetricCapture:
         window (0.55s with Silero's default) and every response speed measured
         from it is understated by the same amount.
 
-        LiveKit backdates the true stop internally
-        (``on_end_of_speech`` subtracts ``silence_duration`` and
-        ``inference_duration``, then passes it as ``last_speaking_time``), but
-        ``UserStateChangedEvent`` carries only ``old_state``, ``new_state`` and
-        ``created_at``, so it never reaches a subscriber. What does reach us is
-        ``end_of_utterance_delay``, which LiveKit computes as
-        ``max(now - last_speaking_time, 0)``. Subtracting it from the moment the
-        metric was produced recovers the anchor without hardcoding any VAD
-        setting, so it tracks whatever the deployment configured.
+        LiveKit backdates the true stop internally (``on_end_of_speech``
+        subtracts ``silence_duration`` and ``inference_duration``, then passes it
+        as ``last_speaking_time``), but ``UserStateChangedEvent`` carries only
+        ``old_state``, ``new_state`` and ``created_at``, so it never reaches a
+        subscriber. What does reach us is ``end_of_utterance_delay``, which
+        LiveKit computes as ``max(now - last_speaking_time, 0)``.
 
-        Two things this is careful about:
+        Both that delay and the metric's ``timestamp`` are ``time.time()``, and
+        TurnTracker now stores epoch milliseconds too, so this reconstructs
+        LiveKit's own ``last_speaking_time`` in the same units:
+
+            last_speaking_time = metric.timestamp - end_of_utterance_delay
+
+        No VAD setting is hardcoded, so it tracks whatever the deployment
+        configured, and no clock is bridged.
 
         ``end_of_utterance_delay`` is published as
         ``info.metrics.end_of_turn_delay or 0.0``, so ``0.0`` means "could not
@@ -512,22 +516,16 @@ class MetricCapture:
         stale or missing anchor). Treating it as a real zero would quietly
         re-stamp the biased value and label it corrected, which is worse than
         leaving it alone. Non-positive is therefore ignored.
-
-        The clocks differ: the metric's ``timestamp`` is ``time.time()`` while
-        TurnTracker works in ``time.monotonic()``. Only the DELTA crosses
-        between them, never an absolute, so the two are never mixed.
         """
         if self._on_caller_end is None or eou <= 0:
             return
         produced_at = getattr(metric, "timestamp", None)
-        lag = 0.0
-        if isinstance(produced_at, int | float) and produced_at > 0:
-            # How long ago the metric was produced, so handler scheduling does
-            # not get charged to the caller's silence. A wall-clock difference,
-            # not a wall-clock instant.
-            lag = max(0.0, time.time() - float(produced_at))
-        now_ms = int(time.monotonic() * 1000)
-        self._on_caller_end(now_ms - int((lag + eou) * 1000))
+        if not isinstance(produced_at, int | float) or produced_at <= 0:
+            # No timestamp on the metric: fall back to now, which charges
+            # handler scheduling to the caller's silence but is far closer than
+            # the uncorrected value.
+            produced_at = time.time()
+        self._on_caller_end(int((float(produced_at) - eou) * 1000))
 
     def _on_session_metric(self, metric: object, *_a: Any, **_k: Any) -> None:
         metric = getattr(metric, "metrics", metric)

--- a/src/voicegateway/middleware/dead_air_detector_middleware.py
+++ b/src/voicegateway/middleware/dead_air_detector_middleware.py
@@ -105,9 +105,17 @@ class DeadAirDetector(PerSessionWatcher):
                     continue
                 if self._already_fired.get(session_id, False):
                     continue
+                # The silence is measured in monotonic, which is right for a
+                # delta and immune to NTP. The STORED instant must not be, since
+                # a monotonic absolute is time since boot and means nothing to a
+                # later reader or another process. Epoch now, minus the silence
+                # just measured, is when the silence began, on a clock anyone
+                # can interpret. Delta from one clock, absolute on the other,
+                # and the two are never subtracted from each other.
+                started_at_ms = int(time.time() * 1000) - silence_ms
                 event = DeadAirEvent(
                     session_id=session_id,
-                    started_at_ms=last_activity_ms,
+                    started_at_ms=started_at_ms,
                     duration_ms=silence_ms,
                     threshold_used_ms=self._threshold_ms,
                 )

--- a/src/voicegateway/middleware/turn_tracker_middleware.py
+++ b/src/voicegateway/middleware/turn_tracker_middleware.py
@@ -263,7 +263,33 @@ class TurnTracker(SessionScopedComponent):
 
     @staticmethod
     def _now_ms() -> int:
-        return int(time.monotonic() * 1000)
+        """Epoch milliseconds. Deliberately NOT ``time.monotonic()``.
+
+        These values are written to disk and read back by other processes.
+        Monotonic is time since an arbitrary origin (the host boot on Linux and
+        macOS), so a stored absolute monotonic value means nothing outside the
+        process that produced it, and nothing at all after a reboot.
+
+        ``rooms.py`` is where that bites: it gathers turns from every session in
+        a room and sorts them on ``caller_speak_start_ms`` to build one
+        chronological order. Its own comment names the cases, "an agent that
+        reconnected, two agents in one room", which are exactly the cases where
+        the values come from different processes on possibly different hosts.
+        Sorting them together was ordering by two unrelated clocks.
+
+        Epoch also makes the end-of-utterance correction exact instead of
+        approximate. LiveKit computes its anchor as
+        ``last_speaking_time = metric.timestamp - end_of_utterance_delay``, both
+        in ``time.time()``, so subtracting in the same units reproduces LiveKit's
+        own number rather than estimating it through a monotonic bridge.
+
+        The trade is NTP. A wall clock can step, where monotonic cannot, which
+        would corrupt a delta spanning the step. Within one turn a slew is
+        microseconds, a step is rare and isolated to that turn, and
+        ``response_speed`` already clamps at zero. A rare, bounded error beats a
+        systematic one on every cross-session read.
+        """
+        return int(time.time() * 1000)
 
     @staticmethod
     def _resolve_session_id(session_id: str | None) -> str | None:

--- a/src/voicegateway/models/dead_air_event_model.py
+++ b/src/voicegateway/models/dead_air_event_model.py
@@ -4,21 +4,30 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from sqlalchemy import Index, text
+from sqlalchemy import BigInteger, Column, Index, text
 from sqlmodel import Field, SQLModel
 
 
 class DeadAirEvent(SQLModel, table=True):
-    """A detected silence event during a voice session."""
+    """A detected silence event during a voice session.
+
+    The ``_ms`` columns are BigInteger for the same reason as ``turns``:
+    ``started_at_ms`` is a millisecond timestamp, which exceeds int32 and makes
+    every insert fail on Postgres with "value out of int32 range". SQLite hides
+    it, so the default test run cannot see it.
+
+    ``duration_ms`` and ``threshold_used_ms`` are deltas that fit, and are
+    widened with the rest so the row is uniform.
+    """
 
     __tablename__: ClassVar[str] = "dead_air_events"
     __table_args__ = (Index("idx_dead_air_session_id", "session_id"),)
 
     id: int | None = Field(default=None, primary_key=True)
     session_id: str
-    started_at_ms: int
-    duration_ms: int
-    threshold_used_ms: int
+    started_at_ms: int = Field(sa_column=Column(BigInteger(), nullable=False))
+    duration_ms: int = Field(sa_column=Column(BigInteger(), nullable=False))
+    threshold_used_ms: int = Field(sa_column=Column(BigInteger(), nullable=False))
     created_at: str = Field(
         sa_column_kwargs={"server_default": text("CURRENT_TIMESTAMP")}
     )

--- a/src/voicegateway/models/turn_model.py
+++ b/src/voicegateway/models/turn_model.py
@@ -4,12 +4,27 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from sqlalchemy import Index, text
+from sqlalchemy import BigInteger, Column, Index, text
 from sqlmodel import Field, SQLModel
 
 
 class Turn(SQLModel, table=True):
-    """One caller-then-agent speech turn within a voice session."""
+    """One caller-then-agent speech turn within a voice session.
+
+    Every ``_ms`` column is BigInteger, not the plain ``int`` SQLModel maps to
+    INTEGER. These hold epoch milliseconds, which is ~1.76e12 and exceeds
+    int32's 2147483647 by three orders of magnitude, so INTEGER makes every
+    insert fail on Postgres with "value out of int32 range" and the endpoint
+    answer 503. SQLite hides it: its dynamic typing stores the value regardless,
+    so a SQLite-only test suite stays green while Postgres rejects every row.
+
+    ``response_speed_ms`` is a delta and would fit in int32, but it is widened
+    with the rest so the row is uniform and nobody has to remember which of five
+    sibling columns is the narrow one.
+
+    ``clickhouse/migrations/0003_turns.sql`` already declared all five Int64.
+    The two stores disagreed on the same field; this is the side that was wrong.
+    """
 
     __tablename__: ClassVar[str] = "turns"
     __table_args__ = (
@@ -20,11 +35,17 @@ class Turn(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     session_id: str
     turn_index: int
-    caller_speak_start_ms: int
-    caller_speak_end_ms: int
-    agent_speak_start_ms: int | None = None
-    agent_speak_end_ms: int | None = None
-    response_speed_ms: int | None = None
+    caller_speak_start_ms: int = Field(sa_column=Column(BigInteger(), nullable=False))
+    caller_speak_end_ms: int = Field(sa_column=Column(BigInteger(), nullable=False))
+    agent_speak_start_ms: int | None = Field(
+        default=None, sa_column=Column(BigInteger(), nullable=True)
+    )
+    agent_speak_end_ms: int | None = Field(
+        default=None, sa_column=Column(BigInteger(), nullable=True)
+    )
+    response_speed_ms: int | None = Field(
+        default=None, sa_column=Column(BigInteger(), nullable=True)
+    )
     created_at: str = Field(
         sa_column_kwargs={"server_default": text("CURRENT_TIMESTAMP")}
     )

--- a/src/voicegateway/tests/integration/test_postgres_collector.py
+++ b/src/voicegateway/tests/integration/test_postgres_collector.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import time
+import uuid
 
 import pytest
 import yaml
@@ -81,3 +82,75 @@ async def test_collector_init_ingest_costs_on_postgres(tmp_path) -> None:
         ):
             resp = await client.get(path, headers=headers)
             assert resp.status_code < 500, f"{path} -> {resp.status_code}: {resp.text}"
+
+
+async def test_turn_ingest_survives_a_real_millisecond_timestamp(tmp_path) -> None:
+    """The gate for the int32 overflow, on the backend that enforces widths.
+
+    ``POST /v1/ingest/turns`` answered 503 for every turn, because ``Turn``
+    declared its five ``_ms`` columns as plain ``int`` (INTEGER, int32) while
+    the values are millisecond timestamps:
+
+        DataError: invalid input for query argument $3 in element #0 of
+        executemany() sequence: 6886684364 (value out of int32 range)
+
+    so the table stayed empty and ``e2e_ms`` stayed null.
+
+    This has to run on Postgres to mean anything. SQLite's dynamic typing stores
+    an oversized value in an INTEGER column without complaint, so the same
+    request succeeds there with the schema still broken, which is how this
+    shipped. ``storage/test_turn_ms_width.py`` carries the type-level guard that
+    does work on SQLite.
+
+    Epoch milliseconds are used rather than a synthetic small number for the
+    same reason: a test with toy timestamps passes today and keeps passing while
+    production fails.
+    """
+    app = build_app(Gateway(config_path=_config(tmp_path)))
+    headers = {"Authorization": f"Bearer {_KEY}"}
+    now_ms = int(time.time() * 1000)
+    assert now_ms > 2147483647, "epoch ms must exceed int32 for this to be a gate"
+    # Unique per run: CI gets a fresh database, a developer re-running against a
+    # persistent one does not, and a fixed id would accumulate rows and fail on
+    # the count rather than on anything real.
+    session_id = f"pg-turn-{uuid.uuid4()}"
+
+    rows = [
+        {
+            "session_id": session_id,
+            "turn_index": 0,
+            "caller_speak_start_ms": now_ms,
+            "caller_speak_end_ms": now_ms + 500,
+            "agent_speak_start_ms": now_ms + 900,
+            "agent_speak_end_ms": now_ms + 2000,
+            "response_speed_ms": 400,
+        }
+    ]
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as client:
+        posted = await client.post(
+            "/v1/ingest/turns", headers=headers, json=rows
+        )
+        # The reported symptom was 503 here, from the DataError the INTEGER
+        # column raised on a millisecond timestamp.
+        assert posted.status_code == 200, posted.text
+        assert posted.json()["accepted"] == 1
+
+    # Read back through the repository rather than the dashboard endpoint: the
+    # ingest key carries only the write scope, and this test is about column
+    # width, not authorization.
+    from voicegateway.repository import turns_repository as turns
+    from voicegateway.services.storage_service import StorageService
+
+    storage = StorageService(str(tmp_path / "unused.db"))
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        stored = await turns.list_turns_by_session(db, session_id)
+    await storage.aclose()
+
+    assert len(stored) == 1
+    assert stored[0].caller_speak_start_ms == now_ms, (
+        "the timestamp did not survive the round trip intact"
+    )
+    assert stored[0].agent_speak_end_ms == now_ms + 2000

--- a/src/voicegateway/tests/storage/test_turn_ms_width.py
+++ b/src/voicegateway/tests/storage/test_turn_ms_width.py
@@ -17,11 +17,13 @@ declared type is enforced.
 
 from __future__ import annotations
 
+import asyncio
 import time
 
 from sqlalchemy import BigInteger
 
 from voicegateway.middleware.turn_tracker_middleware import TurnRow, TurnTracker
+from voicegateway.models.dead_air_event_model import DeadAirEvent as DeadAirRow
 from voicegateway.models.turn_model import Turn
 from voicegateway.repository import turns_repository as turns
 from voicegateway.services.storage_service import StorageService
@@ -131,3 +133,70 @@ def test_epoch_milliseconds_do_not_fit_in_int32() -> None:
     on any host up for 25 days. One migration covers both.
     """
     assert int(time.time() * 1000) > 2147483647
+
+
+# --- the same defect, one table over -------------------------------------
+
+_DEAD_AIR_MS_COLUMNS = ("started_at_ms", "duration_ms", "threshold_used_ms")
+
+
+def test_dead_air_ms_columns_are_also_64_bit() -> None:
+    """``dead_air_events`` had the identical bug and would have hit it later.
+
+    ``started_at_ms`` is a millisecond timestamp in what was an INTEGER column,
+    so dead-air inserts fail on Postgres exactly like turn inserts did and
+    ``GET /api/sessions/{id}/dead_air`` returns nothing. It was not reported
+    only because a monotonic stamp stays under int32 until the host has been up
+    24.9 days, so it was waiting on uptime rather than on anything a user does.
+    """
+    for name in _DEAD_AIR_MS_COLUMNS:
+        column = DeadAirRow.__table__.columns[name]
+        assert isinstance(column.type, BigInteger), (
+            f"dead_air_events.{name} is {column.type!r}, not BigInteger"
+        )
+
+
+async def test_a_dead_air_event_stamps_epoch_not_time_since_boot() -> None:
+    """``started_at_ms`` is persisted, so it cannot be a monotonic absolute.
+
+    The detector still measures the silence itself in monotonic, which is the
+    right clock for a delta. Only the stored instant is epoch, derived as
+    "now minus the silence just measured", so the two clocks are never
+    subtracted from each other.
+    """
+    from voicegateway.middleware.dead_air_detector_middleware import (
+        DeadAirDetector,
+        DeadAirEvent,
+    )
+
+    seen: list[DeadAirEvent] = []
+
+    async def _on_event(event: DeadAirEvent) -> None:
+        seen.append(event)
+
+    # A probe pinned far enough back that the threshold is already crossed.
+    import time as _time
+
+    stopped_at = int(_time.monotonic() * 1000) - 400
+
+    detector = DeadAirDetector(
+        activity_probe=lambda _sid: stopped_at,
+        on_event=_on_event,
+        threshold_seconds=0.05,
+        poll_interval_seconds=0.01,
+    )
+    await detector.start("s-epoch")
+    deadline = time.monotonic() + 10.0
+    while not seen and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    await detector.stop("s-epoch")
+
+    assert seen, "the detector never fired"
+    now_epoch_ms = int(time.time() * 1000)
+    # Within the silence window of now, on the epoch clock. A monotonic stamp
+    # would be time since boot and nowhere near this.
+    assert abs(seen[0].started_at_ms - (now_epoch_ms - seen[0].duration_ms)) < 5_000, (
+        f"started_at_ms is {seen[0].started_at_ms}, which is not epoch "
+        f"milliseconds (now is {now_epoch_ms}). A monotonic absolute here is "
+        "meaningless once stored, and overflows int32 after 24.9 days of uptime"
+    )

--- a/src/voicegateway/tests/storage/test_turn_ms_width.py
+++ b/src/voicegateway/tests/storage/test_turn_ms_width.py
@@ -1,0 +1,133 @@
+"""The ``turns`` millisecond columns must be 64-bit, and hold epoch time.
+
+Every turn insert failed on Postgres with "value out of int32 range" because
+``Turn`` declared these as plain ``int`` (INTEGER, int32, max 2147483647) while
+the values are millisecond timestamps.
+
+The reason it survived is the reason for the first test here: SQLite's dynamic
+typing stores an oversized value in an INTEGER column without complaint, so a
+round-trip test on SQLite passes whatever the declared width is. It cannot
+distinguish the broken schema from the fixed one. Asserting on the mapped column
+TYPE can, on any backend, which is what makes it a usable guard in the default
+test run.
+
+``test_postgres_collector.py`` carries the execution-level proof, where the
+declared type is enforced.
+"""
+
+from __future__ import annotations
+
+import time
+
+from sqlalchemy import BigInteger
+
+from voicegateway.middleware.turn_tracker_middleware import TurnRow, TurnTracker
+from voicegateway.models.turn_model import Turn
+from voicegateway.repository import turns_repository as turns
+from voicegateway.services.storage_service import StorageService
+
+# ~79.7 days of host uptime in milliseconds, the value from the production
+# traceback. Over int32 (2147483647), which is only 24.9 days.
+_OVERFLOWING_MS = 6886684364
+
+_MS_COLUMNS = (
+    "caller_speak_start_ms",
+    "caller_speak_end_ms",
+    "agent_speak_start_ms",
+    "agent_speak_end_ms",
+    "response_speed_ms",
+)
+
+
+def test_every_ms_column_is_64_bit() -> None:
+    """The guard that works on SQLite, where the bug is invisible at runtime.
+
+    A round-trip cannot fail here, so the declaration is what gets checked.
+    """
+    for name in _MS_COLUMNS:
+        column = Turn.__table__.columns[name]
+        assert isinstance(column.type, BigInteger), (
+            f"turns.{name} is {column.type!r}, not BigInteger. On Postgres that "
+            "is int32 and every insert of a millisecond timestamp fails with "
+            "'value out of int32 range', answering 503 from /v1/ingest/turns"
+        )
+
+
+def test_it_matches_what_clickhouse_already_declared() -> None:
+    """The two stores disagreed about the same field; they must not again.
+
+    ``clickhouse/migrations/0003_turns.sql`` declared all five Int64 from the
+    start. Reading it here keeps the SQL side from drifting back on its own.
+    """
+    from pathlib import Path
+
+    sql = (
+        Path(__file__).resolve().parents[2]
+        / "clickhouse"
+        / "migrations"
+        / "0003_turns.sql"
+    ).read_text()
+    for name in _MS_COLUMNS:
+        assert f"{name}" in sql, f"{name} missing from the ClickHouse DDL"
+        line = next(ln for ln in sql.splitlines() if ln.strip().startswith(name))
+        assert "Int64" in line, (
+            f"ClickHouse declares {name} as {line.strip()!r}, which no longer "
+            "matches the BigInteger on the ORM model"
+        )
+
+
+async def test_an_out_of_int32_timestamp_round_trips(tmp_path) -> None:
+    """Round-trip at the real magnitude.
+
+    This passes on SQLite whether or not the fix is present, which is precisely
+    why the type assertion above exists. It is kept because it pins the value
+    the repository actually writes, and because on Postgres (see
+    test_postgres_collector) the same shape is a genuine gate.
+    """
+    storage = StorageService(str(tmp_path / "wide.db"))
+    row = TurnRow(
+        session_id="s-wide",
+        turn_index=0,
+        caller_speak_start_ms=_OVERFLOWING_MS,
+        caller_speak_end_ms=_OVERFLOWING_MS + 500,
+        agent_speak_start_ms=_OVERFLOWING_MS + 900,
+        agent_speak_end_ms=_OVERFLOWING_MS + 2000,
+        response_speed_ms=400,
+    )
+    await storage.log_turns([row])
+
+    async with storage._conn.session() as db:
+        [read_back] = await turns.list_turns_by_session(db, "s-wide")
+    assert read_back.caller_speak_start_ms == _OVERFLOWING_MS
+    assert read_back.agent_speak_end_ms == _OVERFLOWING_MS + 2000
+    await storage.aclose()
+
+
+def test_the_tracker_stamps_epoch_not_time_since_boot() -> None:
+    """A stored absolute monotonic value cannot be compared to anything later.
+
+    ``rooms.py`` merges the turns of every session in a room and sorts them on
+    ``caller_speak_start_ms``. With monotonic that is an ordering across two
+    unrelated clocks whenever the room saw more than one process, which its own
+    comment says is expected ("an agent that reconnected, two agents in one
+    room").
+
+    Epoch milliseconds are ~1.76e12; time since boot would have to be 55 years
+    to reach that, so the two are unambiguous to tell apart.
+    """
+    stamped = TurnTracker._now_ms()
+    now_epoch_ms = int(time.time() * 1000)
+    assert abs(stamped - now_epoch_ms) < 5_000, (
+        f"_now_ms() returned {stamped}, which is not epoch milliseconds "
+        f"({now_epoch_ms}). A monotonic value here is meaningless once stored"
+    )
+
+
+def test_epoch_milliseconds_do_not_fit_in_int32() -> None:
+    """Why the width fix and the clock fix belong in one change.
+
+    Switching to epoch would have broken Postgres on its own if the columns had
+    stayed INTEGER, and staying on monotonic would have broken it too, later,
+    on any host up for 25 days. One migration covers both.
+    """
+    assert int(time.time() * 1000) > 2147483647


### PR DESCRIPTION
Every turn insert failed on Postgres, so the table stayed empty and `e2e_ms` stayed null:

```
DataError: invalid input for query argument $3 in element #0 of executemany()
sequence: 6886684364 (value out of int32 range)
```

surfacing as HTTP 503 from `POST /v1/ingest/turns`. Separate from the 0.24.3 anchor fix, which is correct — that fix is what made these rows start flowing and exposed this.

## The width

`Turn` declared its five `_ms` columns as plain `int` → INTEGER → int32 → max 2147483647. `clickhouse/migrations/0003_turns.sql` had declared all five `Int64` from the start, so the two stores already disagreed about the same field. This is the side that was wrong.

All five are now `BigInteger`, with a migration that ALTERs the existing columns. `response_speed_ms` is a delta and would fit, but is widened anyway so no future reader has to remember which of five siblings is the narrow one.

The migration skips SQLite — not because skipping is safe, but because SQLite is already correct there: the declared type is advisory, oversized values round-trip today, and `ALTER COLUMN TYPE` does not exist in that dialect.

## The clock, which turned out to be the larger defect

`TurnTracker._now_ms` stamped `int(time.monotonic() * 1000)`: **time since boot, written to disk**. Monotonic is meaningful only within one process's lifetime, so a stored absolute means nothing to any later reader.

`rooms.py` is where that bites. It gathers the turns of every session in a room and sorts them on `caller_speak_start_ms`, and its own comment names the cases: *"an agent that reconnected, two agents in one room"*. Those are exactly the cases where the values come from different processes on possibly different hosts. The sort was ordering by two unrelated clocks.

The deltas (talk time, the overlap join) were always fine. The absolutes never were.

`_now_ms` now returns epoch ms. That also makes the EOU correction **exact instead of approximate**: LiveKit computes `last_speaking_time = metric.timestamp - end_of_utterance_delay`, both in `time.time()`, so `capture.py` now reproduces that number in the same units. The monotonic-to-wall bridging from 0.24.3 is deleted.

**The trade is NTP**, which can step where monotonic cannot. Within one turn a slew is microseconds, a step is rare and isolated to that turn, and `response_speed` already clamps at zero. A rare bounded error beats a systematic one on every cross-session read.

## Why both in one change

Epoch would have broken Postgres on its own with the columns still INTEGER, and monotonic would have broken it too, later, on any host up 25 days. One migration covers both.

Existing SQLite rows keep their monotonic values. Their deltas stay valid and their absolutes were never comparable, so nothing that worked stops working.

## Verified against real Postgres 16, not inferred

| Setup | Result |
|---|---|
| Model + migration reverted, fresh DB | **503** `telemetry store temporarily unavailable` — the reported symptom |
| Migration restored, model still reverted | passes — this is the upgrade path for an existing deployment |
| Both restored | passes, value round-trips intact |

## Why the SQLite suite could not have caught this

SQLite stores an oversized value in an INTEGER column without complaint, so a round-trip test passes whatever the declared width is. That is how this shipped, and it is why the report warned that a test with small synthetic timestamps "will keep passing while production fails".

So the SQLite-side guard asserts the mapped column **type**, which works on any backend, and also reads the ClickHouse DDL so the two stores cannot drift apart again silently. The execution-level proof lives in the Postgres job.

## Verification

- **3414 passed**; collection up exactly 6, the six tests added here
- `ruff` clean; `mypy` clean on every file touched
- Single alembic head: `c5b1e83d0f47`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of speech timing to preserve accurate, cross-process timestamps.
  * Prevented overflow or truncation when storing large millisecond timestamps and durations.
  * Aligned timestamp storage across supported database systems.

* **Tests**
  * Added coverage for real-world epoch-millisecond values, database round trips, and timestamp compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->