### PR TITLE
Make the node_samples retention window configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,22 @@ follows [Semantic Versioning](https://semver.org/) and
   artifact, whatever the verdict was: gating CI on a deployment's health stays
   `voicegw livekit check`'s job.
 
+- **`workers.node_sample_max_age_days`** sets how long a raw `node_samples` row
+  is kept. Default `7`, unchanged from when it was hardcoded, so upgrading moves
+  nobody's retention.
+
+  Raise it before running anything you intend to report on for longer than a
+  week: retention equal to the observation window prunes the window's first day
+  before the run ends, and the report then cannot cover the span the run was
+  performed to demonstrate. Retention has to exceed the run, not match it.
+
+  The cost is rows. One target at the default 15s interval writes 5,760 a day,
+  so N targets over D days is roughly `N x 5760 x D`.
+
+  **`workers` is `extra: forbid`**, so writing this key on an earlier version is
+  a startup validation error rather than an ignored setting. The key has to ship
+  before anyone puts it in `voicegw.yaml`.
+
 ### Removed
 
 - **The `voicegw tui` terminal UI is gone.** The four-tab Textual UI (~4,900 LOC

--- a/docs/configuration/voicegw-yaml.md
+++ b/docs/configuration/voicegw-yaml.md
@@ -354,12 +354,25 @@ workers:
   rollup_interval_seconds: 900
   retention_interval_seconds: 3600
   node_scrape_interval_seconds: 15
+  node_sample_max_age_days: 7
 ```
 
 - `enabled` (bool, default `true`): start the background workers.
 - `rollup_interval_seconds` (int, default `900`): how often the latency and agent rollups refresh.
 - `retention_interval_seconds` (int, default `3600`): how often retention runs.
 - `node_scrape_interval_seconds` (int, default `15`): how often the node scrape polls, when it runs at all.
+- `node_sample_max_age_days` (int, default `7`): how long a raw `node_samples` row is kept. Every scrape tick deletes rows older than this, so the table stays bounded whether or not per-project retention is on.
+
+Raise `node_sample_max_age_days` before running anything you intend to report on
+for longer than a week. Retention equal to the observation window prunes the
+window's first day before the run ends, and the report then cannot cover the
+span the run was performed to demonstrate. It has to exceed the run, not match
+it.
+
+The cost is rows: one target at the default 15s interval writes 5,760 rows a
+day, so N targets over D days is roughly `N x 5760 x D`. A thirteen-target fleet
+held for ten days is a few hundred thousand rows and on the order of a hundred
+megabytes.
 
 The node scrape is the one worker that is off by default. It is built only when
 `VOICEGW_NODE_SCRAPE_TARGETS` names at least one target, so an install that does

--- a/docs/guide/node-metrics.md
+++ b/docs/guide/node-metrics.md
@@ -24,7 +24,7 @@ If both are set, the file wins, even when currently empty: an empty file differs
 
 Whether to build the worker is decided once, at `voicegw serve` startup. Exporting `VOICEGW_NODE_SCRAPE_TARGETS` (or `_FILE`) afterward does nothing until restarted.
 
-It also runs only inside that long-lived process (including the daemon's `start`/`restart`), never inside a one-shot CLI command: `voicegw livekit check`, `voicegw livekit latency`, and `voicegw loadtest report` all exit without touching `node_samples`. Poll cadence is `workers.node_scrape_interval_seconds` in [`voicegw.yaml`](/configuration/voicegw-yaml) (default 15s).
+It also runs only inside that long-lived process (including the daemon's `start`/`restart`), never inside a one-shot CLI command: `voicegw livekit check`, `voicegw livekit latency`, and `voicegw loadtest report` all exit without touching `node_samples`. Poll cadence is `workers.node_scrape_interval_seconds` in [`voicegw.yaml`](/configuration/voicegw-yaml) (default 15s), and how long a row survives is `workers.node_sample_max_age_days` (default 7). Raise the retention before a run you mean to report on for longer than a week: at seven days the first day of a seven-day run is pruned before the run ends.
 
 ## A bad entry costs one target, not the process
 

--- a/src/voicegateway/core/events.py
+++ b/src/voicegateway/core/events.py
@@ -100,6 +100,11 @@ def _build_workers(gateway: Gateway) -> list[Any]:
             NodeSamplesWorker(
                 storage,
                 poll_interval_seconds=workers_cfg.node_scrape_interval_seconds,
+                # Retention was hardcoded at 7 days, which is self-defeating for
+                # anyone whose observation window IS 7 days: day one is pruned
+                # before the run ends, so the report cannot cover the span the
+                # run was performed to prove.
+                max_age_seconds=workers_cfg.node_sample_max_age_days * 86400,
             )
         )
         # Logged because the alternative is silence: an operator who typos the

--- a/src/voicegateway/middleware/node_samples_worker_middleware.py
+++ b/src/voicegateway/middleware/node_samples_worker_middleware.py
@@ -175,10 +175,25 @@ _DEFAULT_SCRAPE_TIMEOUT_SECONDS: Final[float] = 5.0
 # cardinality is larger but nowhere near this. A target that streams forever is
 # stopped by this and by the deadline above.
 _DEFAULT_MAX_RESPONSE_BYTES: Final[int] = 4 * 1024 * 1024
-# How long a raw sample lives. Seven days is the observation window the scope
-# commits to (§7: "the client's 7-day requirement is an observation window, met
-# by the scrape worker"), and at ~57k rows/day it caps the table around 400k
-# rows instead of the 5.2M that the 90-day project default would allow.
+# How long a raw sample lives, when the operator has not said. Configurable via
+# workers.node_sample_max_age_days; this is only the fallback.
+#
+# Seven days because it has always been seven days, so upgrading changes nobody's
+# retention. It is NOT a recommendation, and the budget below is the operator's
+# to spend rather than a settled answer.
+#
+# What it costs. One target at the default 15s interval writes 5,760 rows a day,
+# so N targets write N x 5,760 x days. A thirteen-target fleet is roughly 75k
+# rows a day at full coverage and less in practice, since a target that fails a
+# scrape still writes one row rather than one per series. Order of magnitude:
+# ten days of a mid-sized fleet is a few hundred thousand rows and around a
+# hundred megabytes.
+#
+# The trap this default walks into: retention equal to the observation window is
+# self-defeating. A run held for exactly the retention period loses its first
+# day before it ends, so the report cannot cover the span the run existed to
+# demonstrate. Retention has to EXCEED the longest run you intend to report on,
+# and the margin is the operator's call because only they know the run.
 _DEFAULT_MAX_AGE_SECONDS: Final[float] = 7 * 24 * 3600.0
 
 SOURCE_LIVEKIT_SERVER: Final[str] = "livekit-server"

--- a/src/voicegateway/schemas/config_schema.py
+++ b/src/voicegateway/schemas/config_schema.py
@@ -106,6 +106,18 @@ class WorkersConfig(_StrictBase):
     # does NOT turn the scrape on: the worker exists only when
     # VOICEGW_NODE_SCRAPE_TARGETS names at least one target.
     node_scrape_interval_seconds: int = Field(default=15, ge=1)
+    # How long a raw node sample is kept. The default is 7 days, unchanged from
+    # when it was hardcoded, so upgrading alters nobody's retention.
+    #
+    # Raise it when the observation window you need to REPORT on equals the
+    # window you are running: a soak whose retention matches its own duration
+    # prunes its first day before it ends, and the report cannot then cover the
+    # span the run existed to demonstrate. Retention must exceed the run, not
+    # match it.
+    #
+    # The cost is rows. See _DEFAULT_MAX_AGE_SECONDS in
+    # node_samples_worker_middleware for the arithmetic.
+    node_sample_max_age_days: int = Field(default=7, ge=1)
 
 
 class ProjectConfig(_StrictBase):

--- a/src/voicegateway/tests/server/test_lifespan_workers.py
+++ b/src/voicegateway/tests/server/test_lifespan_workers.py
@@ -213,6 +213,80 @@ async def test_node_scrape_interval_is_applied(tmp_path, monkeypatch) -> None:
         assert [w._poll_interval for w in _node_workers(app.state.workers)] == [333]
 
 
+# --- retention: the window the operator configured, not the one we assumed ---
+#
+# The field parsing and the pruning itself were both already correct and both
+# already tested (``test_node_samples_worker_middleware`` proves a tick trims
+# past ``max_age_seconds``). What was missing is the wire between them: the
+# lifespan constructed the worker without passing the value at all, so retention
+# was seven days no matter what the config said, and every test on either side
+# of the gap still passed. These assert on the wire.
+
+
+async def test_node_sample_retention_is_applied(tmp_path, monkeypatch) -> None:
+    """The configured window must reach the worker, not stop at the schema."""
+    monkeypatch.setenv(TARGETS_ENV_VAR, _TARGET)
+    gw = _gateway(
+        tmp_path,
+        monkeypatch,
+        {
+            "cost_tracking": {"enabled": True},
+            "workers": {"node_sample_max_age_days": 30},
+        },
+    )
+    app = build_app(gw)
+    async with lifespan(app):
+        assert [w._max_age_seconds for w in _node_workers(app.state.workers)] == [
+            30 * 86400
+        ]
+
+
+async def test_node_sample_retention_defaults_to_seven_days(
+    tmp_path, monkeypatch
+) -> None:
+    """Upgrading into a configurable field must not move anyone's retention."""
+    monkeypatch.setenv(TARGETS_ENV_VAR, _TARGET)
+    gw = _gateway(tmp_path, monkeypatch, {"cost_tracking": {"enabled": True}})
+    app = build_app(gw)
+    async with lifespan(app):
+        assert [w._max_age_seconds for w in _node_workers(app.state.workers)] == [
+            7 * 86400
+        ]
+
+
+def test_the_config_default_and_the_worker_default_agree() -> None:
+    """Two defaults for one number, so they have to be pinned to each other.
+
+    The worker keeps its own fallback for callers that construct it directly.
+    If the two drift, the wired path and the direct path silently disagree about
+    how long a sample lives, which is the kind of difference nobody notices
+    until a report is missing its first day.
+    """
+    from voicegateway.middleware.node_samples_worker_middleware import (
+        _DEFAULT_MAX_AGE_SECONDS,
+    )
+    from voicegateway.schemas.config_schema import WorkersConfig
+
+    assert WorkersConfig().node_sample_max_age_days * 86400 == _DEFAULT_MAX_AGE_SECONDS
+
+
+def test_a_zero_or_negative_retention_is_refused_at_parse_time() -> None:
+    """``ge=1`` here rather than a ValueError from the worker at startup.
+
+    The worker rejects a non-positive ``max_age_seconds``, but that raises
+    inside the lifespan, which means a typo takes the process down on boot
+    instead of failing the config that caused it.
+    """
+    import pytest as _pytest
+    from pydantic import ValidationError
+
+    from voicegateway.schemas.config_schema import WorkersConfig
+
+    for bad in (0, -1):
+        with _pytest.raises(ValidationError):
+            WorkersConfig.model_validate({"node_sample_max_age_days": bad})
+
+
 async def test_node_scrape_shutdown_is_not_blocked_by_a_hanging_target(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## The bug

`node_samples` retention was hardcoded at seven days. That is self-defeating for anyone whose observation window is itself seven days: day one is pruned before the run ends, so the report cannot cover the span the run was performed to demonstrate. Retention has to **exceed** the run, not match it, and only the operator knows the run.

## The fix

`workers.node_sample_max_age_days`, default `7`, so upgrading moves nobody's retention.

```yaml
workers:
  node_scrape_interval_seconds: 15
  node_sample_max_age_days: 30
```

## Why every existing test still passed

The pruning was already correct and already tested (`test_every_tick_trims_samples_past_the_max_age`). The constructor already accepted and validated `max_age_seconds`. What was missing was the wire between the config and the worker: `_build_workers` constructed `NodeSamplesWorker` passing only `poll_interval_seconds`, so the constructor default won regardless of config, and tests on either side of the gap were both green.

So the new tests assert on the wire, not on the parts:

- `test_node_sample_retention_is_applied` — the configured value reaches the worker. **Verified to fail against the unwired build** and pass with it.
- `test_node_sample_retention_defaults_to_seven_days` — upgrading into a configurable field does not move existing retention.
- `test_the_config_default_and_the_worker_default_agree` — the worker keeps its own fallback for direct callers; the two defaults are now pinned to each other so the wired and direct paths cannot silently disagree.
- `test_a_zero_or_negative_retention_is_refused_at_parse_time` — `ge=1`, so a typo fails the config rather than raising inside the lifespan and taking the process down on boot.

## Note for the release notes

`WorkersConfig` is `extra="forbid"`. An operator who adds `node_sample_max_age_days` to `voicegw.yaml` on a version that predates this PR gets a **validation error on startup**, not an ignored key. The key has to ship before anyone writes it.

## The comment that cited an external document

`_DEFAULT_MAX_AGE_SECONDS` justified its seven days by quoting a scope document with a section reference. Rewritten to be operator-neutral and to state what the setting costs instead: one target at the default 15s interval writes 5,760 rows a day, so N targets over D days is roughly `N x 5760 x D`. A thirteen-target fleet held for ten days is a few hundred thousand rows, order-of-magnitude a hundred megabytes. The budget is the operator's to spend, and the default is not presented as a recommendation.

## Docs

`docs/configuration/voicegw-yaml.md` and `docs/guide/node-metrics.md` both document the key, the retention-must-exceed-the-run rule, and the row cost.

## Gate

`ruff` clean, `mypy` clean on 285 files, `3462 passed, 13 skipped`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable retention period for raw node samples.
  * Retention defaults to seven days and must be at least one day.
  * Reports covering longer periods can now be supported by increasing the retention setting.

* **Documentation**
  * Added guidance on retention periods, reporting windows, scrape frequency, and estimated storage growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->