### PR TITLE
Fix/settle median

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,38 @@ follows [Semantic Versioning](https://semver.org/) and
   sample counts still reads as before, and a window holding one reading says
   `(a single sample)` rather than calling itself a median.
 
+- **The `return_to_baseline` gate takes its baseline from the run, not from
+  whatever the table still holds.** Both windows are now anchored to the run
+  window: the 5 minutes before it starts, and 5 to 10 minutes after it ends.
+
+  The selection was "everything before the run" and "everything after it", each
+  capped at 5,000 rows **ascending**. At a 15s cadence that cap spans about 20.8
+  hours, so the rows it returned were the oldest retained history rather than
+  anything near the run. On a real hour-long 500-concurrent run it produced a
+  baseline from 21 hours earlier and reported a true 1.10x as **0.51x**: a
+  marginal FAIL rendered as a confident PASS.
+
+  It also coupled verdicts to retention. Which rows survive is
+  `workers.node_sample_max_age_days`, so changing retention moved every baseline
+  on every re-rendered report, with nothing connecting the two. Anchoring to the
+  run window breaks that link, which is why this ships in the same release as
+  that setting.
+
+- **The settle window is measured from the end of the run.** It was measured
+  from the baseline sample to the settled sample, which answers a different
+  question and can be arbitrarily large while teardown is still draining, so
+  `MIN_SETTLE_MS` could never fail.
+
+  **Behaviour change**: a report generated before the settle window has elapsed
+  now reports `UNKNOWN` rather than a verdict. Nothing has settled a minute
+  after teardown, so there is no return to report either way. This is what
+  `MIN_SETTLE_MS` always intended.
+
+- **Gate details name the instant their numbers came from**, as
+  `ending 2026-08-05T15:27:00Z`. Two reports carried a 21-hour-old baseline
+  without anyone noticing, because no artifact said which samples produced the
+  numbers and checking one meant querying the database.
+
 ### Changed
 
 - **`voicegw_cost_usd_total` and `voicegw_requests_total` on `GET /v1/metrics`

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime
 from typing import Any
 
 from voicegateway.utils.percentiles import compute_percentiles
@@ -1395,6 +1396,12 @@ class BaselineComparison:
     #: than claiming a sample count it does not have.
     baseline_samples: int | None = None
     post_settle_samples: int | None = None
+    #: When the RUN ended. The only correct anchor for "has teardown been left
+    #: long enough to settle": the gap between the two samples answers a
+    #: different question and can be arbitrarily large while teardown is still
+    #: draining. None keeps the older sample-to-sample check rather than
+    #: dropping the guard entirely.
+    run_end_ms: int | None = None
 
 
 def _over(samples: int | None) -> str:
@@ -1411,6 +1418,20 @@ def _over(samples: int | None) -> str:
         # rests on a single scrape.
         return " (a single sample)"
     return f" (median of {samples} samples)"
+
+
+def _at(at_ms: int | None) -> str:
+    """" ending <UTC instant>", so a reader can go and check the sample.
+
+    The whole reason the 21-hour-old baseline went unnoticed through two
+    delivered reports is that no artifact said WHICH samples produced the
+    numbers, so verifying a verdict meant querying the database. A report that
+    names its own window is checkable by the person holding it.
+    """
+    if at_ms is None:
+        return ""
+    stamp = datetime.fromtimestamp(at_ms / 1000, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return f" ending {stamp}"
 
 
 def _return_to_baseline_gate(
@@ -1455,16 +1476,18 @@ def _return_to_baseline_gate(
             ),
             threshold=tolerance,
         )
-    if c.baseline_at_ms is not None and c.post_settle_at_ms is not None:
-        settled_ms = c.post_settle_at_ms - c.baseline_at_ms
+    anchor = c.run_end_ms if c.run_end_ms is not None else c.baseline_at_ms
+    if anchor is not None and c.post_settle_at_ms is not None:
+        settled_ms = c.post_settle_at_ms - anchor
+        since = "the run ended" if c.run_end_ms is not None else "the first"
         if settled_ms < min_settle_ms:
             return GateResult(
                 gate=RETURN_TO_BASELINE_GATE,
                 status=UNKNOWN,
                 subject=subject,
                 detail=(
-                    f"the second {c.metric} sample on {c.node} was taken "
-                    f"{settled_ms / 1000:.0f}s after the first, inside the "
+                    f"the settled {c.metric} sample on {c.node} was taken "
+                    f"{settled_ms / 1000:.0f}s after {since}, inside the "
                     f"{min_settle_ms / 1000:.0f}s settle window, so it is not a "
                     "post-settle reading and a return cannot be claimed from it"
                 ),
@@ -1479,9 +1502,10 @@ def _return_to_baseline_gate(
         subject=subject,
         detail=(
             f"{c.metric} on {c.node} settled at {c.post_settle:g}"
-            f"{_over(c.post_settle_samples)} against a baseline of "
-            f"{c.baseline:g}{_over(c.baseline_samples)} ({ratio:.2f}x), "
-            f"{relation} the {tolerance:.2f}x tolerance"
+            f"{_over(c.post_settle_samples)}{_at(c.post_settle_at_ms)} against "
+            f"a baseline of {c.baseline:g}{_over(c.baseline_samples)}"
+            f"{_at(c.baseline_at_ms)} ({ratio:.2f}x), {relation} the "
+            f"{tolerance:.2f}x tolerance"
         ),
         metric=f"{c.metric}_baseline_ratio",
         value=ratio,

--- a/src/voicegateway/loadtest/aggregation.py
+++ b/src/voicegateway/loadtest/aggregation.py
@@ -291,6 +291,16 @@ TREND_METRICS: tuple[tuple[str, bool], ...] = (
 #: the trap: it is higher-is-better, so comparing memory_available_bytes here
 #: reports a node that ENDED WITH MORE FREE MEMORY as having failed to return.
 #: Memory is therefore carried as USED, derived from the total/available pair.
+#: How far before the run start an idle baseline may be taken from. Five
+#: minutes: near enough that it describes the same hour as the run, wide enough
+#: that a median has samples to work with at the default 15s cadence.
+BASELINE_WINDOW_MS = 300_000
+
+#: How wide the settle window is, starting at :data:`gates.MIN_SETTLE_MS` after
+#: the run ends. Together those give the 5 to 10 minutes past teardown the
+#: runbook specifies.
+SETTLE_WINDOW_MS = 300_000
+
 BASELINE_METRICS: tuple[str, ...] = (
     "memory_used_bytes",
     "filefd_allocated",
@@ -417,12 +427,50 @@ async def _baseline_comparisons(
     transient cannot carry a verdict on its own. The baseline side gets the same
     treatment and needs it more: a spike there inflates the DENOMINATOR, which
     drags the ratio down and turns a genuine leak into a PASS.
+
+    Both windows are BOUNDED, and anchored to the run rather than to the table.
+    The selection used to be "everything before the run" and "everything after
+    it", each capped at ``limit`` rows ASCENDING. That cap is what made the
+    baseline arbitrary: at 5,000 rows and a 15s cadence it spans about 20.8
+    hours, so the rows it returned were the OLDEST retained history rather than
+    anything near the run. On a real hour-long 500-concurrent run the baseline
+    it produced came from 21 hours before the run started, reporting a true
+    1.10x as 0.51x: a marginal FAIL rendered as a confident PASS, which is the
+    worst direction for an evidence tool.
+
+    It also coupled the verdict to retention. Which rows survive is
+    ``workers.node_sample_max_age_days``, so changing retention silently moved
+    every baseline and therefore every re-rendered verdict, with nothing
+    connecting the two. Anchoring both windows to the run window breaks that
+    link: the same run re-rendered on a differently-pruned table now selects the
+    same samples or none, never different ones.
+
+    The settle window is 5 to 10 minutes after teardown, which is the range the
+    runbook specifies and past LiveKit's reap timeouts. Samples inside the first
+    five minutes are excluded rather than averaged in: teardown that has not
+    finished draining looks like a clean return, and that reads as evidence when
+    it is the absence of it. A report generated before that window has elapsed
+    now says UNKNOWN, which is the honest answer and is what
+    :data:`gates.MIN_SETTLE_MS` always intended. It could not enforce it because
+    it measured from the baseline sample rather than from the end of the run.
     """
     before = await list_samples(
-        db, node=node, source=source, until_ms=window.start_ms - 1, limit=limit
+        db,
+        node=node,
+        source=source,
+        since_ms=window.start_ms - BASELINE_WINDOW_MS,
+        until_ms=window.start_ms - 1,
+        limit=limit,
     )
+    settle_from = window.end_ms + gates.MIN_SETTLE_MS
+    settle_to = settle_from + SETTLE_WINDOW_MS
     after = await list_samples(
-        db, node=node, source=source, since_ms=window.end_ms + 1, limit=limit
+        db,
+        node=node,
+        source=source,
+        since_ms=settle_from,
+        until_ms=settle_to,
+        limit=limit,
     )
 
     def _value(row, metric: str) -> float | None:
@@ -450,13 +498,20 @@ async def _baseline_comparisons(
         reason = None
         if not pre:
             reason = (
-                "not measured: no idle sample was recorded before the test, "
-                "so no baseline was ever established to return to"
+                "not measured: no idle sample was recorded in the "
+                f"{BASELINE_WINDOW_MS // 60_000} minutes before the test, so no "
+                "baseline was established near the run to return to. An older "
+                "sample is not a substitute: it describes a different hour"
             )
         elif not post:
             reason = (
-                "not measured: no sample was recorded after the test window, "
-                "so nothing shows the resource came back"
+                "not measured: no sample was recorded in the settle window, "
+                f"{gates.MIN_SETTLE_MS // 60_000} to "
+                f"{(gates.MIN_SETTLE_MS + SETTLE_WINDOW_MS) // 60_000} minutes "
+                "after the test ended, so nothing shows the resource came back. "
+                "A report generated before that window elapsed cannot answer "
+                "this, and reporting it as a clean return would be evidence of "
+                "nothing"
             )
         out.append(
             BaselineComparison(
@@ -472,6 +527,11 @@ async def _baseline_comparisons(
                 post_settle_at_ms=post[-1].at_ms if post else None,
                 baseline_samples=len(pre) or None,
                 post_settle_samples=len(post) or None,
+                # The anchor the settle check needs. Measured from the end of
+                # the RUN, never from the baseline sample: the distance between
+                # the two samples says nothing about how long teardown was left
+                # to drain.
+                run_end_ms=window.end_ms,
                 unmeasured_reason=reason,
             )
         )

--- a/src/voicegateway/loadtest/judge.py
+++ b/src/voicegateway/loadtest/judge.py
@@ -437,6 +437,10 @@ def _run_baseline_gates(
                 post_settle_samples=(
                     after.post_settle_samples if after else None
                 ),
+                # From the LAST test's window: the settle check asks how long
+                # after the run finished the settled sample was taken, and the
+                # run finished when its last test did.
+                run_end_ms=after.run_end_ms if after else None,
                 unmeasured_reason=(
                     (before.unmeasured_reason if before else None)
                     or (after.unmeasured_reason if after else None)

--- a/src/voicegateway/tests/loadtest/test_aggregation.py
+++ b/src/voicegateway/tests/loadtest/test_aggregation.py
@@ -407,6 +407,14 @@ _BASELINE_MEM = 958_685_000
 _MEM_TOTAL = 4_000_000_000
 _RUN_S = 600  # ten minutes, so the settle check has real time to read
 
+# The window is padded 15s on each side, so the run occupies
+# [T0 - 15s, T0 + _RUN_S + 15s]. These offsets put the fixtures inside the two
+# windows the gate reads: the 5 minutes before the run, and 5 to 10 minutes
+# after it. Sample timing is part of what is under test here, not scaffolding:
+# a settle sample taken a minute after teardown is not a post-settle reading.
+_BASELINE_AT = -300  # seconds, first of eight at 15s -> -300 to -195
+_SETTLE_AT = _RUN_S + 315  # 5m15s past the padded end, first of seven
+
 
 def _under_load() -> list:
     """Samples DURING the run. A node is correlated to a test by having been
@@ -428,7 +436,7 @@ async def _flat_baseline_then(db: AsyncSession, settle) -> None:
     """Flat idle before the run, then the given (fd, mem_used) trace after it."""
     rows = [
         _sample(
-            -600 + i * 15,
+            _BASELINE_AT + i * 15,
             filefd_allocated=float(_BASELINE_FD),
             memory_total_bytes=float(_MEM_TOTAL),
             memory_available_bytes=float(_MEM_TOTAL - _BASELINE_MEM),
@@ -437,7 +445,7 @@ async def _flat_baseline_then(db: AsyncSession, settle) -> None:
     ]
     rows += [
         _sample(
-            _RUN_S + 60 + i * 15,
+            _SETTLE_AT + i * 15,
             filefd_allocated=float(fd),
             memory_total_bytes=float(_MEM_TOTAL),
             memory_available_bytes=float(_MEM_TOTAL - used),
@@ -531,7 +539,7 @@ async def test_a_spike_in_the_baseline_cannot_hide_a_leak(db: AsyncSession) -> N
     """
     rows = [
         _sample(
-            -600 + i * 15,
+            _BASELINE_AT + i * 15,
             filefd_allocated=float(1600 if i == 7 else _BASELINE_FD),
             memory_total_bytes=float(_MEM_TOTAL),
             memory_available_bytes=float(_MEM_TOTAL - _BASELINE_MEM),
@@ -540,7 +548,7 @@ async def test_a_spike_in_the_baseline_cannot_hide_a_leak(db: AsyncSession) -> N
     ]
     rows += [
         _sample(
-            _RUN_S + 60 + i * 15,
+            _SETTLE_AT + i * 15,
             filefd_allocated=1500.0,
             memory_total_bytes=float(_MEM_TOTAL),
             memory_available_bytes=float(_MEM_TOTAL - _BASELINE_MEM),
@@ -590,3 +598,164 @@ def test_a_single_sample_says_so_rather_than_calling_itself_a_median() -> None:
     assert result.status == gates.PASS
     assert "a single sample" in result.detail
     assert "median" not in result.detail
+
+
+# --------------------------------------------------------------------------
+# The baseline comes from the run, not from whatever the table still holds
+# --------------------------------------------------------------------------
+#
+# The selection used to be "everything before the run", ascending, capped at
+# 5,000 rows. At a 15s cadence that cap spans about 20.8 hours, so the rows it
+# returned were the OLDEST retained history rather than anything near the run.
+#
+# The numbers below are a real hour-long 500-concurrent run. Its true ratio was
+# marginal, 1.10x against a 1.10x tolerance. The old selection reported 0.51x,
+# because it took its baseline from 21 hours earlier when the box was carrying
+# 1.94 GB. A marginal FAIL rendered as a confident PASS.
+
+_GB = 1_000_000_000
+_TRUE_BASELINE = 0.7405 * _GB
+_TRUE_SETTLE = 0.8147 * _GB
+_STALE_BASELINE = 1.9362 * _GB  # 21 hours before the run, and irrelevant to it
+_HOUR_S = 3600
+
+
+async def test_an_old_sample_cannot_become_the_baseline(db: AsyncSession) -> None:
+    """The regression, in one test: a true 1.10x must not report as 0.51x.
+
+    The stale block is deliberately large. Under the old ascending-with-a-limit
+    selection the oldest rows are exactly the ones that win, so a fixture with
+    only a few of them would pass against the broken code and prove nothing.
+    """
+    stale = [
+        _sample(
+            -21 * _HOUR_S + i * 15,
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _STALE_BASELINE),
+        )
+        for i in range(240)  # an hour of it, 21 hours before the run
+    ]
+    near = [
+        _sample(
+            _BASELINE_AT + i * 15,
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _TRUE_BASELINE),
+        )
+        for i in range(20)
+    ]
+    settled = [
+        _sample(
+            _SETTLE_AT + i * 15,
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _TRUE_SETTLE),
+        )
+        for i in range(20)
+    ]
+    await insert_samples(db, stale + near + settled + _under_load())
+
+    result = (await _baseline_gates(db))["sfu-1/memory_used_bytes"]
+    assert result.value == pytest.approx(_TRUE_SETTLE / _TRUE_BASELINE, rel=1e-3)
+    # What the old selection produced. Named so the failure message says which
+    # bug came back rather than just quoting two floats.
+    assert result.value != pytest.approx(_TRUE_SETTLE / _STALE_BASELINE, rel=1e-2), (
+        "the baseline came from the stale block 21 hours before the run"
+    )
+
+
+async def test_retention_does_not_move_the_verdict(db: AsyncSession) -> None:
+    """The coupling that made the retention setting a silent verdict-changer.
+
+    Which rows survive is ``workers.node_sample_max_age_days``, and the old
+    selection read the oldest of them, so changing retention moved every
+    baseline on every re-rendered report with nothing connecting the two. The
+    same run must now read the same, pruned or not.
+    """
+    near = [
+        _sample(
+            _BASELINE_AT + i * 15,
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _TRUE_BASELINE),
+        )
+        for i in range(20)
+    ]
+    settled = [
+        _sample(
+            _SETTLE_AT + i * 15,
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _TRUE_SETTLE),
+        )
+        for i in range(20)
+    ]
+    await insert_samples(db, near + settled + _under_load())
+    pruned = (await _baseline_gates(db))["sfu-1/memory_used_bytes"]
+
+    # Now the same run on a table that kept a day of older history.
+    await insert_samples(
+        db,
+        [
+            _sample(
+                -21 * _HOUR_S + i * 15,
+                memory_total_bytes=float(_MEM_TOTAL),
+                memory_available_bytes=float(_MEM_TOTAL - _STALE_BASELINE),
+            )
+            for i in range(240)
+        ],
+    )
+    retained = (await _baseline_gates(db))["sfu-1/memory_used_bytes"]
+
+    assert retained.value == pytest.approx(pruned.value, rel=1e-9)
+    assert retained.status == pruned.status
+
+
+async def test_a_report_generated_before_the_settle_window_says_unknown(
+    db: AsyncSession,
+) -> None:
+    """Not a PASS, and this is a behaviour change worth stating plainly.
+
+    Running the report a minute after teardown used to produce a verdict from
+    whatever the newest row happened to be. Nothing has settled a minute after
+    teardown, so there is no return to report either way, and UNKNOWN is what
+    ``MIN_SETTLE_MS`` always intended. It could not enforce it because it
+    measured from the baseline sample rather than from the end of the run.
+    """
+    rows = [
+        _sample(
+            _BASELINE_AT + i * 15,
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _TRUE_BASELINE),
+        )
+        for i in range(20)
+    ]
+    rows += [
+        _sample(
+            _RUN_S + 60 + i * 15,  # one minute after teardown, still draining
+            memory_total_bytes=float(_MEM_TOTAL),
+            memory_available_bytes=float(_MEM_TOTAL - _TRUE_SETTLE),
+        )
+        for i in range(4)
+    ]
+    await insert_samples(db, rows + _under_load())
+
+    result = (await _baseline_gates(db))["sfu-1/memory_used_bytes"]
+    assert result.status == gates.UNKNOWN
+    assert "settle window" in result.detail
+
+
+async def test_the_detail_names_the_instant_its_baseline_came_from(
+    db: AsyncSession,
+) -> None:
+    """A verdict nobody can check is not evidence.
+
+    Two reports carried a 21-hour-old baseline without anyone noticing, because
+    no artifact said which samples produced the numbers: verifying one meant
+    querying the database.
+    """
+    await _flat_baseline_then(db, _SETTLE_TRACE)
+    detail = (await _baseline_gates(db))["sfu-1/filefd_allocated"].detail
+
+    from datetime import UTC, datetime
+
+    expected = datetime.fromtimestamp(
+        (T0 + (_BASELINE_AT + 7 * 15) * SEC) / 1000, tz=UTC
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert expected in detail, detail


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved return-to-baseline validation by using bounded five-minute windows around each test run.
  - Settle timing now starts when the test run completes, improving verdict accuracy.
  - Reports generated before sufficient settling now correctly show an unknown status.
  - Diagnostic details now identify the timestamps used for baseline and post-settle values.
  - Prevented stale historical samples from affecting baseline results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->