### PR TITLE
Say what the lifecycle gate measured, not what it inferred

### DIFF
--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -1797,8 +1797,21 @@ class LifecycleReading:
     """One subject's process-start times and OOM counter across a window.
 
     ``start_times`` is ``process_start_time_seconds`` in time order. It is a
-    CONSTANT for the life of a process, so any increase inside a window means
-    that process restarted mid-run, and a crash presents exactly that way.
+    CONSTANT for the life of one process, so an increase means the series is no
+    longer being served by the process that was serving it.
+
+    That is NOT the same as "it restarted mid-run", and the difference is
+    decidable: compare the new start time against ``window_start_s``. A process
+    that restarted during the window started during the window, so its new start
+    time falls inside it. A new start time that PREDATES the window belongs to a
+    process that was already running before the run began, which means the
+    series moved to a different process rather than one process restarting. A
+    scrape target list refreshed mid-run does exactly that, and both machines
+    can have been up for hours.
+
+    Both are findings, because counter rates across the change are unusable
+    either way, and both fail. Only the claim differs, and the gate must make
+    the one it can support.
 
     ``oom_kills`` is ``node_vmstat_oom_kill``, cumulative since boot, so an
     increase inside the window means the kernel killed something DURING the run.
@@ -1812,6 +1825,10 @@ class LifecycleReading:
     source: str | None = None
     start_times: tuple[float | None, ...] = ()
     oom_kills: tuple[float | None, ...] = ()
+    # When the window opened, epoch seconds, so a new start time can be placed
+    # inside or before it. None means the caller did not supply it, and the gate
+    # then makes the weaker claim rather than guessing which case it has.
+    window_start_s: float | None = None
 
 
 def _rose(values: Sequence[float | None]) -> tuple[bool, float | None, float | None]:
@@ -1847,15 +1864,50 @@ def process_lifecycle_gate(reading: LifecycleReading) -> GateResult:
     measured_ooms = [v for v in reading.oom_kills if v is not None]
 
     if restarted:
+        # What is MEASURED is that the series stopped being served by the
+        # process that was serving it. Whether that was a restart depends on
+        # where the new start time falls, and saying "restarted during the
+        # window" without checking asserts a cause the data may contradict.
+        started_inside = (
+            reading.window_start_s is not None
+            and last_start is not None
+            and last_start >= reading.window_start_s
+        )
+        predates_window = (
+            reading.window_start_s is not None
+            and last_start is not None
+            and last_start < reading.window_start_s
+        )
+        if started_inside:
+            claim = (
+                f"{subject} restarted during the window: the process serving it "
+                f"changed and the new process started at {last_start}, inside "
+                "the window. A crash presents this way too, so this covers both"
+            )
+        elif predates_window:
+            ago = reading.window_start_s - last_start  # type: ignore[operator]
+            claim = (
+                f"the process serving {subject} changed during the window, and "
+                f"it did NOT restart inside it: the new process reports a start "
+                f"time of {last_start}, which is {ago:.0f}s BEFORE the window "
+                "opened, so it was already running when the run began. The "
+                "series moved between processes, which a scrape target list "
+                "refreshed mid-run will do"
+            )
+        else:
+            claim = (
+                f"the process serving {subject} changed during the window: "
+                "whether it restarted cannot be said, because the window start "
+                "was not supplied to compare the new start time against"
+            )
         return GateResult(
             gate=PROCESS_LIFECYCLE_GATE,
             status=FAIL,
             subject=subject,
             detail=(
-                f"{subject} restarted during the window: "
-                f"process_start_time_seconds rose from {first_start} to "
-                f"{last_start}. A crash presents this way too, so this covers "
-                "both, and every counter rate across the restart is unusable."
+                f"{claim}. process_start_time_seconds rose from {first_start} "
+                f"to {last_start}, and every counter rate across the change is "
+                "unusable whichever of the two it was."
             ),
             metric="process_restarts",
             value=1.0,

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -349,6 +349,12 @@ async def _lifecycle_reading(
         source=source,
         start_times=tuple(row.process_start_time_seconds for row in rows),
         oom_kills=tuple(row.vmstat_oom_kill for row in oom_rows),
+        # Epoch SECONDS: process_start_time_seconds is in seconds and the two
+        # are compared directly, where the window is carried in milliseconds.
+        # Without this the gate cannot tell a process that restarted inside the
+        # window from a series that moved to a process which was already
+        # running before it, and it used to call both a restart.
+        window_start_s=window.start_ms / 1000.0,
     )
 
 

--- a/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
+++ b/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
@@ -50,12 +50,23 @@ def _trend(values, *, rising_is_bad=True, metric="sip_calls_active"):
 
 
 def test_a_rising_start_time_is_a_restart() -> None:
-    """process_start_time_seconds is constant for a process's life."""
+    """process_start_time_seconds is constant for a process's life.
+
+    ``window_start_s`` is supplied so this exercises the restart it is named
+    for. The new start time (1900) falls inside the window (opened at 1700), so
+    the process started during the run. Without the window the gate makes the
+    weaker claim instead, which this test would still have passed on a
+    substring while asserting nothing.
+    """
     gate = gates.process_lifecycle_gate(
-        _life(start_times=(1785.0, 1785.0, 1900.0), oom_kills=(0.0, 0.0, 0.0))
+        _life(
+            start_times=(1785.0, 1785.0, 1900.0),
+            oom_kills=(0.0, 0.0, 0.0),
+            window_start_s=1700.0,
+        )
     )
     assert gate.status == gates.FAIL
