### PR TITLE
Stamp an agent configuration revision on every row (closes #245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ## Unreleased
 
+### Added
+
+- **`attach(revision=...)` stamps which build of the agent's configuration
+  produced every row.** Optional, with a `VOICEGW_AGENT_REVISION` fallback, on
+  cost, latency, turn and dead-air rows.
+
+  Rows carried `project`, `agent_id` and `tenant_id`, none of which says which
+  version of the agent was running: the prompt, the model ids, the voice, the
+  interruption thresholds. So "this got slower last Tuesday" was answerable only
+  by joining deploy logs kept elsewhere against timestamps by hand, and that
+  join stops working the moment two versions run at once, which is every canary
+  and every gradual rollout.
+
+  The value is **opaque**: a content hash, a git sha, a semver string and a
+  deploy id are all valid, nothing parses it, it is only grouped and filtered
+  by. The argument beats the environment, which is the opposite precedence to
+  the capture kill-switches and deliberate: those override what an agent asked
+  for, where this is the agent reporting a fact about itself.
+
+  Absent stays absent. No hostname, no timestamp, no default, because an
+  invented revision would silently split aggregates that belong together.
+
+  Readable as `?revision=` on `/api/costs` (empty string selects rows that
+  declared none) and as a `by_revision` rollup present on every cost summary, so
+  a p95 spanning a configuration change shows as two agents rather than one
+  blended figure.
+
 ### Fixed
 
 - **The turns guide no longer documents a bug that was fixed, and now states

--- a/alembic/versions/a3f7d21c9b04_agent_config_revision.py
+++ b/alembic/versions/a3f7d21c9b04_agent_config_revision.py
@@ -1,0 +1,47 @@
+"""add revision to requests, turns and dead_air_events
+
+Revision ID: a3f7d21c9b04
+Revises: c5b1e83d0f47
+Create Date: 2026-08-18 22:40:00.000000
+
+Which build of the agent's configuration produced a row: the prompt, the model
+ids, the voice, the interruption thresholds. Without it, "this got slower last
+Tuesday" is answerable only by joining deploy logs kept somewhere else against
+timestamps by hand, and that join stops working the moment two versions run at
+once, which is every canary and every gradual rollout.
+
+Nullable on every table. A row written before this, or by a caller who declares
+no revision, stays valid and every existing read behaves exactly as it did.
+
+OPAQUE BY DESIGN: a content hash, a git sha, a semver string and a deploy id are
+all valid values. Nothing here parses it, it is only grouped and filtered by, so
+choosing between them stays the operator's business. Indexed on requests where
+the per-revision aggregates are read.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a3f7d21c9b04"
+down_revision: str | None = "c5b1e83d0f47"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLES = ("requests", "turns", "dead_air_events")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.add_column(table, sa.Column("revision", sa.String(), nullable=True))
+    op.create_index("idx_requests_revision", "requests", ["revision"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_requests_revision", table_name="requests")
+    for table in _TABLES:
+        op.drop_column(table, "revision")

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -315,6 +315,25 @@ def _resolve_dispatch_name(session: Any) -> str | None:
     return name if isinstance(name, str) else None
 
 
+def _resolve_revision(revision: str | None) -> str | None:
+    """Which build of the agent's configuration is running.
+
+    ARGUMENT WINS over the environment, which is the opposite precedence to the
+    capture kill-switches and deliberately so. Those are a fleet-wide operator
+    override of what an agent asked for; this is the agent REPORTING a fact
+    about itself, and a process knows its own revision better than the
+    environment it was launched into. The environment is the fallback for
+    deployments that stamp it at rollout rather than in code.
+
+    Returns None when neither is set, and that must stay cheap: no default, no
+    hostname, no timestamp. An invented revision would silently split
+    aggregates that belong together, which is worse than not grouping at all.
+    """
+    if revision:
+        return revision
+    return os.environ.get("VOICEGW_AGENT_REVISION") or None
+
+
 def _resolve_channel(session: Any) -> str | None:
     """Best-effort telephony-vs-web classification for the dashboard's per-call chip.
 
@@ -395,6 +414,7 @@ def attach(
     project: str | None = None,
     agent_id: str | None = None,
     tenant_id: str | None = None,
+    revision: str | None = None,
     channel: str | None = None,
     collector_url: str | None = None,
     api_key: str | None = None,
@@ -525,6 +545,7 @@ def attach(
         project=resolved_project,
         agent_id=agent_id,
         tenant_id=tenant_id,
+        revision=revision,
         collector_url=collector_url,
         api_key=api_key,
         sink=sink,
@@ -666,7 +687,9 @@ class _SpeechActivity:
         return self._last_ms
 
 
-def _build_dead_air_detector(sink: Sink, project: str | None) -> tuple[Any, Any]:
+def _build_dead_air_detector(
+    sink: Sink, project: str | None, revision: str | None = None
+) -> tuple[Any, Any]:
     """A detector whose events persist through the sink, and its activity clock.
 
     Returns ``(detector, activity)``; the caller binds ``activity`` to the same
@@ -688,6 +711,7 @@ def _build_dead_air_detector(sink: Sink, project: str | None) -> tuple[Any, Any]
         activity_probe=activity.probe,
         on_event=_on_event,
         threshold_seconds=_dead_air_threshold_s(project),
+        revision=revision,
     )
     return detector, activity
 
@@ -726,7 +750,9 @@ def _turn_flush_size(project: str | None) -> int:
     return size
 
 
-def _build_turn_tracker(sink: Sink, project: str | None) -> Any:
+def _build_turn_tracker(
+    sink: Sink, project: str | None, revision: str | None = None
+) -> Any:
     """A TurnTracker whose flush writes turns through the sink.
 
     The flush callback is what was missing: TurnTracker's default is a no-op
@@ -747,6 +773,7 @@ def _build_turn_tracker(sink: Sink, project: str | None) -> Any:
         flush_callback=_flush,
         flush_size=_turn_flush_size(project),
         precise_end_required=True,
+        revision=revision,
     )
 
 
@@ -1081,6 +1108,7 @@ def _attach_livekit(
     project: str = "default",
     agent_id: str | None = None,
     tenant_id: str | None = None,
+    revision: str | None = None,
     collector_url: str | None = None,
     api_key: str | None = None,
     sink: Sink | None = None,
@@ -1104,6 +1132,7 @@ def _attach_livekit(
     resolved_room = room or _resolve_room(session)
     resolved_channel = _resolve_channel(session)
     resolved_dispatch_name = _resolve_dispatch_name(session)
+    resolved_revision = _resolve_revision(revision)
     session_id = get_or_create_session_id()
     if tenant_id is not None:
         set_tenant(tenant_id)
@@ -1111,7 +1140,11 @@ def _attach_livekit(
         sink = _build_default_sink(resolved_collector, resolved_key)
 
     # Built before MetricCapture, which needs the correction hook below.
-    turn_tracker = _build_turn_tracker(sink, project) if _turns_enabled(turns) else None
+    turn_tracker = (
+        _build_turn_tracker(sink, project, resolved_revision)
+        if _turns_enabled(turns)
+        else None
+    )
 
     def _correct_caller_end(at_ms: int) -> None:
         """Re-stamp the caller's speech end from the EOU-derived anchor.
@@ -1141,6 +1174,7 @@ def _attach_livekit(
         room=resolved_room,
         channel=resolved_channel,
         dispatch_name=resolved_dispatch_name,
+        revision=resolved_revision,
         on_caller_end=_correct_caller_end if turn_tracker is not None else None,
     )
     capture.bind(session)
@@ -1161,7 +1195,7 @@ def _attach_livekit(
     # room -> session_id -> turns, so a tracker keyed on anything else produces
     # turns that exist but never appear in /v1/rooms/{room}/latency.
     dead_air_detector, activity = (
-        _build_dead_air_detector(sink, project)
+        _build_dead_air_detector(sink, project, resolved_revision)
         if _dead_air_enabled(dead_air)
         else (None, None)
     )

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -292,6 +292,7 @@ class MetricCapture:
         sink: Sink,
         project: str,
         agent_id: str | None,
+        revision: str | None = None,
         session_id: str | None,
         tenant_id: str | None = None,
         room: str | None = None,
@@ -303,6 +304,9 @@ class MetricCapture:
         self._sink = sink
         self._project = project
         self._agent_id = agent_id
+        # Agent configuration revision, stamped on every row this capture
+        # writes. See _resolve_revision in attach.py for precedence.
+        self._revision = revision
         self._session_id = session_id
         self._tenant_id = tenant_id
         self._room = room
@@ -403,6 +407,7 @@ class MetricCapture:
             fallback_from=fallback_from,
             session_id=self._session_id,
             agent_id=self._agent_id,
+            revision=self._revision,
         )
         network = _network_meta(metric)
         if network:
@@ -430,6 +435,7 @@ class MetricCapture:
             error_message=str(error),
             session_id=self._session_id,
             agent_id=self._agent_id,
+            revision=self._revision,
         )
         self._stamp_context(record)
         self._schedule(self._sink.log_request(record))
@@ -556,6 +562,7 @@ class MetricCapture:
             status="success",
             session_id=self._session_id,
             agent_id=self._agent_id,
+            revision=self._revision,
         )
         eou_meta: dict[str, Any] = {
             "end_of_utterance_delay": float(eou),
@@ -693,6 +700,7 @@ class MetricCapture:
                 cached_input_units=max(0.0, d_cached),
                 session_id=self._session_id,
                 agent_id=self._agent_id,
+            revision=self._revision,
             )
             record.metadata = {"reconciled": True}
             self._stamp_context(record)

--- a/src/voicegateway/middleware/cost_tracker_middleware.py
+++ b/src/voicegateway/middleware/cost_tracker_middleware.py
@@ -180,6 +180,7 @@ class CostTracker:
         pricing_source: str = "",
         session_id: str | None = None,
         agent_id: str | None = None,
+        revision: str | None = None,
     ) -> RequestRecord:
         """Create a request record with cost calculated."""
         cost, cost_dec = self._resolve_cost(
@@ -212,6 +213,7 @@ class CostTracker:
             status=status,
             fallback_from=fallback_from,
             error_message=error_message,
+            revision=revision,
             session_id=session_id,
             agent_id=agent_id,
         )

--- a/src/voicegateway/middleware/dead_air_detector_middleware.py
+++ b/src/voicegateway/middleware/dead_air_detector_middleware.py
@@ -26,6 +26,8 @@ class DeadAirEvent:
     started_at_ms: int
     duration_ms: int
     threshold_used_ms: int
+    # Agent configuration revision. See RequestRecord.revision.
+    revision: str | None = None
 
 
 ActivityProbe = Callable[[str], int | None]
@@ -49,6 +51,7 @@ class DeadAirDetector(PerSessionWatcher):
         on_event: EventCallback | None = None,
         threshold_seconds: float = _DEFAULT_THRESHOLD_SECONDS,
         poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+        revision: str | None = None,
     ) -> None:
         if threshold_seconds <= 0:
             raise ValueError(f"threshold_seconds must be > 0, got {threshold_seconds}")
@@ -60,6 +63,9 @@ class DeadAirDetector(PerSessionWatcher):
         self._on_event: EventCallback = on_event or _noop_callback
         self._threshold_ms = int(threshold_seconds * 1000)
         self._poll_interval = poll_interval_seconds
+        # Agent configuration revision, stamped on every event. See
+        # _resolve_revision in attach.py.
+        self._revision = revision
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._already_fired: dict[str, bool] = {}
 
@@ -118,6 +124,7 @@ class DeadAirDetector(PerSessionWatcher):
                     started_at_ms=started_at_ms,
                     duration_ms=silence_ms,
                     threshold_used_ms=self._threshold_ms,
+                    revision=self._revision,
                 )
                 self._already_fired[session_id] = True
                 try:

--- a/src/voicegateway/middleware/turn_tracker_middleware.py
+++ b/src/voicegateway/middleware/turn_tracker_middleware.py
@@ -29,6 +29,8 @@ class TurnRow:
     agent_speak_start_ms: int | None = None
     agent_speak_end_ms: int | None = None
     response_speed_ms: int | None = None
+    # Agent configuration revision. See RequestRecord.revision.
+    revision: str | None = None
 
 
 FlushCallback = Callable[[list[TurnRow]], Awaitable[None]]
@@ -71,6 +73,7 @@ class TurnTracker(SessionScopedComponent):
         flush_size: int = _DEFAULT_FLUSH_SIZE,
         *,
         precise_end_required: bool = False,
+        revision: str | None = None,
     ) -> None:
         """``precise_end_required`` gates ``response_speed_ms`` on a real anchor.
 
@@ -91,6 +94,10 @@ class TurnTracker(SessionScopedComponent):
         self._flush_callback: FlushCallback = flush_callback or _noop_flush
         self._flush_size = flush_size
         self._precise_end_required = precise_end_required
+        # Stamped on every row this tracker writes. Session-scoped rather than
+        # per-turn: an agent's configuration cannot change mid-session, and
+        # threading it per call would invite a caller to vary it within one.
+        self._revision = revision
         self._sessions: dict[str, _SessionState] = {}
         self._lock = asyncio.Lock()
 
@@ -200,6 +207,7 @@ class TurnTracker(SessionScopedComponent):
                 caller_speak_end_ms=caller_end,
                 agent_speak_start_ms=agent_start,
                 response_speed_ms=response_speed,
+                revision=self._revision,
             )
             state.buffered_turns.append(turn)
             state.turn_index += 1
@@ -305,6 +313,7 @@ class TurnTracker(SessionScopedComponent):
                     agent_speak_start_ms=None,
                     agent_speak_end_ms=None,
                     response_speed_ms=None,
+                    revision=self._revision,
                 )
                 state.buffered_turns.append(tail)
                 state.turn_index += 1

--- a/src/voicegateway/models/dead_air_event_model.py
+++ b/src/voicegateway/models/dead_air_event_model.py
@@ -34,3 +34,6 @@ class DeadAirEvent(SQLModel, table=True):
 
     # 0005: tenant attribution
     tenant_id: str | None = None
+
+    # Agent configuration revision. See RequestRecord.revision.
+    revision: str | None = None

--- a/src/voicegateway/models/request_model.py
+++ b/src/voicegateway/models/request_model.py
@@ -48,6 +48,11 @@ class RequestRecord:
     metadata: dict[str, Any] = field(default_factory=dict)
     session_id: str | None = None  # ContextVar-derived session correlation
     agent_id: str | None = None  # fleet: self-reported agent/instance label
+    # Which build of the agent's CONFIGURATION produced this row: prompt, model
+    # ids, voice, thresholds. Opaque: a content hash, a git sha, a semver string
+    # and a deploy id are all valid and the collector never parses it, it only
+    # groups by it. Choosing between them is the operator's business.
+    revision: str | None = None
     # Billing: the rate card in effect stamps a billable price + audit token
     # at write time. Immutable once written; defaults are a cost pass-through.
     rated_price_usd: float = 0.0
@@ -124,3 +129,5 @@ class Request(SQLModel, table=True):
 
     # Phase 1 fleet: per-agent/instance attribution (self-reported label)
     agent_id: str | None = None
+    # Agent configuration revision (opaque; grouped, never parsed).
+    revision: str | None = None

--- a/src/voicegateway/models/turn_model.py
+++ b/src/voicegateway/models/turn_model.py
@@ -46,6 +46,8 @@ class Turn(SQLModel, table=True):
     response_speed_ms: int | None = Field(
         default=None, sa_column=Column(BigInteger(), nullable=True)
     )
+    # Agent configuration revision (opaque; grouped, never parsed).
+    revision: str | None = None
     created_at: str = Field(
         sa_column_kwargs={"server_default": text("CURRENT_TIMESTAMP")}
     )

--- a/src/voicegateway/repository/cost_repository.py
+++ b/src/voicegateway/repository/cost_repository.py
@@ -62,6 +62,7 @@ def _build_where(
     project: str | None,
     tenant: str | None,
     agent: str | None = None,
+    revision: str | None = None,
     include_project: bool = True,
 ) -> tuple[str, dict[str, Any]]:
     """Compose the WHERE clause + named params for a window-+-filter query."""
@@ -85,6 +86,16 @@ def _build_where(
         else:
             where += " AND agent_id = :agent"
             params["agent"] = agent
+    if revision is not None:
+        # Empty string selects rows that declared NO revision, matching the
+        # tenant and agent filters above. Without it there is no way to ask
+        # "what did the un-stamped agents do", which is the population you most
+        # want to find right after rolling the stamp out.
+        if revision == "":
+            where += " AND revision IS NULL"
+        else:
+            where += " AND revision = :revision"
+            params["revision"] = revision
     return where, params
 
 
@@ -97,11 +108,17 @@ async def get_cost_summary(
     end_ts: float | None = None,
     tenant: str | None = None,
     agent: str | None = None,
+    revision: str | None = None,
 ) -> dict[str, Any]:
     """Return total / by_provider / by_model cost rollups for the window."""
     since, until = resolve_window(period, start_ts, end_ts)
     where, params = _build_where(
-        since=since, until=until, project=project, tenant=tenant, agent=agent
+        since=since,
+        until=until,
+        project=project,
+        tenant=tenant,
+        agent=agent,
+        revision=revision,
     )
 
     result = await session.execute(
@@ -242,6 +259,44 @@ async def get_cost_by_project(
             f"""SELECT project, SUM(cost_usd) as cost, COUNT(*) as count
                 FROM requests {where}
                 GROUP BY project ORDER BY cost DESC"""
+        ),
+        params,
+    )
+    return {r[0]: {"cost": r[1], "requests": r[2]} for r in result}
+
+
+async def get_cost_by_revision(
+    session: AsyncSession,
+    period: str = "today",
+    project: str | None = None,
+    start_ts: float | None = None,
+    end_ts: float | None = None,
+    tenant: str | None = None,
+    agent: str | None = None,
+) -> dict[str, Any]:
+    """Return cost rollup grouped by agent configuration revision.
+
+    THE POINT OF THE COLUMN. Two revisions live in one window is what every
+    canary and every gradual rollout looks like, and a p95 computed across that
+    boundary is a p95 of two different agents with nothing saying so. Grouping
+    separates them instead of blending them.
+
+    Rows that declared no revision group under the empty string rather than
+    being dropped. Dropping them would make the totals here disagree with the
+    unfiltered summary for no visible reason, and during a rollout the
+    un-stamped population is exactly the half being migrated away from.
+    """
+    since, until = resolve_window(period, start_ts, end_ts)
+    where, params = _build_where(
+        since=since, until=until, project=project, tenant=tenant, agent=agent
+    )
+    result = await session.execute(
+        text(
+            f"""SELECT COALESCE(revision, '') AS rev,
+                       SUM(cost_usd) AS cost,
+                       COUNT(*) AS count
+                FROM requests {where}
+                GROUP BY rev ORDER BY cost DESC"""
         ),
         params,
     )

--- a/src/voicegateway/repository/dead_air_repository.py
+++ b/src/voicegateway/repository/dead_air_repository.py
@@ -15,8 +15,9 @@ if TYPE_CHECKING:
 
 _INSERT_EVENT = text(
     "INSERT INTO dead_air_events ("
-    "session_id, started_at_ms, duration_ms, threshold_used_ms, tenant_id"
-    ") VALUES (:session_id, :started_at_ms, :duration_ms, :threshold_used_ms, :tenant_id)"
+    "session_id, started_at_ms, duration_ms, threshold_used_ms, tenant_id, revision"
+    ") VALUES (:session_id, :started_at_ms, :duration_ms, :threshold_used_ms, "
+    ":tenant_id, :revision)"
 )
 
 
@@ -36,6 +37,7 @@ async def create_event(
             "duration_ms": event.duration_ms,
             "threshold_used_ms": event.threshold_used_ms,
             "tenant_id": resolved,
+            "revision": event.revision,
         },
     )
     await session.commit()

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -45,13 +45,13 @@ _INSERT_REQUEST = text(
         rated_price_usd, rate_rule,
         ttfb_ms, total_latency_ms, status,
         fallback_from, error_message, metadata, session_id,
-        tenant_id, agent_id)
+        tenant_id, agent_id, revision)
        VALUES (:id, :timestamp, :project, :modality, :model_id, :provider,
                :input_units, :output_units, :cached_input_units, :cost_usd, :pricing_source,
                :rated_price_usd, :rate_rule,
                :ttfb_ms, :total_latency_ms, :status,
                :fallback_from, :error_message, :metadata, :session_id,
-               :tenant_id, :agent_id)"""
+               :tenant_id, :agent_id, :revision)"""
 )
 
 
@@ -186,6 +186,7 @@ async def log_request(session: AsyncSession, record: RequestRecord) -> None:
             "session_id": record.session_id,
             "tenant_id": request_tenant_id,
             "agent_id": record.agent_id,
+            "revision": record.revision,
         },
     )
     if record.session_id:

