### PR TITLE
Stop the appendix reading as a description of the run

### DIFF
--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -2063,6 +2063,30 @@ def appendix_entry(
     return entry
 
 
+def _run_day(payload: dict[str, Any]) -> str | None:
+    """The day the RUN happened, for dating appendix entries against.
+
+    ``run.started_at_ms`` first, because that is when the thing being reported
+    actually ran. ``generated_at`` is when the report was WRITTEN, which is
+    later (minutes, on a normal import) and can land on the next day for a run
+    that finishes near midnight. Anchoring on it would label an entry recorded
+    during such a run as "before this run", which is a wrong badge, and a
+    staleness badge that is sometimes wrong is worse than none: the first time
+    a reader sees one on a current entry they stop believing it everywhere.
+
+    Falls back to ``generated_at`` for payloads carrying no run timestamp, and
+    to None when neither is readable, which marks nothing rather than
+    everything.
+    """
+    started = (payload.get("run") or {}).get("started_at_ms")
+    if isinstance(started, (int, float)) and started > 0:
+        return (
+            datetime.fromtimestamp(started / 1000.0, tz=UTC).date().isoformat()
+        )
+    generated = payload.get("generated_at")
+    return str(generated)[:10] if isinstance(generated, str) else None
+
+
 def _recorded_before(item: dict[str, Any], run_day: str | None) -> str:
     """Mark an entry whose recorded date precedes the run it is attached to.
 
@@ -2082,10 +2106,7 @@ def _recorded_before(item: dict[str, Any], run_day: str | None) -> str:
 def _render_appendix(payload: dict[str, Any]) -> str:
     """The reproducible-assets appendix, or a statement that there is none."""
     appendix = payload.get("appendix") or {}
-    # The day the report was generated, used only to mark entries recorded
-    # earlier. Absent or malformed, nothing is marked rather than everything.
-    generated = payload.get("generated_at")
-    run_day = str(generated)[:10] if isinstance(generated, str) else None
+    run_day = _run_day(payload)
     sections = []
     for key, heading, blurb in (
         (

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -2029,28 +2029,63 @@ def redact_urls(text: str) -> str:
     return _SCHEMELESS_RE.sub(lambda m: m.group(1), reduced)
 
 
-def appendix_entry(*, label: str, detail: str, citation: str) -> dict[str, str]:
+def appendix_entry(
+    *,
+    label: str,
+    detail: str,
+    citation: str,
+    recorded_at: str | None = None,
+) -> dict[str, str]:
     """One cited fact for the appendix.
 
     ``citation`` is required for the same reason a machine type needs one: this
     module cannot derive a command line, so an uncited one would be an invented
     instruction presented as a record of what was run.
+
+    ``recorded_at`` is the ISO date the fact was OBSERVED, and it is what lets
+    the renderer mark an entry that predates the run it is attached to. Optional
+    because the appendix is assembled by the caller and older ones carry the
+    date inside the citation prose, where nothing can compare it. Supplying it
+    is how a fact stops silently reading as current.
     """
     if not citation.strip():
         raise ValueError(
             f"appendix entry {label!r} needs a citation: an uncited command is "
             "indistinguishable from one this report invented"
         )
-    return {
+    entry = {
         "label": label,
         "detail": redact_urls(detail),
         "citation": citation,
     }
+    if recorded_at:
+        entry["recorded_at"] = recorded_at
+    return entry
+
+
+def _recorded_before(item: dict[str, Any], run_day: str | None) -> str:
+    """Mark an entry whose recorded date precedes the run it is attached to.
+
+    Only fires when the entry carries ``recorded_at``. A date buried in citation
+    prose cannot be compared, so an undated entry is left alone rather than
+    guessed at: the alternative is parsing free text and marking the wrong ones.
+    """
+    recorded = item.get("recorded_at")
+    if not recorded or not run_day or str(recorded)[:10] >= run_day:
+        return ""
+    return (
+        f" <span class='sub'>(recorded {_esc(str(recorded)[:10])}, "
+        "before this run)</span>"
+    )
 
 
 def _render_appendix(payload: dict[str, Any]) -> str:
     """The reproducible-assets appendix, or a statement that there is none."""
     appendix = payload.get("appendix") or {}
+    # The day the report was generated, used only to mark entries recorded
+    # earlier. Absent or malformed, nothing is marked rather than everything.
+    generated = payload.get("generated_at")
+    run_day = str(generated)[:10] if isinstance(generated, str) else None
     sections = []
     for key, heading, blurb in (
         (
@@ -2075,7 +2110,7 @@ def _render_appendix(payload: dict[str, Any]) -> str:
         rows = "".join(
             "<tr>"
             f"<td class='mono'>{_esc(item['label'])}</td>"
-            f"<td>{_esc(item['detail'])}</td>"
+            f"<td>{_esc(item['detail'])}{_recorded_before(item, run_day)}</td>"
             f"<td class='sub'>{_esc(item['citation'])}</td>"
             "</tr>"
             for item in entries
@@ -2097,7 +2132,14 @@ def _render_appendix(payload: dict[str, Any]) -> str:
         "<h2>Reproducible test assets</h2>"
         "<p>What it takes to run this again. Scenario files and generator "
         "configuration are referenced by name rather than reproduced here: they "
-        "are the work of whoever authored them.</p>" + "".join(sections)
+        "are the work of whoever authored them.</p>"
+        "<p class='sub'><b>This is background, not a description of the run "
+        "above.</b> Each item is a fact somebody recorded when the Source "
+        "column says, and nothing here is re-verified against this run. Where "
+        "an item names a fleet size, a version or a limit, read it as what was "
+        "true when it was recorded: the deployment may have changed since, and "
+        "the measured sections above are the authority on what actually "
+        "ran.</p>" + "".join(sections)
     )
 
 

--- a/src/voicegateway/tests/cli/test_loadtest_appendix.py
+++ b/src/voicegateway/tests/cli/test_loadtest_appendix.py
@@ -192,3 +192,125 @@ def test_no_generator_scenario_or_config_lives_in_this_repo() -> None:
         if ".venv" not in p.parts and "node_modules" not in p.parts
     ]
     assert not offenders, f"generator scenario files in the repo: {offenders}"
+
+
+# ---------------------------------------------------------------------------
+# The appendix must not read as a description of the run
+# ---------------------------------------------------------------------------
+
+
+def _appendix_html(entries, *, generated_at="2026-08-10T15:39:43+00:00") -> str:
+    from voicegateway.livekit_diag import run_report
+
+    return run_report._render_appendix(
+        {"appendix": {"toolchain": entries}, "generated_at": generated_at}
+    )
+
+
+def test_the_appendix_says_it_is_not_a_description_of_the_run() -> None:
+    """The harm this prevents is a reader taking background as configuration.
+
+    A toolchain entry reading "two nodes, max_active_calls 150 per node" is a
+    fact somebody recorded on a day, not a statement about the run it is
+    attached to. Shipped unlabelled next to measured sections, it reads as the
+    topology under test, and a reader sizing from it believes the wrong fleet
+    was measured.
+    """
+    from voicegateway.livekit_diag import run_report
+
+    html = _appendix_html(
+        [
+            run_report.appendix_entry(
+                label="livekit-sip",
+                detail="v1.8.0, two nodes, max_active_calls 150 per node",
+                citation="docker inspect, 2026-08-02",
+            )
+        ]
+    )
+    assert "not a description of the run" in html
+    assert "the measured sections above are the authority" in html
+
+
+def test_an_entry_recorded_before_the_run_is_marked() -> None:
+    """A date that can be compared is worth more than one buried in prose."""
+    from voicegateway.livekit_diag import run_report
+
+    html = _appendix_html(
+        [
+            run_report.appendix_entry(
+                label="livekit-sip",
+                detail="v1.8.0, two nodes",
+                citation="docker inspect",
+                recorded_at="2026-08-02",
+            )
+        ]
+    )
+    assert "recorded 2026-08-02, before this run" in html
+
+
+def test_an_entry_recorded_during_the_run_is_not_marked() -> None:
+    from voicegateway.livekit_diag import run_report
+
+    html = _appendix_html(
+        [
+            run_report.appendix_entry(
+                label="livekit-sip",
+                detail="v1.8.0",
+                citation="docker inspect",
+                recorded_at="2026-08-10",
+            )
+        ]
+    )
+    assert "before this run" not in html
+
+
+def test_an_undated_entry_is_left_alone_rather_than_guessed_at() -> None:
+    """Dates inside citation prose cannot be compared.
+
+    Parsing them out to mark entries would mark the wrong ones, and a wrong
+    staleness badge is worse than none: it teaches a reader to ignore the badge.
+    """
+    from voicegateway.livekit_diag import run_report
+
+    html = _appendix_html(
+        [
+            run_report.appendix_entry(
+                label="livekit-sip",
+                detail="v1.8.0, two nodes",
+                citation="docker inspect on i-027deaece242ba587, 2026-08-02",
+            )
+        ]
+    )
+    assert "before this run" not in html
+    # The disclaimer still covers it, which is why not marking is survivable.
+    assert "not a description of the run" in html
+
+
+def test_recorded_at_is_optional_and_absent_when_not_given() -> None:
+    """Existing callers pass three keyword arguments and must keep working."""
+    from voicegateway.livekit_diag import run_report
+
+    entry = run_report.appendix_entry(
+        label="l", detail="d", citation="c"
+    )
+    assert "recorded_at" not in entry
+    assert set(entry) == {"label", "detail", "citation"}
+
+
+def test_a_run_with_no_generated_at_marks_nothing() -> None:
+    """No run date means no comparison, so nothing is claimed about staleness."""
+    from voicegateway.livekit_diag import run_report
+
+    html = run_report._render_appendix(
+        {
+            "appendix": {
+                "toolchain": [
+                    run_report.appendix_entry(
+                        label="l", detail="d", citation="c",
+                        recorded_at="2020-01-01",
+                    )
+                ]
+            }
+        }
+    )
+    assert "before this run" not in html

--- a/src/voicegateway/tests/cli/test_loadtest_appendix.py
+++ b/src/voicegateway/tests/cli/test_loadtest_appendix.py
@@ -314,3 +314,58 @@ def test_a_run_with_no_generated_at_marks_nothing() -> None:
         }
     )
     assert "before this run" not in html
+
+
+def test_the_anchor_is_the_run_not_the_report_generation() -> None:
+    """A run that crosses midnight must not mislabel its own entries.
+
+    generated_at is when the report was WRITTEN, which is later than the run and
+    can land on the next day. Anchoring on it would label an entry recorded
+    during the run as "before this run", which is a wrong badge, and one wrong
+    badge teaches a reader to ignore every badge.
+
+    Here the run started 2026-08-09 23:50 UTC and the report was generated after
+    midnight. The entry was recorded on the run's own day.
+    """
+    from voicegateway.livekit_diag import run_report
+
+    html = run_report._render_appendix(
+        {
+            "appendix": {
+                "toolchain": [
+                    run_report.appendix_entry(
+                        label="livekit-sip",
+                        detail="v1.8.0",
+                        citation="docker inspect",
+                        recorded_at="2026-08-09",
+                    )
+                ]
+            },
+            "run": {"started_at_ms": 1786319400000},  # 2026-08-09 23:50 UTC
+            "generated_at": "2026-08-10T00:05:00+00:00",
+        }
+    )
+    assert "before this run" not in html, (
+        "an entry recorded on the run's own day was marked stale because the "
+        "report was generated after midnight"
+    )
+
+
+def test_generated_at_is_the_fallback_when_no_run_timestamp() -> None:
+    """Payloads carrying no run timestamp still date their entries."""
+    from voicegateway.livekit_diag import run_report
+
+    html = run_report._render_appendix(
+        {
+            "appendix": {
+                "toolchain": [
+                    run_report.appendix_entry(
+                        label="l", detail="d", citation="c",
+                        recorded_at="2026-08-02",
+                    )
+                ]
+            },
+            "generated_at": "2026-08-10T15:39:43+00:00",
+        }
+    )
+    assert "recorded 2026-08-02, before this run" in html

--- a/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
+++ b/src/voicegateway/tests/loadtest/test_lifecycle_gates.py
@@ -424,9 +424,13 @@ def test_a_new_start_time_predating_the_window_is_not_a_restart() -> None:
     than one process restarting. A scrape target list refreshed mid-run does
     exactly this, and both machines can have been up for hours.
 
-    The numbers are the ones from a real run: the window opened at
-    1786374592.118 and the incoming process reported a start of 1786373687.16,
-    905s earlier. The gate called that "restarted during the window".
+    The values below are ILLUSTRATIVE, shaped like a real run rather than quoted
+    from one, and the assertion checks the gap this test's own arithmetic
+    produces (1786374592.118 - 1786373687.16 = 904.958, rendered "905s"). When
+    the real artifact was regenerated it rendered 891s, so the two differ
+    slightly, most likely in which instant is taken as the window start. Do not
+    read 905 as a figure from any artifact; what is under test is that the gate
+    reports the gap it computed, not the size of any particular gap.
     """
     gate = gates.process_lifecycle_gate(
         _life(
@@ -439,6 +443,7 @@ def test_a_new_start_time_predating_the_window_is_not_a_restart() -> None:
     assert "did NOT restart inside it" in gate.detail
     assert "restarted during the window" not in gate.detail
     # It must say how far outside, so a reader can check rather than trust.
+    # Derived from the inputs above, not copied from an artifact.
     assert "905s BEFORE" in gate.detail
     assert "moved between processes" in gate.detail
 


### PR DESCRIPTION
The appendix ships next to the measured sections and reads like part of them. A toolchain entry saying **"v1.8.0, two nodes, max_active_calls 150 per node"** is a fact somebody recorded on a day. Attached to a run of a four-node fleet at 200, it tells a reader the wrong topology was tested.

## The content is not wrong. The framing was.

Entries are assembled by the caller, every one carries a citation, and several sections are genuinely timeless (the generator's flag semantics, Little's law). What was wrong is that the lead paragraph said *"what it takes to run this again"*, which reads as **this run's setup**.

It now says plainly:

> **This is background, not a description of the run above.** Each item is a fact somebody recorded when the Source column says, and nothing here is re-verified against this run. Where an item names a fleet size, a version or a limit, read it as what was true when it was recorded: the deployment may have changed since, and the measured sections above are the authority on what actually ran.

**Labelling beats regenerating.** Making the appendix reflect the run would mean deriving fleet facts at report time from something that observed them, and nothing does. These are hand-recorded observations with citations, which is exactly why `appendix_entry` has required a citation from the start.

## A disclaimer everybody skims is weak on its own

So `appendix_entry` also takes an optional `recorded_at`, and an entry whose recorded date precedes the run is marked inline:

> v1.8.0, two nodes *(recorded 2026-08-02, before this run)*

**Optional on purpose.** Existing callers pass three keyword arguments and keep working, and older appendices carry their date inside citation prose where nothing can compare it.

**An undated entry is left alone rather than guessed at.** Parsing dates out of free text would mark the wrong entries, and a wrong staleness badge is worse than none: it teaches a reader to ignore the badge.

## Tests

Six. The two that matter: the disclaimer is present, and an entry recorded before the run is marked while one recorded during it is not.

The rest hold the edges — an undated entry is unmarked but still covered by the disclaimer, a payload with no `generated_at` claims nothing, and the three-argument signature still returns exactly three keys.

## Also in here

A provenance correction to `test_lifecycle_gates` from the previous branch. Its docstring said the timestamps were "the numbers from a real run". Regenerating the artifact rendered the gap as **891s** where the test's own arithmetic gives 905s, so at least one value differs.

The assertion is unchanged and still correct for the values the test constructs. The docstring now presents them as illustrative and records the discrepancy. A test claiming a provenance it does not have is the same class of problem as an assertion that stopped discriminating.

## No schema change, no migration

Report-generation only.

**3448 passed.** `ruff` and `mypy` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reproducible-asset entries can now include recording dates.
  * Reports identify older entries recorded before the report date.
  * Appendix text clarifies that background information is not authoritative or re-verified.

* **Documentation**
  * Updated test documentation to clarify illustrative values and derived timing calculations.

* **Tests**
  * Added coverage for date annotations, undated and same-day entries, backward compatibility, and missing report dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->