### PR TITLE
Do not fail a node over a change its counter cannot express

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Fixed
 
+- **The `return_to_baseline` gate no longer fails a node over a change its
+  counter cannot meaningfully express.** A ratio outside tolerance is now a
+  failure only when the absolute change also clears a per-metric floor.
+
+  A pure ratio made the gate's sensitivity depend on the magnitude of the
+  counter rather than on anything about the node. At 2,688 descriptors a 10%
+  tolerance allows 268; at 864 it allows 86; at 320 it allows 32.
+
+  `filefd_allocated` is quantized, which makes that concrete. Observed across a
+  real fleet: 256 distinct values, every one a multiple of 32, smallest gap
+  exactly 32. That is the kernel, not the exporter: `/proc/sys/fs/file-nr`'s
+  allocated count is a percpu_counter read without folding in the per-CPU
+  deltas, and the fold happens per `percpu_counter_batch`, which is
+  `max(32, 2 x online CPUs)`. At 320 descriptors a single unavoidable tick of
+  that counter is a 10% move and failed the gate on its own.
+
+  The floor is 128 descriptors, four ticks on the common case, and 8 for
+  `sockstat_udp_inuse`, which is not quantized but is a small integer count with
+  the same magnitude problem. `memory_used_bytes` is **deliberately unfloored**:
+  it is continuous and large, so its ratio means what it says.
+
+  A suppressed failure says so. The detail reports the ratio that would have
+  failed and the floor that stopped it, and the ratio stays on the result.
+
 - **The `return_to_baseline` gate no longer lets one scrape decide a node's
   verdict.** Both sides of the ratio are now a median over their window, and the
   gate detail says how many samples each was taken over.

--- a/src/voicegateway/livekit_diag/gates.py
+++ b/src/voicegateway/livekit_diag/gates.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Final
 
 from voicegateway.utils.percentiles import compute_percentiles
 
