### PR TITLE
Pin what makes talk_over_rate's zero trustworthy (closes #242)

### DIFF
--- a/src/voicegateway/tests/repository/test_talk_over_unmeasured.py
+++ b/src/voicegateway/tests/repository/test_talk_over_unmeasured.py
@@ -1,0 +1,77 @@
+"""What makes ``talk_over_rate``'s zero trustworthy, pinned rather than assumed.
+
+Issue #242 reported the harm: a session reporting "no talk-over" when it had in
+fact measured nothing. `count_overlap_turns` compares `agent_speak_end_ms`
+against `caller_speak_start_ms` in SQL, and a NULL start makes that comparison
+NULL, so the row would fail to match and land in the count as "did not overlap".
+A zero built that way is a claim the data cannot support, told to somebody who
+opened that view BECAUSE they suspect a barge-in problem.
+
+That cannot happen, and this file pins the two reasons:
+
+* `turns.caller_speak_start_ms` is NOT NULL, so a turn row without a caller
+  start cannot be written. The NULL-comparison path is unreachable.
+* A session with no turns at all reports None, not 0.0. That is the only way
+  "nothing was measured" can actually arise, and it already reads as unmeasured.
+
+Relaxing that constraint without handling the unmeasured case would reintroduce
+exactly the reported defect, silently, which is why the constraint is asserted
+here instead of trusted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import text
+
+from voicegateway.repository import session_repository as sessions
+from voicegateway.services.storage_service import StorageService
+
+
+async def test_a_turn_cannot_be_written_without_a_caller_start(
+    tmp_path: Path,
+) -> None:
+    """The constraint that makes the SQL comparison's NULL branch unreachable."""
+    storage = StorageService(str(tmp_path / "schema.db"))
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        result = await db.execute(
+            text("SELECT \"notnull\" FROM pragma_table_info('turns') WHERE name = :n"),
+            {"n": "caller_speak_start_ms"},
+        )
+        row = result.fetchone()
+    await storage.aclose()
+    assert row is not None, "turns.caller_speak_start_ms is missing entirely"
+    assert bool(row[0]), (
+        "caller_speak_start_ms became nullable. count_overlap_turns compares it "
+        "in SQL, so a NULL now counts as 'did not overlap' and talk_over_rate "
+        "reports a confident 0.0 for a session that measured nothing. Handle the "
+        "unmeasured case before relaxing this."
+    )
+
+
+async def test_a_session_with_no_turns_reports_unmeasured_not_zero(
+    tmp_path: Path,
+) -> None:
+    """The only way "nothing measured" can arise, and it already reads as such."""
+    storage = StorageService(str(tmp_path / "empty.db"))
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        await db.execute(
+            text(
+                "INSERT INTO sessions (id, project, started_at) "
+                "VALUES ('s', 'default', 0)"
+            )
+        )
+        await db.commit()
+    async with storage._conn.session() as db:
+        await sessions.finalize_session_metrics(db, "s")
+    async with storage._conn.session() as db:
+        result = await db.execute(
+            text("SELECT talk_over_rate FROM sessions WHERE id = 's'")
+        )
+        row = result.fetchone()
+    await storage.aclose()
+    assert row is not None
+    assert row[0] is None, f"expected unmeasured, got {row[0]!r}"


### PR DESCRIPTION
Issue #242 asked for four things. **Three were already true**, and the fourth is structural rather than missing. So this adds the guard rather than the fix, and is deliberately small.

The issue was filed against 0.24.4. Checking each acceptance item against the current default branch rather than trusting the text:

| # | Acceptance | Status |
|---|---|---|
| 1 | Turn row under 1.6.x carries non-null `caller_speak_start_ms` | **Already met** by `980cd8d` (2026-08-09) |
| 2 | `count_overlap_turns` non-zero for a real talk-over | **Already met**, follows from 1 |
| 3 | Regression test driving only `user_state_changed` | **Already met** by `test_livekit_state_events.py` |
| 4 | A turn with no caller start reports unmeasured, not zero | **Structural**, pinned here |

`980cd8d` ("Drive turn boundaries from the state events LiveKit actually emits") binds `user_state_changed` to the turn onset on the `new_state == "speaking"` edge, which is exactly the fallback the issue asked for. `test_a_full_turn_from_only_the_real_event_set` and eight siblings already drive a fake session from only the real event set.

## Why item 4 needed a guard and not a fix

The concern is real: `count_overlap_turns` compares `agent_speak_end_ms` against `caller_speak_start_ms` in SQL, and a NULL start makes that comparison NULL, so the row would fail to match and land in the count as "did not overlap". A zero built that way is a claim the data cannot support, told to somebody who opened the view *because* they suspect a barge-in problem.

It cannot happen, for two reasons that were both true by accident and neither of which was asserted:

- `turns.caller_speak_start_ms` is **NOT NULL**, so that row cannot be written and the NULL branch is unreachable.
- The only way "nothing measured" can actually arise is a session with no turns at all, and that already reports `None`.

Relaxing the constraint without handling the unmeasured case would silently reintroduce the reported defect. Both reasons are now pinned, with the failure mode written into the assertion message.

## One thing I did and undid

I first wrote a `measurable_turns` guard into `finalize_session_metrics` and reverted it. It defended a state the schema forbids. Dead defensive code on a metrics path is worse than none: the next reader takes its existence as evidence that the state occurs, and writes more code around it.

That was caught by running the test, which failed with `NOT NULL constraint failed` on the fixture I wrote to simulate the bad row. The fixture could not construct the state the issue describes, which is the answer.

## Gates

ruff clean, mypy clean on 285 files, 3495 passed (+2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to ensure talk-over metrics are reported as unmeasured when a session has no turns.
  * Verified that caller speech start times are always recorded for valid turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds focused regression coverage documenting why an unmeasured session cannot incorrectly report a zero talk-over rate.
- Asserts that `turns.caller_speak_start_ms` remains non-nullable.
- Asserts that a session containing no turns retains a null `talk_over_rate`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The added tests use the migrated SQLite schema correctly and accurately verify both the non-null caller-start constraint and the persisted unmeasured result for sessions without turns.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/tests/repository/test_talk_over_unmeasured.py | Adds schema and empty-session regression tests that accurately pin the invariants supporting trustworthy talk-over metrics. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Pin what makes talk\_over\_rate&#39;s zero tru..."](https://github.com/mahimailabs/voicegateway/commit/11e3cc3e0fc59335f711222dd38d59e7d17efdf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54602388)</sub>

<!-- /greptile_comment -->