### PR TITLE
Refuse a per-node capacity when the rows are parallel generators

### DIFF
--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -565,6 +565,11 @@ def _capacity_for(tests: list[dict], plan: dict | None = None) -> dict:
             # artifact can answer. A row missing either end reports None, which
             # the derivation treats as unrecorded rather than as short.
             duration_seconds=_step_duration_seconds(test),
+            # The window fingerprint. Rows written by parallel generators all
+            # report the same fleet over the same window, and this is what lets
+            # the derivation notice rather than sizing a node from one
+            # generator's share.
+            samples_in_window=test.get("node_samples_in_window"),
         )
         for test in tests
     ]

--- a/src/voicegateway/loadtest/capacity.py
+++ b/src/voicegateway/loadtest/capacity.py
@@ -156,6 +156,16 @@ class RampStep:
     # turn a missing field into a missing capacity table. The derivation says so
     # in its reason instead, so the gap is visible rather than acted on.
     duration_seconds: float | None = None
+    # How many node samples the step's window covered. Not used to measure
+    # anything: it is the WINDOW FINGERPRINT, and it exists so concurrent
+    # generators can be told apart from sequential ramp steps.
+    #
+    # Two steps that ran one after another looked at different stretches of
+    # time, so they cannot have seen the same number of samples AND the same
+    # peak CPU. Two generator processes running side by side over one window
+    # see exactly that, because both are reading the same fleet. Without this
+    # the two are indistinguishable and a parallel run is sized as a ramp.
+    samples_in_window: int | None = None
 
 
 @dataclass(frozen=True)
