### PR TITLE
Take the return-to-baseline levels as medians, not one sample each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ## Unreleased
 
+### Fixed
+
+- **The `return_to_baseline` gate no longer lets one scrape decide a node's
+  verdict.** Both sides of the ratio are now a median over their window, and the
+  gate detail says how many samples each was taken over.
+
+  The settle side used to be the newest row in `node_samples`. Generating the
+  report straight after a run, which is the documented flow, therefore read the
+  scrape that had just caught the collector host running the import and the
+  report generator, and failed that node for the reporting tool's own footprint.
+  The same run regenerated later passed, because by then the newest row was an
+  ordinary one, so the verdict depended on when someone typed a command.
+
+  The baseline side had the same fragility in the more dangerous direction: a
+  spike there inflates the denominator, drags the ratio down and turns a real
+  leak into a PASS. Both are now medians.
+
+  Detection is not weakened. A leak holds the value up across the whole window,
+  so the median moves with it; a transient cannot carry a verdict alone.
+
+  **Gate details change wording**: `settled at 1344 (median of 7 samples)
+  against a baseline of 1248 (median of 8 samples)`. A comparison built without
+  sample counts still reads as before, and a window holding one reading says
+  `(a single sample)` rather than calling itself a median.
+
 ### Changed
 
 - **`voicegw_cost_usd_total` and `voicegw_requests_total` on `GET /v1/metrics`

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -1369,6 +1369,17 @@ class BaselineComparison:
     The two ``*_at_ms`` timestamps are optional but load-bearing when present:
     they are what lets the gate refuse a "post-settle" sample that was taken
     before the settle window elapsed.