--- a/src/voicegateway/repository/turns_repository.py
+++ b/src/voicegateway/repository/turns_repository.py
@@ -24,12 +24,12 @@ _INSERT_TURN = text(
     "session_id, turn_index, "
     "caller_speak_start_ms, caller_speak_end_ms, "
     "agent_speak_start_ms, agent_speak_end_ms, "
-    "response_speed_ms, tenant_id"
+    "response_speed_ms, tenant_id, revision"
     ") VALUES ("
     ":session_id, :turn_index, "
     ":caller_speak_start_ms, :caller_speak_end_ms, "
     ":agent_speak_start_ms, :agent_speak_end_ms, "
-    ":response_speed_ms, :tenant_id"
+    ":response_speed_ms, :tenant_id, :revision"
     ")"
 )
 
@@ -44,6 +44,7 @@ def _turn_to_params(turn: TurnRow, tenant_id: str | None) -> dict[str, object]:
         "agent_speak_end_ms": turn.agent_speak_end_ms,
         "response_speed_ms": turn.response_speed_ms,
         "tenant_id": tenant_id,
+        "revision": turn.revision,
     }
 
 
@@ -83,7 +84,7 @@ async def list_turns_by_session(
             "SELECT session_id, turn_index, "
             "caller_speak_start_ms, caller_speak_end_ms, "
             "agent_speak_start_ms, agent_speak_end_ms, "
-            "response_speed_ms "
+            "response_speed_ms, revision "
             "FROM turns WHERE session_id = :session_id "
             "ORDER BY turn_index ASC"
         ),

