### PR TITLE
Add GET /api/nodes/live, the newest node sample per target

### DIFF
--- a/docs/api/dashboard-api.md
+++ b/docs/api/dashboard-api.md
@@ -371,6 +371,53 @@ A series the scrape did not return is named and counted rather than dropped or z
 
 Authentication matches `/api/correlation`, including the 403 for a tenant-scoped key: a node is infrastructure serving every tenant at once, so there is no tenant-scoped answer to give.
 
+## GET /api/nodes/live
+
+The newest sample per `(node, source)`, for watching a fleet **while** something is happening to it. `/api/nodes` above answers "what did the boxes look like during this call" and is keyed by recent calls; this answers "what is the fleet doing now" and is keyed by the targets themselves.
+
+It adds no collection. The collector already scrapes every target on its interval and writes `node_samples`; this is a read of rows that are already on disk. There is no WebSocket: a caller that wants a live view polls this.
+
+**Query parameters**
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `stale_after_seconds` | `15` (one scrape interval) | How old a target's newest sample may be before it is reported `stale`. Max `300`. |
+
+**Response:**
+
+```json
+{
+  "stale_after_seconds": 15.0,
+  "samples_stored": 4210,
+  "nodes": [
+    {
+      "node": "sfu-1",
+      "source": "livekit-server",
+      "at_ms": 1786276490564,
+      "age_seconds": 3.1,
+      "stale": false,
+      "outcome": "ok",
+      "rooms": 12,
+      "participants": 48,
+      "packet_bytes_total": 91823741,
+      "load1": null
+    }
+  ]
+}
+```
+
+Every stored column keeps its own name and value. A column the scrape did not return arrives as `null`, never `0`: an idle node and an unwatched one must stay distinguishable, and the unwatched one is the emergency.
+
+One entry per `(node, source)` pair, not per node. The same box is usually scraped twice per tick (once as `livekit-server`, once as `node-exporter`), and each exporter sees a different set of series.
+
+`stale` says only that nothing has been written for that target for longer than `stale_after_seconds`. It is **not a health verdict**: it cannot distinguish a dead node from a stopped exporter from a collector that is not running. `outcome` on the row is what says why a scrape failed when one did happen. The reading itself is still served when stale rather than withheld, because the last thing a node reported is often what you want to see; it is labelled so it cannot be mistaken for current.
+
+An empty `nodes` with a non-zero `samples_stored` means every target has aged out of the table. With `samples_stored` at `0`, nothing has ever been scraped here.
+
+`503` when storage is disabled, rather than an empty fleet: "nothing is scraped" and "this deployment records nothing" are different facts.
+
+Authentication matches `/api/nodes`, including the 403 for a tenant-scoped key, and for the same reason.
+
 ## GET /api/server/overview
 
 A read-only, non-billing snapshot of the LiveKit deployment the metered agents run on, annotated with VoiceGateway's own cost and latency: rooms, egress, ingress, SIP trunks/dispatch rules (from the LiveKit control plane), plus the local fleet roster. This is a control-plane list and a local DB read on every field: **no synthetic probe and no billed call**, unlike Diagnostics.

--- a/src/voicegateway/repository/node_samples_repository.py
+++ b/src/voicegateway/repository/node_samples_repository.py
@@ -38,7 +38,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select, text
+from sqlalchemy import and_, func, select, text
 
 from voicegateway.models.node_sample_model import NodeSample
 
