### PR TITLE
Say which number answers "what did the caller wait" (closes #244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Fixed
 
+- **The turns guide no longer documents a bug that was fixed, and now states
+  which number answers "what did the caller wait".**
+
+  It carried a note saying turn capture had not been given the
+  `user_state_changed` fallback, so a caller's turn start could go uncaptured on
+  `livekit-agents` 1.6. That stopped being true in `980cd8d`, and the page kept
+  telling readers their turn data was unreliable.
+
+  It also described `response_speed_ms` without saying that
+  `caller_speak_end_ms` is corrected from `EOUMetrics.end_of_utterance_delay`,
+  which is the only reason the figure means anything. Measured from the stop
+  event instead, it would be short by the whole VAD silence window (0.55s on
+  Silero's default) on every turn, always flatteringly, and the size of that
+  error moves with each operator's `min_silence_duration`. The page now says so,
+  and says why there is deliberately no second uncorrected column: absent reads
+  as "not measured", where the uncorrected value would read as "fast".
+
+  The turn-close description also now covers holding the turn open across tool
+  calls.
+
 - **A turn covering a tool call now reports the time to the answer, not to the
   holding line.** The turn is held open while any tool call is in flight, so the
   agent's filler audio no longer closes it.

--- a/docs/guide/turns.md
+++ b/docs/guide/turns.md
@@ -10,7 +10,7 @@ A turn's boundary is speech events, not dialogue turns in the conversational sen
 
 1. The caller starts speaking: `caller_speak_start_ms` is latched.
 2. The caller stops speaking: `caller_speak_end_ms` is latched.
-3. The agent's first audio frame plays: the turn closes and a row is appended, with `response_speed_ms = max(0, agent_speak_start_ms - caller_speak_end_ms)`.
+3. The agent's first audio frame plays: the turn closes and a row is appended, with `response_speed_ms = max(0, agent_speak_start_ms - caller_speak_end_ms)`. A turn with a tool call still in flight does **not** close here: that first frame is filler ("let me pull that up"), and closing on it would report the wait to the holding line rather than to the answer. The turn closes on the first frame after every tool call goes terminal, whether it completed, failed or was cancelled (`src/voicegateway/middleware/turn_tracker_middleware.py`).
 4. The agent's last audio frame play sets `agent_speak_end_ms` on that same row.
 
 If the agent starts responding before the caller's stop event lands, `caller_speak_end_ms` backfills to the agent's start time and `response_speed_ms` is `null` rather than negative. A caller turn that never gets an agent response (session ends first) is still written, with `agent_speak_start_ms` / `agent_speak_end_ms` / `response_speed_ms` all `null`
@@ -20,9 +20,19 @@ Turns buffer in memory per session and flush to storage at 25 buffered rows or o
 
 The `turns` table also backs two aggregates: `aggregate_response_speed` (p50/p95/p99 over non-null `response_speed_ms`) and `count_overlap_turns`, a talk-over/barge-in count where the caller started before the prior turn's agent finished (`src/voicegateway/repository/turns_repository.py:90-140`). When turns exist for a session, these feed five columns back onto that session's row: `talk_time_seconds`, `per_minute_cost_usd`, `response_speed_p50_ms`, `response_speed_p95_ms`, `talk_over_rate` (`src/voicegateway/repository/session_repository.py:154-201`).
 
+## Which number answers "what did the caller wait"
+
+`response_speed_ms` does, and it is the only one, because it is measured from when the caller **actually** stopped rather than from when the pipeline noticed.
+
+Those differ by the whole VAD silence window, 0.55s on Silero's default. LiveKit raises the stop only after voice activity has waited that window out, so a speed measured from it is short by the same amount on every turn, always in the flattering direction. It reads as good latency rather than as a bug, and the size of the error moves with each operator's `min_silence_duration`, so two deployments could not compare numbers.
+
+The correction comes from `EOUMetrics.end_of_utterance_delay`, which LiveKit measures from the caller's real stop. Subtracting it lands back on the true anchor and tracks any VAD configuration, where adding a constant would not.
+
 <Note>
-Turn boundaries are anchored to the discrete `user_started_speaking` / `agent_started_speaking` LiveKit events. `livekit-agents` 1.6 stopped emitting `user_started_speaking` (onset moved to `user_state_changed`); VoiceGateway's own latency capture had to add that event as a fallback (`src/voicegateway/inference/session/capture.py:344-354`). Turn capture has not been given the same fallback, so on 1.6 a caller's turn start can go uncaptured.
+There is deliberately **no second, uncorrected column**. When a turn carries no end-of-utterance measurement, `response_speed_ms` is `null` rather than falling back to the uncorrected figure. A number that is systematically half a second optimistic is worse than no number, because somebody tuning toward a target answer time would tune against it without knowing. Absent says "not measured"; the uncorrected value would say "fast".
 </Note>
+
+Turn boundaries come from `user_state_changed` / `agent_state_changed`, which are the events `livekit-agents` in the supported range actually emits; the four discrete `*_started_speaking` events stay bound for other frameworks and cost nothing where they never fire (`src/voicegateway/inference/session/attach.py`).
 
 ## How the transcript differs
 


### PR DESCRIPTION
Issue #244 asked for a corrected elapsed field beside `response_speed_ms`, because the existing one measured from when the pipeline *noticed* the caller stop rather than from when they actually stopped.

**The correction is already there**, and in a better shape than the issue proposed. So this is documentation only.

## What was already true

`attach.py`'s `_correct_caller_end` re-stamps `caller_speak_end_ms` from the EOU-derived anchor with `precise=True`, and `precise_end_required=True` makes `response_speed_ms` **null** when no correction arrived, rather than reporting the optimistic figure.

`tests/inference/test_response_speed_anchor.py` pins it across nine cases, including `test_without_an_eou_metric_the_speed_is_absent_not_wrong` and `test_an_unmeasurable_eou_is_not_treated_as_zero`.

| # | Acceptance | Status |
|---|---|---|
| 1 | Rows carry the existing and the corrected value | **Met differently, and better** (see below) |
| 2 | Corrected value null, not a copy, without EOU | **Already met**, `precise_end_required` |
| 3 | Aggregate exposes percentiles | **Already met**, over the corrected column |
| 4 | Docs say which answers "what did the caller wait" | **Open** — this PR |

On item 1: rather than keeping an optimistic column and adding a corrected one beside it, the single column **is** the corrected one and is absent when it cannot be corrected. That is the same rule the issue argues for, with one column fewer and no way to read the wrong one by accident.

## Why the docs were worse than silent

`docs/guide/turns.md` still carried the note saying turn capture lacked the `user_state_changed` fallback, so a caller's turn start could go uncaptured on `livekit-agents` 1.6. `980cd8d` fixed that and #242 closed it. The page was telling readers their turn data was unreliable when it was not.

It also described `response_speed_ms` without mentioning the EOU correction at all, which is the only reason the figure means anything. Measured from the stop event it would be short by the whole VAD silence window (0.55s on Silero's default) on every turn, always in the flattering direction, with the size of the error moving with each operator's `min_silence_duration` so two deployments could not compare numbers.

The page now states which figure answers the question, why the uncorrected one is systematically optimistic rather than merely noisy, and why there is deliberately no second uncorrected column: absent reads as "not measured", where the uncorrected value would read as "fast".

## Also fixed here

The turn-close description now covers holding the turn open across tool calls, which shipped in #250 without the guide being updated in the same PR. That was my miss.

## Gates

docs validator PASS (79 pages), ruff clean, 3500 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the turns guide to explain how turns remain open during tool calls and close after subsequent agent activity.
  * Clarified response speed calculations, including end-of-utterance corrections and cases where the metric is unavailable.
  * Documented state-change events for supported agent versions while retaining discrete events for other frameworks.
* **Changelog**
  * Added release notes covering the updated turn behavior, metrics, and event guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR explains that `response_speed_ms` uses the EOU-corrected caller-stop anchor and describes tool-call-aware turn closure.

- Removes an obsolete warning about missing LiveKit state-event fallback.
- Explains why latency is null when an EOU correction is unavailable.
- Updates the changelog with the clarified turn-capture behavior.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking documentation clarification needed around framework-specific event bindings.

The documented response-speed and tool-lifecycle behavior matches the implementation, while the phrase “for other frameworks” can mislead users because the discrete handlers are registered only on the LiveKit attachment path.

**Files Needing Attention:** docs/guide/turns.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/guide/turns.md | Clarifies response-speed anchoring and tool-call closure, but overstates discrete event binding as available to other frameworks. |
| CHANGELOG.md | Accurately summarizes the documentation corrections and previously shipped turn behavior. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mahimailabs%2Fvoicegateway%20PR%20%23251%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mahimailabs%2Fvoicegateway&pr=251&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Fguide%2Fturns.md%3A35%0A**Narrow%20the%20event-binding%20scope**%0A%0AThe%20discrete%20handlers%20are%20registered%20only%20on%20the%20LiveKit%20attachment%20path%2C%20while%20Pipecat%20leaves%20turn%20capture%20unused%2C%20so%20%E2%80%9Cfor%20other%20frameworks%E2%80%9D%20incorrectly%20suggests%20that%20non-LiveKit%20adapters%20receive%20these%20turn-boundary%20events.%0A%0A%60%60%60suggestion%0ATurn%20boundaries%20come%20from%20%60user_state_changed%60%20%2F%20%60agent_state_changed%60%2C%20which%20are%20the%20events%20%60livekit-agents%60%20in%20the%20supported%20range%20actually%20emits%3B%20the%20four%20discrete%20%60*_started_speaking%60%20events%20stay%20bound%20for%20future%20LiveKit%20builds%20and%20cost%20nothing%20where%20they%20never%20fire%20%28%60src%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%60%29.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=251&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22mahimailabs%2Fvoicegateway%22%20on%20the%20existing%20branch%20%22feat%2Fperceived-wait-beside-response-speed%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fperceived-wait-beside-response-speed%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2Fguide%2Fturns.md%3A35%0A**Narrow%20the%20event-binding%20scope**%0A%0AThe%20discrete%20handlers%20are%20registered%20only%20on%20the%20LiveKit%20attachment%20path%2C%20while%20Pipecat%20leaves%20turn%20capture%20unused%2C%20so%20%E2%80%9Cfor%20other%20frameworks%E2%80%9D%20incorrectly%20suggests%20that%20non-LiveKit%20adapters%20receive%20these%20turn-boundary%20events.%0A%0A%60%60%60suggestion%0ATurn%20boundaries%20come%20from%20%60user_state_changed%60%20%2F%20%60agent_state_changed%60%2C%20which%20are%20the%20events%20%60livekit-agents%60%20in%20the%20supported%20range%20actually%20emits%3B%20the%20four%20discrete%20%60*_started_speaking%60%20events%20stay%20bound%20for%20future%20LiveKit%20builds%20and%20cost%20nothing%20where%20they%20never%20fire%20%28%60src%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%60%29.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=251&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/guide/turns.md:35
**Narrow the event-binding scope**

The discrete handlers are registered only on the LiveKit attachment path, while Pipecat leaves turn capture unused, so “for other frameworks” incorrectly suggests that non-LiveKit adapters receive these turn-boundary events.

```suggestion
Turn boundaries come from `user_state_changed` / `agent_state_changed`, which are the events `livekit-agents` in the supported range actually emits; the four discrete `*_started_speaking` events stay bound for future LiveKit builds and cost nothing where they never fire (`src/voicegateway/inference/session/attach.py`).
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Say which number answers &quot;what did the c..."](https://github.com/mahimailabs/voicegateway/commit/6598ad70890b12d7ea6d5afadd7ddacfcba2f67c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54614761)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->