### PR TITLE
Move the PyPI publisher pin so it accepts metadata 2.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,8 +47,16 @@ jobs:
     - name: Build wheel (bundles dashboard SPA)
       run: bash tools/scripts/build_wheel.sh
 
+    # Twine v7 lives inside this action, and v7 is what accepts core
+    # packaging metadata 2.5. THAT IS WHY THIS PIN MOVED, and moving it
+    # is the fix rather than pinning the builder backwards: hatchling
+    # 1.32 emits Metadata-Version 2.5 unconditionally, PyPI already
+    # accepts 2.5 (hatchling's own wheel on PyPI carries it), and the
+    # only component that refused it was the twine frozen inside the
+    # v1.14.0 pin below. v0.24.10 built a valid wheel and never
+    # published because of it.
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
         packages-dir: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Fixed
 
+- **The PyPI publish works again. `0.24.10` never reached PyPI**; install it from
+  PyPI and you get `0.24.9`. The Docker images and the GitHub release for
+  `0.24.10` published normally, so only the PyPI artifact is missing, and this
+  release carries the same code plus this fix.
+
+  Nothing was wrong with the wheel. `pyproject.toml` requires `hatchling` with no
+  upper bound, so the build resolved hatchling 1.32.0, which writes
+  `Metadata-Version: 2.5` unconditionally (a package with nothing but a name and
+  a version gets it). The publish action was pinned to v1.14.0, whose bundled
+  twine validates only up to 2.4, so `twine check` failed before upload with
+  `InvalidDistribution: '2.5' is not a valid metadata version`. `0.24.9` shipped
+  `Metadata-Version: 2.4` from an older hatchling, which dates the drift.
+
+  Fixed by moving the pin to v1.14.2, which bundles twine v7 precisely to accept
+  metadata 2.5. **Not** by pinning hatchling backwards: PyPI already accepts 2.5
+  (hatchling's own wheel on PyPI carries it), so the stale checker was the whole
+  defect and capping the builder would have been working around it.
+
 - **A report no longer tells an operator to re-run a scrape that was already
   complete.** A gate that could not divide because nothing declared its
   denominator is now filed apart from a gate whose series was never scraped, and


### PR DESCRIPTION
`v0.24.10` built a valid wheel and never published. Docker and the GitHub release went out normally, so **only the PyPI artifact is missing**: `pip install voicegateway` still gets `0.24.9`.

## What actually failed

`twine check`, inside the publish action, before any upload was attempted:

```
Checking dist/voicegateway-0.24.10-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

**Nothing is wrong with the wheel.** Each link below was checked rather than assumed:

| Check | Result |
|---|---|
| `0.24.9` wheel, downloaded from PyPI | `Metadata-Version: 2.4` |
| Trivial hatchling package built today (name + version only, no license, no deps) | `Metadata-Version: 2.5` |
| hatchling version resolved | 1.32.0 |
| `pyproject.toml:184` | `requires = ["hatchling", "hatch-vcs"]`, no upper bound |
| `publish.yml` pin before this PR | `cef2210` = v1.14.0, April 2026 |

hatchling 1.32.0 emits `2.5` unconditionally, so nothing in our metadata triggered it. The unpinned backend floated forward between the two tags while the SHA-pinned action's twine stayed frozen at a validator that stops at 2.4.

## Why bump the action rather than cap hatchling

**PyPI already accepts metadata 2.5.** hatchling 1.32.0's own wheel, on PyPI right now, carries `Metadata-Version: 2.5`.

So the only component refusing a valid artifact was the frozen twine. Capping hatchling would also have made the publish succeed, but it would mean pinning away from a metadata version the index accepts in order to accommodate a stale checker, and leaving the real staleness in place.

v1.14.2's release notes are explicit that this is the fix:

> what *most* people will find useful is @takluyver's update of Twine to v7 that we use internally (#416). This version will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI.

Pin moves `cef2210` (v1.14.0) → `dc37677` (v1.14.2), keeping the immutable-SHA convention and the version comment the workflow header asks for.

## Not included, and why

I originally suggested adding a CI job that builds a wheel and runs `twine check`, on the grounds that no PR check builds a wheel. **That would not have caught this** and I withdrew it: CI would install a current twine, which accepts 2.5 happily, while the failure came from the *older* twine frozen inside the action. A guard that passes on the exact input that broke the release is worse than no guard.

The defect is that the builder floats and the publisher is frozen, and the two only meet at tag time. The fix that addresses that class is dependency automation on GitHub Actions (there is no `dependabot.yml` or `renovate.json` in this repo, which is why an April pin was still live in August). That changes the PR flow for every workflow in the repo, so it is left as a separate decision rather than folded in here.

## Verification

This workflow only runs on a `v*.*.*` tag push, so CI cannot exercise it on this PR. What is verified here is the diagnosis, not the outcome: the fix is confirmed by the action's own release notes naming metadata 2.5, and by PyPI demonstrably hosting 2.5 wheels. The real check is the next tag push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PyPI package publishing compatibility with metadata generated by newer build tooling.
  * Docker images and GitHub release artifacts remain unaffected.

* **Documentation**
  * Updated the changelog with details about the publishing fix and affected release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->