@@ -790,6 +790,110 @@ async def trim_older_than(
     return removed
 
 
+@dataclass(frozen=True)
+class LatestNodeSample:
+    """The newest sample for one ``(node, source)`` target, with its age.
+
+    ``age_ms`` is measured against a caller-supplied ``now_ms`` rather than a
+    clock read in here, so every target in one response is aged against ONE
+    instant. Reading the clock per row would let the first and last target in a
+    large fleet be judged against different nows, and a target could be reported
+    fresh or stale depending on where it happened to sit in the list.
+
+    ``stale`` is the whole reason this dataclass exists rather than a bare row.
+    The newest sample for a dead target is still a sample: it has real numbers
+    in it and no field that says they stopped being true. A caller polling a
+    live view would render the last reading a crashed node ever produced
+    exactly like a healthy one, and the longer the node stays dead the more
+    confidently wrong the view gets.
+    """
+
+    sample: NodeSampleRow
+    age_ms: int
+    stale: bool
+
+
+async def latest_per_target(
+    db: AsyncSession,
+    *,
+    now_ms: int,
+    stale_after_ms: int,
+) -> list[LatestNodeSample]:
+    """The newest sample for every ``(node, source)``, ordered by node then source.
+
+    One row per target, never a window: this answers "what is the fleet doing
+    right now", where :func:`list_samples` answers "what did this target do over
+    this span".
+
+    The newest row is selected by ``(at_ms, id)``, the same ordering
+    ``list_samples`` uses, so two samples sharing a timestamp resolve the same
+    way in both. Without the ``id`` tiebreak "the latest" would be whichever the
+    backend happened to return first, which is not stable across backends or
+    even across runs.
+
+    Done as one grouped query rather than discovering targets and then reading
+    each: a fleet scraped by three exporters is 3N round trips the other way,
+    against a SQLite writer that is also absorbing scrapes.
+
+    ``stale_after_ms`` is the caller's definition of "should have been replaced
+    by now", not a policy decided here. A row is stale when nothing has arrived
+    for longer than the scrape interval, because by then the next scrape was
+    already due and did not land.
+    """
+    # Grouped max on at_ms, not on id: id alone would pick the highest rowid
+    # rather than the newest sample, and those differ whenever a scrape is
+    # written out of order. The (node, source, at_ms) index leads with the pair,
+    # so this is an index scan rather than a table scan.
+    at_max = (
+        select(
+            NodeSample.node.label("n"),  # type: ignore[attr-defined]
+            NodeSample.source.label("s"),  # type: ignore[attr-defined]
+            func.max(NodeSample.at_ms).label("max_at_ms"),
+        )
+        .group_by(
+            NodeSample.node,
+            NodeSample.source,
+        )
+        .subquery()
+    )
+    stmt = (
+        select(NodeSample)
+        .join(
+            at_max,
+            and_(
+                NodeSample.node == at_max.c.n,  # type: ignore[arg-type]
+                NodeSample.source == at_max.c.s,  # type: ignore[arg-type]
+                NodeSample.at_ms == at_max.c.max_at_ms,  # type: ignore[arg-type]
+            ),
+        )
+        .order_by(
+            NodeSample.node.asc(),  # type: ignore[attr-defined]
+            NodeSample.source.asc(),  # type: ignore[attr-defined]
+            NodeSample.id.desc(),  # type: ignore[union-attr]
+        )
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+
+    out: list[LatestNodeSample] = []
+    seen: set[tuple[str, str]] = set()
+    for sample in rows:
+        key = (sample.node, sample.source)
+        if key in seen:
+            # Two samples share the newest at_ms; the id DESC ordering above put
+            # the tiebreak winner first, so the rest are skipped.
+            continue
+        seen.add(key)
+        age_ms = now_ms - sample.at_ms
+        out.append(
+            LatestNodeSample(
+                sample=_row(sample),
+                age_ms=age_ms,
+                stale=age_ms > stale_after_ms,
+            )
+        )
+    return out
+
+
 async def count_samples(db: AsyncSession, *, node: str | None = None) -> int:
     """How many samples are stored (optionally for one node). For tests and ops."""
     if node is None:
@@ -810,12 +914,14 @@ __all__ = [
     "GAUGE_COLUMNS",
     "VALUE_COLUMNS",
     "CounterRate",
+    "LatestNodeSample",
     "NodeSampleInput",
     "NodeSampleRow",
     "UtilisationPoint",
     "count_samples",
     "counter_rates",
     "insert_samples",
+    "latest_per_target",
     "list_samples",
     "read_counter_rate",
     "trim_older_than",

--- a/src/voicegateway/server/api/dashboard/nodes_live.py
+++ b/src/voicegateway/server/api/dashboard/nodes_live.py
@@ -1,0 +1,146 @@
+"""Dashboard endpoint: GET /api/nodes/live, what the fleet is doing right now.
+
+The sibling of ``dashboard/nodes.py`` and deliberately not the same question.
+``GET /api/nodes`` is per-CALL correlation: keyed by recent calls, capped at ten
+of them, read once per mount. It answers "what did the boxes look like during
+this call". Neither it nor ``dashboard/loadtest.py`` (which lists IMPORTED runs,
+and a run is imported after it has finished) can answer "what is the fleet doing
+while this campaign is in flight", which is what a load-test runner needs to
+show a fleet live.
+
+**This adds no collection.** The rows are already on disk: the collector scrapes
+every target on its own interval and writes ``node_samples``. This is a read of
+what is already there. VoiceGateway profiles; it does not gain the ability to
+run anything, and this endpoint must not become the place that changes.
+
+The design rules are ``dashboard/nodes.py``'s, for the same reasons:
+
+* **A NULL is data.** Every ``None`` the repository produced is forwarded as
+  ``null`` and none is defaulted to 0. The whole T3 design stores NULL rather
+  than 0 so the last hop can tell an unmeasured series from a measured zero, and
+  a live view is exactly where flattening it would do the most harm: a node
+  whose exporter stopped answering would render as a node carrying no traffic.
+* **Pure passthrough.** Nothing here computes. Which row is newest, how old it
+  is and whether that makes it stale are all decided in
+  ``node_samples_repository.latest_per_target``. This handler adds no field and
+  no verdict of its own.
+* **A stale target is not a healthy zero.** The newest sample for a dead target
+  is still a sample, with real numbers in it and no field that says they stopped
+  being true. Every entry therefore carries ``age_seconds`` and ``stale``, and
+  the response carries the ``stale_after_seconds`` it judged against, so a
+  reader can see the threshold rather than infer it. Without that, a crashed
+  node renders identically to a healthy one and gets more convincing the longer
+  it stays down.
+* **Polled, never pushed.** The dashboard has zero WebSocket by design. A caller
+  that wants a live view polls this, which is why the freshness fields are part
+  of the payload rather than something the transport implies.
+
+Auth is declared ONCE on the router, as ``dashboard/nodes.py`` does it: a
+per-handler dependency is a thing a later handler can forget.
+:func:`require_principal` is the dependency the sibling dashboard reads use.
+
+A tenant-bound principal is refused rather than served, for the reason
+``dashboard/nodes.py`` gives: ``node_samples`` has no tenant dimension at all,
+because a node is infrastructure and serves every tenant at once. There is no
+scoped answer to give, and serving the deployment-wide one to a tenant key would
+publish every other tenant's infrastructure. The self-hosted operator default
+(no credential, or a static config key) is an admin principal and is unaffected.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from voicegateway.server.api._deps import (
+    Principal,
+    get_gateway,
+    require_principal,
+)
+
+if TYPE_CHECKING:
+    from voicegateway.core.gateway import Gateway
+
+router = APIRouter(
+    prefix="/nodes",
+    tags=["dashboard"],
+    dependencies=[Depends(require_principal)],
+)
+
+# When a target's newest sample is old enough to stop calling it current.
+#
+# One scrape interval, not two: at one interval the next scrape was already due
+# and did not land, which is the earliest moment the data stops describing now.
+# A sample may legitimately be almost a full interval old, so this is the first
+# threshold that separates "waiting for the next tick" from "the tick did not
+# come".
+#
+# Restated here rather than imported from the scrape worker, which owns it as a
+# private default: the read side should not reach into the worker's internals,
+# and a guard test asserts the two stay equal so restating cannot drift into
+# disagreeing.
+DEFAULT_STALE_AFTER_SECONDS = 15.0
+
+# The widest a caller may loosen the freshness bar. Past this the word "live"
+# stops meaning anything: a five minute old reading of a fleet under a load
+# campaign describes a fleet that no longer exists.
+MAX_STALE_AFTER_SECONDS = 300.0
+
+
+@router.get("/live")
+async def get_live_nodes(
+    stale_after_seconds: float = Query(
+        DEFAULT_STALE_AFTER_SECONDS, gt=0, le=MAX_STALE_AFTER_SECONDS
+    ),
+    gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
+) -> dict[str, Any]:
+    """Return the newest ``node_samples`` row per ``(node, source)``.
+
+    Shape: ``{"stale_after_seconds": float, "samples_stored": int, "nodes":
+    [<node_samples row> + {"age_seconds": float, "stale": bool}]}``. The stored
+    columns keep their own names and values, so a NULL column arrives as
+    ``null``.
+
+    One entry per target, never a window. ``source`` is part of the key because
+    the same node is usually scraped twice per tick (once as ``livekit-server``
+    and once as ``node-exporter``), and collapsing them would drop half the
+    series or silently prefer one exporter's view of the box.
+
+    ``stale`` is not a health verdict about the node. It says only that nothing
+    has been written for this target for longer than ``stale_after_seconds``,
+    which can equally mean the node died, the exporter stopped answering, or the
+    collector is not running. The endpoint cannot tell those apart and does not
+    pretend to; ``outcome`` on the row itself is what says why a scrape failed
+    when one did happen.
+
+    An empty ``nodes`` list with a non-zero ``samples_stored`` means every
+    target has aged out of the table entirely; with ``samples_stored`` at 0 it
+    means nothing has ever been scraped here.
+
+    503 when storage is disabled, rather than an empty list: "nothing is
+    scraped" and "this deployment records nothing" are different facts, and the
+    reader must not be shown the first when the second is true.
+    """
+    if gateway.storage is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "storage is not configured, so no node sample could have been "
+                "recorded. This is not an idle fleet."
+            ),
+        )
+    if not principal.is_admin:
+        # See the module docstring: node samples have no tenant dimension, so
+        # the only alternatives are refusing and leaking.
+        raise HTTPException(
+            status_code=403,
+            detail="node samples are deployment-wide infrastructure and have no "
+            "per-tenant answer",
+        )
+    return await gateway.storage.latest_node_samples(
+        now_ms=int(time.time() * 1000),
+        stale_after_ms=int(stale_after_seconds * 1000),
+    )

--- a/src/voicegateway/server/routes.py
+++ b/src/voicegateway/server/routes.py
@@ -74,6 +74,9 @@ from voicegateway.server.api.dashboard import (
     nodes as dashboard_nodes,
 )
 from voicegateway.server.api.dashboard import (
+    nodes_live as dashboard_nodes_live,
+)
+from voicegateway.server.api.dashboard import (
     projects as dashboard_projects,
 )
 from voicegateway.server.api.dashboard import (
@@ -142,6 +145,12 @@ dashboard_router.include_router(dashboard_correlation.router)
 # is a weaker claim than "during this call" and a window nobody scraped is not a
 # healthy node.
 dashboard_router.include_router(dashboard_nodes.router)
+# GET /api/nodes/live. The same rows as /api/nodes above, asked the other
+# question: newest per (node, source) rather than overlapping a call's window,
+# so a caller polling during a load campaign can see the fleet now. Registered
+# after /api/nodes because both routers carry the /nodes prefix and the literal
+# /live path must not be shadowed by a parameterised sibling later.
+dashboard_router.include_router(dashboard_nodes_live.router)
 # GET /api/loadtest/runs. Read-only, so it belongs here behind
 # require_principal and NOT on the /v1/calls router, which carries
 # require_scope("write") on the router itself. Tests are embedded in each run

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -793,6 +793,50 @@ class StorageService:
                 )
         return {"pad_ms": resolved_pad, "samples_stored": stored, "calls": out}
 
+    async def latest_node_samples(
+        self, *, now_ms: int, stale_after_ms: int
+    ) -> dict[str, Any]:
+        """The newest sample per ``(node, source)``, for a live fleet view.
+
+        Shape: ``{"stale_after_seconds": float, "samples_stored": int,
+        "nodes": [{"node", "source", "at_ms", "age_seconds", "stale", ...the
+        stored columns unchanged}]}``.
+
+        A passthrough: the repository decides which row is newest and whether it
+        is stale, and this flattens the row onto the entry so a reader gets the
+        stored columns under their own names rather than nested a level down.
+        Every value stays exactly as stored, so a NULL arrives as ``null`` and
+        never as 0.
+
+        ``samples_stored`` is the whole table's row count, carried for the same
+        reason ``correlate_recent_calls_to_nodes`` carries it: with no scrape
+        target configured the node list is honestly empty, and only the row
+        count separates "this deployment scrapes nothing" from "the fleet is
+        quiet right now".
+        """
+        import dataclasses
+
+        from voicegateway.repository import node_samples_repository as node_samples
+
+        await self._ensure_initialized()
+        async with self._conn.session() as db:
+            stored = await node_samples.count_samples(db)
+            latest = await node_samples.latest_per_target(
+                db, now_ms=now_ms, stale_after_ms=stale_after_ms
+            )
+        return {
+            "stale_after_seconds": stale_after_ms / 1000.0,
+            "samples_stored": stored,
+            "nodes": [
+                {
+                    **dataclasses.asdict(entry.sample),
+                    "age_seconds": entry.age_ms / 1000.0,
+                    "stale": entry.stale,
+                }
+                for entry in latest
+            ],
+        }
+
     # ------------------------------------------------------------------
     # Diagnostics runs (LiveKit probe runs started from the dashboard)
     # ------------------------------------------------------------------

--- a/src/voicegateway/tests/server/test_nodes_live_endpoint.py
+++ b/src/voicegateway/tests/server/test_nodes_live_endpoint.py
@@ -1,0 +1,426 @@
+"""GET /api/nodes/live: the newest node sample per target, with its freshness.
+
+Four things these tests exist to hold:
+
+1. **One entry per (node, source), and it is the newest one.** The same node is
+   usually scraped twice per tick, once as ``livekit-server`` and once as
+   ``node-exporter``, so the key is the pair. Collapsing to the node alone would
+   drop half the series or silently prefer one exporter's view of the box.
+2. **A NULL is data.** Every unmeasured column arrives as ``null``. The T3
+   design stores NULL rather than 0 so the last hop can tell an unmeasured
+   series from a measured zero, and a live view is where flattening it does the
+   most harm: a node whose exporter went quiet would render as a node carrying
+   no traffic.
+3. **A stale target is not a healthy zero.** The newest sample for a dead target
+   is still a sample, with real numbers and nothing in it that says they stopped
+   being true. ``age_seconds`` and ``stale`` are what stop a crashed node
+   rendering identically to a live one.
+4. **Storage disabled is 503, not an empty fleet.** "Nothing is scraped" and
+   "this deployment records nothing" are different facts.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.repository import api_keys_repository as api_keys
+from voicegateway.repository import node_samples_repository as node_samples
+from voicegateway.server import build_app
+
+_URL = "/api/nodes/live"
+
+_BASE_CONFIG: dict = {
+    "providers": {"openai": {"api_key": "k"}},
+    "models": {"stt": {}, "llm": {}, "tts": {}},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+
+def _write_config(tmp_path, extra: dict | None = None) -> str:
+    path = tmp_path / "voicegw.yaml"
+    with open(path, "w") as fh:
+        yaml.dump({**_BASE_CONFIG, **(extra or {})}, fh)
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """No ambient api key deciding whether auth applies."""
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+
+
+@pytest.fixture
+def gateway(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "nodes-live.db"))
+    return Gateway(config_path=_write_config(tmp_path))
+
+
+@pytest.fixture
+async def client(gateway):
+    transport = ASGITransport(app=build_app(gateway))
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+async def _insert(
+    storage,
+    *,
+    node: str,
+    source: str,
+    at_ms: int,
+    outcome: str = "ok",
+    **values,
+) -> None:
+    """Write one scrape row straight through the repository."""
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        await node_samples.insert_samples(
+            db,
+            [
+                node_samples.NodeSampleInput(
+                    node=node,
+                    source=source,
+                    at_ms=at_ms,
+                    outcome=outcome,
+                    values=values,
+                )
+            ],
+        )
+
+
+def _entry(body: dict, node: str, source: str) -> dict:
+    matches = [
+        e for e in body["nodes"] if e["node"] == node and e["source"] == source
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one entry for ({node}, {source}), got {len(matches)}"
+    )
+    return matches[0]
+
+
+# --- one row per target, the newest ----------------------------------------
+
+
+async def test_serves_only_the_newest_sample_per_target(client, gateway):
+    """Three scrapes of one target collapse to the last one."""
+    now = _now_ms()
+    for offset, rooms in ((3000, 1), (2000, 2), (1000, 7)):
+        await _insert(
+            gateway.storage,
+            node="sfu-1",
+            source="livekit-server",
+            at_ms=now - offset,
+            rooms=rooms,
+        )
+
+    resp = await client.get(_URL)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body["nodes"]) == 1
+    assert _entry(body, "sfu-1", "livekit-server")["rooms"] == 7
+
+
+async def test_one_node_scraped_by_two_exporters_is_two_entries(client, gateway):
+    """``source`` is half the key. The same box reports different series to
+    each exporter, and merging them would drop one set."""
+    now = _now_ms()
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=now - 1000,
+        rooms=4,
+    )
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="node-exporter",
+        at_ms=now - 1000,
+        load1=0.5,
+    )
+
+    body = (await client.get(_URL)).json()
+
+    assert len(body["nodes"]) == 2
+    assert _entry(body, "sfu-1", "livekit-server")["rooms"] == 4
+    assert _entry(body, "sfu-1", "node-exporter")["load1"] == 0.5
+
+
+async def test_every_target_in_the_fleet_appears(client, gateway):
+    now = _now_ms()
+    for node in ("sfu-1", "sfu-2", "sip-1"):
+        await _insert(
+            gateway.storage,
+            node=node,
+            source="livekit-server",
+            at_ms=now - 500,
+            rooms=1,
+        )
+
+    body = (await client.get(_URL)).json()
+
+    assert sorted(e["node"] for e in body["nodes"]) == ["sfu-1", "sfu-2", "sip-1"]
+
+
+# --- a NULL is data --------------------------------------------------------
+
+
+async def test_an_unmeasured_column_arrives_as_null_never_zero(client, gateway):
+    """The distinction the whole T3 design exists to preserve.
+
+    ``rooms`` is measured at 0 here and ``participants`` was never scraped. If
+    both came back as 0 a reader could not tell an idle node from an unwatched
+    one, and the unwatched one is the emergency.
+    """
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=_now_ms() - 1000,
+        rooms=0,
+    )
+
+    entry = _entry((await client.get(_URL)).json(), "sfu-1", "livekit-server")
+
+    assert entry["rooms"] == 0, "a measured zero must survive as zero"
+    assert entry["participants"] is None, (
+        "an unmeasured series was defaulted to 0, which reads as a node "
+        "carrying no traffic rather than one nobody could see"
+    )
+    assert entry["packet_bytes_total"] is None
+
+
+async def test_a_failed_scrape_keeps_its_outcome_and_null_values(client, gateway):
+    """A row that failed is still served, because the failure is the news."""
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=_now_ms() - 1000,
+        outcome="timeout",
+    )
+
+    entry = _entry((await client.get(_URL)).json(), "sfu-1", "livekit-server")
+
+    assert entry["outcome"] == "timeout"
+    assert entry["rooms"] is None
+
+
+# --- freshness -------------------------------------------------------------
+
+
+async def test_a_target_past_the_window_is_reported_stale(client, gateway):
+    """The newest sample of a dead node still has real numbers in it.
+
+    Nothing on the row itself says they stopped being true, so without ``stale``
+    a crashed node renders exactly like a healthy one, and more convincingly the
+    longer it stays down.
+    """
+    now = _now_ms()
+    await _insert(
+        gateway.storage,
+        node="fresh",
+        source="livekit-server",
+        at_ms=now - 2_000,
+        rooms=1,
+    )
+    await _insert(
+        gateway.storage,
+        node="dead",
+        source="livekit-server",
+        at_ms=now - 120_000,
+        rooms=99,
+    )
+
+    body = (await client.get(_URL)).json()
+
+    fresh = _entry(body, "fresh", "livekit-server")
+    dead = _entry(body, "dead", "livekit-server")
+    assert fresh["stale"] is False
+    assert dead["stale"] is True, (
+        "a target whose newest sample is two minutes old was served as current"
+    )
+    # The reading is still there; it is labelled, not withheld.
+    assert dead["rooms"] == 99
+    assert dead["age_seconds"] >= 100
+
+
+async def test_the_threshold_travels_with_the_answer(client, gateway):
+    """A verdict whose threshold is invisible cannot be checked by the reader."""
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=_now_ms() - 1000,
+        rooms=1,
+    )
+
+    body = (await client.get(_URL)).json()
+
+    assert body["stale_after_seconds"] == 15.0
+
+
+async def test_the_caller_may_widen_the_window(client, gateway):
+    """The same sample, judged against a looser bar, is not stale."""
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=_now_ms() - 30_000,
+        rooms=1,
+    )
+
+    default = (await client.get(_URL)).json()
+    widened = (await client.get(f"{_URL}?stale_after_seconds=60")).json()
+
+    assert _entry(default, "sfu-1", "livekit-server")["stale"] is True
+    assert _entry(widened, "sfu-1", "livekit-server")["stale"] is False
+    assert widened["stale_after_seconds"] == 60.0
+
+
+async def test_an_absurd_window_is_refused(client):
+    """Past a few minutes the word "live" stops meaning anything."""
+    resp = await client.get(f"{_URL}?stale_after_seconds=99999")
+    assert resp.status_code == 422
+
+
+# --- empty and disabled are different --------------------------------------
+
+
+async def test_no_samples_is_an_empty_fleet_not_an_error(client):
+    body = (await client.get(_URL)).json()
+    assert body["nodes"] == []
+    assert body["samples_stored"] == 0
+
+
+async def test_samples_stored_separates_quiet_from_unconfigured(client, gateway):
+    """With no scrape target the list is honestly empty, and only the row count
+    says whether this deployment scrapes at all."""
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=_now_ms() - 1000,
+        rooms=1,
+    )
+
+    body = (await client.get(_URL)).json()
+
+    assert body["samples_stored"] == 1
+
+
+async def test_storage_disabled_returns_503_not_an_empty_fleet(tmp_path, monkeypatch):
+    """ "Nothing is scraped" and "this deployment records nothing" are
+    different facts."""
+    monkeypatch.delenv("VOICEGW_DB_PATH", raising=False)
+    config = _write_config(tmp_path, {"cost_tracking": {"enabled": False}})
+    gw = Gateway(config_path=config)
+    assert gw.storage is None
+    transport = ASGITransport(app=build_app(gw, enable_dashboard=False))
+
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get(_URL)
+
+    assert resp.status_code == 503
+    assert "not configured" in resp.json()["detail"]
+
+
+# --- auth ------------------------------------------------------------------
+
+
+async def test_the_operator_default_with_no_keys_still_reads_it(client, gateway):
+    """No credential = the self-hosted operator, unchanged."""
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=_now_ms() - 1000,
+        rooms=1,
+    )
+
+    resp = await client.get(_URL)
+
+    assert resp.status_code == 200
+    assert len(resp.json()["nodes"]) == 1
+
+
+async def test_a_tenant_key_is_refused_rather_than_shown_the_fleet(client, gateway):
+    """A node is infrastructure and serves every tenant at once, so there is no
+    scoped answer. Serving the deployment-wide one would publish every other
+    tenant's infrastructure."""
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=_now_ms() - 1000,
+        rooms=1,
+    )
+    async with gateway.storage._conn.session() as db:
+        created = await api_keys.create_api_key(db, name="acme-ui", tenant_id="acme")
+
+    resp = await client.get(
+        _URL, headers={"Authorization": f"Bearer {created.plaintext}"}
+    )
+
+    assert resp.status_code == 403
+
+
+# --- the threshold is not invented here ------------------------------------
+
+
+def test_the_default_window_matches_the_scrape_interval() -> None:
+    """Restated on the read side, so a guard keeps the two equal.
+
+    The endpoint must not decide on its own what "current" means. If the scrape
+    worker's interval changes and this does not, every target starts reporting
+    stale (or nothing ever does), and neither failure announces itself.
+    """
+    from voicegateway.middleware import node_samples_worker_middleware as worker
+    from voicegateway.server.api.dashboard import nodes_live
+
+    assert (
+        nodes_live.DEFAULT_STALE_AFTER_SECONDS
+        == worker._DEFAULT_POLL_INTERVAL_SECONDS
+    )
+
+
+async def test_two_samples_sharing_a_timestamp_resolve_stably(client, gateway):
+    """``id`` breaks the tie, the same way ``list_samples`` breaks it.
+
+    Without a tiebreak "the latest" is whichever row the backend happened to
+    return first, which is not stable across backends or even across runs, and
+    the live view would flicker between two readings of the same instant.
+    """
+    at_ms = _now_ms() - 1000
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=at_ms,
+        rooms=1,
+    )
+    await _insert(
+        gateway.storage,
+        node="sfu-1",
+        source="livekit-server",
+        at_ms=at_ms,
+        rooms=2,
+    )
+
+    first = _entry((await client.get(_URL)).json(), "sfu-1", "livekit-server")
+    second = _entry((await client.get(_URL)).json(), "sfu-1", "livekit-server")
+
+    assert first["rooms"] == 2, "the later-written row did not win the tie"
+    assert second["rooms"] == first["rooms"], "the answer was not stable"


