### PR TITLE
Make voicegw run on a bare install, and stop describing it as LiveKit-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 ## Project
 
-VoiceGateway: cost tracking and reconciliation for LiveKit voice agents. Returns native LiveKit STT, LLM, and TTS plugin instances across cloud providers (OpenAI, Deepgram, Anthropic, Groq, Cartesia, ElevenLabs, AssemblyAI) and local models (Whisper, Kokoro, Piper). LLM, STT, and TTS prices all flow through `voice-prices` (a fork of `pydantic/genai-prices`). Ships `voicegw reconcile` for verifying recorded numbers against provider invoices, plus per-modality cost tracking, resolver-time fallback chains, rate limiting, and a web dashboard.
+VoiceGateway: cost tracking and reconciliation for voice agents on LiveKit, Pipecat and OpenRTC. Meters the native STT, LLM, and TTS instances you pass to `attach()` / `guard()` across cloud providers (OpenAI, Deepgram, Anthropic, Groq, Cartesia, ElevenLabs, AssemblyAI) and local models (Whisper, Kokoro, Piper). LLM, STT, and TTS prices all flow through `voice-prices` (a fork of `pydantic/genai-prices`). Ships `voicegw reconcile` for verifying recorded numbers against provider invoices, plus per-modality cost tracking, resolver-time fallback chains, rate limiting, and a web dashboard.
 
 ## Commands
 
@@ -44,7 +44,7 @@ docker compose --profile local up -d     # + Ollama
 - `registry.py` — Lazy provider factory (instantiates on first use)
 - `model_id.py` — Parses `provider/model` format strings
 
-**Providers (`src/voicegateway/providers/`):** Each extends `BaseProvider` from `base.py`. 11 implementations covering cloud and local models.
+**Providers (`src/voicegateway/inference/providers/`):** Each extends `BaseProvider` from `base_provider.py`. 11 implementations covering cloud and local models.
 
 **Middleware (`src/voicegateway/middleware/`):** Cost tracking, latency monitoring, rate limiting, request logging, fallback chains. All wrap provider calls. v0.6.0 guardrails are LLM-side only: `InstrumentedLLM._apply_guardrails` uses `middleware/guardrails.py` and `middleware/guardrail_prompts/` to inject the guardrail prompt/tool, reject reserved tool-name collisions, and write fired/bypassed audit rows.
 
@@ -56,7 +56,7 @@ docker compose --profile local up -d     # + Ollama
 
 **Dashboard UI (`src/dashboard/`):** two SPAs plus branding assets. `frontend/` is the React/TypeScript/Vite dashboard (Recharts, Neo-Brutalism aesthetic); `console/` is a smaller SPA built on `@openorca-ui/react`. `api/` now holds only `static/branding/` images and no Python. The combined server serves the built SPA at `/` (see `server/static.py`).
 
-**Public API:** `voicegateway/__init__.py` exports `Gateway`, `ModelId`, `GatewayConfig`.
+**Public API:** `voicegateway/__init__.py` exports `attach`, `guard`, `Observer`, `register_worker`, `inference`, `__version__`. There is no `Gateway` / `ModelId` factory surface: it was removed in the framework-agnostic reshape, and metering now happens by wrapping instances you construct.
 
 ## Key Patterns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ## Unreleased
 
