### PR TITLE
Count distinct findings in the profile headlines, not rows

### DIFF
--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -2611,6 +2611,46 @@ def _glance_reference(key: str, gate: str, threshold: float | None) -> str:
     return figure
 
 
+def distinct_facts(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The rows that state something different, in their original order.
+
+    A gate row is emitted once per STEP, and on a run whose steps are parallel
+    generator processes every one of them reads the same fleet over the same
+    window. Twelve processes then produce twelve identical rows: same subject,
+    same value, same verdict. They are one fact echoed twelve times.
+
+    Counting those as twelve is where the damage is. A headline of "worst of 192
+    measured" is really the worst of 16, and a reader counting FAIL rows
+    concludes something is widespread when four facts are being repeated.
+
+    Distinctness is (subject, value), not the row count, because that is what
+    separates the two cases the report must not conflate:
+
+    * A genuine ramp measures the same subject at each step and gets a DIFFERENT
+      value each time. Those are real repeated measurements and all of them
+      count, which is why this cannot simply collapse per subject.
+    * Parallel generators measure one thing and report it N times. Same subject,
+      identical value, so they collapse to the one fact they are.
+
+    Two ramp steps that happen to measure the same subject at exactly the same
+    value also collapse, and that is correct rather than a compromise: they are
+    one measurement, stated twice.
+
+    The rows themselves are kept everywhere they are rendered. A row per step is
+    arguably the right DATA, carrying which step saw what, and it is only the
+    counting that was lying.
+    """
+    seen: set[tuple[Any, Any]] = set()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        key = (row.get("subject"), row.get("value"))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(row)
+    return out
+
+
 def _glance_trend_row(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Steady-state drift, as a COUNT of resources rather than as one figure.
 
@@ -2624,7 +2664,10 @@ def _glance_trend_row(rows: list[dict[str, Any]]) -> dict[str, Any]:
     whether anything moved at all, so the value is how many measured resources
     the gate found drifting.
     """
-    over = [row for row in rows if row["reading"] == "over"]
+    # Distinct on both sides of the ratio, so "2 of 5" cannot become "24 of 60"
+    # on a run with twelve generators saying the same thing.
+    facts = distinct_facts(rows)
+    over = [row for row in facts if row["reading"] == "over"]
     threshold = next((r["threshold"] for r in rows if r["threshold"] is not None), None)
     floor = "its own steady-state baseline"
     if threshold is not None:
@@ -2634,7 +2677,7 @@ def _glance_trend_row(rows: list[dict[str, Any]]) -> dict[str, Any]:
         # Short, because the Value column is a narrow numeric column shared with
         # percentages: a sentence in it wraps and right-aligns into something a
         # reader has to stop and parse, which is the opposite of a glance.
-        "value": f"{len(over)} of {len(rows)}",
+        "value": f"{len(over)} of {len(facts)}",
         "why": (
             "Measured resources drifting. A count, not a figure: drift is in "
             "each resource's own units, so there is no worst one to quote."
@@ -2710,10 +2753,14 @@ def _glance_rows(
         if key == gates.RESOURCE_TREND_GATE:
             out.append(_glance_trend_row(rows))
             continue
+        # The WORST is picked from every row, since a duplicate cannot change
+        # which is worst. The COUNT is of distinct facts, because that is the
+        # number a reader takes as how much evidence is behind the figure.
         pick = _glance_pick(rows, key)
+        facts = distinct_facts(rows)
         why = _esc(str(pick["subject"] or "")) or "no subject recorded"
-        if len(rows) > 1:
-            why += f", worst of {len(rows)} measured"
+        if len(facts) > 1:
+            why += f", worst of {len(facts)} measured"
         out.append(
             {
                 "what": _GLANCE_NAMES.get(key, pick["name"]),
@@ -2871,6 +2918,22 @@ def _render_profile_measurements(measured: list[dict[str, Any]]) -> str:
         "whether landing on either side of it is acceptable, because that "
         "depends on what the deployment is for.</p>"
     ]
+    # Say so when the table repeats itself. A gate is evaluated once per step,
+    # and on a run whose steps are parallel generator processes each fact is
+    # recorded once per process, so the same subject and value appear many times
+    # over. The rows are kept because which step saw what is real data, but a
+    # reader scanning the table counts rows, and without this a handful of
+    # findings echoed across a dozen processes reads as a widespread problem.
+    facts = len(distinct_facts(measured))
+    if facts < len(measured):
+        out.append(
+            f'<div class="note">These {len(measured)} rows state {facts} '
+            "distinct findings. A gate is evaluated once per step, so a run "
+            "whose steps ran in parallel records every finding once per "
+            "process. Rows repeating a subject and a value are the same "
+            "finding, not separate ones, and the counts in the summary above "
+            "are of distinct findings rather than of rows.</div>"
+        )
     # PROFILE_GROUPS order first, then anything unclassified, so a new gate
     # surfaces at the bottom of the section instead of shuffling the groups a
     # reader knows.

--- a/src/voicegateway/tests/loadtest/test_profile_report.py
+++ b/src/voicegateway/tests/loadtest/test_profile_report.py
@@ -721,3 +721,132 @@ class TestPerCallMediaCountsReachThePayload:
         )
         assert row["establishment_ratio"] == 1.0
         assert row["calls_answered_without_inbound"] == 12198
+
+
+# ---------------------------------------------------------------------------
+# One fact echoed per generator process is one fact
+# ---------------------------------------------------------------------------
+
+
+def _fact(subject: str, value: float, *, reading: str = "ok") -> dict:
+    """A glance row as _profile_glance_rows builds them."""
+    return {
+        "key": "resource_trend",
+        "gate": "resource_trend",
+        "name": "n",
+        "meaning": "m",
+        "subject": subject,
+        "step": None,
+        "value": value,
+        "threshold": 1.1,
+        "detail": "",
+        "reading": reading,
+    }
+
+
+def test_identical_rows_from_parallel_generators_are_one_fact() -> None:
+    """Twelve processes reading one fleet report one thing twelve times.
+
+    Same subject, byte-identical value, same verdict. Counting them as twelve
+    is what turns "worst of 16" into "worst of 192".
+    """
+    rows = [_fact("sip-1/livekit-sip", 0.5465968586387453) for _ in range(12)]
+    assert len(run_report.distinct_facts(rows)) == 1
+
+
+def test_a_real_ramp_keeps_every_step() -> None:
+    """Steps measuring the same subject at DIFFERENT values are real repeats.
+
+    This is why distinctness cannot collapse per subject: a seven-step ramp
+    measures one node seven times and all seven count.
+    """
+    rows = [_fact("sip-1/livekit-sip", v) for v in (0.31, 0.48, 0.55, 0.66)]
+    assert len(run_report.distinct_facts(rows)) == 4
+
+
+def test_different_subjects_at_the_same_value_are_different_facts() -> None:
+    """Four nodes all sitting at 55% is four findings, not one."""
+    rows = [_fact(f"sip-{n}/livekit-sip", 0.55) for n in (1, 2, 3, 4)]
+    assert len(run_report.distinct_facts(rows)) == 4
+
+
+def test_order_is_preserved_so_the_first_of_a_group_survives() -> None:
+    rows = [_fact("a", 1.0), _fact("b", 2.0), _fact("a", 1.0), _fact("c", 3.0)]
+    assert [r["subject"] for r in run_report.distinct_facts(rows)] == ["a", "b", "c"]
+
+
+def test_the_worst_of_count_is_distinct_not_row_count() -> None:
+    """The headline a reader takes as how much evidence is behind the figure.
+
+    Sixteen distinct facts echoed across twelve processes rendered as 192.
+    """
+    measured = []
+    for subject in (f"sip-{n}/livekit-sip" for n in (1, 2, 3, 4)):
+        for _ in range(12):
+            measured.append(
+                {
+                    "key": "node_cpu",
+                    "gate": "node_cpu",
+                    "name": "File descriptors",
+                    "meaning": "m",
+                    "subject": subject,
+                    "step": None,
+                    "value": 0.42,
+                    "threshold": 0.2,
+                    "detail": "",
+                    "reading": "ok",
+                }
+            )
+    assert len(measured) == 48
+
+    rows = run_report._glance_rows({"tests": []}, measured)
+
+    [row] = [r for r in rows if r["what"] == run_report._GLANCE_NAMES["node_cpu"]]
+    assert "worst of 4 measured" in row["why"], (
+        f"the count still includes the echoes: {row['why']}"
+    )
+    assert "worst of 48" not in row["why"]
+
+
+def test_the_trend_ratio_counts_distinct_on_both_sides() -> None:
+    """"2 of 5" must not inflate to "24 of 60" on a twelve-generator run."""
+    measured = []
+    for subject, reading in (
+        ("sip-1/memory", "over"),
+        ("sip-2/memory", "over"),
+        ("sip-3/memory", "ok"),
+        ("sip-4/memory", "ok"),
+        ("sfu-1/memory", "ok"),
+    ):
+        for _ in range(12):
+            measured.append(_fact(subject, 1.16 if reading == "over" else 1.01,
+                                  reading=reading))
+
+    rows = run_report._glance_rows({"tests": []}, measured)
+
+    [row] = [
+        r for r in rows
+        if r["what"] == run_report._GLANCE_NAMES[gates.RESOURCE_TREND_GATE]
+    ]
+    assert row["value"] == "2 of 5", f"inflated by the echoes: {row['value']}"
+
+
+def test_the_measurements_table_says_when_it_repeats_itself() -> None:
+    """A reader scanning the table counts rows, not findings.
+
+    The rows are kept, because which step saw what is real data. But four
+    findings echoed across twelve processes render as forty-eight rows, and
+    without a note that reads as a widespread problem.
+    """
+    measured = [
+        _fact(f"sip-{n}/livekit-sip", 0.55) for n in (1, 2, 3, 4) for _ in range(12)
+    ]
+    html = run_report._render_profile_measurements(measured)
+    assert "These 48 rows state 4 distinct findings" in html
+
+
+def test_a_table_with_no_repeats_carries_no_note() -> None:
+    """A normal ramp report must not gain an explanation it does not need."""
+    measured = [_fact(f"sip-{n}/livekit-sip", 0.1 * n) for n in (1, 2, 3, 4)]
+    html = run_report._render_profile_measurements(measured)
+    assert "distinct findings" not in html


### PR DESCRIPTION
A gate is evaluated once per step. On a run whose steps are parallel generator processes, every process reads the same fleet over the same window, so each finding is recorded once per process. The rows were then counted as if each were a separate measurement.

Measured against a real twelve-generator artifact, before and after:

| Headline | Before | After |
|---|---|---|
| File descriptors free | worst of **192** | worst of **16** |
| Restarts and OOM kills | worst of **192** | worst of **16** |
| Peak CPU, worst node | worst of **120** | worst of **10** |
| Peak memory, worst node | worst of **120** | worst of **10** |
| RTP media ports free | worst of **72** | worst of **6** |
| Inbound / outbound bandwidth | worst of **96** | worst of **8** |
| Resource drift, steady state | 0 of **216** | 0 of **18** |

## The rows are kept; the counting was what lied

A row per step is arguably the right **data** — it carries which step saw what. The count is what a reader takes as how much evidence sits behind a figure, and that was inflated by the generator count.

## Distinctness is (subject, value), and that choice is the whole design

It separates the two cases this must not conflate:

- A **genuine ramp** measures one subject at each step and gets a *different* value each time. All of those count. Collapsing per subject would have destroyed real information.
- **Parallel generators** measure one thing and report it N times: same subject, byte-identical value. They collapse to the one finding they are.

The discrimination is visible in the same run's untouched rows. **"Calls established, worst of 12" stays 12**, because twelve processes each established their own calls and those are twelve findings. **"Return to baseline, worst of 27" stays 27.** Two of thirteen headlines were already right and remain so, which is how the rule earns trust rather than just producing smaller numbers.

The **worst is still picked from every row**, since a duplicate cannot change which is worst. Only the count changes.

## The table says when it repeats itself

The Measurements table keeps every row and now carries:

> These 1359 rows state 169 distinct findings. A gate is evaluated once per step, so a run whose steps ran in parallel records every finding once per process...

A reader scanning a table counts rows, and four findings echoed across twelve processes render as forty-eight rows that read as a widespread problem. **The note appears only when there is duplication**, so an ordinary ramp report is unchanged.

## Tests

Eight, including that a ramp keeps every step, four nodes at the same value stay four findings, order is preserved so the first of a group survives, and a table with no repeats carries no note.

Verified against the real artifact rather than on fixtures alone.

## No schema change, no migration

Report-generation only.

**3450 passed.** `ruff` and `mypy` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected report summaries and trend calculations so repeated measurements are counted only once.
  * Preserved detailed measurement rows while clearly indicating when they represent fewer distinct findings.
  * Maintained the original order and separate tracking of genuinely different subjects and values.

* **Tests**
  * Added coverage verifying accurate glance summaries, trend ratios, and repeated-measurement reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->