--- a/src/voicegateway/server/api/dashboard/costs.py
+++ b/src/voicegateway/server/api/dashboard/costs.py
@@ -39,6 +39,13 @@ async def get_costs(
     project: str | None = Query(None),
     tenant: str | None = Query(None),
     agent: str | None = Query(None),
+    revision: str | None = Query(
+        None,
+        description=(
+            "Agent configuration revision. Pass an empty string to select rows "
+            "that declared none."
+        ),
+    ),
     gateway: Gateway = Depends(get_gateway),
     principal: Principal = Depends(require_principal),
 ) -> dict:
@@ -78,6 +85,13 @@ async def get_costs(
         include_pricing_source=True,
         tenant=resolved,
         agent=agent,
+        revision=revision,
+    )
+    # Always present, so a caller can see a rollout split without knowing to ask
+    # for it. A p95 computed across a configuration change is a p95 of two
+    # different agents, and this is what says so.
+    summary["by_revision"] = await gateway.storage.get_cost_by_revision(
+        period, project=project, tenant=resolved, agent=agent
     )
     if project is None:
         summary["by_project"] = await gateway.storage.get_cost_by_project(

--- a/src/voicegateway/services/cost_service.py
+++ b/src/voicegateway/services/cost_service.py
@@ -45,9 +45,13 @@ class CostService:
         end_ts: float | None = None,
         tenant: str | None = None,
         agent: str | None = None,
+        revision: str | None = None,
     ) -> dict[str, Any]:
         """Return total / by_provider / by_model rollups."""