+### Fixed
+
+- **`voicegw` now runs on a bare `pip install voicegateway`.** It did not:
+  `voicegw --help` raised `ModuleNotFoundError: No module named 'livekit'`
+  before printing anything.
+
+  `cli/__init__` imported every command module eagerly, and `livekit_cli`
+  reaches `livekit_diag.admin`, which imports the LiveKit SDK at module scope.
+  So a Pipecat or OpenRTC user could not reach `voicegw costs`, which needs no
+  framework at all, without installing a framework they do not use. On a tool
+  whose claim is that it is framework-agnostic, that is the claim failing at the
+  first command.
+
+  `livekit_cli` is the only command module affected: every other one was checked
+  individually and imports clean, so exactly one import is guarded rather than
+  all of them. With the SDK absent, `voicegw livekit` (and `voicegw livekit
+  <anything>`) exits 2 naming the extra to install, rather than vanishing from
+  the command list as though the feature did not exist.
+
+- **Pricing no longer installs three weeks stale.** The `voice-prices>=0.1.0,<0.2`
+  cap silently held new installs on the 0.1.0 dataset (2026-07-24) while 0.2.0
+  and 0.3.0 shipped in August, so a freshly installed VoiceGateway costed calls
+  against old prices. Now `>=0.3.0,<1`.
+
+  The remaining `<1` is not caution about 0.x releases. It is the one guard
+  against a deliberate breaking release landing in users' installs unannounced,
+  which an unbounded runtime dependency cannot prevent.
+
 ### Added
 
 - **The import warning's silence on an idle node is now pinned by a test.** No

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-VoiceGateway: cost tracking and reconciliation for LiveKit voice agents. Returns native LiveKit STT, LLM, and TTS plugin instances across cloud providers (OpenAI, Deepgram, Anthropic, Groq, Cartesia, ElevenLabs, AssemblyAI) and local models (Whisper, Kokoro, Piper). LLM, STT, and TTS prices all flow through `voice-prices` (a fork of `pydantic/genai-prices`). Ships `voicegw reconcile` for verifying recorded numbers against provider invoices, plus per-modality cost tracking, resolver-time fallback chains, rate limiting, and a web dashboard.
+VoiceGateway: cost tracking and reconciliation for voice agents on LiveKit, Pipecat and OpenRTC. Meters the native STT, LLM, and TTS instances you pass to `attach()` / `guard()` across cloud providers (OpenAI, Deepgram, Anthropic, Groq, Cartesia, ElevenLabs, AssemblyAI) and local models (Whisper, Kokoro, Piper). LLM, STT, and TTS prices all flow through `voice-prices` (a fork of `pydantic/genai-prices`). Ships `voicegw reconcile` for verifying recorded numbers against provider invoices, plus per-modality cost tracking, resolver-time fallback chains, rate limiting, and a web dashboard.
 
 ## Commands
 
@@ -44,7 +44,7 @@ docker compose --profile local up -d     # + Ollama
 - `registry.py` — Lazy provider factory (instantiates on first use)
 - `model_id.py` — Parses `provider/model` format strings
 
-**Providers (`src/voicegateway/providers/`):** Each extends `BaseProvider` from `base.py`. 11 implementations covering cloud and local models.
+**Providers (`src/voicegateway/inference/providers/`):** Each extends `BaseProvider` from `base_provider.py`. 11 implementations covering cloud and local models.
 
 **Middleware (`src/voicegateway/middleware/`):** Cost tracking, latency monitoring, rate limiting, request logging, fallback chains. All wrap provider calls.
 
@@ -60,7 +60,7 @@ docker compose --profile local up -d     # + Ollama
 
 **Marketing site:** Only the Next.js landing page at <https://voicegateway.dev> lives in the separate [`mahimailabs/voicegateway-web`](https://github.com/mahimailabs/voicegateway-web) repo (deployed on Vercel). The engine repo has no Vercel connection.
 
-**Public API:** `voicegateway/__init__.py` exports `Gateway`, `ModelId`, `GatewayConfig`.
+**Public API:** `voicegateway/__init__.py` exports `attach`, `guard`, `Observer`, `register_worker`, `inference`, `__version__`. There is no `Gateway` / `ModelId` factory surface: it was removed in the framework-agnostic reshape, and metering now happens by wrapping instances you construct.
 
 ## Key Patterns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,14 @@ dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.0",
     "cryptography>=43.0",