-    assert "restarted" in gate.detail
+    assert "restarted during the window" in gate.detail
 
 
 def test_a_steady_start_time_across_the_window_passes() -> None:
@@ -397,3 +408,87 @@ def test_count_gates_are_registered_and_are_not_ratios(gate) -> None:
     """A count rendered as a percentage is what RATIO_GATES exists to prevent."""
     assert gate in gates.ALL_GATES
     assert gate not in gates.RATIO_GATES
+
+
+# --------------------------------------------------------------------------
+# What a rising start time actually proves
+# --------------------------------------------------------------------------
+
+
+def test_a_new_start_time_predating_the_window_is_not_a_restart() -> None:
+    """The claim the gate used to make, and could not support.
+
+    A process that restarted during the window started during the window. A new
+    start time from BEFORE the window belongs to a process that was already
+    running when the run began, so the series moved between processes rather
+    than one process restarting. A scrape target list refreshed mid-run does
+    exactly this, and both machines can have been up for hours.
+
+    The numbers are the ones from a real run: the window opened at
+    1786374592.118 and the incoming process reported a start of 1786373687.16,
+    905s earlier. The gate called that "restarted during the window".
+    """
+    gate = gates.process_lifecycle_gate(
+        _life(
+            start_times=(1786373510.14, 1786373510.14, 1786373687.16),
+            oom_kills=(0.0, 0.0, 0.0),
+            window_start_s=1786374592.118,
+        )
+    )
+    assert gate.status == gates.FAIL, "the change is still a finding"
+    assert "did NOT restart inside it" in gate.detail
+    assert "restarted during the window" not in gate.detail
+    # It must say how far outside, so a reader can check rather than trust.
+    assert "905s BEFORE" in gate.detail
+    assert "moved between processes" in gate.detail
+
+
+def test_without_a_window_the_gate_makes_the_weaker_claim() -> None:
+    """Older callers supply no window, so the question cannot be decided.
+
+    The honest answer is the one true in both cases: the process serving the
+    series changed. Guessing "restart" to keep the old wording would be
+    asserting a cause on no evidence.
+    """
+    gate = gates.process_lifecycle_gate(
+        _life(start_times=(1785.0, 1785.0, 1900.0), oom_kills=(0.0, 0.0, 0.0))
+    )
+    assert gate.status == gates.FAIL
+    assert "the process serving" in gate.detail
+    assert "cannot be said" in gate.detail
+    assert "restarted during the window" not in gate.detail
+
+
+def test_every_branch_says_the_rates_are_unusable() -> None:
+    """Whichever it was, counter rates across the change cannot be trusted.
+
+    That is the operational consequence and it does not depend on the cause, so
+    no branch may drop it while arguing about which happened.
+    """
+    readings = (
+        _life(start_times=(100.0, 200.0), oom_kills=(0.0,), window_start_s=150.0),
+        _life(start_times=(100.0, 200.0), oom_kills=(0.0,), window_start_s=900.0),
+        _life(start_times=(100.0, 200.0), oom_kills=(0.0,)),
+    )
+    for reading in readings:
+        gate = gates.process_lifecycle_gate(reading)
+        assert gate.status == gates.FAIL
+        assert "unusable" in gate.detail
+
+
+def test_the_pass_branch_still_claims_only_what_it_measured() -> None:
+    """The PASS side was already accurate and must stay that way.
+
+    It says the start time HELD, which is what was observed. The two branches
+    disagreeing about what the metric means is what this change fixes, so the
+    accurate one is pinned too.
+    """
+    gate = gates.process_lifecycle_gate(
+        _life(
+            start_times=(1785.0, 1785.0, 1785.0),
+            oom_kills=(0.0, 0.0, 0.0),
+            window_start_s=1700.0,
+        )
+    )
+    assert gate.status == gates.PASS
+    assert "held one process start time" in gate.detail

--- a/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
+++ b/src/voicegateway/tests/middleware/test_node_samples_worker_middleware.py
@@ -251,9 +251,31 @@ async def test_a_real_zero_is_stored_as_zero(storage) -> None:
 
 
 async def test_a_hanging_target_times_out_and_records_the_gap(storage) -> None:
-    """The tick must end on its own deadline, with a row that says why."""
+    """The tick must end on its own deadline, with a row that says why.
+
+    Asserted on what the CODE recorded, not on the test's wall clock. The
+    deadline is an ``asyncio.wait_for`` around the fetch, so an outcome of
+    ``timeout`` is proof it fired: had it not, the handler's 30s sleep would
+    have completed and the outcome would be ``ok``. That evidence does not move
+    with machine load.
+
+    The wall-clock bound this used to carry (``elapsed < 3``) was a proxy for
+    the same thing and a worse one. It failed in CI at 4.2s inside a 3446-test
+    coverage run, on behaviour that was entirely correct: the log recorded
+    ``sfu-1/livekit-server=timeout`` exactly as intended. In isolation the same
+    test takes 0.36s, and 0.43s under coverage, so the number was measuring
+    runner contention rather than the deadline.
+
+    The one thing the wall clock did catch that the outcome does not is a retry
+    storm: a deadline enforced ten times still ends in ``timeout``. That is now
+    checked directly by counting scrapes, which is deterministic where a
+    stopwatch is not, and stricter than any threshold would be.
+    """
+    attempts = 0
 
     async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
         await asyncio.sleep(30)  # never answers within the deadline
         return httpx.Response(200, text="livekit_room_total 1\n")
 
@@ -263,15 +285,21 @@ async def test_a_hanging_target_times_out_and_records_the_gap(storage) -> None:
         scrape_timeout_seconds=0.15,
         transport=_transport(handler),
     )
-    started = asyncio.get_running_loop().time()
-    await asyncio.wait_for(worker.tick_now(), timeout=5)
-    elapsed = asyncio.get_running_loop().time() - started
-    assert elapsed < 3, "a hanging target held the tick open"
+    # The hang guard, and the only timing left. Generous on purpose: it exists
+    # to fail a tick that waits out the handler's 30s sleep, not to time the
+    # deadline, which the outcome below does exactly.
+    await asyncio.wait_for(worker.tick_now(), timeout=10)
 
     row = (await _rows(storage, "sfu-1", SOURCE_LIVEKIT_SERVER))[0]
-    assert row.outcome == OUTCOME_TIMEOUT
+    assert row.outcome == OUTCOME_TIMEOUT, (
+        "the scrape deadline did not fire: the tick waited for the target"
+    )
     assert row.series_found is None
     assert row.rooms is None
+    assert attempts == 1, (
+        f"the target was scraped {attempts} times for one tick. The deadline "
+        "fired, but a retry loop around it costs the tick a multiple of it"
+    )
 
 
 async def test_a_hanging_target_does_not_hold_up_a_healthy_one(storage) -> None:


### PR DESCRIPTION
The FAIL branch reported **"restarted during the window"** whenever `process_start_time_seconds` rose. A rising start time means the series stopped being served by the process that was serving it. It does not mean that process restarted, and on a real run it was not one:

```
window opened          1786374592.118
incoming start time    1786373687.16    <- 905s BEFORE the window
```

A process that restarted during the window started during the window, so its new start time falls **inside** it. One that predates the window was already running when the run began, which means the **series moved between processes**. A scrape target list refreshed mid-run does exactly that, and both machines can have been up for hours.

The gate named a cause the data contradicts, on a criterion that fails a run.

## The same gate already knew better

The PASS branch says the subject *"held one process start time across N sample(s)"*, which is exactly what was observed. So one gate made two different claims about one metric depending on which way it went, and the wrong one was on the failing side.

## The fix

`LifecycleReading` carries `window_start_s`, and the FAIL branch now decides between three statements rather than asserting one:

| New start time | Claim |
|---|---|
| inside the window | restarted during the window, as before |
| before the window | the process serving it changed and did **not** restart inside the window, with the gap in seconds and the likely cause named |
| no window supplied | the process serving it changed; whether it restarted cannot be said |

**Still FAIL in all three.** Counter rates across the change are unusable whichever happened, which is the operational consequence and does not depend on the cause, so every branch keeps saying it. Only the claim changes.

On the real numbers it now reads:

> the process serving sip-2/livekit-sip changed during the window, and it did NOT restart inside it: the new process reports a start time of 1786373687.16, which is 905s BEFORE the window opened, so it was already running when the run began. The series moved between processes, which a scrape target list refreshed mid-run will do.

Seconds, not milliseconds: `process_start_time_seconds` is in seconds and the two are compared directly, while `NodeWindow` carries milliseconds. The conversion sits at the one place the window is read.

## One existing test adapted, and it is the review point

`test_a_rising_start_time_is_a_restart` asserted `"restarted" in gate.detail` and supplied no window. After this change it would have passed on the substring inside *"whether it **restarted** cannot be said"* — asserting nothing while looking green.

It now supplies a window the new start falls inside, so it exercises the restart it is named for, and asserts the full phrase rather than a fragment.

## Tests

Five added:

- the predating case, built from the real numbers above
- the no-window case
- the unusable-rates consequence, asserted across all three branches
- the PASS wording, pinned now that the two branches are meant to agree

**3436 passed.** `ruff` and `mypy` clean.

## Scope

This branch is only the lifecycle claim. The `gates[]` duplication and the static appendix are held deliberately: both are inflation rather than incorrectness, and this one can flip a verdict.