-        if self._use_duckdb():
+        # The DuckDB reader has no revision predicate, so a revision-filtered
+        # read goes to SQLite rather than silently returning the UNFILTERED
+        # rollup, which would answer a question nobody asked and look right.
+        if revision is None and self._use_duckdb():
             try:
                 return await asyncio.to_thread(
                     duckdb_reader.cost_summary,
@@ -70,6 +74,28 @@ class CostService:
                 period=period,
                 project=project,
                 include_pricing_source=include_pricing_source,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                tenant=tenant,
+                agent=agent,
+                revision=revision,
+            )
+
+    async def get_by_revision(
+        self,
+        period: str = "today",
+        project: str | None = None,
+        start_ts: float | None = None,
+        end_ts: float | None = None,
+        tenant: str | None = None,
+        agent: str | None = None,
+    ) -> dict[str, Any]:
+        """Cost rollup grouped by agent configuration revision."""
+        async with self._db.session() as s:
+            return await repo.get_cost_by_revision(
+                s,
+                period=period,
+                project=project,
                 start_ts=start_ts,
                 end_ts=end_ts,
                 tenant=tenant,

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -131,6 +131,7 @@ class StorageService:
         end_ts: float | None = None,
         tenant: str | None = None,
         agent: str | None = None,
+        revision: str | None = None,
     ) -> dict[str, Any]:
         """Delegate to CostService.get_summary."""
         await self._ensure_initialized()