@@ -170,6 +170,45 @@ ALL_GATES: frozenset[str] = frozenset(
 # Go hands freed heap back to the OS lazily, so a drained process holds its
 # resident size long after the heap emptied, and gating on it would report a leak
 # on healthy runs.
+#: Absolute change a metric must move before a ratio outside tolerance counts
+#: as a failure. A metric absent from here is governed by the ratio alone.
+#:
+#: A pure ratio makes the gate's sensitivity depend on the MAGNITUDE of the
+#: counter rather than on anything about the node. At 2,688 descriptors a 10%
+#: tolerance allows 268; at 864 it allows 86; at 320 it allows 32. So a node
+#: holding few descriptors is gated an order of magnitude more tightly than a
+#: busy one, for no reason connected to health.
+#:
+#: ``filefd_allocated`` makes that concrete because it is QUANTIZED. Observed
+#: across a real fleet: 256 distinct values, every one a multiple of 32, with a
+#: smallest gap of exactly 32. That is the kernel's doing, not the exporter's:
+#: ``/proc/sys/fs/file-nr``'s allocated count is a percpu_counter read without
+#: folding in the per-CPU deltas, and the fold happens per
+#: ``percpu_counter_batch``, which is ``max(32, 2 x online CPUs)``. A machine
+#: cannot report a change smaller than one batch, so at 320 descriptors a single
+#: unavoidable tick of the counter is a 10% move and fails the gate on its own.
+#:
+#: 128 is four of those ticks on the common case. It suppresses the tick-level
+#: noise that fails small nodes while staying far below any leak worth
+#: reporting: a run leaking descriptors per call over hundreds of calls moves
+#: this by hundreds or thousands, not by 96. Note the resolution is coarser on a
+#: machine with more than 16 CPUs, where 128 is two ticks rather than four.
+#:
+#: ``sockstat_udp_inuse`` is not quantized, but it is a small integer count with
+#: the same magnitude problem: a node idling on 4 UDP sockets and settling on 5
+#: is 1.25x. Unlike the descriptor floor this value is a judgement rather than a
+#: measurement, and it is deliberately small.
+#:
+#: ``memory_used_bytes`` is ABSENT on purpose. It is continuous and large, so
+#: the ratio means what it says, and a real run has already been delivered whose
+#: memory verdict sits at a marginal 1.10x. A floor here would silently turn
+#: that into a pass, which is the direction this gate must never move on its
+#: own.
+MIN_ABSOLUTE_CHANGE: Final[dict[str, float]] = {
+    "filefd_allocated": 128.0,
+    "sockstat_udp_inuse": 8.0,
+}
+
 BASELINE_HEAP = "heap_inuse_bytes"
 BASELINE_GOROUTINES = "go_goroutines"
 
@@ -1494,6 +1533,31 @@ def _return_to_baseline_gate(
                 threshold=tolerance,
             )
     ratio = c.post_settle / c.baseline
+    floor = MIN_ABSOLUTE_CHANGE.get(c.metric)
+    increase = c.post_settle - c.baseline
+    if ratio > tolerance and floor is not None and increase < floor:
+        # Outside the tolerance, but by less than this counter can meaningfully
+        # express. Reported as a pass that SAYS SO, never as a silent one: the
+        # ratio stays on the result, so a reader sees the number that would have
+        # failed and why it did not.
+        return GateResult(
+            gate=RETURN_TO_BASELINE_GATE,
+            status=PASS,
+            subject=subject,
+            detail=(
+                f"{c.metric} on {c.node} settled at {c.post_settle:g}"
+                f"{_over(c.post_settle_samples)}{_at(c.post_settle_at_ms)} "
+                f"against a baseline of {c.baseline:g}"
+                f"{_over(c.baseline_samples)}{_at(c.baseline_at_ms)} "
+                f"({ratio:.2f}x, outside the {tolerance:.2f}x tolerance), but "
+                f"the change of {increase:g} is under the {floor:g} this "
+                "counter needs before a difference means anything, so it is not "
+                "a failure to return"
+            ),
+            metric=f"{c.metric}_baseline_ratio",
+            value=ratio,
+            threshold=tolerance,
+        )
     status = PASS if ratio <= tolerance else FAIL
     relation = "within" if status == PASS else "outside"
     return GateResult(

--- a/src/voicegateway/tests/livekit_diag/test_gates.py
+++ b/src/voicegateway/tests/livekit_diag/test_gates.py
@@ -1488,3 +1488,116 @@ class TestTwoWayMediaGate:
         # exact misstatement RATIO_GATES exists to prevent.
         assert gates.TWO_WAY_MEDIA_GATE in gates.ALL_GATES
         assert gates.TWO_WAY_MEDIA_GATE not in gates.RATIO_GATES
+
+
+# ---------------------------------------------------------------------------
+# A change the counter cannot meaningfully express must not decide a verdict
+#
+# filefd_allocated is quantized: observed across a real fleet, 256 distinct
+# values, every one a multiple of 32, smallest gap exactly 32. The kernel reads
+# /proc/sys/fs/file-nr's allocated count from a percpu_counter without folding
+# in the per-CPU deltas, and folds per percpu_counter_batch = max(32, 2 x CPUs).
+#
+# A pure ratio therefore gates a node by the MAGNITUDE of its counter: at 320
+# descriptors one unavoidable tick is 10% and fails on its own, while at 2,688 a
+# tick is 1.2% and three of them pass.
+# ---------------------------------------------------------------------------
+
+# The real failure this came from, verbatim: a load generator that finished
+# BELOW its own steady state (median 1184 in the half hour before the run) and
+# was failed anyway on a 96-descriptor move, which is three ticks of a counter
+# that cannot express less than one.
+_FD = "filefd_allocated"
+_FD_BASELINE = 864.0
+_FD_SETTLE = 960.0
+
+
+def test_a_few_ticks_of_a_quantized_counter_is_not_a_failure():
+    [gate] = gates.return_to_baseline_gates(
+        [_cmp(_FD, _FD_BASELINE, _FD_SETTLE)], tolerance=1.10
+    )
+    assert gate.status == gates.PASS, gate.detail
+    # The ratio that would have failed is still on the result. Suppressing the
+    # verdict must not also suppress the number a reader would want to see.
+    assert gate.value == pytest.approx(_FD_SETTLE / _FD_BASELINE, rel=1e-3)
+    assert gate.value > 1.10
+    assert "under the 128" in gate.detail
+
+
+def test_the_same_ratio_at_a_real_magnitude_still_fails():
+    """The floor must not be a way to disable the gate.
+
+    Ten times the descriptors, the identical 1.11x, and now the move is 960:
+    far past anything the counter's resolution can explain.
+    """
+    [gate] = gates.return_to_baseline_gates(
+        [_cmp(_FD, _FD_BASELINE * 10, _FD_SETTLE * 10)], tolerance=1.10
+    )
+    assert gate.status == gates.FAIL, gate.detail
+    assert gate.value == pytest.approx(_FD_SETTLE / _FD_BASELINE, rel=1e-3)
+
+
+def test_a_descriptor_leak_just_past_the_floor_still_fails():
+    """The boundary is a real edge, so it is pinned rather than assumed."""
+    [under] = gates.return_to_baseline_gates(
+        [_cmp(_FD, 864.0, 864.0 + 127.0)], tolerance=1.10
+    )
+    [over] = gates.return_to_baseline_gates(
+        [_cmp(_FD, 864.0, 864.0 + 128.0)], tolerance=1.10
+    )
+    assert under.status == gates.PASS
+    assert over.status == gates.FAIL
+
+
+def test_the_floor_never_turns_a_passing_ratio_into_anything_else():
+    """It only ever suppresses a FAIL; it cannot manufacture one."""
+    [gate] = gates.return_to_baseline_gates(
+        [_cmp(_FD, 864.0, 880.0)], tolerance=1.10
+    )
+    assert gate.status == gates.PASS
+    assert "under the" not in gate.detail  # the ordinary within-tolerance detail
+
+
+def test_a_drop_below_baseline_is_not_dragged_into_the_floor_branch():
+    """A node that settled LOWER than it started is inside tolerance anyway.
+
+    Pinned because the floor compares a signed increase: a large decrease is a
+    small number in the wrong direction, and must not be read as "a small move".
+    """
+    [gate] = gates.return_to_baseline_gates(
+        [_cmp(_FD, 2000.0, 800.0)], tolerance=1.10
+    )
+    assert gate.status == gates.PASS
+    assert gate.value == pytest.approx(0.4)
+
+
+def test_memory_is_deliberately_not_floored():
+    """A marginal memory verdict must stay a verdict.
+
+    A delivered 500-concurrent report turns on a memory ratio sitting at exactly
+    1.10x. A floor on this metric would silently move that to a pass, which is
+    the one direction this gate must never move on its own. Memory is continuous
+    and large-magnitude, so the ratio means what it says.
+    """
+    assert "memory_used_bytes" not in gates.MIN_ABSOLUTE_CHANGE
+    # A 74 MB move on a 0.74 GB baseline: the real marginal case, still judged.
+    [gate] = gates.return_to_baseline_gates(
+        [_cmp("memory_used_bytes", 740_500_000.0, 814_700_000.0)], tolerance=1.09
+    )
+    assert gate.status == gates.FAIL
+
+
+def test_every_baseline_metric_has_a_decision_recorded():
+    """Each metric is either floored or explicitly not, never overlooked.
+
+    A metric added to BASELINE_METRICS without thinking about magnitude inherits
+    the pure-ratio behaviour silently, which is exactly how the descriptor case
+    reached a client report.
+    """
+    from voicegateway.loadtest.aggregation import BASELINE_METRICS
+
+    decided = set(gates.MIN_ABSOLUTE_CHANGE) | {"memory_used_bytes"}
+    assert set(BASELINE_METRICS) <= decided, (
+        f"no floor decision recorded for {set(BASELINE_METRICS) - decided}: add "
+        "it to MIN_ABSOLUTE_CHANGE, or to this test's exemption with a reason"
+    )


### PR DESCRIPTION
Follows 0.24.8. Found by chasing the last failing gate on a re-rendered report.

## The failure

```
loadgen-1/filefd_allocated
settled at 960 (median of 20) against a baseline of 864 (median of 20), 1.11x, outside 1.10x
```

Not a leak. Against its own steady state that node finished **lower** than it started:

| window | median |
|---|---|
| 30 to 5 min before the run (steady state) | 1184 |
| 5 to 0 min before (gate baseline) | 864 |
| 5 to 10 min after end (gate settle) | 960 |

settle / steady state = **0.811**.

## The general defect

A pure ratio makes the gate's sensitivity depend on the **magnitude** of the counter, not on anything about the node:

| descriptors | one tick | three ticks |
|---|---|---|
| 320 | 10.0% | FAIL on one tick |
| 864 | 3.7% | 11.1%, FAIL |
| 2688 | 1.2% | 3.6%, PASS |

`filefd_allocated` is **quantized**, which makes it concrete. Observed across a real fleet: 256 distinct values, every one a multiple of 32, smallest gap exactly 32.

That is the kernel rather than the exporter, and it is worth stating because it also predicts where the resolution differs: `/proc/sys/fs/file-nr`'s allocated count is a `percpu_counter` read *without* folding in the per-CPU deltas, and the fold happens per `percpu_counter_batch`, which is `max(32, 2 x online CPUs)`. So 32 is the floor of the resolution, and a machine with more than 16 CPUs reports in steps of 64 or more.

That prediction was then measured independently: across a twelve-node fleet and five instance types, the GCD of each node's distinct values is 32 on every one, and every instance type is at or below 8 vCPU, so `max(32, 2 x vCPU)` is 32 throughout. The 96 that failed `loadgen-1` is three ticks of a counter that cannot express less than one.

## The mechanism chosen

A fixed per-metric floor, in `gates.MIN_ABSOLUTE_CHANGE`. A ratio outside tolerance fails only if the absolute change also clears it.

| metric | floor | basis |
|---|---|---|
| `filefd_allocated` | 128 | four ticks of the 32-descriptor batch; measured |
| `sockstat_udp_inuse` | 8 | not quantized, but a small integer count with the same magnitude problem; a judgement, deliberately small |
| `memory_used_bytes` | none | it does not have the defect the floor corrects; see below |

**I did not derive the resolution from the samples.** The GCD of observed differences is more elegant, but it is undefined exactly when a window is flat, which is what a good baseline looks like, so it would need a fallback for the common case. Widening it to all history for that node would recouple the verdict to retained history, which #234 just removed. A constant is reproducible from the run window alone.

**Why `memory_used_bytes` is unfloored.** Both its series come from node_exporter's meminfo collector, which reads `/proc/meminfo` in kB and multiplies by 1024, so the smallest change it can express is 1024 bytes: roughly 0.0001% of a 1e9 reading, four orders of magnitude below any tolerance anyone would set. The situation that produced the descriptor bug, where three ticks of a counter that cannot express less than one tick came to 11%, cannot arise. A floor there buys nothing while being able to turn a measured failure into a pass.

The second commit corrects this reasoning. The first justified it by a delivered run's memory verdict sitting at 1.10x, on the line. That figure predated #234 and was computed with a settle window still catching teardown; the bounded window moved it, and the highest memory ratio on that run now renders as 1.026x. The decision was right, the reason was falsifiable by re-rendering a report, and a reason like that invites someone to reopen a settled decision.

**No node is special-cased.** Nothing here knows what a generator is: special-casing the symptom would leave every low-descriptor node over-gated.

## A suppressed failure says so

```
filefd_allocated on loadgen-1 settled at 960 (median of 20 samples) ending ...
against a baseline of 864 (median of 20 samples) ending ... (1.11x, outside the
1.10x tolerance), but the change of 96 is under the 128 this counter needs
before a difference means anything, so it is not a failure to return
```

The ratio stays on the result, so suppressing the verdict does not suppress the number.

## Tests

`test_a_few_ticks_of_a_quantized_counter_is_not_a_failure` uses the reported case verbatim (864 / 960, 1.111x against 1.10) and was verified to **fail against 0.24.8** and pass with the fix. Alongside it:

- the same 1.11x at ten times the magnitude still FAILs, so the floor is not a way to disable the gate
- the 127/128 boundary is pinned on both sides
- the floor can only ever suppress a FAIL, never manufacture one
- a node settling *below* baseline is not dragged into the floor branch by the signed comparison
- `test_every_baseline_metric_has_a_decision_recorded` requires each metric to be floored or explicitly exempt, so the next one added cannot inherit pure-ratio behaviour by omission

## Not addressed here

Both raised and both agreed as out of scope: the 5-minute pre-run baseline window being contaminated by run preparation (what "baseline" means differs by node lifecycle), and the report having no notion of which nodes are the system under test. The second is the one that lets a load generator and a monitoring host decide a client's verdict, and it needs a way to declare node roles.

Related: `go_goroutines` is a small integer count with the same magnitude problem. It is documented as a baseline metric but nothing constructs a comparison for it today, so it stays unfloored rather than acquiring an invented constant.

## Gate

`ruff` clean, `mypy` clean on 285 files, `3479 passed, 13 skipped` (7 new).