### PR DESCRIPTION
A load-test runner needs to show a fleet live **while** a campaign is in flight, and nothing served that.

- `/api/loadtest/runs` lists IMPORTED runs, which by definition exist after the run finished.
- `/api/nodes` is per-CALL correlation: keyed by recent calls, capped at ten, read once per mount. It answers "what did the boxes look like during this call".

`GET /api/nodes/live` answers "what is the fleet doing now": the newest `node_samples` row per `(node, source)`.

## It adds no collection

The collector already scrapes every target on its interval and writes `node_samples`. This is a read of rows already on disk. No WebSocket, no execution. VoiceGateway profiles; it does not gain the ability to run anything.

## Built to `dashboard/nodes.py`'s rules

**A NULL is data.** Every `None` is forwarded as `null` and none is defaulted to `0`. A live view is where flattening that would do the most harm: a node whose exporter went quiet would render as a node carrying no traffic, which is the opposite of what happened.

**Pure passthrough.** Which row is newest, how old it is, and whether that makes it stale are all decided in `node_samples_repository.latest_per_target`. The handler adds no field and no verdict.

**A stale target is not a healthy zero.** The newest sample for a dead node is still a sample: real numbers, and nothing on the row saying they stopped being true. So every entry carries `age_seconds` and `stale`, and the response echoes the `stale_after_seconds` it judged against, so a reader sees the threshold rather than inferring it. The reading is labelled, not withheld, because the last thing a node reported is usually what you want to see.