+
+    ``baseline`` and ``post_settle`` are each a MEDIAN over their side of the
+    run, never a single reading, and the two ``*_samples`` counts say how many
+    readings went into them. One scrape landing during a GC pause, a log
+    rotation or any other momentary spike must not be able to decide a verdict
+    on its own: a real leak holds the value up across the whole window and so
+    moves the median with it, while a transient does not.
+
+    The counts are what make that legible downstream. Without them a report says
+    "settled at 1344" and a reader goes looking for a sample carrying 1344 that
+    may not exist, so the gate quotes the count alongside the value.
     """
 
     node: str
@@ -1379,6 +1390,27 @@ class BaselineComparison:
     post_settle_at_ms: int | None = None
     source: str | None = None
     unmeasured_reason: str | None = None
+    #: How many readings the medians above were taken over. None means the
+    #: caller did not say, and the gate then quotes the values plainly rather
+    #: than claiming a sample count it does not have.
+    baseline_samples: int | None = None
+    post_settle_samples: int | None = None
+
+
+def _over(samples: int | None) -> str:
+    """" (median of N samples)", or nothing when the caller did not say.
+
+    Separated so the value and its provenance cannot drift apart: any detail
+    quoting a median quotes what it is a median OF, in the same breath.
+    """
+    if samples is None:
+        return ""
+    if samples == 1:
+        # Not "median of 1 sample", which reads as a statistic when it is just
+        # the one reading. Saying so is the point: it tells a reader the verdict
+        # rests on a single scrape.
+        return " (a single sample)"
+    return f" (median of {samples} samples)"
 
 
 def _return_to_baseline_gate(
@@ -1446,9 +1478,10 @@ def _return_to_baseline_gate(
         status=status,
         subject=subject,
         detail=(
-            f"{c.metric} on {c.node} settled at {c.post_settle:g} against a "
-            f"baseline of {c.baseline:g} ({ratio:.2f}x), {relation} the "
-            f"{tolerance:.2f}x tolerance"
+            f"{c.metric} on {c.node} settled at {c.post_settle:g}"
+            f"{_over(c.post_settle_samples)} against a baseline of "
+            f"{c.baseline:g}{_over(c.baseline_samples)} ({ratio:.2f}x), "
+            f"{relation} the {tolerance:.2f}x tolerance"
         ),
         metric=f"{c.metric}_baseline_ratio",
         value=ratio,

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -47,6 +47,7 @@ turn it into UNKNOWN rather than PASS.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from statistics import median
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -399,6 +400,23 @@ async def _baseline_comparisons(
     A missing side yields an UNKNOWN comparison rather than being skipped. No
     pre-run idle sample means nobody established what baseline WAS, and a run
     that never measured its starting point cannot show it returned to it.
+
+    Both sides are MEDIANS, not the single nearest reading on each end. Taking
+    one sample per side meant any momentary spike that a 15-second scrape
+    happened to catch became the verdict for the whole node. That is not
+    hypothetical: the settle side took the newest row in the table, so a report
+    generated straight after a run (the documented flow) read the sample that
+    caught the collector host running the import and the report generator
+    themselves, and failed the node for the reporting tool's own footprint.
+    Regenerating the same run later passed, because by then the newest row was
+    an ordinary one, which is a verdict that depends on when someone typed a
+    command.
+
+    A median does not weaken detection. A real descriptor or memory leak holds
+    the value up across the settle window, so it moves the median with it; a
+    transient cannot carry a verdict on its own. The baseline side gets the same
+    treatment and needs it more: a spike there inflates the DENOMINATOR, which
+    drags the ratio down and turns a genuine leak into a PASS.
     """
     before = await list_samples(
         db, node=node, source=source, until_ms=window.start_ms - 1, limit=limit
@@ -418,6 +436,10 @@ async def _baseline_comparisons(
             return float(total - available)
         value = getattr(row, metric)
         return None if value is None else float(value)
+
+    def _median(rows: list, metric: str) -> float | None:
+        values = [v for r in rows if (v := _value(r, metric)) is not None]
+        return median(values) if values else None
 
     out: list[BaselineComparison] = []
     for metric in BASELINE_METRICS:
@@ -441,10 +463,15 @@ async def _baseline_comparisons(
                 node=node,
                 source=source,
                 metric=metric,
-                baseline=_value(pre[-1], metric) if pre else None,
-                post_settle=_value(post[-1], metric) if post else None,
+                baseline=_median(pre, metric),
+                post_settle=_median(post, metric),
+                # The timestamps stay the nearest reading on each side: they
+                # anchor the settle-window check, which asks how much time
+                # elapsed and not what the level was.
                 baseline_at_ms=pre[-1].at_ms if pre else None,
                 post_settle_at_ms=post[-1].at_ms if post else None,
+                baseline_samples=len(pre) or None,
+                post_settle_samples=len(post) or None,
                 unmeasured_reason=reason,
             )
         )

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -429,6 +429,14 @@ def _run_baseline_gates(
                 post_settle=after.post_settle if after else None,
                 baseline_at_ms=before.baseline_at_ms if before else None,
                 post_settle_at_ms=after.post_settle_at_ms if after else None,
+                # Forwarded, not recomputed: the medians and their counts are
+                # decided once, in _baseline_comparisons. Dropping them here
+                # would leave the report quoting a median with nothing saying
+                # what it was taken over.
+                baseline_samples=before.baseline_samples if before else None,
+                post_settle_samples=(
+                    after.post_settle_samples if after else None
+                ),
                 unmeasured_reason=(
                     (before.unmeasured_reason if before else None)
                     or (after.unmeasured_reason if after else None)

--- a/src/voicegateway/tests/loadtest/test_aggregation.py
+++ b/src/voicegateway/tests/loadtest/test_aggregation.py
@@ -372,3 +372,221 @@ def test_a_gauge_is_refused_as_a_counter(db: AsyncSession) -> None:
     assert aggregation.MEMORY_TOTAL_COLUMN in GAUGE_COLUMNS
     # Memory is never diffed, so asking for its rate is a caller bug.
     assert aggregation.MEMORY_AVAILABLE_COLUMN not in COUNTER_COLUMNS
+
+
+# --------------------------------------------------------------------------
+# Return to baseline: one sample must not decide a verdict
+# --------------------------------------------------------------------------
+#
+# The settle side used to be the single newest row in the table. A report
+# generated straight after a run (the documented flow) therefore read the scrape
+# that had just caught the collector host running the import and the report
+# generator, and failed that node for the reporting tool's own footprint. The
+# same run regenerated an hour later passed, because by then the newest row was
+# an ordinary one. A verdict that depends on when someone typed a command is not
+# a verdict.
+#
+# The numbers below are a real 15-second trace of that: flat at 1312 to 1344
+# descriptors and about 1.02 GB across eight minutes, with one sample carrying
+# 1408 and 1.118 GB.
+
+_TOLERANCE = 1.10
+
+# (fd, memory_used_bytes) per 15s scrape after the run.
+_SETTLE_TRACE = [
+    (1344, 999_000_000),
+    (1312, 1_040_000_000),
+    (1408, 1_118_040_000),  # the report generator's own process, and nothing else
+    (1312, 1_040_000_000),
+    (1312, 1_027_000_000),
+    (1344, 1_051_000_000),
+    (1344, 1_008_000_000),
+]
+_BASELINE_FD = 1248
+_BASELINE_MEM = 958_685_000
+_MEM_TOTAL = 4_000_000_000
+_RUN_S = 600  # ten minutes, so the settle check has real time to read
+
+
+def _under_load() -> list:
+    """Samples DURING the run. A node is correlated to a test by having been
+    sampled inside its window, so without these there is no node to compare and
+    no gate at all. Their values do not feed this gate: it reads idle-before
+    against settled-after, never the load itself."""
+    return [
+        _sample(
+            i * 60,
+            filefd_allocated=1400.0,
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - 1_800_000_000),
+        )
+        for i in range(_RUN_S // 60 + 1)
+    ]
+
+
+async def _flat_baseline_then(db: AsyncSession, settle) -> None:
+    """Flat idle before the run, then the given (fd, mem_used) trace after it."""
+    rows = [
+        _sample(
+            -600 + i * 15,
+            filefd_allocated=float(_BASELINE_FD),
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _BASELINE_MEM),
+        )
+        for i in range(8)
+    ]
+    rows += [
+        _sample(
+            _RUN_S + 60 + i * 15,
+            filefd_allocated=float(fd),
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - used),
+        )
+        for i, (fd, used) in enumerate(settle)
+    ]
+    await insert_samples(db, rows + _under_load())
+
+
+async def _baseline_gates(db: AsyncSession):
+    agg = await aggregation.aggregate_test_window(
+        db, started_at_ms=T0, ended_at_ms=T0 + _RUN_S * SEC
+    )
+    assert agg is not None
+    return {
+        g.subject: g
+        for g in gates.return_to_baseline_gates(
+            agg.baseline_comparisons, tolerance=_TOLERANCE
+        )
+    }
+
+
+async def test_one_spike_in_a_flat_settle_window_is_not_a_failure(
+    db: AsyncSession,
+) -> None:
+    """The production case: the reporting tool measuring itself.
+
+    Under the old single-sample reading both of these were FAIL, at 1.13x and
+    1.17x, from the one scrape that overlapped the report generator.
+    """
+    await _flat_baseline_then(db, _SETTLE_TRACE)
+    results = await _baseline_gates(db)
+
+    fd = results["sfu-1/filefd_allocated"]
+    assert fd.status == gates.PASS, fd.detail
+    assert fd.value == pytest.approx(1344 / _BASELINE_FD, rel=1e-3)
+
+    mem = results["sfu-1/memory_used_bytes"]
+    assert mem.status == gates.PASS, mem.detail
+    assert mem.value == pytest.approx(1_040_000_000 / _BASELINE_MEM, rel=1e-3)
+
+
+async def test_a_sustained_leak_still_fails(db: AsyncSession) -> None:
+    """The median must not be a way to pass a real leak.
+
+    Every settle sample is held up, not one, which is what a descriptor or
+    memory leak looks like. The median moves with it.
+    """
+    leaked = [(1500, 1_400_000_000) for _ in _SETTLE_TRACE]
+    await _flat_baseline_then(db, leaked)
+    results = await _baseline_gates(db)
+
+    assert results["sfu-1/filefd_allocated"].status == gates.FAIL
+    assert results["sfu-1/memory_used_bytes"].status == gates.FAIL
+
+
+async def test_a_leak_that_starts_midway_through_settle_still_fails(
+    db: AsyncSession,
+) -> None:
+    """A median over N is not a majority vote that a leak has to win outright.
+
+    Four of seven samples elevated is a resource that went up and stayed up, and
+    it must read as one even though three earlier samples were clean.
+    """
+    climbing = [
+        (1312, 1_000_000_000),
+        (1312, 1_000_000_000),
+        (1344, 1_020_000_000),
+        (1600, 1_500_000_000),
+        (1600, 1_500_000_000),
+        (1600, 1_500_000_000),
+        (1600, 1_500_000_000),
+    ]
+    await _flat_baseline_then(db, climbing)
+    results = await _baseline_gates(db)
+
+    assert results["sfu-1/filefd_allocated"].status == gates.FAIL
+    assert results["sfu-1/memory_used_bytes"].status == gates.FAIL
+
+
+async def test_a_spike_in_the_baseline_cannot_hide_a_leak(db: AsyncSession) -> None:
+    """The dangerous direction, and why the baseline is a median too.
+
+    A spike on the BEFORE side inflates the denominator, which drags the ratio
+    down and turns a genuine leak into a clean bill of health. One reading of
+    1600 among seven flat ones must not do that.
+
+    The spike is on the LAST sample before the run deliberately: that is the one
+    the single-sample reading took, so anywhere else in the window the test
+    would pass against the old code and prove nothing.
+    """
+    rows = [
+        _sample(
+            -600 + i * 15,
+            filefd_allocated=float(1600 if i == 7 else _BASELINE_FD),
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _BASELINE_MEM),
+        )
+        for i in range(8)
+    ]
+    rows += [
+        _sample(
+            _RUN_S + 60 + i * 15,
+            filefd_allocated=1500.0,
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _BASELINE_MEM),
+        )
+        for i in range(7)
+    ]
+    await insert_samples(db, rows + _under_load())
+    results = await _baseline_gates(db)
+
+    fd = results["sfu-1/filefd_allocated"]
+    assert fd.status == gates.FAIL, fd.detail
+    # 1500/1248, not 1500/1600: the spike did not become the baseline.
+    assert fd.value == pytest.approx(1500 / _BASELINE_FD, rel=1e-3)
+
+
+async def test_the_detail_says_what_the_number_is_a_median_of(
+    db: AsyncSession,
+) -> None:
+    """A reader must not go hunting for a sample carrying the quoted value.
+
+    "settled at 1344" with no qualifier sends someone looking for a scrape that
+    read 1344 at a particular instant, which for a median need not exist at all.
+    """
+    await _flat_baseline_then(db, _SETTLE_TRACE)
+    detail = (await _baseline_gates(db))["sfu-1/filefd_allocated"].detail
+    assert "median of 7 samples" in detail
+    assert "median of 8 samples" in detail
+
+
+def test_a_single_sample_says_so_rather_than_calling_itself_a_median() -> None:
+    """One reading either side is still allowed, and must be labelled as one."""
+    [result] = gates.return_to_baseline_gates(
+        [
+            gates.BaselineComparison(
+                node="sfu-1",
+                metric="filefd_allocated",
+                baseline=1000.0,
+                post_settle=1010.0,
+                baseline_at_ms=T0,
+                post_settle_at_ms=T0 + 900_000,
+                baseline_samples=1,
+                post_settle_samples=1,
+            )
+        ],
+        tolerance=_TOLERANCE,
+    )
+    assert result.status == gates.PASS
+    assert "a single sample" in result.detail
+    assert "median" not in result.detail


