### PR TITLE
voicegw baseline pin and check: a drift gate for CI (closes #246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Added
 
+- **`voicegw baseline pin` and `voicegw baseline check`: a drift gate for CI.**
+  Pin a known-good window's figures to a file, recompute over a later window,
+  exit non-zero when something moved.
+
+  Latency and cost regressions are the ones that ship, because nothing fails
+  when they do. A test suite catches an agent that is broken; nothing caught an
+  agent that got 300ms slower or 40% more expensive per call, and the caller
+  feels the first while the bill shows the second.
+
+  **Exit codes are stable API**: `0` within tolerance, `1` drifted (named, with
+  the delta), `2` could not compare. Tolerance is per metric rather than one
+  global number, because cost and p95 do not move for the same reasons.
+
+  What it refuses to call a pass: too few samples, a metric missing from the new
+  window, a pinned zero, and an improvement beyond tolerance (a 50% drop is
+  either very good news or a measurement that broke). Drift outranks
+  insufficiency, so a real regression is never buried behind a warning about a
+  different metric. A metric the new window *grew* is not a failure, otherwise
+  every measurement added here would break every baseline on upgrade.
+
+  Each metric carries the sample count it was taken over, and the file records
+  what identifies the window, so a baseline is reproducible rather than a
+  snapshot of an unnamed moment.
+
 - **`attach(revision=...)` stamps which build of the agent's configuration
   produced every row.** Optional, with a `VOICEGW_AGENT_REVISION` fallback, on
   cost, latency, turn and dead-air rows.

--- a/docs/cli/baseline.md
+++ b/docs/cli/baseline.md
@@ -1,0 +1,59 @@
+---
+title: "baseline"
+description: "Pin a known-good window of figures, then fail CI when a later one drifts."
+---
+
+Latency and cost regressions are the ones that ship, because nothing fails when they do. A test suite catches an agent that is broken. Nothing catches an agent that got 300ms slower or 40% more expensive per call, and the caller feels the first while the bill shows the second.
+
+## pin
+
+`voicegw baseline pin` writes the current window's figures to a file.
+
+| Flag | Does |
+|---|---|
+| `--config, -c` | Path to `voicegw.yaml`. |
+| `--period` | `today`, `week` (default), `month`, `all`. |
+| `--project, -p` | Filter by project. |
+| `--out, -o` | Output file. Default `voicegw-baseline.json`. |
+
+The file records **what identifies the window**, not just the numbers, so a baseline is reproducible rather than a snapshot of an unnamed moment. Each metric carries the sample count it was taken over, because a percentile over three calls and one over two hundred are different claims and a file holding only the value cannot tell them apart afterwards.
+
+## check
+
+`voicegw baseline check` recomputes over a later window and exits non-zero on drift. It defaults to the pinned window, so a check without `--period` compares like with like.
+
+<Note>
+**Exit codes are stable.** CI depends on them, so they are API rather than an implementation detail:
+
+- **0** every compared metric is within tolerance
+- **1** at least one metric drifted, named with its delta
+- **2** nothing drifted, but at least one metric could not be compared
+
+Anything added later takes a new number rather than renumbering these.
+</Note>
+
+## What it refuses to call a pass
+
+A comparison that cannot be made must not read as a pass, because a green exit is indistinguishable from a real one to the job reading it.
+
+- **Too few samples** reports insufficient data rather than passing. Three calls against a baseline of two hundred is not a result.
+- **A metric missing from the new window** is unmeasured and named. This is the case where something quietly stopped being collected.
+- **A pinned zero** is reported rather than divided by: everything is an infinite increase from zero.
+- **An improvement beyond tolerance** is reported too. A 50% drop is either very good news or a measurement that broke, and both deserve a human look.
+- **Drift outranks insufficiency.** If one metric regressed and another had too few samples, the exit code is 1, so the real finding is not buried behind a warning.
+
+A metric the new window *grew* is not a failure. Only metrics present in the pinned file are compared, otherwise every measurement added to VoiceGateway would break every existing baseline on upgrade, which trains people to delete the gate.
+
+## Tolerances
+
+Per metric, not one global number: cost and p95 do not move for the same reasons and do not deserve the same slack.
+
+| Metric | Default |
+|---|---|
+| `response_speed_p50_ms` | 15% |
+| `response_speed_p95_ms` | 20% |
+| `llm_ttft_p95_ms` | 20% |
+| `tts_ttfb_p95_ms` | 20% |
+| `cost_per_call_usd` | 10% |
+
+These are ours, not contracted. They are a starting point that fails loudly, not a threshold anybody measured.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -77,7 +77,8 @@
               "cli/logs",
               "cli/export-costs",
               "guide/cost-reconciliation",
-              "cli/reconcile"
+              "cli/reconcile",
+              "cli/baseline"
             ]
           },
           {

--- a/src/voicegateway/cli/__init__.py
+++ b/src/voicegateway/cli/__init__.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import typer
 
+from voicegateway.cli import baseline_cli as _baseline  # noqa: F401, E402
 from voicegateway.cli import brand_cli as _brand  # noqa: F401, E402
 from voicegateway.cli import calls_cli as _calls  # noqa: F401, E402
 from voicegateway.cli import check_cli as _check  # noqa: F401, E402

--- a/src/voicegateway/cli/baseline_cli.py
+++ b/src/voicegateway/cli/baseline_cli.py
@@ -1,0 +1,211 @@
+"""``voicegw baseline pin`` and ``voicegw baseline check``: a drift gate for CI.
+
+Nothing here imports an optional SDK, so the bare-install rule from #241 holds:
+a `pip install voicegateway` with no extras can run both commands.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from voicegateway.cli._app import app, console
+from voicegateway.cli.base_cli import BaseCli
+from voicegateway.services.baseline_service import (
+    BASELINE_VERSION,
+    DEFAULT_MIN_SAMPLES,
+    DEFAULT_TOLERANCES,
+    EXIT_DRIFT,
+    EXIT_INSUFFICIENT,
+    EXIT_OK,
+    compare,
+)
+
+_cli = BaseCli()
+
+baseline_app = typer.Typer(
+    help="Pin a known-good window of figures, then fail CI when a later one drifts."
+)
+
+
+async def _p95_ttfb(
+    storage: Any, modality: str, period: str, project: str | None
+) -> dict[str, Any]:
+    """p95 first-byte for one stage, with the count it was taken over.
+
+    Computed here rather than in SQL because SQLite has no percentile function
+    and the turns aggregate already sets the precedent of pulling the column and
+    cutting it in Python.
+    """
+    import statistics
+
+    from sqlalchemy import text as _text
+
+    from voicegateway.repository.cost_repository import resolve_window
+
+    since, until = resolve_window(period)
+    where = "WHERE timestamp >= :since AND modality = :modality AND ttfb_ms IS NOT NULL"
+    params: dict[str, Any] = {"since": since, "modality": modality}
+    if until is not None:
+        where += " AND timestamp < :until"
+        params["until"] = until
+    if project:
+        where += " AND project = :project"
+        params["project"] = project
+    async with storage._conn.session() as db:
+        result = await db.execute(
+            _text(f"SELECT ttfb_ms FROM requests {where}"), params
+        )
+        values = [float(r[0]) for r in result]
+    if not values:
+        return {"value": None, "samples": 0}
+    if len(values) == 1:
+        return {"value": values[0], "samples": 1}
+    cuts = statistics.quantiles(values, n=100, method="inclusive")
+    return {"value": cuts[94], "samples": len(values)}
+
+
+async def _collect(storage: Any, period: str, project: str | None) -> dict[str, Any]:
+    """The current window's figures, each with the sample count behind it.
+
+    THE SAMPLE COUNT TRAVELS WITH THE VALUE rather than being derived later.
+    A percentile over three calls and one over two hundred are different claims,
+    and a file that records only the number cannot tell them apart afterwards.
+    """
+    from voicegateway.repository import turns_repository as turns
+
+    metrics: dict[str, dict[str, Any]] = {}
+
+    async with storage._conn.session() as db:
+        speed = await turns.aggregate_response_speed(db)
+        result = await db.execute(
+            turns.text("SELECT COUNT(*) FROM turns WHERE response_speed_ms IS NOT NULL")
+        )
+        row = result.fetchone()
+        turn_samples = int(row[0]) if row else 0
+    metrics["response_speed_p50_ms"] = {
+        "value": speed.get("p50_ms"),
+        "samples": turn_samples,
+    }
+    metrics["response_speed_p95_ms"] = {
+        "value": speed.get("p95_ms"),
+        "samples": turn_samples,
+    }
+
+    # Stage components, straight from the rows rather than reshaped out of the
+    # per-model rollup: the baseline compares one number per stage, and going
+    # via by_model would make the answer depend on which models happened to be
+    # in the window.
+    for modality, name in (("llm", "llm_ttft_p95_ms"), ("tts", "tts_ttfb_p95_ms")):
+        metrics[name] = await _p95_ttfb(storage, modality, period, project)
+
+    summary = await storage.get_cost_summary(period, project=project)
+    calls = int(summary.get("request_count") or 0)
+    total = float(summary.get("total") or 0.0)
+    metrics["cost_per_call_usd"] = {
+        "value": (total / calls) if calls else None,
+        "samples": calls,
+    }
+
+    return {
+        "version": BASELINE_VERSION,
+        # What identifies the window, so a baseline is reproducible rather than
+        # a snapshot of an unnamed moment.
+        "window": {"period": period, "project": project},
+        "metrics": metrics,
+    }
+
+
+@baseline_app.command("pin")
+def pin(
+    config: str = typer.Option(None, "--config", "-c", help="Path to voicegw.yaml"),
+    period: str = typer.Option("week", "--period", help="today | week | month | all"),
+    project: str = typer.Option(None, "--project", "-p", help="Filter by project"),
+    out: Path = typer.Option(
+        Path("voicegw-baseline.json"), "--out", "-o", help="Where to write it"
+    ),
+) -> None:
+    """Write the current window's figures to a file."""
+    gw = _cli.require_gateway(config)
+    storage = _cli.require_storage(gw)
+    payload = _cli.async_run(_collect(storage, period, project))
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    measured = sum(1 for m in payload["metrics"].values() if m["value"] is not None)
+    console.print(f"Pinned {measured} metric(s) to [cyan]{out}[/cyan] ({period}).")
+    for name, m in sorted(payload["metrics"].items()):
+        shown = "unmeasured" if m["value"] is None else f"{m['value']:g}"
+        console.print(f"  {name}: {shown} ({m['samples']} samples)")
+
+
+@baseline_app.command("check")
+def check(
+    config: str = typer.Option(None, "--config", "-c", help="Path to voicegw.yaml"),
+    baseline: Path = typer.Option(
+        Path("voicegw-baseline.json"), "--baseline", "-b", help="Pinned file to compare"
+    ),
+    period: str = typer.Option(None, "--period", help="Defaults to the pinned window"),
+    project: str = typer.Option(None, "--project", "-p", help="Filter by project"),
+    min_samples: int = typer.Option(
+        DEFAULT_MIN_SAMPLES, "--min-samples", help="Below this, report insufficient"
+    ),
+) -> None:
+    """Recompute over a later window and exit non-zero on drift.
+
+    Exit codes are STABLE, because CI depends on them:
+
+    * 0 every compared metric is within tolerance
+    * 1 at least one metric drifted
+    * 2 nothing drifted, but at least one metric could not be compared
+    """
+    try:
+        pinned = json.loads(baseline.read_text())
+    except OSError as exc:
+        _cli.fail(f"cannot read {baseline}: {exc}", code=2)
+    except json.JSONDecodeError as exc:
+        _cli.fail(f"{baseline} is not valid JSON: {exc}", code=2)
+
+    if pinned.get("version") != BASELINE_VERSION:
+        _cli.fail(
+            f"{baseline} was pinned by baseline version "
+            f"{pinned.get('version')!r}; this build writes {BASELINE_VERSION}. "
+            "Re-pin rather than comparing against fields that may have moved.",
+            code=2,
+        )
+
+    window = pinned.get("window") or {}
+    resolved_period = period or window.get("period") or "week"
+    resolved_project = project if project is not None else window.get("project")
+
+    gw = _cli.require_gateway(config)
+    storage = _cli.require_storage(gw)
+    current = _cli.async_run(_collect(storage, resolved_period, resolved_project))
+    report = compare(pinned, current, min_samples=min_samples)
+
+    console.print(
+        f"\n[bold]Baseline check[/bold] ({resolved_period}) against {baseline}\n"
+    )
+    for finding in report.findings:
+        colour = {
+            "ok": "green",
+            "drift": "red",
+            "unmeasured": "yellow",
+            "insufficient": "yellow",
+        }[finding.status]
+        console.print(f"  [{colour}]{finding.describe()}[/{colour}]")
+
+    code = report.exit_code
+    if code == EXIT_OK:
+        console.print("\n[green]No drift.[/green]")
+    elif code == EXIT_DRIFT:
+        console.print("\n[red]Drift detected.[/red]")
+    else:
+        console.print("\n[yellow]Could not compare every metric.[/yellow]")
+    raise typer.Exit(code)
+
+
+app.add_typer(baseline_app, name="baseline")
+
+__all__ = ["DEFAULT_TOLERANCES", "EXIT_DRIFT", "EXIT_INSUFFICIENT", "EXIT_OK", "pin"]

--- a/src/voicegateway/services/baseline_service.py
+++ b/src/voicegateway/services/baseline_service.py
@@ -1,0 +1,205 @@
+"""Pin a known-good window, then fail CI when a later one drifts from it.
+
+The percentiles and costs were readable and comparing two releases was manual:
+read the numbers, remember the old ones, decide. Latency and cost regressions
+are the ones that ship, because nothing fails when they do. A test suite catches
+an agent that is broken; nothing catches an agent that got 300ms slower or 40%
+more expensive per call, and the caller feels the first while the bill shows the
+second.
+
+Four rules shape everything here, and they are all the same rule: A COMPARISON
+THAT CANNOT BE MADE MUST NOT READ AS A PASS.
+
+* Tolerance is per metric. Cost and p95 do not move for the same reasons and do
+  not deserve the same slack.
+* Sample count is part of the comparison. Three calls against a baseline of two
+  hundred is not a result.
+* A metric missing from the new window is UNMEASURED and named, never a pass.
+* The output says what moved and by how much. A bare non-zero exit sends
+  somebody back to the dashboard to work out what happened, which is the work
+  this was supposed to remove.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Bumped when the pinned file's shape changes incompatibly. A baseline pinned
+#: by an older version is refused rather than silently compared against fields
+#: that have moved underneath it.
+BASELINE_VERSION = 1
+
+#: Fractional drift allowed per metric before it counts as a regression.
+#:
+#: Deliberately NOT one global number. A p95 wanders with traffic mix and a few
+#: slow calls move it; a per-call cost is arithmetic over a rate card and should
+#: barely move at all, so the same 20% slack that is noise for one is a bill
+#: nobody agreed to for the other.
+#:
+#: These are OURS, not contracted, and a caller can override any of them. They
+#: are a starting point that fails loudly rather than a threshold anybody
+#: measured.
+DEFAULT_TOLERANCES: dict[str, float] = {
+    "response_speed_p50_ms": 0.15,
+    "response_speed_p95_ms": 0.20,
+    "llm_ttft_p95_ms": 0.20,
+    "tts_ttfb_p95_ms": 0.20,
+    "cost_per_call_usd": 0.10,
+}
+
+#: Below this many samples a window cannot support a comparison. Ten is low
+#: enough to let a small smoke run report, and high enough that one outlier
+#: cannot carry a percentile on its own.
+DEFAULT_MIN_SAMPLES = 10
+
+# Exit codes. STABLE: CI depends on these, so they are API and not an
+# implementation detail. Anything added later takes a new number rather than
+# renumbering these.
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_INSUFFICIENT = 2
+
+
+@dataclass
+class Finding:
+    """One metric's verdict, carrying enough to act without the dashboard."""
+
+    metric: str
+    status: str  # "ok" | "drift" | "unmeasured" | "insufficient"
+    baseline: float | None = None
+    current: float | None = None
+    delta_fraction: float | None = None
+    tolerance: float | None = None
+    baseline_samples: int | None = None
+    current_samples: int | None = None
+    note: str = ""
+
+    def describe(self) -> str:
+        """One line naming what moved and by how much."""
+        if self.status == "unmeasured":
+            return f"{self.metric}: UNMEASURED in the new window ({self.note})"
+        if self.status == "insufficient":
+            return (
+                f"{self.metric}: INSUFFICIENT DATA "
+                f"({self.current_samples} samples, needs {self.note})"
+            )
+        assert self.baseline is not None and self.current is not None
+        pct = (self.delta_fraction or 0.0) * 100.0
+        arrow = "up" if pct >= 0 else "down"
+        tol = (self.tolerance or 0.0) * 100.0
+        verdict = "DRIFT" if self.status == "drift" else "ok"
+        return (
+            f"{self.metric}: {verdict} {self.baseline:g} -> {self.current:g} "
+            f"({arrow} {abs(pct):.1f}%, tolerance {tol:.0f}%)"
+        )
+
+
+@dataclass
+class Report:
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def exit_code(self) -> int:
+        """Drift outranks insufficiency: a measured regression is the worse news.
+
+        Reporting "insufficient" while a metric that DID have enough samples
+        regressed would bury the finding the command exists to surface.
+        """
+        if any(f.status == "drift" for f in self.findings):
+            return EXIT_DRIFT
+        if any(f.status in ("unmeasured", "insufficient") for f in self.findings):
+            return EXIT_INSUFFICIENT
+        return EXIT_OK
+
+
+def compare(
+    pinned: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    tolerances: dict[str, float] | None = None,
+    min_samples: int = DEFAULT_MIN_SAMPLES,
+) -> Report:
+    """Compare a freshly collected window against a pinned one.
+
+    Only metrics present in the PINNED file are compared. A metric the new
+    window grew is not a regression and saying so would make every added
+    measurement a CI failure; a metric the new window LOST is unmeasured and is
+    reported, because that is the case where something quietly stopped being
+    collected.
+    """
+    tol = {**DEFAULT_TOLERANCES, **(tolerances or {})}
+    report = Report()
+    base_metrics = pinned.get("metrics", {})
+    cur_metrics = current.get("metrics", {})
+
+    for name in sorted(base_metrics):
+        base = base_metrics[name]
+        base_value = base.get("value")
+        cur = cur_metrics.get(name)
+        if cur is None or cur.get("value") is None:
+            report.findings.append(
+                Finding(
+                    metric=name,
+                    status="unmeasured",
+                    baseline=base_value,
+                    baseline_samples=base.get("samples"),
+                    note="the new window produced no value",
+                )
+            )
+            continue
+        cur_samples = int(cur.get("samples") or 0)
+        if cur_samples < min_samples:
+            report.findings.append(
+                Finding(
+                    metric=name,
+                    status="insufficient",
+                    baseline=base_value,
+                    current=cur.get("value"),
+                    baseline_samples=base.get("samples"),
+                    current_samples=cur_samples,
+                    note=str(min_samples),
+                )
+            )
+            continue
+        if not base_value:
+            # A pinned zero has no meaningful fractional drift: everything is an
+            # infinite increase from zero. Reported rather than divided by.
+            report.findings.append(
+                Finding(
+                    metric=name,
+                    status="unmeasured",
+                    baseline=base_value,
+                    current=cur.get("value"),
+                    note="the pinned value is zero, so a ratio says nothing",
+                )
+            )
+            continue
+        delta = (float(cur["value"]) - float(base_value)) / float(base_value)
+        allowed = tol.get(name, 0.0)
+        report.findings.append(
+            Finding(
+                metric=name,
+                status="drift" if abs(delta) > allowed else "ok",
+                baseline=float(base_value),
+                current=float(cur["value"]),
+                delta_fraction=delta,
+                tolerance=allowed,
+                baseline_samples=base.get("samples"),
+                current_samples=cur_samples,
+            )
+        )
+    return report
+
+
+__all__ = [
+    "BASELINE_VERSION",
+    "DEFAULT_MIN_SAMPLES",
+    "DEFAULT_TOLERANCES",
+    "EXIT_DRIFT",
+    "EXIT_INSUFFICIENT",
+    "EXIT_OK",
+    "Finding",
+    "Report",
+    "compare",
+]

--- a/src/voicegateway/tests/cli/test_baseline_drift_gate.py
+++ b/src/voicegateway/tests/cli/test_baseline_drift_gate.py
@@ -1,0 +1,243 @@
+"""A comparison that cannot be made must not read as a pass.
+
+Latency and cost regressions are the ones that ship, because nothing fails when
+they do. A test suite catches an agent that is broken; nothing caught an agent
+that got 300ms slower or 40% more expensive per call, and the caller feels the
+first while the bill shows the second.
+
+Every test here is the same rule seen from a different side. The dangerous
+failure is not a missed regression, it is a green exit code on a window that
+never supported the comparison, because that is indistinguishable from a real
+pass to the CI job reading it.
+"""
+
+from __future__ import annotations
+
+from voicegateway.services.baseline_service import (
+    EXIT_DRIFT,
+    EXIT_INSUFFICIENT,
+    EXIT_OK,
+    compare,
+)
+
+
+def _window(**metrics) -> dict:
+    """A collected window. Each metric carries the count it was taken over."""
+    return {
+        "version": 1,
+        "window": {"period": "week", "project": None},
+        "metrics": {
+            name: {"value": value, "samples": samples}
+            for name, (value, samples) in metrics.items()
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# Round trip and the happy path
+# --------------------------------------------------------------------------
+
+
+def test_an_unchanged_window_passes() -> None:
+    pinned = _window(response_speed_p95_ms=(800.0, 200))
+    report = compare(pinned, _window(response_speed_p95_ms=(800.0, 200)))
+    assert report.exit_code == EXIT_OK
+
+
+def test_movement_inside_tolerance_is_not_drift() -> None:
+    """5% on a metric allowed 20%. A gate that fires on noise gets disabled."""
+    pinned = _window(response_speed_p95_ms=(800.0, 200))
+    report = compare(pinned, _window(response_speed_p95_ms=(840.0, 200)))
+    assert report.exit_code == EXIT_OK
+
+
+# --------------------------------------------------------------------------
+# Drift, named and quantified
+# --------------------------------------------------------------------------
+
+
+def test_a_regression_fails_and_names_the_metric_and_the_delta() -> None:
+    """A bare non-zero exit sends somebody back to the dashboard to work out
+    what happened, which is the work this command exists to remove."""
+    pinned = _window(response_speed_p95_ms=(800.0, 200))
+    report = compare(pinned, _window(response_speed_p95_ms=(1200.0, 200)))
+    assert report.exit_code == EXIT_DRIFT
+    line = next(f.describe() for f in report.findings if f.status == "drift")
+    assert "response_speed_p95_ms" in line
+    assert "800" in line and "1200" in line
+    assert "50.0%" in line
+
+
+def test_tolerance_is_per_metric_not_global() -> None:
+    """Cost and p95 do not move for the same reasons.
+
+    12% is inside p95's 20% and outside cost's 10%. One global number would have
+    to be wrong for one of them, and the cost side is the one that quietly bills.
+    """
+    pinned = _window(response_speed_p95_ms=(800.0, 200), cost_per_call_usd=(0.10, 200))
+    report = compare(
+        pinned,
+        _window(response_speed_p95_ms=(896.0, 200), cost_per_call_usd=(0.112, 200)),
+    )
+    by_metric = {f.metric: f.status for f in report.findings}
+    assert by_metric["response_speed_p95_ms"] == "ok"
+    assert by_metric["cost_per_call_usd"] == "drift"
+
+
+def test_an_improvement_beyond_tolerance_is_still_reported() -> None:
+    """A 50% drop is either very good news or a measurement that broke.
+
+    Both are worth a human look, and silently passing the second is how a
+    collector that stopped recording reads as a performance win.
+    """
+    pinned = _window(response_speed_p95_ms=(800.0, 200))
+    report = compare(pinned, _window(response_speed_p95_ms=(400.0, 200)))
+    assert report.exit_code == EXIT_DRIFT
+
+
+# --------------------------------------------------------------------------
+# The cases that must not read as a pass
+# --------------------------------------------------------------------------
+
+
+def test_too_few_samples_reports_insufficient_rather_than_passing() -> None:
+    """Three calls against a baseline of two hundred is not a result."""
+    pinned = _window(response_speed_p95_ms=(800.0, 200))
+    report = compare(pinned, _window(response_speed_p95_ms=(805.0, 3)))
+    assert report.exit_code == EXIT_INSUFFICIENT
+    assert "INSUFFICIENT DATA" in report.findings[0].describe()
+
+
+def test_a_metric_missing_from_the_new_window_is_named_not_passed() -> None:
+    """This is the case where something quietly stopped being collected."""
+    pinned = _window(response_speed_p95_ms=(800.0, 200), cost_per_call_usd=(0.10, 200))
+    report = compare(pinned, _window(cost_per_call_usd=(0.10, 200)))
+    assert report.exit_code == EXIT_INSUFFICIENT
+    missing = next(f for f in report.findings if f.status == "unmeasured")
+    assert missing.metric == "response_speed_p95_ms"
+    assert "UNMEASURED" in missing.describe()
+
+
+def test_a_null_value_counts_as_unmeasured_not_as_zero() -> None:
+    """Absent is not zero, the same rule the turn rows follow."""
+    pinned = _window(response_speed_p95_ms=(800.0, 200))
+    report = compare(pinned, _window(response_speed_p95_ms=(None, 200)))
+    assert report.exit_code == EXIT_INSUFFICIENT
+
+
+def test_a_pinned_zero_is_reported_rather_than_divided_by() -> None:
+    """Everything is an infinite increase from zero, which is not a ratio."""
+    pinned = _window(cost_per_call_usd=(0.0, 200))
+    report = compare(pinned, _window(cost_per_call_usd=(0.05, 200)))
+    assert report.exit_code == EXIT_INSUFFICIENT
+
+
+def test_drift_outranks_insufficiency() -> None:
+    """A measured regression is the worse news and must not be buried.
+
+    Reporting exit 2 while a metric that DID have enough samples regressed would
+    hide the finding the command exists to surface.
+    """
+    pinned = _window(response_speed_p95_ms=(800.0, 200), cost_per_call_usd=(0.10, 200))
+    report = compare(
+        pinned,
+        _window(response_speed_p95_ms=(1600.0, 200), cost_per_call_usd=(0.10, 2)),
+    )
+    assert report.exit_code == EXIT_DRIFT
+
+
+def test_a_metric_the_new_window_grew_is_not_a_failure() -> None:
+    """Only pinned metrics are compared.
+
+    Otherwise every measurement added to VoiceGateway would break every existing
+    baseline in CI on upgrade, which trains people to delete the gate.
+    """
+    pinned = _window(response_speed_p95_ms=(800.0, 200))
+    report = compare(
+        pinned,
+        _window(response_speed_p95_ms=(800.0, 200), brand_new_metric=(42.0, 200)),
+    )
+    assert report.exit_code == EXIT_OK
+    assert [f.metric for f in report.findings] == ["response_speed_p95_ms"]
+
+
+# --------------------------------------------------------------------------
+# The commands themselves, end to end
+# --------------------------------------------------------------------------
+
+
+def test_pin_and_check_round_trip(tmp_path) -> None:
+    """A pinned baseline round-trips, and check re-reads the same window.
+
+    Goes through the real CLI rather than the compare() above, because the file
+    format is the contract between two invocations that may be weeks and one
+    upgrade apart.
+    """
+    import json
+
+    import yaml
+    from typer.testing import CliRunner
+
+    from voicegateway.cli._app import app
+
+    runner = CliRunner()
+    db = tmp_path / "b.db"
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.dump({"cost_tracking": {"enabled": True, "db_path": str(db)}})
+    )
+    out = tmp_path / "baseline.json"
+
+    pinned = runner.invoke(
+        app,
+        [
+            "baseline",
+            "pin",
+            "--config",
+            str(config),
+            "--out",
+            str(out),
+            "--period",
+            "all",
+        ],
+    )
+    assert pinned.exit_code == 0, pinned.output
+    payload = json.loads(out.read_text())
+    assert payload["version"] == 1
+    # The window is recorded, so a baseline is reproducible rather than a
+    # snapshot of an unnamed moment.
+    assert payload["window"]["period"] == "all"
+    assert "response_speed_p95_ms" in payload["metrics"]
+
+    checked = runner.invoke(
+        app, ["baseline", "check", "--config", str(config), "--baseline", str(out)]
+    )
+    # An empty database measures nothing, and "nothing to compare" must not be
+    # a pass. That is the whole point.
+    assert checked.exit_code == EXIT_INSUFFICIENT, checked.output
+
+
+def test_a_baseline_from_another_version_is_refused(tmp_path) -> None:
+    """Comparing against fields that may have moved is worse than not comparing."""
+    import json
+
+    import yaml
+    from typer.testing import CliRunner
+
+    from voicegateway.cli._app import app
+
+    runner = CliRunner()
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.dump(
+            {"cost_tracking": {"enabled": True, "db_path": str(tmp_path / "x.db")}}
+        )
+    )
+    stale = tmp_path / "old.json"
+    stale.write_text(json.dumps({"version": 999, "window": {}, "metrics": {}}))
+
+    result = runner.invoke(
+        app, ["baseline", "check", "--config", str(config), "--baseline", str(stale)]
+    )
+    assert result.exit_code == 2
+    assert "999" in result.output


### PR DESCRIPTION
The percentiles were readable and comparing two releases was manual: read the numbers, remember the old ones, decide.

Latency and cost regressions are the ones that ship, because **nothing fails when they do**. A test suite catches an agent that is broken. Nothing caught an agent that got 300ms slower or 40% more expensive per call, and the caller feels the first while the bill shows the second.

## The four design points, which are one rule

The issue asked for four things to be decided deliberately. They all turn out to be the same rule: **a comparison that cannot be made must not read as a pass**, because a green exit is indistinguishable from a real one to the CI job reading it.

**Tolerance per metric, not one global number.** 12% is inside p95's 20% and outside cost's 10%; one number would have to be wrong for one of them, and the cost side is the one that quietly bills. There is a test pinning exactly that case.

**Sample count travels with each value in the file**, rather than being derived later. A percentile over three calls and one over two hundred are different claims, and a file holding only the number cannot tell them apart weeks afterwards.

**A metric missing from the new window is unmeasured and named**, never a pass. This is the case where something quietly stopped being collected.

**The output says what moved and by how much**: `response_speed_p95_ms: DRIFT 800 -> 1200 (up 50.0%, tolerance 20%)`. A bare non-zero exit sends somebody back to the dashboard to work out what happened, which is the work this was supposed to remove.

## Exit codes, documented as stable

CI depends on them, so they are API rather than an implementation detail:

- **0** every compared metric within tolerance
- **1** at least one metric drifted
- **2** nothing drifted, but at least one could not be compared

**Drift outranks insufficiency.** If one metric regressed and another had too few samples, the exit is 1. Reporting 2 there would bury the finding the command exists to surface.

## Two decisions the issue did not raise

**An improvement beyond tolerance still fails.** A 50% drop is either very good news or a measurement that broke, and silently passing the second is how a collector that stopped recording reads as a performance win.

**Only metrics present in the pinned file are compared.** Otherwise every measurement added to VoiceGateway would break every existing baseline in CI on upgrade, which trains people to delete the gate.

## Notes

Nothing in the new modules imports an optional SDK, so the bare-install rule from #241 holds and `test_bare_install_cli.py` stays green (verified).

Stage-component percentiles are computed from the rows rather than reshaped out of the per-model rollup: the baseline compares one number per stage, and going via `by_model` would make the answer depend on which models happened to be in the window.

## Gates

ruff clean, mypy clean on 287 files, docs validator PASS (80 pages), 3527 passed (+13).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `voicegw baseline pin` and `voicegw baseline check` as a CI drift gate with versioned baseline files, per-metric tolerances, sample thresholds, and stable exit codes.
- Adds collection and comparison services for response latency, stage latency, and per-call cost.
- Registers and documents the new CLI command group.
- Adds drift, insufficiency, compatibility, and CLI round-trip tests.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until scoped response-speed collection and the permanently unmeasured cost metric are fixed.

The new gate compares response-speed data from outside the declared window and cannot collect cost-per-call data because it reads a summary field that no backend returns.

**Files Needing Attention:** src/voicegateway/cli/baseline_cli.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/cli/baseline_cli.py | Adds baseline collection and CLI commands, but response-speed metrics ignore window scope and cost-per-call collection can never produce a value. |
| src/voicegateway/services/baseline_service.py | Implements deterministic per-metric comparisons, insufficiency handling, drift precedence, and stable exit codes. |
| src/voicegateway/tests/cli/test_baseline_drift_gate.py | Covers comparison semantics and an empty-database round trip but does not exercise scoped response-speed collection or a populated cost metric. |
| docs/cli/baseline.md | Documents baseline commands, stable exit codes, insufficiency behavior, and default tolerances. |
| src/voicegateway/cli/__init__.py | Registers the baseline command module with the existing CLI package. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    P[baseline pin] --> C[_collect window metrics]
    C --> F[Versioned baseline JSON]
    F --> K[baseline check]
    K --> N[_collect current metrics]
    N --> X[compare values, samples, tolerances]
    X --> O[Exit 0: within tolerance]
    X --> D[Exit 1: drift]
    X --> I[Exit 2: insufficient or unmeasured]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mahimailabs%2Fvoicegateway%20PR%20%23253%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mahimailabs%2Fvoicegateway&pr=253&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Fcli%2Fbaseline_cli.py%3A83-88%0A**Response-speed%20window%20scope%20is%20ignored**%0A%0AWhen%20a%20baseline%20uses%20a%20bounded%20period%20or%20%60--project%60%2C%20these%20queries%20aggregate%20every%20response-speed%20turn%20and%20sample%20instead%20of%20the%20requested%20window%2C%20causing%20unrelated%20historical%20or%20cross-project%20traffic%20to%20mask%20real%20drift%20or%20produce%20false%20drift.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fvoicegateway%2Fcli%2Fbaseline_cli.py%3A105-110%0A**Cost%20metric%20is%20always%20unmeasured**%0A%0A%60get_cost_summary%60%20does%20not%20return%20%60request_count%60%2C%20so%20this%20lookup%20always%20resolves%20to%20zero%20and%20%60cost_per_call_usd%60%20is%20always%20stored%20as%20%60None%60%2C%20causing%20cost%20checks%20to%20report%20insufficiency%20instead%20of%20detecting%20cost%20regressions.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22mahimailabs%2Fvoicegateway%22%20on%20the%20existing%20branch%20%22feat%2Fbaseline-pin-and-check%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fbaseline-pin-and-check%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Fcli%2Fbaseline_cli.py%3A83-88%0A**Response-speed%20window%20scope%20is%20ignored**%0A%0AWhen%20a%20baseline%20uses%20a%20bounded%20period%20or%20%60--project%60%2C%20these%20queries%20aggregate%20every%20response-speed%20turn%20and%20sample%20instead%20of%20the%20requested%20window%2C%20causing%20unrelated%20historical%20or%20cross-project%20traffic%20to%20mask%20real%20drift%20or%20produce%20false%20drift.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fvoicegateway%2Fcli%2Fbaseline_cli.py%3A105-110%0A**Cost%20metric%20is%20always%20unmeasured**%0A%0A%60get_cost_summary%60%20does%20not%20return%20%60request_count%60%2C%20so%20this%20lookup%20always%20resolves%20to%20zero%20and%20%60cost_per_call_usd%60%20is%20always%20stored%20as%20%60None%60%2C%20causing%20cost%20checks%20to%20report%20insufficiency%20instead%20of%20detecting%20cost%20regressions.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/voicegateway/cli/baseline_cli.py:83-88
**Response-speed window scope is ignored**

When a baseline uses a bounded period or `--project`, these queries aggregate every response-speed turn and sample instead of the requested window, causing unrelated historical or cross-project traffic to mask real drift or produce false drift.

### Issue 2
src/voicegateway/cli/baseline_cli.py:105-110
**Cost metric is always unmeasured**

`get_cost_summary` does not return `request_count`, so this lookup always resolves to zero and `cost_per_call_usd` is always stored as `None`, causing cost checks to report insufficiency instead of detecting cost regressions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add voicegw baseline pin and check: a dr..."](https://github.com/mahimailabs/voicegateway/commit/89df849f1ab50b72d1c9ba9935da9989f6730707) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54633576)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->