### PR TITLE
Do not send an operator to re-run a scrape that was complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Fixed
 
+- **A report no longer tells an operator to re-run a scrape that was already
+  complete.** A gate that could not divide because nothing declared its
+  denominator is now filed apart from a gate whose series was never scraped, and
+  is sent to a re-import rather than a re-capture.
+
+  The two read identically in the report and their remedies point opposite ways.
+  On a real 500-concurrent hour, 32 `resource_headroom` gates went UNKNOWN
+  because a SIP tier had scaled to 4 while the `--network-baseline` file still
+  stopped at sip-2. `network_receive_bytes_total` was present in 257 of 257
+  node_exporter samples for both nodes: nothing was missing from the scrape.
+  `not_collected` said "the series was not in this run's scrape" and advised
+  re-running against the current scrape configuration, an hour of fleet time
+  that could not have changed the outcome. The gate's own detail line beside it
+  said the true thing the whole time. Adding two lines of JSON and re-importing
+  the same artifacts took 908 PASS / 51 UNKNOWN to 940 PASS / 19 UNKNOWN.
+
+- **`voicegw loadtest import` now names the scraped nodes that have no declared
+  network baseline.** Import is the only point where the declared names and the
+  scraped names are both in hand, so it is the only place a tier that scaled
+  since the baseline file was written can be caught.
+
+  ```
+  1 scraped node(s) carried network throughput with no declared baseline (sip-3),
+  so their network headroom gates will read UNKNOWN.
+  ```
+
+  Warned on the nodes the bandwidth gate will actually iterate, so a node with
+  no measured throughput produces no row and no warning. This is the fix that
+  catches the class: the two above are the same omission found weeks later, in a
+  report, one release before delivery.
+
+- **`--network-baseline` and `--plan` ignore top-level keys starting with `_`,**
+  so a declaration can carry its own provenance. Every top-level key was parsed
+  as an entry, so a `"_comment"` naming where the published figures came from
+  was refused as a malformed node. The documented copy in a repo therefore could
+  not be loaded, a stripped duplicate got hand-placed on the collector, and the
+  two drifted with nothing comparing them. That drift is what let the missing
+  SIP tier above survive to the report.
+
 - **The `return_to_baseline` gate no longer fails a node over a change its
   counter cannot meaningfully express.** A ratio outside tolerance is now a
   failure only when the absolute change also clears a per-metric floor.

--- a/docs/cli/loadtest.md
+++ b/docs/cli/loadtest.md
@@ -61,6 +61,22 @@ The peak a step actually reached still comes from the artifacts, never overwritt
 
 It is the only source for the bandwidth-headroom gate's denominator. A node with no entry reports UNKNOWN, never a percentage of a guess. It is a floor, not a ceiling: an instance bursts above it, so utilisation computed against it reads high, the safe direction for a headroom check.
 
+Both files ignore top-level keys starting with `_`, so a declaration can carry its own provenance and the copy in your repo can be the copy that runs:
+
+```json
+{"_comment": "published c7i.2xlarge figure, AWS docs, checked 2026-08",
+ "sip-1": {"in_bps": 3125000000, "out_bps": 3125000000}}
+```
+
+**Import warns about nodes you did not declare.** When the scrape shows a node carrying throughput and no baseline was declared for it, the import names it:
+
+```
+1 scraped node(s) carried network throughput with no declared baseline (sip-3),
+so their network headroom gates will read UNKNOWN.
+```
+
+Import is the only point where the declared names and the scraped names are both in hand, so it is the only place a tier that scaled since the file was written can be caught. Fix it by adding the node and re-importing the **same** artifacts: nothing was missing from the scrape, so re-capturing the run cannot help.
+
 ## runs
 
 `voicegw loadtest runs` lists imported runs, newest first, with each row's provenance read off whether `artifact_sha256` is set. Flags: `--config, -c`; `--project, -p` to filter; `--limit, -n` for how many (default 20).