### PR DESCRIPTION
For 0.24.8, alongside #232.

## The bug

The `return_to_baseline` gate failed nodes for the reporting tool's own footprint.

`_baseline_comparisons` read `list_samples(...)` ascending and took `post[-1]`, so the settle level was **the newest row in `node_samples` at report time**. Running `loadtest import` and `loadtest report` straight after a run, which is the documented `make collect && make report` flow, means the newest row is the scrape that just caught those two processes starting on the collector host. That one 15-second sample became the verdict for the whole node.

Regenerating the same run later passed, because by then the newest row was an ordinary one. A verdict that depends on when someone typed a command is not a verdict, and it hits on the normal path every time.

## The fix

Both sides of the ratio are a median over their window rather than a single reading.

Detection is not weakened: a real descriptor or memory leak holds the value up across the whole settle window, so the median moves with it. A transient cannot carry a verdict alone.

## The baseline side needed it more

A spike on the **before** side inflates the denominator, drags the ratio down, and turns a genuine leak into a PASS. A false pass is worse than a false failure for an evidence tool, so the baseline is a median too. `test_a_spike_in_the_baseline_cannot_hide_a_leak` pins it, with the spike deliberately on the last pre-run sample, which is the one the old code took: anywhere else it would pass against the old reading and prove nothing.