@@ -138,6 +139,27 @@ class StorageService:
             period=period,
             project=project,
             include_pricing_source=include_pricing_source,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            tenant=tenant,
+            agent=agent,
+            revision=revision,
+        )
+
+    async def get_cost_by_revision(
+        self,
+        period: str = "today",
+        project: str | None = None,
+        start_ts: float | None = None,
+        end_ts: float | None = None,
+        tenant: str | None = None,
+        agent: str | None = None,
+    ) -> dict[str, Any]:
+        """Delegate to CostService.get_by_revision."""
+        await self._ensure_initialized()
+        return await self._cost_service.get_by_revision(
+            period=period,
+            project=project,
             start_ts=start_ts,
             end_ts=end_ts,
             tenant=tenant,

--- a/src/voicegateway/tests/inference/test_agent_config_revision.py
+++ b/src/voicegateway/tests/inference/test_agent_config_revision.py
@@ -1,0 +1,148 @@
+"""Which build of the agent's configuration produced a row.
+
+Rows carried `project`, `agent_id` and `tenant_id`, none of which says which
+version of the agent was running: the prompt, the model ids, the voice, the
+interruption thresholds. So "this got slower last Tuesday" was answerable only
+by joining deploy logs kept somewhere else against timestamps by hand.
+
+That join stops working the moment two versions run at once, which is what every
+canary and every gradual rollout is, and that is the case where the question
+matters most. It also makes the percentile views honest: a p95 computed across a
+configuration change is a p95 of two different agents, and nothing said so.
+
+The value is OPAQUE. A content hash, a git sha, a semver string and a deploy id
+are all valid; nothing parses it, it is only grouped and filtered by.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from voicegateway.inference.session.attach import _resolve_revision
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
+from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
+from voicegateway.middleware.turn_tracker_middleware import TurnRow, TurnTracker
+
+_ENV = "VOICEGW_AGENT_REVISION"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    before = os.environ.pop(_ENV, None)
+    yield
+    os.environ.pop(_ENV, None)
+    if before is not None:
+        os.environ[_ENV] = before
+
+
+# --------------------------------------------------------------------------
+# Precedence
+# --------------------------------------------------------------------------
+
+
+def test_the_argument_wins_over_the_environment() -> None:
+    """Opposite precedence to the capture kill-switches, deliberately.
+
+    Those are a fleet-wide operator override of what an agent asked for. This is
+    the agent REPORTING a fact about itself, and a process knows its own
+    revision better than the environment it was launched into.
+    """
+    os.environ[_ENV] = "from-env"
+    assert _resolve_revision("from-arg") == "from-arg"
+
+
+def test_the_environment_is_the_fallback() -> None:
+    """For deployments that stamp the revision at rollout rather than in code."""
+    os.environ[_ENV] = "from-env"
+    assert _resolve_revision(None) == "from-env"
+
+
+def test_neither_set_stays_none_rather_than_inventing_one() -> None:
+    """No hostname, no timestamp, no default.
+
+    An invented revision would silently SPLIT aggregates that belong together,
+    which is worse than not grouping at all: the reader sees two agents where
+    there was one and cannot tell that the split is an artefact.
+    """
+    assert _resolve_revision(None) is None
+
+
+def test_an_empty_string_is_not_a_revision() -> None:
+    """Empty is absent. Stamping "" would create a group nobody declared."""
+    os.environ[_ENV] = ""
+    assert _resolve_revision("") is None
+
+
+# --------------------------------------------------------------------------
+# It reaches every row type
+# --------------------------------------------------------------------------
+
+
+def test_a_cost_row_carries_it() -> None:
+    record = CostTracker().create_record(
+        model_id="openai/gpt-4o-mini",
+        modality="llm",
+        provider="openai",
+        project="default",
+        revision="abc123",
+    )
+    assert record.revision == "abc123"
+
+
+def test_a_cost_row_without_one_is_unchanged() -> None:
+    """Absent must behave exactly as before, so nothing existing moves."""
+    record = CostTracker().create_record(
+        model_id="openai/gpt-4o-mini",
+        modality="llm",
+        provider="openai",
+        project="default",
+    )
+    assert record.revision is None
+
+
+async def test_a_turn_row_carries_it() -> None:
+    tracker = TurnTracker(flush_size=1000, revision="abc123")
+    await tracker.on_user_started_speaking(session_id="s", at_ms=1000)
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=2000, precise=True)
+    await tracker.on_agent_audio_first_frame(session_id="s", at_ms=2300)
+    assert tracker._sessions["s"].buffered_turns[0].revision == "abc123"
+
+
+async def test_a_turn_left_open_at_session_close_carries_it_too() -> None:
+    """The tail row written on close is a row like any other and must match.
+
+    Missing it would make the LAST turn of every session fall out of a
+    per-revision aggregate, which is the turn most likely to be the interesting
+    one when a session ended badly.
+    """
+    written: list[TurnRow] = []
+
+    async def _flush(rows: list[TurnRow]) -> None:
+        written.extend(rows)
+
+    tracker = TurnTracker(flush_callback=_flush, flush_size=1000, revision="abc123")
+    await tracker.on_user_started_speaking(session_id="s", at_ms=1000)
+    await tracker.on_user_stopped_speaking(session_id="s", at_ms=2000, precise=True)
+    await tracker.close_session("s")
+    assert written, "the open turn was not written on close"
+    assert written[-1].revision == "abc123"
+
+
+def test_a_dead_air_event_carries_it() -> None:
+    event = DeadAirEvent(
+        session_id="s",
+        started_at_ms=1000,
+        duration_ms=5000,
+        threshold_used_ms=4000,
+        revision="abc123",
+    )
+    assert event.revision == "abc123"
+
+
+def test_the_turn_row_default_is_absent() -> None:
+    row = TurnRow(
+        session_id="s", turn_index=0, caller_speak_start_ms=0, caller_speak_end_ms=1
+    )
+    assert row.revision is None

--- a/src/voicegateway/tests/inference/test_agent_config_revision.py
+++ b/src/voicegateway/tests/inference/test_agent_config_revision.py
@@ -146,3 +146,75 @@ def test_the_turn_row_default_is_absent() -> None:
         session_id="s", turn_index=0, caller_speak_start_ms=0, caller_speak_end_ms=1
     )
     assert row.revision is None
+
+
+# --------------------------------------------------------------------------
+# Two revisions in one window must be separable, not blended
+# --------------------------------------------------------------------------
+
+
+async def _seeded(tmp_path):
+    """A window holding two revisions plus one un-stamped row."""
+    from voicegateway.services.storage_service import StorageService
+
+    storage = StorageService(str(tmp_path / "rev.db"))
+    await storage._ensure_initialized()
+    tracker = CostTracker()
+    for rev, cost in (("v1", 0.10), ("v1", 0.20), ("v2", 0.05), (None, 0.01)):
+        record = tracker.create_record(
+            model_id="openai/gpt-4o-mini",
+            modality="llm",
+            provider="openai",
+            project="default",
+            revision=rev,
+        )
+        record.cost_usd = cost
+        await storage.log_request(record)
+    return storage
+
+
+async def test_two_revisions_produce_separable_aggregates(tmp_path) -> None:
+    """The reason the column exists.
+
+    Two revisions live in one window is what every canary and every gradual
+    rollout looks like. Blended, the p95 is a p95 of two different agents with
+    nothing saying so.
+    """
+    storage = await _seeded(tmp_path)
+    by_rev = await storage.get_cost_by_revision("all")
+    await storage.aclose()
+    assert round(by_rev["v1"]["cost"], 4) == 0.30
+    assert by_rev["v1"]["requests"] == 2
+    assert round(by_rev["v2"]["cost"], 4) == 0.05
+
+
+async def test_unstamped_rows_group_rather_than_vanish(tmp_path) -> None:
+    """They are the population being migrated away from during a rollout.
+
+    Dropping them would also make this rollup disagree with the unfiltered
+    total for no visible reason.
+    """
+    storage = await _seeded(tmp_path)
+    by_rev = await storage.get_cost_by_revision("all")
+    summary = await storage.get_cost_summary("all")
+    await storage.aclose()
+    assert round(by_rev[""]["cost"], 4) == 0.01
+    assert round(sum(v["cost"] for v in by_rev.values()), 4) == round(
+        summary["total"], 4
+    )
+
+
+async def test_filtering_by_revision_selects_only_that_one(tmp_path) -> None:
+    storage = await _seeded(tmp_path)
+    only_v1 = await storage.get_cost_summary("all", revision="v1")
+    await storage.aclose()
+    assert round(only_v1["total"], 4) == 0.30
+
+
+async def test_the_empty_string_filter_selects_the_unstamped(tmp_path) -> None:
+    """Matching the tenant and agent filters, and the only way to ask
+    "what did the un-stamped agents do"."""
+    storage = await _seeded(tmp_path)
+    unstamped = await storage.get_cost_summary("all", revision="")
+    await storage.aclose()
+    assert round(unstamped["total"], 4) == 0.01


### PR DESCRIPTION
Rows carried `project`, `agent_id` and `tenant_id`, none of which says which version of the agent produced the call: the prompt, the model ids, the voice, the interruption thresholds. "This got slower last Tuesday" was answerable only by joining deploy logs kept elsewhere against timestamps by hand, and **that join stops working the moment two versions run at once** — which is every canary and every gradual rollout, and the case where the question matters most.

## The interface

One optional `attach(revision=...)` with a `VOICEGW_AGENT_REVISION` fallback, stamped on all three row types: `requests` (cost and latency), `turns`, `dead_air_events`.

**The argument beats the environment**, which is the opposite precedence to the capture kill-switches and deliberate. Those are a fleet-wide operator override of what an agent asked for; this is the agent *reporting a fact about itself*, and a process knows its own revision better than the environment it was launched into.

**Absent stays absent.** No hostname, no timestamp, no default. An invented revision would silently *split* aggregates that belong together, showing two agents where there was one with nothing marking the split as an artefact. Empty string is absent for the same reason.

**Opaque.** A content hash, a git sha, a semver string and a deploy id are all valid. Nothing parses the value; it is only grouped and filtered by, so choosing stays the operator's business.

## Reading it back

- `?revision=` on `/api/costs`. An **empty string selects rows that declared none**, matching the tenant and agent filters. Without it there is no way to ask "what did the un-stamped agents do", which is exactly the population being migrated away from during a rollout.
- A `by_revision` rollup on every cost summary, present whether or not it was asked for, so a p95 spanning a configuration change shows as two agents rather than one blended figure.
- Un-stamped rows group under `""` rather than being dropped, so the rollup still sums to the unfiltered total. Dropping them would make the two disagree for no visible reason.

A revision-filtered read goes to SQLite rather than DuckDB: the DuckDB reader has no revision predicate and would otherwise return the **unfiltered** rollup — the wrong answer, to a question nobody asked, looking entirely correct.

## Migration

`a3f7d21c9b04`, chained off the single head `c5b1e83d0f47` and verified to leave one head. Nullable on all three tables and indexed on `requests`, so rows written before this and callers who declare nothing behave exactly as they do now.

## A bug these tests found

`_INSERT_REQUEST` names its columns explicitly, so `revision` was accepted by the model, accepted by the migration, and **silently dropped on the way to the table**. The `turns` and `dead_air_events` inserts had the same shape and I caught those while writing them; this one only surfaced once a test read the value back rather than asserting on the object.

That is the argument for the aggregate tests existing at all: every test that only checked the in-memory row passed the whole time.

## Also

The turn written when a session closes with a turn still open is stamped too. Missing it would drop the **last turn of every session** out of per-revision aggregates, which is the turn most likely to matter when a session ended badly.

Verified by mutation: forcing the bound parameter to `None` turns the four aggregate tests red and leaves the rest green.

## Gates

ruff clean, mypy clean on 285 files, 3514 passed (+14). Migration applies clean from base with all three columns present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional agent configuration revision tracking across requests, turns, and dead-air events.
  * Added revision filtering and cost rollups, including grouping records without a revision.
  * Added revision support to the costs dashboard.
  * Explicit revision settings now take precedence over environment-based settings.

* **Bug Fixes**
  * Preserved absent and empty revision values consistently across telemetry and cost summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an optional agent-configuration revision to request, turn, and dead-air persistence, with revision filtering and grouped cost summaries.

- Adds nullable revision columns and an index through an Alembic migration.
- Propagates revision through LiveKit capture, row models, and repositories.
- Adds SQLite cost filtering and a `by_revision` rollup, bypassing DuckDB for filtered reads.
- Adds persistence and aggregate tests for stamped and unstamped rows.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until revision stamping is propagated through the supported Pipecat attachment path; the missing versioned documentation is also actionable but non-blocking.

LiveKit rows carry the configured revision, but Pipecat attachment drops both explicit and environment-derived revisions before request records are created, causing those rows to be omitted from their declared revision filters and rollups.

**Files Needing Attention:** src/voicegateway/inference/session/attach.py, src/voicegateway/inference/pipecat/observer.py, and versioned docs for attach and /api/costs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/voicegateway/inference/session/attach.py | Adds revision resolution and LiveKit propagation, but the supported Pipecat dispatch silently drops the new argument. |
| src/voicegateway/inference/pipecat/observer.py | Although unchanged, this active request-writing path receives no revision from the changed attach interface and therefore persists unstamped Pipecat rows. |
| src/voicegateway/repository/cost_repository.py | Adds safely parameterized revision filtering and a grouped rollup that retains unstamped rows under the empty key. |
| src/voicegateway/server/api/dashboard/costs.py | Exposes revision filtering and by_revision results through the authenticated dashboard endpoint, but the public behavior lacks a versioned docs update. |
| alembic/versions/a3f7d21c9b04_agent_config_revision.py | Adds nullable revision columns to all three tables and indexes request revisions for aggregate reads. |
| src/voicegateway/tests/inference/test_agent_config_revision.py | Covers resolution, persistence, and aggregation but omits the Pipecat attach path where revision propagation is incomplete. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/voicegateway/inference/session/attach.py`, line 527-542 ([link](https://github.com/mahimailabs/voicegateway/blob/3a3ebfcd4216b62460436b20620ecf0a22e766c7/src/voicegateway/inference/session/attach.py#L527-L542)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Pipecat revision stamping is dropped**

   When `attach(revision=...)` receives a Pipecat task, this branch calls `_attach_pipecat` without forwarding or resolving the revision, so its observer persists request rows with `revision=None`; revision-filtered summaries then omit those rows and rollout aggregates incorrectly classify them as unstamped.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/voicegateway/inference/session/attach.py
   Line: 527-542

   Comment:
   **Pipecat revision stamping is dropped**

   When `attach(revision=...)` receives a Pipecat task, this branch calls `_attach_pipecat` without forwarding or resolving the revision, so its observer persists request rows with `revision=None`; revision-filtered summaries then omit those rows and rollout aggregates incorrectly classify them as unstamped.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%0ALine%3A%20527-542%0A%0AComment%3A%0A**Pipecat%20revision%20stamping%20is%20dropped**%0A%0AWhen%20%60attach%28revision%3D...%29%60%20receives%20a%20Pipecat%20task%2C%20this%20branch%20calls%20%60_attach_pipecat%60%20without%20forwarding%20or%20resolving%20the%20revision%2C%20so%20its%20observer%20persists%20request%20rows%20with%20%60revision%3DNone%60%3B%20revision-filtered%20summaries%20then%20omit%20those%20rows%20and%20rollout%20aggregates%20incorrectly%20classify%20them%20as%20unstamped.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22mahimailabs%2Fvoicegateway%22%20on%20the%20existing%20branch%20%22feat%2Fagent-config-revision%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fagent-config-revision%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%0ALine%3A%20527-542%0A%0AComment%3A%0A**Pipecat%20revision%20stamping%20is%20dropped**%0A%0AWhen%20%60attach%28revision%3D...%29%60%20receives%20a%20Pipecat%20task%2C%20this%20branch%20calls%20%60_attach_pipecat%60%20without%20forwarding%20or%20resolving%20the%20revision%2C%20so%20its%20observer%20persists%20request%20rows%20with%20%60revision%3DNone%60%3B%20revision-filtered%20summaries%20then%20omit%20those%20rows%20and%20rollout%20aggregates%20incorrectly%20classify%20them%20as%20unstamped.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mahimailabs%2Fvoicegateway%20PR%20%23252%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mahimailabs%2Fvoicegateway&pr=252&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%3A527-542%0A**Pipecat%20revision%20stamping%20is%20dropped**%0A%0AWhen%20%60attach%28revision%3D...%29%60%20receives%20a%20Pipecat%20task%2C%20this%20branch%20calls%20%60_attach_pipecat%60%20without%20forwarding%20or%20resolving%20the%20revision%2C%20so%20its%20observer%20persists%20request%20rows%20with%20%60revision%3DNone%60%3B%20revision-filtered%20summaries%20then%20omit%20those%20rows%20and%20rollout%20aggregates%20incorrectly%20classify%20them%20as%20unstamped.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%3A414-417%0A**Public%20revision%20APIs%20lack%20documentation**%0A%0AThis%20adds%20the%20public%20%60attach%28revision%3D...%29%60%20argument%20and%20%60%2Fapi%2Fcosts%3Frevision%3D%60%20behavior%20without%20updating%20the%20versioned%20%60docs%2F%60%20content%2C%20leaving%20users%20unable%20to%20discover%20the%20environment%20fallback%2C%20precedence%20rules%2C%20or%20empty-string%20filtering%20semantics%20from%20the%20published%20documentation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22mahimailabs%2Fvoicegateway%22%20on%20the%20existing%20branch%20%22feat%2Fagent-config-revision%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fagent-config-revision%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%3A527-542%0A**Pipecat%20revision%20stamping%20is%20dropped**%0A%0AWhen%20%60attach%28revision%3D...%29%60%20receives%20a%20Pipecat%20task%2C%20this%20branch%20calls%20%60_attach_pipecat%60%20without%20forwarding%20or%20resolving%20the%20revision%2C%20so%20its%20observer%20persists%20request%20rows%20with%20%60revision%3DNone%60%3B%20revision-filtered%20summaries%20then%20omit%20those%20rows%20and%20rollout%20aggregates%20incorrectly%20classify%20them%20as%20unstamped.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%3A414-417%0A**Public%20revision%20APIs%20lack%20documentation**%0A%0AThis%20adds%20the%20public%20%60attach%28revision%3D...%29%60%20argument%20and%20%60%2Fapi%2Fcosts%3Frevision%3D%60%20behavior%20without%20updating%20the%20versioned%20%60docs%2F%60%20content%2C%20leaving%20users%20unable%20to%20discover%20the%20environment%20fallback%2C%20precedence%20rules%2C%20or%20empty-string%20filtering%20semantics%20from%20the%20published%20documentation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/voicegateway/inference/session/attach.py:527-542
**Pipecat revision stamping is dropped**

When `attach(revision=...)` receives a Pipecat task, this branch calls `_attach_pipecat` without forwarding or resolving the revision, so its observer persists request rows with `revision=None`; revision-filtered summaries then omit those rows and rollout aggregates incorrectly classify them as unstamped.

### Issue 2
src/voicegateway/inference/session/attach.py:414-417
**Public revision APIs lack documentation**

This adds the public `attach(revision=...)` argument and `/api/costs?revision=` behavior without updating the versioned `docs/` content, leaving users unable to discover the environment fallback, precedence rules, or empty-string filtering semantics from the published documentation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Make revisions readable: filter and per-..."](https://github.com/mahimailabs/voicegateway/commit/3a3ebfcd4216b62460436b20620ecf0a22e766c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54627397)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/mahimailabs/voicegateway/blob/main/CLAUDE.md))

<!-- /greptile_comment -->