--- a/src/voicegateway/cli/loadtest_cli.py
+++ b/src/voicegateway/cli/loadtest_cli.py
@@ -208,9 +208,15 @@ def import_run(
     gw = _cli.require_gateway(config)
     storage = _cli.require_storage(gw)
 
-    async def _write() -> list[str]:
+    async def _write() -> tuple[list[str], set[str]]:
         await storage.upsert_load_run(plan.run)
         correlated: list[str] = []
+        # Every node the scrape showed carrying throughput, so the undeclared
+        # ones can be named below. Collected from bandwidth_peaks rather than
+        # from the scrape target list because that is the exact set the
+        # bandwidth gate will iterate: a node with no measured rate produces no
+        # headroom row at all and must not be warned about.
+        throughput_nodes: set[str] = set()
         for test in plan.tests:
             # Correlate BEFORE writing, so the row lands complete rather than
             # being written once without the fleet columns and again with them.
@@ -231,6 +237,7 @@ def import_run(
                     node_samples_in_window=aggregate.node_samples_in_window,
                 )
             )
+            throughput_nodes.update(name for name, _dir in aggregate.bandwidth_peaks)
             if aggregate.node_samples_in_window:
                 correlated.append(
                     f"{test.name}: {aggregate.node_samples_in_window} node samples "
@@ -239,9 +246,9 @@ def import_run(
                     f"({peak_label(_cpu_samples(aggregate))}), "
                     f"memory {_pct(aggregate.peak_memory_utilisation)}"
                 )
-        return correlated
+        return correlated, throughput_nodes
 
-    correlated = _cli.async_run(_write())
+    correlated, throughput_nodes = _cli.async_run(_write())
     if correlated:
         console.print("\n[dim]Fleet during each test (overlap, not attribution):[/dim]")
         for line in correlated:
@@ -250,6 +257,23 @@ def import_run(
         _cli.warn(
             "No node samples overlap these test windows, so peak CPU and memory "
             "are not measured. They stay NULL rather than reading 0."
+        )
+
+    # THE ONLY PLACE BOTH LISTS ARE IN ONE HAND. The baseline file is written by
+    # an operator and the node names come out of the scrape, so nothing before
+    # this point can compare them and nothing after it still has the file. Left
+    # unsaid, a tier that scaled after the file was written turns into UNKNOWN
+    # headroom rows in a report read weeks later, which is where this was
+    # actually found: a SIP tier grew to 4 while the file still stopped at
+    # sip-2, and 32 gates went UNKNOWN for want of two lines of JSON.
+    undeclared = sorted(throughput_nodes - set(baselines))
+    if undeclared:
+        _cli.warn(
+            f"{len(undeclared)} scraped node(s) carried network throughput with "
+            f"no declared baseline ({', '.join(undeclared)}), so their network "
+            "headroom gates will read UNKNOWN. The series is here and only the "
+            "denominator is missing: add them to --network-baseline and "
+            "re-import these same artifacts. Nothing needs re-capturing."
         )
     _cli.success(f"Imported {plan.run.id}: {len(plan.tests)} tests.")
 
@@ -284,6 +308,24 @@ def list_runs(
             "[green]measured[/green]" if measured else "[yellow]synthetic[/yellow]",
         )
     console.print(table)
+
+
+def _is_annotation_key(name: str) -> bool:
+    """Whether a top-level key is the file documenting itself, not a declaration.
+
+    Both option files below are hand-written by an operator and every top-level
+    key in them is otherwise parsed as an entry, so a ``"_comment"`` explaining
+    where the figures came from is refused as a malformed node. That has a cost
+    worth naming: the copy kept in a repo cannot be the copy that runs, so a
+    stripped duplicate gets hand-placed on the collector, the two drift, and
+    nothing compares them. One engagement lost a whole SIP tier's baseline that
+    way and did not find out until the report.
+
+    JSON has no comment syntax, so the convention has to come from here. An
+    underscore prefix is the usual one, and a node named with a leading
+    underscore is not a hostname anybody has.
+    """
+    return name.startswith("_")
 
 
 def _plan_from_file(path: Path) -> dict[str, dict[str, float]]:
@@ -329,6 +371,8 @@ def _plan_from_file(path: Path) -> dict[str, dict[str, float]]:
 
     plan: dict[str, dict[str, float]] = {}
     for name, value in raw.items():
+        if _is_annotation_key(name):
+            continue
         step = value if isinstance(value, dict) else {"target_concurrency": value}
         target = step.get("target_concurrency")
         if not isinstance(target, int) or isinstance(target, bool) or target <= 0:
@@ -388,6 +432,10 @@ def _network_baselines_from_file(path: Path) -> dict[str, dict[str, float]]:
     number cover both would put an assumption inside a declaration that exists to
     hold none.
 
+    Top-level keys starting with an underscore are the file's own documentation
+    and are skipped: see :func:`_is_annotation_key` for why that is worth a
+    convention.
+
     THIS FILE IS THE ONLY SOURCE. No instance type is mapped to a bandwidth
     anywhere in this code, and none may be added. A lookup table would hand a
     denominator to a node whose instance type nobody verified, and the report
@@ -419,6 +467,8 @@ def _network_baselines_from_file(path: Path) -> dict[str, dict[str, float]]:
 
     baselines: dict[str, dict[str, float]] = {}
     for node, value in raw.items():
+        if _is_annotation_key(node):
+            continue
         if not isinstance(value, dict):
             raise typer.BadParameter(
                 f"{path}: {node!r} must be an object carrying in_bps and "

--- a/src/voicegateway/livekit_diag/run_report.py
+++ b/src/voicegateway/livekit_diag/run_report.py
@@ -2380,6 +2380,17 @@ _PROFILE_MEASUREMENTS: dict[str, tuple[str, str]] = {
 #: Grouped by cause rather than by gate so the section reads as a setup
 #: checklist. Twelve rows saying "not measured" are one action when they share a
 #: cause, and a reader who has to derive that themselves does not.
+#:
+#: A MISSING DENOMINATOR IS NOT A MISSING SERIES, and the two are separate
+#: entries because their remediations point opposite ways. A series nobody
+#: scraped needs the fleet run again; a node nobody declared a baseline for
+#: needs two lines of JSON and a re-import of the artifacts already on disk.
+#: These were one bucket, and the fallback told an operator holding 257 good
+#: samples per node to "re-run against the current scrape configuration": an
+#: hour of 500-concurrent fleet time that could not have changed the outcome,
+#: while the gate's own detail line sitting beside it said the true thing. When
+#: a row's remedy is wrong it is worse than absent, because absent makes
+#: somebody look.
 _PROFILE_CAUSES: tuple[tuple[tuple[str, ...], str, str], ...] = (
     (
         (
@@ -2399,6 +2410,15 @@ _PROFILE_CAUSES: tuple[tuple[tuple[str, ...], str, str], ...] = (
         "A trend is computed over thirds of the steady-state window and each "
         f"third needs at least {gates.MIN_TREND_SAMPLES} usable samples. Run for "
         "longer, or sample more often. Too short to tell is not flat.",
+    ),
+    (
+        ("baseline was declared for",),
+        "Nothing declared the denominator it divides by",
+        "The series WAS collected. What is missing is the operator-declared "
+        "figure it would be measured against, and each row's detail names the "
+        "node that wants one. Add that node to the --network-baseline file and "
+        "RE-IMPORT THE SAME ARTIFACTS. Re-capturing cannot help and costs a "
+        "fleet-hour: nothing was absent from the scrape.",
     ),
     (
         (),

--- a/src/voicegateway/tests/loadtest/test_missing_denominator.py
+++ b/src/voicegateway/tests/loadtest/test_missing_denominator.py
@@ -1,0 +1,294 @@
+"""A missing DENOMINATOR is not a missing SERIES, and the difference is an hour.
+
+Both read UNKNOWN and the two remedies point opposite ways. A series nobody
+scraped needs the fleet run again. A node nobody declared a network baseline for
+needs two lines of JSON and a re-import of the artifacts already on disk.
+
+Filed as one bucket, the report told an operator holding 257 good node_exporter
+samples per node to "re-run against the current scrape configuration". That is a
+500-concurrent fleet hour that could not have changed the outcome, and the gate's
+own detail line sitting beside it said the true thing the whole time: the node
+carried throughput and nothing declared a baseline for it. Thirty-two gates on
+one real run were UNKNOWN because a SIP tier scaled to 4 while the baseline file
+still stopped at sip-2.
+
+So there are three defences here and they are deliberately at three different
+depths:
+
+* the CLASSIFIER stops sending the operator to the wrong remedy (after the fact),
+* the IMPORT WARNING names the undeclared nodes while they can still be fixed
+  cheaply (before the report is ever read), and
+* the baseline file may now carry its own documentation, so the copy in a repo
+  and the copy on the collector can be the same bytes. They drifted, and that
+  drift is what let the omission survive to the report.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+import yaml
+from typer.testing import CliRunner
+
+from voicegateway.cli._app import app
+from voicegateway.cli.loadtest_cli import (
+    _network_baselines_from_file,
+    _plan_from_file,
+)
+from voicegateway.livekit_diag import run_report
+from voicegateway.repository import node_samples_repository as node_samples
+from voicegateway.services.storage_service import StorageService
+
+runner = CliRunner()
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "loadtest"
+ACCEPTANCE = FIXTURES / "acceptance-500"
+
+NODE = "sfu-1"
+SOURCE = "node-exporter"
+WINDOW = (1_785_661_201_000, 1_785_661_320_000)
+COUNTER_ORIGIN_S = 1_785_661_200
+RX_BYTES_PER_SECOND = 50_000_000.0
+TX_BYTES_PER_SECOND = 60_000_000.0
+DECLARED_BASELINE_BPS = 3_125_000_000.0
+
+
+# --------------------------------------------------------------------------
+# The classifier: which remedy a gap is sent to
+# --------------------------------------------------------------------------
+
+
+def _uncollected(detail: str, subject: str = "sip-3/network_in"):
+    """One not-collected entry, built from the detail a gate actually recorded.
+
+    ``value`` is None because that is what puts a gate in the not-collected list
+    at all: the classification under test reads only the prose beside it.
+    """
+    entries = run_report.not_collected_entries(
+        [
+            {
+                "gate": "resource_headroom",
+                "subject": subject,
+                "status": "unknown",
+                "value": None,
+                "detail": detail,
+            }
+        ]
+    )
+    assert entries is not None
+    return entries[0]
+
+
+#: Verbatim from ``_bandwidth_gates_for``. Copied rather than imported so that
+#: rewording the gate's prose without rewording the marker fails HERE, loudly,
+#: instead of silently routing the row back to the re-capture remedy.
+NO_BASELINE_DETAIL = (
+    "sip-3 carried throughput but no inbound baseline was declared for it, and "
+    "there is nothing to measure link capacity against. The instance type is "
+    "deliberately not read to infer one"
+)
+
+
+def test_a_missing_denominator_is_not_filed_as_a_missing_series() -> None:
+    """The bug: 32 gates told an operator to re-run a scrape that was complete."""
+    entry = _uncollected(NO_BASELINE_DETAIL)
+    assert "not in this run's scrape" not in entry["cause"]
+    assert "denominator" in entry["cause"]
+
+
+def test_the_remedy_says_re_import_and_never_re_capture() -> None:
+    """The whole cost of the old wording was one wrong verb.
+
+    Asserted as a positive AND a negative: a remedy that adds "re-import" while
+    leaving "re-run the scrape" in place has not fixed anything for a reader who
+    stops at the first instruction.
+    """
+    change = _uncollected(NO_BASELINE_DETAIL)["change"]
+    assert "--network-baseline" in change
+    assert "RE-IMPORT THE SAME ARTIFACTS" in change
+    assert "Re-run against" not in change
+
+
+def test_the_node_that_wants_a_baseline_is_still_named_verbatim() -> None:
+    """The shared remedy cannot name a node, so the per-row detail must."""
+    assert "sip-3" in _uncollected(NO_BASELINE_DETAIL)["recorded"]
+
+
+def test_a_genuinely_unscraped_series_still_routes_to_a_re_run() -> None:
+    """The guard on the fix. The old remedy is right for the case it was written
+    for, and narrowing it must not empty it."""
+    entry = _uncollected("nothing in this run's scrape carried the series it needs")
+    assert "not in this run's scrape" in entry["cause"]
+    assert "Re-run against" in entry["change"]
+
+
+def test_a_baseline_that_was_never_ESTABLISHED_is_not_a_missing_denominator() -> None:
+    """Two different absent baselines, one word apart in the prose.
+
+    ``return_to_baseline`` says "no baseline was ESTABLISHED" when no idle sample
+    exists outside the window, and that one really does need another run. The
+    marker keys on "declared", so this must not be captured by it.
+    """
+    entry = _uncollected(
+        "not measured: no sample outside the test window carried this resource, "
+        "so no baseline was established and nothing shows it came back"
+    )
+    assert "denominator" not in entry["cause"]
+
+
+# --------------------------------------------------------------------------
+# The import warning: named while it is still cheap to fix
+# --------------------------------------------------------------------------
+
+
+async def _seed(db_path: Path) -> None:
+    """One node whose window carries the throughput counters and nothing else
+    interesting. The rate is what makes a bandwidth peak exist, so the counters
+    have to climb in absolute time rather than restart per window."""
+    storage = StorageService(db_path=str(db_path))
+    await storage._ensure_initialized()
+    start_ms, end_ms = WINDOW
+    async with storage._conn.session() as db:
+        rows = []
+        for index in range(0, (end_ms - start_ms) // 10_000 + 1):
+            at_ms = start_ms + index * 10_000
+            since_origin = at_ms // 1000 - COUNTER_ORIGIN_S
+            rows.append(
+                node_samples.NodeSampleInput(
+                    node=NODE,
+                    source=SOURCE,
+                    at_ms=at_ms,
+                    outcome="ok",
+                    values={
+                        "network_receive_bytes_total": (
+                            RX_BYTES_PER_SECOND * since_origin
+                        ),
+                        "network_transmit_bytes_total": (
+                            TX_BYTES_PER_SECOND * since_origin
+                        ),
+                    },
+                )
+            )
+        await node_samples.insert_samples(db, rows)
+    await storage.aclose()
+
+
+def _import(tmp_path: Path, *, declare: bool):
+    """Seed a scrape carrying throughput, then import with or without a baseline."""
+    import asyncio
+
+    db = tmp_path / "throwaway.db"
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.dump({"cost_tracking": {"enabled": True, "db_path": str(db)}})
+    )
+    # Before the import: correlation happens at import time, so a sample written
+    # afterwards would never reach the row.
+    asyncio.run(_seed(db))
+
+    argv = [
+        "loadtest",
+        "import",
+        str(ACCEPTANCE),
+        "--captured",
+        "--config",
+        str(config),
+    ]
+    if declare:
+        baseline = tmp_path / "network-baseline.json"
+        baseline.write_text(
+            json.dumps(
+                {
+                    NODE: {
+                        "in_bps": DECLARED_BASELINE_BPS,
+                        "out_bps": DECLARED_BASELINE_BPS,
+                    }
+                }
+            )
+        )
+        argv += ["--network-baseline", str(baseline)]
+    return runner.invoke(app, argv)
+
+
+def test_import_names_the_scraped_node_that_has_no_declared_baseline(
+    tmp_path: Path,
+) -> None:
+    """The class fix. Import is the only place both lists are in one hand.
+
+    The baseline file is written by an operator and the node names come out of
+    the scrape: nothing earlier can compare them and nothing later still holds
+    the file. Unsaid here, a tier that scaled after the file was written becomes
+    UNKNOWN headroom rows in a report read weeks later.
+    """
+    result = _import(tmp_path, declare=False)
+    assert result.exit_code == 0, result.output
+    assert NODE in result.output
+    assert "no declared baseline" in result.output
+    assert "UNKNOWN" in result.output
+
+
+def test_the_warning_points_at_a_re_import_not_a_re_capture(tmp_path: Path) -> None:
+    """Same wrong verb, caught at the other end of the pipeline."""
+    output = _import(tmp_path, declare=False).output
+    assert "re-import" in output
+    assert "Nothing needs re-capturing" in output
+
+
+def test_a_declared_node_is_not_warned_about(tmp_path: Path) -> None:
+    """The warning has to go quiet once it is satisfied, or it trains an
+    operator to scroll past it."""
+    result = _import(tmp_path, declare=True)
+    assert result.exit_code == 0, result.output
+    assert "no declared baseline" not in result.output
+
+
+# --------------------------------------------------------------------------
+# The file may document itself
+# --------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "declaration.json"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_a_baseline_file_may_carry_a_comment(tmp_path: Path) -> None:
+    """JSON has no comment syntax, so the convention has to come from the reader.
+
+    Without this the documented copy in a repo could not be loaded, so a stripped
+    duplicate was hand-placed on the collector and the two drifted with nothing
+    comparing them. That drift is how a whole SIP tier's baseline went missing.
+    """
+    path = _write(
+        tmp_path,
+        {
+            "_comment": ["published c7i.2xlarge figure, AWS docs, checked 2026-08"],
+            "sip-1": {"in_bps": 3_125_000_000, "out_bps": 3_125_000_000},
+        },
+    )
+    assert _network_baselines_from_file(path) == {
+        "sip-1": {"in_bps": 3_125_000_000.0, "out_bps": 3_125_000_000.0}
+    }
+
+
+def test_a_plan_file_may_carry_a_comment_too(tmp_path: Path) -> None:
+    """The sibling file, fixed with it. A convention that works in one of two
+    hand-written files beside each other is a trap rather than a convention."""
+    path = _write(tmp_path, {"_comment": "from the scenario file", "ramp-100": 100})
+    assert _plan_from_file(path) == {"ramp-100": {"target_concurrency": 100}}
+
+
+def test_a_misspelled_field_is_still_refused(tmp_path: Path) -> None:
+    """Skipping ``_`` keys must not become skipping validation.
+
+    A node is not a comment, and a declaration that looks complete and is not is
+    the exact failure this whole file exists about.
+    """
+    path = _write(tmp_path, {"sip-1": {"in_bps": 1, "out_bsp": 1}})
+    with pytest.raises(typer.BadParameter) as excinfo:
+        _network_baselines_from_file(path)
+    assert "out_bsp" in str(excinfo.value)


### PR DESCRIPTION
A gate that could not divide because nothing declared its denominator was filed as a gate whose series was never scraped. The two read identically in the report and their remedies point opposite ways: one needs the fleet run again, the other needs two lines of JSON and a re-import of the artifacts already on disk.

Found on a real 500-concurrent hour. 32 `resource_headroom` gates read UNKNOWN on sip-3 and sip-4 because the SIP tier had scaled to 4 while the `--network-baseline` file still stopped at sip-2. `network_receive_bytes_total` was present in **257 of 257** node_exporter samples on both nodes, so nothing was missing from the scrape. `not_collected` said "the series was not in this run's scrape" and advised re-running against the current scrape configuration: an hour of fleet time that could not have changed the outcome. The gate's own detail line, sitting beside it, said the true thing the whole time. Adding two lines of JSON and re-importing the same artifacts took 908 PASS / 51 UNKNOWN to 940 PASS / 19 UNKNOWN.

## Three defences, at three depths

**The classifier** separates a missing denominator from a missing series and points at a re-import rather than a re-capture. It keys on `"declared"`, so the *other* absent baseline in `return_to_baseline` ("no baseline was **established**", which genuinely does need another run) is not captured by it. Both directions are asserted.

**The import warning** is the fix that catches the class:

```
1 scraped node(s) carried network throughput with no declared baseline (sip-3),
so their network headroom gates will read UNKNOWN. The series is here and only
the denominator is missing: add them to --network-baseline and re-import these
same artifacts. Nothing needs re-capturing.
```

Import is the only point holding both the declared names and the scraped names, so it is the only place a tier that scaled since the file was written can be caught. Warned off `bandwidth_peaks`, which is the exact set the bandwidth gate iterates, so a node with no measured throughput produces no row and no warning. The other two fixes are the same omission found weeks later, in a report, one release before delivery.

**`_`-prefixed top-level keys are ignored** in `--network-baseline` *and* `--plan`. Every top-level key was parsed as an entry, so a `"_comment"` naming where the published AWS figures came from was refused as a malformed node. The documented copy in a repo therefore could not be loaded, a stripped duplicate got hand-placed on the collector, and the two drifted with nothing comparing them. That drift is what let the missing tier survive to the report. Applied to both files because a convention that works in one of two hand-written files beside each other is a trap.

## Notes

- `run_report.py` is left unformatted where it already was: `ruff format` disagrees with it at HEAD, CI runs only `ruff check` and `mypy`, and reformatting it here would bury the diff.
- Reported from the LiveKit SFU load-testing side. The remaining 19 UNKNOWN on that run are correct and none are addressed here: 10 `sockstat_udp_inuse` where the baseline is 3 sockets and the floor properly declines to divide, 8 redis-exporter series that do not exist, and 1 pps.

## Gates

ruff clean, mypy clean on 285 files, 3490 passed (+11 new).