## Tests

Both discriminating tests were verified to **fail against the 0.24.7 single-sample reading** and pass with the fix:

- `test_one_spike_in_a_flat_settle_window_is_not_a_failure` uses the real trace: flat at 1312 to 1344 descriptors and about 1.02 GB across eight minutes, with one sample at 1408 and 1.118 GB. Was FAIL at 1.13x and 1.17x; now PASS at 1.077x and 1.085x.
- `test_a_spike_in_the_baseline_cannot_hide_a_leak` is the false-PASS direction.
- `test_a_sustained_leak_still_fails` and `test_a_leak_that_starts_midway_through_settle_still_fails` pin that the median is not a way to launder a leak. The second is the one worth keeping: four of seven samples elevated is a resource that went up and stayed up, and it must read as one.
- `test_the_detail_says_what_the_number_is_a_median_of` and `test_a_single_sample_says_so_rather_than_calling_itself_a_median`.

## Detail string changes

```
filefd_allocated on <node> settled at 1344 (median of 7 samples) against a
baseline of 1248 (median of 8 samples) (1.08x), within the 1.10x tolerance
```

A comparison built without sample counts reads exactly as before, and a window holding one reading says `(a single sample)` rather than calling itself a median.

## Not done here

Two related defects in the same function, reported separately rather than folded in:

1. `list_samples` is ascending **with a limit** (5,000, about 20.8 hours at a 15s cadence), so `before` is the *oldest* retained window, not the samples near the run. Which rows are called "the baseline" therefore depends on how much history the table holds. I reproduced a 2.000 to 0.500 ratio swing on identical data and an identical run window, with only the retained history differing. Medianing helps but does not fix the selection.
2. `min_settle_ms` is checked as `post_settle_at_ms - baseline_at_ms` (gates.py), so it measures baseline-to-post, not teardown-to-post. With a baseline hours before the run that check can never fail.

## Gate

`ruff` clean, `mypy` clean on 285 files, `3464 passed, 13 skipped`.