-    "voice-prices>=0.1.0,<0.2",
+    # Prices are the product here, so the floor moves forward rather than the
+    # ceiling holding still. The old `<0.2` cap silently pinned installs to the
+    # 0.1.0 dataset (2026-07-24) while 0.2.0 and 0.3.0 shipped in August, so a
+    # freshly installed VoiceGateway costed calls against three-week-old
+    # prices. The remaining `<1` is not caution about 0.x: it is the one guard
+    # against a deliberate breaking release landing in users' installs
+    # unannounced, which an unbounded runtime dependency cannot prevent.
+    "voice-prices>=0.3.0,<1",
     "bcrypt>=4.0",
     "pillow>=10.0",
     "psutil>=5.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "voicegateway"
 dynamic = ["version"]
-description = "Cost tracking and reconciliation for LiveKit voice agents: modality-aware unit accounting (audio-minutes, tokens, characters) backed by voice-prices."
+description = "Cost tracking and reconciliation for voice agents on LiveKit, Pipecat and OpenRTC: modality-aware unit accounting (audio-minutes, tokens, characters) backed by voice-prices."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"

--- a/src/dashboard/README.dockerhub.md
+++ b/src/dashboard/README.dockerhub.md
@@ -1,6 +1,6 @@
 # mahimairaja/voicegateway-dashboard
 