@@ -404,6 +414,34 @@ def _steady_state_steps(
     return eligible, too_short, unrecorded
 
 
+def concurrent_generators(steps: list[RampStep]) -> int:
+    """How many steps share one measurement window, or 0 if none do.
+
+    A sequential ramp holds one concurrency, measures, then moves to the next.
+    Its steps therefore look at DIFFERENT stretches of time, and cannot report
+    the same peak CPU from the same number of node samples.
+
+    Generator processes running side by side report exactly that, because each
+    one is reading the whole fleet over the whole run. When they do, the rows
+    are not ramp steps at all: each ``peak_concurrency`` is what ONE GENERATOR
+    carried, and the fleet carried their sum, spread over however many nodes
+    were serving. None of those three numbers is the same thing, and only the
+    first is in the artifact.
+
+    Matched on the pair rather than on CPU alone: two genuinely separate steps
+    can coincidentally peak at the same utilisation, but not while also covering
+    an identical sample count.
+    """
+    windows: dict[tuple[float, int], int] = {}
+    for step in steps:
+        if step.peak_cpu_utilisation is None or step.samples_in_window is None:
+            continue
+        key = (step.peak_cpu_utilisation, step.samples_in_window)
+        windows[key] = windows.get(key, 0) + 1
+    largest = max(windows.values(), default=0)
+    return largest if largest > 1 else 0
+
+
 def derive_calls_per_node(
     steps: list[RampStep],
     *,
@@ -424,7 +462,8 @@ def derive_calls_per_node(
       generator's limit sized as a node's limit buys the wrong fleet.
     * No step reached the CPU ceiling. The node was never saturated, so the
       largest concurrency observed is a floor on its capacity, not a measure of
-      it, and sizing from it would UNDER-provision.
+      it. Sizing from a floor treats it as a maximum and buys MORE nodes than
+      the run showed were needed, so it OVER-provisions.
     * Nothing measured CPU at all. An unscraped ramp demonstrates nothing.
     * No step declared what it asked for, so a plateau could not be ruled out.
       "No plateau detected" from a ramp that recorded neither targets nor rates
@@ -485,6 +524,28 @@ def derive_calls_per_node(
             "rather than the node's, and sizing from it would be a guess" + tail
         )
 
+    # Concurrent generators, checked BEFORE any concurrency is quoted. Every
+    # branch below reads a step's peak_concurrency as a number one node carried,
+    # and on a parallel run that is a per-GENERATOR figure. Quoting it in a
+    # sentence about a node is the whole defect: a reader sizes a fleet from a
+    # number that is smaller than the truth by the generator count, deploys more
+    # nodes than the run showed were needed, and the report never says so.
+    shared = concurrent_generators(steps)
+    if shared > 1:
+        carried = sum(s.peak_concurrency or 0 for s in steps)
+        return None, (
+            f"{shared} of these {len(steps)} entries report the same peak CPU "
+            f"over the same {steps[0].samples_in_window} node samples, so they "
+            "measured ONE window rather than a sequence of capacity steps. They "
+            "are generator processes running in parallel, not a ramp. Each "
+            "peak concurrency is what one GENERATOR carried"
+            + (f" (summing to {carried} across the fleet)" if carried else "")
+            + ", and per-node capacity is that total divided by the number of "
+            "nodes that served it, which this artifact does not record. Re-run "
+            "as a ramp that raises concurrency in held steps, or supply the "
+            "serving node count, and this can be derived" + tail
+        )
+
     # Narrowed into concrete pairs rather than filtered in place: a step is only
     # evidence when it carries BOTH halves, and pulling them out here means
     # nothing downstream has to re-assert that they are present.
@@ -517,7 +578,8 @@ def derive_calls_per_node(
             f"no step reached the {cpu_ceiling:.0%} CPU ceiling (peak observed "
             f"{highest:.1%}), so the node was never saturated. It carries AT "
             f"LEAST {best} calls, which is a floor on its capacity and not a "
-            "measure of it: sizing from it would under-provision" + tail
+            "measure of it: sizing from a floor buys MORE nodes than the run "
+            "showed were needed, so it over-provisions" + tail
         )
 
     return best, (
@@ -570,6 +632,7 @@ __all__ = [
     "PlateauFinding",
     "RampStep",
     "capacity_table",
+    "concurrent_generators",
     "derive_calls_per_node",
     "detect_plateau",
     "nodes_for",

--- a/src/voicegateway/tests/loadtest/test_capacity.py
+++ b/src/voicegateway/tests/loadtest/test_capacity.py
@@ -147,10 +147,17 @@ def test_a_plateaued_ramp_yields_no_figure_at_all() -> None:
 
 
 def test_a_node_never_saturated_yields_a_floor_not_a_measure() -> None:
-    """Sizing from an unsaturated node under-provisions.
+    """Sizing from an unsaturated node OVER-provisions.
 
     Every step stayed well under the ceiling, so the largest concurrency seen is
-    a lower bound on capacity, not capacity.
+    a lower bound on capacity, not capacity. Treating that floor as the maximum
+    divides the target by too small a number, so it buys MORE nodes than the run
+    showed were needed. ``nodes_for`` demonstrates it: a 500-call target sized
+    from a true 300/node needs 3 nodes, and sized from a 200/node floor needs 4.
+
+    The assertion below read "under-provision" until 2026-08, matching the
+    wording in the message it checked. Both were backwards, and the report told
+    operators the opposite of what over-sizing does to their bill.
     """
     gentle = [
         RampStep(target_concurrency=n, peak_concurrency=n, peak_cpu_utilisation=cpu)
@@ -159,7 +166,8 @@ def test_a_node_never_saturated_yields_a_floor_not_a_measure() -> None:
     value, reason = capacity.derive_calls_per_node(gentle, cpu_ceiling=0.70)
     assert value is None
     assert "AT LEAST 200" in reason
-    assert "under-provision" in reason
+    assert "over-provisions" in reason
+    assert "under-provision" not in reason
 
 
 def test_a_properly_saturated_ramp_yields_the_highest_sustained_concurrency() -> None:
@@ -517,3 +525,128 @@ def test_the_duration_filter_runs_before_the_plateau_scan() -> None:
     _value, reason = capacity.derive_calls_per_node(steps, cpu_ceiling=0.70)
     assert "ran for under 300s" in reason
     assert "stopped scaling" not in reason
+
+
+# --- parallel generators are not a ramp -------------------------------------
+
+
+def _parallel_generators(
+    count: int = 12,
+    *,
+    per_process_peak: int = 51,
+    cpu: float = 0.5465968586387453,
+    samples: int = 1374,
+) -> list[RampStep]:
+    """Rows shaped like a real churn run: N generators, one shared window.
+
+    Every field that varies between genuine ramp steps is identical here, which
+    is the point. The processes all watched the same fleet for the same 20
+    minutes, so they report the same peak CPU from the same sample count, and
+    only ``peak_concurrency`` is theirs alone.
+    """
+    return [
+        RampStep(
+            target_concurrency=per_process_peak,
+            peak_concurrency=per_process_peak,
+            peak_cpu_utilisation=cpu,
+            duration_seconds=1200.0,
+            samples_in_window=samples,
+        )
+        for _ in range(count)
+    ]
+
+
+def test_parallel_generators_are_detected_as_one_window() -> None:
+    steps = _parallel_generators()
+    assert capacity.concurrent_generators(steps) == 12
+
+
+def test_a_real_ramp_is_not_mistaken_for_parallel_generators() -> None:
+    """Sequential steps see different windows, so they must still derive.
+
+    The detector keys on the pair, so a ramp whose steps happen to share a CPU
+    reading is safe as long as their sample counts differ, which for genuinely
+    separate stretches of time they do.
+    """
+    ramp = [
+        RampStep(
+            target_concurrency=n,
+            peak_concurrency=n,
+            peak_cpu_utilisation=cpu,
+            duration_seconds=600.0,
+            samples_in_window=samples,
+        )
+        for n, cpu, samples in (
+            (100, 0.31, 300),
+            (150, 0.48, 305),
+            (200, 0.66, 298),
+            (250, 0.79, 301),
+        )
+    ]
+    assert capacity.concurrent_generators(ramp) == 0
+    value, _reason = capacity.derive_calls_per_node(ramp, cpu_ceiling=0.70)
+    assert value == 200
+
+
+def test_parallel_generators_do_not_yield_a_per_node_capacity() -> None:
+    """The regression this exists for.
+
+    Twelve generator processes each peaked at 51 while the fleet carried 612
+    across four SIP nodes, which is 153 per node. The report used to answer
+    "it carries AT LEAST 51 calls", a per-generator number in a sentence about
+    a node. An operator sizing from 51 buys three times the nodes the run
+    showed were needed.
+    """
+    value, reason = capacity.derive_calls_per_node(
+        _parallel_generators(), cpu_ceiling=0.70
+    )
+
+    assert value is None, f"a per-node capacity was derived from 12 generators: {value}"
+    assert "51" not in reason.replace("612", ""), (
+        "the per-generator concurrency is still quoted in the refusal, which is "
+        f"how it was read as a per-node figure: {reason}"
+    )
+    assert "AT LEAST" not in reason
+    # It must say WHY, and name the missing input rather than implying the run
+    # was fine.
+    assert "parallel" in reason
+    assert "612" in reason, "the fleet total is what a reader needs to size from"
+    assert "node" in reason
+
+
+def test_the_refusal_names_the_missing_divisor() -> None:
+    """A refusal that does not say what would fix it just looks like a bug."""
+    _value, reason = capacity.derive_calls_per_node(
+        _parallel_generators(), cpu_ceiling=0.70
+    )
+    assert "node count" in reason or "number of nodes" in reason
+
+
+def test_one_generator_is_not_treated_as_parallel() -> None:
+    """A single row shares a window with nothing, so the ramp path still runs."""
+    single = _parallel_generators(count=1)
+    assert capacity.concurrent_generators(single) == 0
+    value, reason = capacity.derive_calls_per_node(single, cpu_ceiling=0.70)
+    # Unsaturated, so it still refuses, but by the floor path rather than this
+    # one: the two refusals are different facts.
+    assert value is None
+    assert "parallel" not in reason
+
+
+def test_steps_missing_the_fingerprint_are_not_guessed_at() -> None:
+    """No sample count means the question cannot be answered, so it is not.
+
+    Older artifacts carry no window fingerprint. Treating absence as "not
+    parallel" is the existing behaviour and is the safe direction here: it
+    leaves those runs exactly as they were rather than refusing retroactively.
+    """
+    unfingerprinted = [
+        RampStep(
+            target_concurrency=51,
+            peak_concurrency=51,
+            peak_cpu_utilisation=0.54,
+            duration_seconds=1200.0,
+        )
+        for _ in range(12)
+    ]
+    assert capacity.concurrent_generators(unfingerprinted) == 0


### PR DESCRIPTION
The capacity block read each entry in `tests[]` as a ramp step on one node. They are load-generator **processes**.

A run with 12 generators against 4 SIP nodes therefore reported per-process concurrency in a sentence about a node:

> It carries AT LEAST **51** calls, which is a floor on its capacity and not a measure of it: sizing from it would under-provision

The fleet carried **612** concurrent across **4** nodes, which is **153 per node**. An operator sizing from 51 buys roughly three times the nodes the run showed were needed, and twelve times that if they read 51 as the whole fleet's per-node figure.

## The rows already said they were not a ramp

All 12 report `peak_cpu_utilisation` `0.5465968586387453` and `node_samples_in_window` `1374`, byte-identical, each spanning the full 1200s run.

Sequential steps look at different stretches of time and cannot produce that. Parallel processes reading one fleet over one window produce exactly it. Nothing was reading the signal.

## The fix

`RampStep` gains `samples_in_window`, the window fingerprint, and `concurrent_generators()` reports how many steps share a window. When more than one does, the derivation refuses **before any concurrency is quoted**, because every branch below it reads `peak_concurrency` as a number one node carried.

Matched on the `(cpu, samples)` **pair**, not CPU alone: two genuine steps can coincidentally peak alike, but not while also covering an identical sample count.

Against the real artifact it now reads:

> 12 of these 12 entries report the same peak CPU over the same 1374 node samples, so they measured ONE window rather than a sequence of capacity steps. They are generator processes running in parallel, not a ramp. Each peak concurrency is what one GENERATOR carried (summing to 612 across the fleet), and per-node capacity is that total divided by the number of nodes that served it, which this artifact does not record.

**Took option (b) of the two suggested.** Dividing by a node count recovered from gate subject strings would put a real number there, but it would come from parsing labels rather than from anything the run measured. This codebase's rule for an absent value is to say so, and a null with the missing input named beats a confident wrong number.

## "under-provision" was backwards, same sentence

Treating a floor as a maximum divides the target by too small a number and buys **more** nodes. That is over-provisioning. Demonstrated with the module's own `nodes_for`:

| Sized from | Nodes for 500 concurrent |
|---|---|
| true 300/node | 3 |
| 200/node floor | 4 |

The first refusal in the same function already said "over-provisions" for the identical shape, so the file disagreed with itself.

## One existing test changed, and it is the one to review

`test_a_node_never_saturated_yields_a_floor_not_a_measure` asserted `"under-provision" in reason`, and its docstring said sizing from an unsaturated node under-provisions. It **encoded the bug rather than catching it**. It now asserts the corrected direction and records what it used to claim.

## Tests

Seven added, including the regression asked for: 12 processes, per-process peak 51, shared window. It asserts no per-node figure is derived, that **51 no longer appears in the refusal at all**, that the fleet total does, and that the missing divisor is named.

Also held: a ramp whose steps have distinct sample counts still derives 200 as before; one generator is not treated as parallel; rows carrying no fingerprint are left exactly as they were rather than refused retroactively.

**3438 passed.** `ruff` and `mypy` clean.

## Not in this PR

Three further issues were reported alongside this one. I verified all three against the same artifact but left them out, because each is a distinct defect in a different module and folding them in would make this unreviewable:

1. **`gates[]` repeats each fact once per process.** Confirmed: 1423 rows collapse to 169 distinct `(metric, subject, value)`, and 26 FAILs to 4. Headline counts like "worst of N measured" overstate by the generator count.
2. **`process_restarts` over-claims.** Confirmed: a FAIL reads "restarted during the window" for a start time of `1786373687`, while the window opens at `1786374592`, so the reported start is **905s before the window**. The gate detected that the reported start time changed, which is a weaker claim. The PASS wording on the same gate ("held one process start time") is already accurate, so the two disagree.
3. **The appendix is static.** Ships unchanged regardless of the run it describes.

Happy to take them next, separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load-test capacity calculations when multiple generators report data from the same observation window.
  * Prevented per-generator measurements from being used to derive misleading per-node capacity.
  * Updated under-saturation guidance to identify potential over-provisioning.
  * Preserved existing behavior for sequential ramps and measurements without window data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->