**Polled, never pushed.** No WebSocket, which is why freshness is in the payload rather than implied by the transport.

**Auth once on the router**, and a tenant-bound principal is refused: `node_samples` has no tenant dimension, because a node is infrastructure serving every tenant at once. There is no scoped answer, and the deployment-wide one would publish every other tenant's infrastructure.

**503 when storage is disabled**, following `dashboard/loadtest.py`: "nothing is scraped" and "this deployment records nothing" are different facts.

## Two judgment calls worth review

**The threshold is one scrape interval, not two.** At one interval the next scrape was already due and did not land, which is the earliest honest moment to stop calling the data current. It is restated on the read side rather than imported from the worker's private default, with a guard test keeping the two equal — if the worker's interval changes and this does not, every target starts reporting stale (or nothing ever does), and neither failure announces itself.

**The query groups on `at_ms`, not `id`.** Grouping on `id` picks the highest rowid rather than the newest sample, and those differ whenever a scrape is written out of order. `id` is kept only as the tiebreak, matching `list_samples`. Tested: without it "the latest" is whichever row the backend returns first, which is not stable across runs, and a live view would flicker between two readings of the same instant.

One grouped query rather than discovering targets then reading each, which would be 3N round trips against a SQLite writer already absorbing scrapes.

## Tests

16, covering each case in the brief: one row per `(node, source)` and it is the newest; two exporters on one node stay two entries; a NULL arrives as `null` while a measured zero survives as zero; a target past the window is stale rather than current; a widened window changes that verdict; storage disabled is 503; a tenant key is refused; the operator default with no keys still reads it.

## Gate

`uvx ruff check src` clean. `mypy<2` clean at 285 files. **3432 passed**; collected tests 3426 to 3442, up exactly the 16 added, never decreased.

Docs updated at `docs/api/dashboard-api.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live node dashboard endpoint showing the latest sample for each node and data source.
  * Displays sample freshness, stale status, scrape outcomes, and missing metric values.
  * Supports configurable staleness thresholds and clearly distinguishes empty fleets from unavailable storage.
  * Access is restricted to authorized administrators.

* **Documentation**
  * Added API documentation covering response behavior, authentication, freshness rules, and storage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->