-Web dashboard for [VoiceGateway](https://hub.docker.com/r/mahimairaja/voicegateway) -- cost tracking and reconciliation for LiveKit voice agents.
+Web dashboard for [VoiceGateway](https://hub.docker.com/r/mahimairaja/voicegateway) -- cost tracking and reconciliation for voice agents on LiveKit, Pipecat and OpenRTC.
 
 Full documentation: **[docs.voicegateway.dev](https://docs.voicegateway.dev)**
 

--- a/src/voicegateway/Dockerfile
+++ b/src/voicegateway/Dockerfile
@@ -81,7 +81,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPATH="/install/lib/python3.12/site-packages"
 
 LABEL org.opencontainers.image.title="VoiceGateway" \
-      org.opencontainers.image.description="Cost tracking and reconciliation for LiveKit voice agents, with MCP server for coding agents" \
+      org.opencontainers.image.description="Cost tracking and reconciliation for voice agents on LiveKit, Pipecat and OpenRTC, with MCP server for coding agents" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.url="https://voicegateway.dev" \
       org.opencontainers.image.documentation="https://docs.voicegateway.dev" \

--- a/src/voicegateway/README.dockerhub.md
+++ b/src/voicegateway/README.dockerhub.md
@@ -1,6 +1,6 @@
 # mahimairaja/voicegateway
 
-Cost tracking and reconciliation for LiveKit voice agents. Returns native LiveKit STT/LLM/TTS plugin instances; per-modality unit accounting (audio-minutes, tokens, characters) with prices from `voice-prices` (LLM, STT, and TTS); MCP server for coding agents.
+Cost tracking and reconciliation for voice agents on LiveKit, Pipecat and OpenRTC. Meters the native STT/LLM/TTS instances you pass to `attach()` / `guard()`; per-modality unit accounting (audio-minutes, tokens, characters) with prices from `voice-prices` (LLM, STT, and TTS); MCP server for coding agents.
 
 Full documentation: **[docs.voicegateway.dev](https://docs.voicegateway.dev)**
 

--- a/src/voicegateway/cli/__init__.py
+++ b/src/voicegateway/cli/__init__.py
@@ -22,6 +22,8 @@ function-first by design.
 
 from __future__ import annotations
 
+import typer
+
 from voicegateway.cli import brand_cli as _brand  # noqa: F401, E402
 from voicegateway.cli import calls_cli as _calls  # noqa: F401, E402
 from voicegateway.cli import check_cli as _check  # noqa: F401, E402
@@ -31,7 +33,6 @@ from voicegateway.cli import doctor_cli as _doctor  # noqa: F401, E402
 from voicegateway.cli import export_costs_cli as _export_costs  # noqa: F401, E402
 from voicegateway.cli import init_cli as _init  # noqa: F401, E402
 from voicegateway.cli import lifecycle_cli as _lifecycle  # noqa: F401, E402
-from voicegateway.cli import livekit_cli as _livekit  # noqa: F401, E402
 from voicegateway.cli import loadtest_cli as _loadtest  # noqa: F401, E402
 from voicegateway.cli import logs_cli as _logs  # noqa: F401, E402
 from voicegateway.cli import mcp_cli as _mcp  # noqa: F401, E402
@@ -47,5 +48,59 @@ from voicegateway.cli import serve_cli as _serve  # noqa: F401, E402
 from voicegateway.cli import status_cli as _status  # noqa: F401, E402
 from voicegateway.cli._app import app, console
 from voicegateway.cli.base_cli import BaseCli
+
+
+def _register_absent_extra(
+    name: str, extra: str, target: typer.Typer | None = None
+) -> None:
+    """Stand a placeholder in for a command whose optional SDK is absent.
+
+    Registering NOTHING would be worse. ``voicegw livekit`` would then be "no
+    such command", which reads as the feature not existing rather than as one
+    install away, and nothing in the output lets a reader tell those apart.
+
+    Registered as a COMMAND rather than as a Typer group, which is the only
+    shape that answers ``voicegw livekit agents``. A group resolves its
+    subcommand strictly and fails with "No such command 'agents'", naming the
+    wrong problem: the subcommand is real, the SDK behind it is not. A single
+    command with ``allow_extra_args`` swallows the rest of the line and reports
+    the actual cause. That was checked both ways round, because the group form
+    looks correct and is not.
+
+    Brackets are escaped for Rich. ``[{extra}]`` unescaped is parsed as a
+    markup tag and silently deleted, which turned the install instruction into
+    ``pip install 'voicegateway'``: still valid, still runnable, and it does not
+    install the thing the message exists to ask for.
+    """
+    install = f"pip install 'voicegateway\\[{extra}]'"
+    # ``target`` exists so a test can register onto a throwaway Typer instead of
+    # mutating the process-wide ``app``, which other tests read.
+    into = app if target is None else target
+
+    @into.command(
+        name=name,
+        help=f"Unavailable here: needs `{install}`.",
+        context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    )
+    def _absent(ctx: typer.Context) -> None:
+        console.print(
+            f"[red]`voicegw {name}` needs the '{extra}' extra, which is not "
+            f"installed.[/red]\nInstall it with: {install}"
+        )
+        raise typer.Exit(2)
+
+
+# THE ONLY COMMAND GROUP THAT NEEDS A FRAMEWORK SDK, and therefore the only
+# import here that is allowed to fail. It is last and guarded because an
+# unguarded one took the whole CLI down: on a bare `pip install voicegateway`,
+# `voicegw --help` raised ModuleNotFoundError: No module named 'livekit' from
+# livekit_cli -> livekit_diag.admin, so a Pipecat or OpenRTC user could not
+# reach `voicegw costs` (which needs no framework at all) without installing a
+# framework they do not use. Every other cli module imports clean on a bare
+# install; that was verified module by module, and this is the one exception.
+try:
+    from voicegateway.cli import livekit_cli as _livekit  # noqa: F401, E402
+except ImportError:
+    _register_absent_extra("livekit", "livekit")
 
 __all__ = ["BaseCli", "app", "console"]

--- a/src/voicegateway/cli/_app.py
+++ b/src/voicegateway/cli/_app.py
@@ -9,7 +9,10 @@ from voicegateway import __version__
 
 app = typer.Typer(
     name="voicegw",
-    help="VoiceGateway: cost tracking and reconciliation for LiveKit voice agents",
+    help=(
+        "VoiceGateway: cost tracking and reconciliation for voice agents "
+        "(LiveKit, Pipecat, OpenRTC)"
+    ),
     no_args_is_help=True,
 )
 console = Console()

--- a/src/voicegateway/cli/daemon/templates/systemd.service
+++ b/src/voicegateway/cli/daemon/templates/systemd.service
@@ -41,7 +41,7 @@
 # files (no file-log paths in the variable list, intentionally).
 
 [Unit]
-Description=VoiceGateway daemon (cost tracking for LiveKit voice agents)
+Description=VoiceGateway daemon (cost tracking for LiveKit, Pipecat and OpenRTC voice agents)
 Documentation=https://vg.openrtc.tech
 After=network-online.target
 Wants=network-online.target

--- a/src/voicegateway/server/main.py
+++ b/src/voicegateway/server/main.py
@@ -75,7 +75,7 @@ class ApplicationBuilder:
             version=__version__,
             description=(
                 "HTTP API for VoiceGateway: cost tracking and reconciliation "
-                "for LiveKit voice agents."
+                "for voice agents on LiveKit, Pipecat and OpenRTC."
             ),
             lifespan=lifespan,
         )

--- a/src/voicegateway/tests/cli/test_bare_install_cli.py
+++ b/src/voicegateway/tests/cli/test_bare_install_cli.py
@@ -1,0 +1,126 @@
+"""The CLI must run on a bare ``pip install voicegateway``.
+
+It did not. `voicegw --help` raised ``ModuleNotFoundError: No module named
+'livekit'`` before printing anything, because ``cli/__init__`` imported every
+command module eagerly and ``livekit_cli`` reaches ``livekit_diag.admin``, which
+imports the LiveKit SDK at module scope. So a Pipecat or OpenRTC user could not
+reach ``voicegw costs``, which needs no framework at all, without installing a
+framework they do not use. On a tool whose whole claim is that it is
+framework-agnostic, that is the claim failing at the first command.
+
+Every other command module imports clean on a bare install. That was checked
+module by module rather than assumed, and ``livekit_cli`` is the only exception,
+which is why exactly one import here is guarded rather than all of them.
+
+The subprocess test below is the one that would actually catch a regression. The
+dev environment always has the LiveKit SDK installed, so nothing running
+in-process can observe the failure: a test that cannot see the fault it guards
+is not a guard. Blocking the import inside this process instead would mean
+reloading ``voicegateway.cli`` against the process-wide ``app``, re-registering
+every command onto it and corrupting the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import typer
+from typer.testing import CliRunner
+
+from voicegateway.cli import _register_absent_extra
+
+runner = CliRunner()
+
+
+# --------------------------------------------------------------------------
+# What the placeholder says
+# --------------------------------------------------------------------------
+
+
+def _stub() -> typer.Typer:
+    """A throwaway app carrying the placeholder, so the real one is untouched."""
+    into = typer.Typer()
+    _register_absent_extra("livekit", "livekit", target=into)
+    return into
+
+
+def test_the_placeholder_names_the_extra_with_its_brackets_intact() -> None:
+    """The bug this pins is a SILENT one: the message stayed grammatical.
+
+    ``[livekit]`` unescaped is read as a Rich markup tag and deleted, so the
+    instruction rendered as ``pip install 'voicegateway'``. Still valid, still
+    runnable, and it installs precisely the thing that was already installed. A
+    reader follows it, nothing changes, and the message that was supposed to fix
+    them is the reason they are stuck.
+    """
+    result = runner.invoke(_stub(), ["livekit"])
+    assert result.exit_code == 2
+    assert "voicegateway[livekit]" in result.output
+
+
+def test_the_placeholder_answers_a_subcommand_rather_than_rejecting_it() -> None:
+    """``voicegw livekit agents`` must report the SDK, not the subcommand.
+
+    Registered as a Typer group this fails with "No such command 'agents'",
+    which names the wrong problem: the subcommand is real and the SDK behind it
+    is not. Nobody types the bare group first; they type the command they want.
+    """
+    result = runner.invoke(_stub(), ["livekit", "agents", "--url", "x"])
+    assert result.exit_code == 2
+    assert "voicegateway[livekit]" in result.output
+
+
+# --------------------------------------------------------------------------
+# The regression itself, in a process where the SDK is genuinely unimportable
+# --------------------------------------------------------------------------
+
+
+_PROBE = textwrap.dedent(
+    """
+    import importlib.abc, sys
+
+    class _Block(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "livekit" or fullname.startswith("livekit."):
+                raise ImportError("blocked: simulating a bare install")
+            return None
+
+    sys.meta_path.insert(0, _Block())
+    for name in [m for m in sys.modules if m.startswith("livekit")]:
+        del sys.modules[name]
+
+    import typer.main
+    import voicegateway.cli as c
+
+    # Built click app, not app.registered_commands: Typer leaves ``name`` None
+    # when a command does not set one and derives it from the function at build
+    # time, so reading the registration list reports ``costs`` as absent when it
+    # is registered and working.
+    names = set(typer.main.get_command(c.app).commands)
+    print("IMPORTED_OK")
+    print("HAS_LIVEKIT", "livekit" in names)
+    print("HAS_COSTS", "costs" in names)
+    """
+)
+
+
+def test_the_cli_imports_with_the_livekit_sdk_unimportable() -> None:
+    """The actual regression, in a subprocess so the block is real.
+
+    Asserts three things, and the third is the point of the whole change: the
+    package imports at all, the placeholder took the ``livekit`` name so the
+    command is not silently missing, and ``costs`` is reachable. ``costs`` is
+    what a reader without LiveKit actually came for.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "IMPORTED_OK" in proc.stdout
+    assert "HAS_LIVEKIT True" in proc.stdout
+    assert "HAS_COSTS True" in proc.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -3835,15 +3835,15 @@ wheels = [
 
 [[package]]
 name = "voice-prices"
-version = "0.1.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/4a/b6f03355abc1f2c946f679d3aaaac39e842fadbca00dc67d366470bdc26e/voice_prices-0.1.0.tar.gz", hash = "sha256:aa2dd840eb1c03309e03128c4f91fb55f455277490aa677b6414f4ee0977b7c4", size = 80332, upload-time = "2026-07-24T20:01:11.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/db/d619c99888c08eec6decdc0b72967f9fb70ade814f156f2de66e81921ba9/voice_prices-0.3.0.tar.gz", hash = "sha256:2a8059ea694e5f237dcbbad8d1b06bb76503ed12b764e4daee239d5ec458e069", size = 84882, upload-time = "2026-08-08T17:00:25.282Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/56/edfa3ad88eb1db51369351c336401f76893de912af2ea205498778ca1271/voice_prices-0.1.0-py3-none-any.whl", hash = "sha256:a5006aa5d22b2d083c34166fad17d58baf62ca754ee4e510651f621ee29bebf5", size = 84832, upload-time = "2026-07-24T20:01:10.302Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1b/1cd363519500da90ea98a5442ce9f31015260aafbeb44b27a4aeff2d248a/voice_prices-0.3.0-py3-none-any.whl", hash = "sha256:0e7d1430123623596c4a9265ec1dbbe8eded9ceddf6f69a5e1abc8ee31f3bbcc", size = 89439, upload-time = "2026-08-08T17:00:23.698Z" },
 ]
 
 [[package]]
@@ -3979,7 +3979,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'collector'", specifier = ">=0.32.0" },
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.32.0" },
     { name = "uvicorn", marker = "extra == 'dev'", specifier = ">=0.32.0" },
-    { name = "voice-prices", specifier = ">=0.1.0,<0.2" },
+    { name = "voice-prices", specifier = ">=0.3.0,<1" },
 ]
 provides-extras = ["collector", "dashboard", "dev", "livekit", "pipecat"]
 


### PR DESCRIPTION
Found while checking whether VoiceGateway is demo-ready for a "calculate the operational cost of a voice agent, any stack" article. Three things contradicted that premise, all on the path a reader follows.

## 1. `voicegw` did not run on a bare install

```
$ pip install voicegateway
$ voicegw --help
ModuleNotFoundError: No module named 'livekit'
```

`cli/__init__` imported every command module eagerly. `livekit_cli` reaches `livekit_diag.admin`, which does `from livekit import api` at module scope. So a Pipecat or OpenRTC user could not reach `voicegw costs`, which needs no framework at all, without installing a framework they do not use.

`livekit_cli` is the **only** affected module. All 26 were checked individually against a bare install rather than assumed, so exactly one import is guarded instead of a blanket try/except:

```
cli modules total: 26
FAIL ON BARE INSTALL:
   livekit_cli -> livekit
count: 1
```

With the SDK absent the group is replaced by a placeholder that names the extra and exits 2. With the extra installed the real group registers unchanged.

**Two bugs found by running it, not reading it.** Both were in my first version and both were things my own comments claimed already worked:

- As a Typer **group**, `voicegw livekit agents` failed with `No such command 'agents'`, naming the wrong problem: the subcommand is real, the SDK behind it is not, and nobody types the bare group first. Registered as a command with `allow_extra_args` instead.
- Rich parsed `[livekit]` as a markup tag and **deleted it**, rendering the instruction as `pip install 'voicegateway'`: still valid, still runnable, and it installs exactly what is already there. A reader follows it, nothing changes, and the message meant to unblock them is why they stay stuck. Bracket now escaped.

## 2. Pricing installed three weeks stale

`voice-prices>=0.1.0,<0.2` silently held new installs on the 0.1.0 dataset (2026-07-24) while 0.2.0 and 0.3.0 shipped on Aug 7 and 8. For a cost-tracking tool that is the product being wrong. Now `>=0.3.0,<1`.

Verified 0.3.0 returns identical figures for `deepgram/nova-3`, `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `cartesia/sonic-2` and `elevenlabs/eleven_turbo_v2_5`, so the dataset moves forward without moving a number under an existing user.

The `<1` is deliberate and is not caution about 0.x. It is the one guard against a deliberate breaking release landing in installs unannounced. An unbounded *build* dependency is exactly what broke the 0.24.10 publish.

## 3. Nine places called it LiveKit-only, two of them described a removed API

The PyPI summary, both Docker Hub READMEs, the image label, the systemd unit, the FastAPI description and `voicegw --help` all read *"cost tracking and reconciliation for LiveKit voice agents"*. The package page contradicted the framework-agnostic claim on the first line a reader sees.

Worse, two also advertised *"Returns native LiveKit STT, LLM, and TTS plugin instances"*, which is the factory surface removed in the reshape. Verified rather than assumed:

```python
__all__ == ['Observer', 'attach', 'guard', 'inference', 'register_worker', '__version__']
# no Gateway, no ModelId
```

Anyone evaluating from PyPI or Docker Hub was reading about a surface they could not import. Descriptions now name the three supported frameworks and say what the tool does: it meters the instances you pass to `attach()` / `guard()`.

Also corrects two claims in `CLAUDE.md` / `AGENTS.md` that cost real time this session: providers live at `inference/providers/` with the base in `base_provider.py` (the "11 implementations" count was right and is kept), and the Public API line promised `Gateway`, `ModelId`, `GatewayConfig`, none of which are exported.

## The test

Runs in a subprocess with `livekit` blocked on `meta_path`. The dev environment always has the SDK installed, so nothing in-process can observe the fault, and a test that cannot see what it guards is not a guard. Blocking it in-process would mean reloading `voicegateway.cli` against the module-wide `app` and re-registering every command onto it.

Verified by mutation: restoring the eager import turns that test red and leaves the rest green.

## Gates

ruff clean, mypy clean on 285 files, 3493 passed. The 14 skips are environmental (pipecat, postgres, openai plugin absent locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded voice-agent support and cost tracking across LiveKit, Pipecat, and OpenRTC.
  * Native STT, LLM, and TTS instances can now be included in metering.
* **Bug Fixes**
  * CLI now starts successfully without the optional LiveKit SDK.
  * Added clear installation guidance when LiveKit commands are unavailable.
  * LiveKit command arguments are handled gracefully.
  * Pricing compatibility now supports versions from 0.3.0 up to, but not including, 1.0.0.
* **Documentation**
  * Updated product descriptions, CLI help, and integration guidance for supported platforms and metering APIs.
* **Tests**
  * Added coverage for bare-install CLI behavior and helpful error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->