### PR TITLE
Capture per-tool-call rows from tool_execution_updated (closes #247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Added
 
+- **One row per tool call, from `tool_execution_updated`.** Tool name, start,
+  duration and outcome (completed, failed, cancelled), correlated to the turn
+  and session it belongs to, with per-tool aggregates on the read path.
+
+  On agents that call tools the tool is usually the largest term in a slow turn,
+  and it was the one term the views could not show. `llm_ttft_ms` and
+  `tts_ttfb_ms` are both small and both visible; the multi-second external call
+  sitting between them was neither.
+
+  **No arguments and no results are captured anywhere.** There is no column for
+  either, the capture reads the tool's name and never its `arguments`, and the
+  collector wire shape is written field by field rather than dumping the model,
+  so a payload column added later cannot start leaving the agent by accident.
+  A name and a duration are a timing measurement; the payload is a disclosure,
+  and keeping them apart is exactly what lets this default on. All three are
+  asserted by tests rather than promised in comments.
+
+  A call still in flight counts toward its tool's call count but not its
+  average: treating a missing duration as zero would pull the average toward
+  "instant" precisely when a tool hung, which is the case somebody went looking
+  for.
+
 - **`voicegw baseline pin` and `voicegw baseline check`: a drift gate for CI.**
   Pin a known-good window's figures to a file, recompute over a later window,
   exit non-zero when something moved.

--- a/alembic/versions/b8e2f04a7d31_tool_calls.py
+++ b/alembic/versions/b8e2f04a7d31_tool_calls.py
@@ -1,0 +1,57 @@
+"""create tool_calls
+
+Revision ID: b8e2f04a7d31
+Revises: a3f7d21c9b04
+Create Date: 2026-08-19 00:45:00.000000
+
+One row per tool call: name, start, duration, outcome, correlated to the turn
+and session it belongs to. On agents that call tools the tool is usually the
+largest term in a slow turn, and it was the one term the views could not show.
+
+NO COLUMN FOR ARGUMENTS OR RESULTS, deliberately and permanently. A tool's
+payload is the operator's data; a name and a duration are a timing measurement.
+That separation is what lets this capture default on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b8e2f04a7d31"
+down_revision: str | None = "a3f7d21c9b04"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tool_calls",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("call_id", sa.String(), nullable=False),
+        sa.Column("tool_name", sa.String(), nullable=False),
+        sa.Column("started_at_ms", sa.BigInteger(), nullable=False),
+        sa.Column("duration_ms", sa.BigInteger(), nullable=True),
+        sa.Column("outcome", sa.String(), nullable=True),
+        sa.Column("turn_index", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.String(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+        sa.Column("tenant_id", sa.String(), nullable=True),
+        sa.Column("revision", sa.String(), nullable=True),
+    )
+    op.create_index("idx_tool_calls_session_id", "tool_calls", ["session_id"])
+    op.create_index("idx_tool_calls_tool_name", "tool_calls", ["tool_name"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_tool_calls_tool_name", table_name="tool_calls")
+    op.drop_index("idx_tool_calls_session_id", table_name="tool_calls")
+    op.drop_table("tool_calls")

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from typing import TYPE_CHECKING, Any
 
 from voicegateway.inference.session.context import (
@@ -18,7 +19,8 @@ if TYPE_CHECKING:
     from voicegateway.middleware.cost_tracker_middleware import CostTracker
     from voicegateway.middleware.dead_air_detector_middleware import DeadAirDetector
     from voicegateway.middleware.turn_tracker_middleware import TurnTracker
-    from voicegateway.services.sinks import Sink
+    from voicegateway.models.tool_call_model import ToolCall
+from voicegateway.services.sinks import Sink
 
 DEFAULT_DB_PATH = "~/.config/voicegateway/voicegw.db"
 
@@ -782,6 +784,8 @@ def _bind_turn_events(
     session_id: str,
     tracker: Any,
     activity: Any = None,
+    sink: Any = None,
+    revision: str | None = None,
 ) -> None:
     """Wire the speech-boundary events onto an AgentSession.
 
@@ -887,6 +891,37 @@ def _bind_turn_events(
             # speaking -> idle/listening/thinking are all the agent finishing.
             _agent_stopped(event)
 
+    # In-flight tool calls awaiting their terminal event, by call_id. Holds only
+    # the name and the start instant: no arguments, ever. The dict is what pairs
+    # a start with its end, and it is bounded by the calls actually dispatched.
+    open_tools: dict[str, tuple[str, int]] = {}
+
+    _OUTCOME = {"done": "completed", "error": "failed", "cancelled": "cancelled"}
+
+    def _write_tool_call(call_id: str, status: str | None) -> None:
+        """Emit one finished tool call, correlated to the turn it belongs to."""
+        started = open_tools.pop(call_id, None)
+        if sink is None or started is None:
+            # An end with no start: the subscription began mid-call, or the SDK
+            # reported a terminal event twice. Writing a row with an invented
+            # start would put a fabricated duration into the aggregate.
+            return
+        name, started_at_ms = started
+        ended_at_ms = int(time.time() * 1000)
+        row = ToolCall(
+            session_id=session_id,
+            call_id=call_id,
+            tool_name=name,
+            started_at_ms=started_at_ms,
+            duration_ms=max(0, ended_at_ms - started_at_ms),
+            outcome=_OUTCOME.get(status or "", None),
+            turn_index=(
+                tracker.current_turn_index(session_id) if tracker is not None else None
+            ),
+            revision=revision,
+        )
+        _schedule_turn_event(sink.log_tool_calls([row]), "tool_call_row")
+
     def _on_tool_execution_updated(event: Any = None, *_a: Any, **_k: Any) -> None:
         """Hold the turn open across a tool call so filler does not close it.
 
@@ -909,6 +944,13 @@ def _bind_turn_events(
             call = getattr(update, "function_call", None)
             call_id = getattr(call, "call_id", None)
             if call_id is not None:
+                # The NAME only. `call.arguments` is right there and is never
+                # read: a tool's payload is the operator's data, and this
+                # capture defaults on precisely because it takes none of it.
+                open_tools[call_id] = (
+                    str(getattr(call, "name", "") or "unknown"),
+                    int(time.time() * 1000),
+                )
                 _schedule_turn_event(
                     tracker.on_tool_started(session_id=session_id, call_id=call_id),
                     "tool_call_started",
@@ -916,6 +958,7 @@ def _bind_turn_events(
         elif kind == "tool_call_ended":
             call_id = getattr(update, "call_id", None)
             if call_id is not None:
+                _write_tool_call(call_id, getattr(update, "status", None))
                 _schedule_turn_event(
                     tracker.on_tool_ended(session_id=session_id, call_id=call_id),
                     "tool_call_ended",
@@ -1202,7 +1245,9 @@ def _attach_livekit(
     # One binding for both: the activity clock rides the same four events the
     # tracker does, and either half may be None.
     if turn_tracker is not None or activity is not None:
-        _bind_turn_events(session, session_id, turn_tracker, activity)
+        _bind_turn_events(
+            session, session_id, turn_tracker, activity, sink, resolved_revision
+        )
     # Expose for tests and for graceful shutdown, as with _vg_capture above.
     for _attr, _value in (
         ("_vg_dead_air", dead_air_detector),

--- a/src/voicegateway/middleware/turn_tracker_middleware.py
+++ b/src/voicegateway/middleware/turn_tracker_middleware.py
@@ -218,6 +218,25 @@ class TurnTracker(SessionScopedComponent):
         if flush_now:
             await self.flush_session(sid)
 
+    def current_turn_index(self, session_id: str | None = None) -> int | None:
+        """Which turn a tool call dispatched right now belongs to.
+
+        Read WITHOUT the lock and deliberately so: this is called from the
+        synchronous event handler that writes a tool row, and taking the lock
+        there would need an await the caller does not have. The value is a
+        monotonically increasing int written under the lock elsewhere, so the
+        worst case is attributing a call to the turn either side of a boundary,
+        which is a correlation hint rather than a measurement.
+
+        None when nothing is tracked for the session, so a caller stamps absent
+        rather than 0, which would claim the first turn.
+        """
+        sid = self._resolve_session_id(session_id)
+        if sid is None:
+            return None
+        state = self._sessions.get(sid)
+        return None if state is None else state.turn_index
+
     async def on_tool_started(
         self,
         session_id: str | None = None,

--- a/src/voicegateway/models/__init__.py
+++ b/src/voicegateway/models/__init__.py
@@ -32,11 +32,13 @@ from voicegateway.models.replay_event_model import (
 from voicegateway.models.request_model import Request, RequestRecord
 from voicegateway.models.session_model import Session
 from voicegateway.models.tenant_model import Tenant
+from voicegateway.models.tool_call_model import ToolCall
 from voicegateway.models.transcript_turn_model import TranscriptTurn
 from voicegateway.models.turn_model import Turn
 from voicegateway.models.worker_model import Worker
 
 __all__ = [
+    "ToolCall",
     "AgentObservation",
     "AgentProbeResult",
     "BaseModel",

--- a/src/voicegateway/models/tool_call_model.py
+++ b/src/voicegateway/models/tool_call_model.py
@@ -1,0 +1,57 @@
+"""ORM model for the ``tool_calls`` table.
+
+On agents that call tools, the tool is usually the largest term in a slow turn
+and it was the one term the views could not show. ``llm_ttft_ms`` and
+``tts_ttfb_ms`` are both small and both visible; the multi-second external call
+sitting between them was neither.
+
+NO ARGUMENTS AND NO RESULTS ARE STORED, and there is deliberately no column for
+either. A tool's payload is the operator's data, and whatever their tools handle
+is not ours to keep by default. A name and a duration are a TIMING MEASUREMENT;
+the payload is a DISCLOSURE. Keeping them apart is exactly what lets this
+default on, the same argument by which ``snapshots`` defaults off.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sqlalchemy import BigInteger, Column, Index, text
+from sqlmodel import Field, SQLModel
+
+
+class ToolCall(SQLModel, table=True):
+    """One tool call: what ran, when, for how long, and how it ended."""
+
+    __tablename__: ClassVar[str] = "tool_calls"
+    __table_args__ = (
+        Index("idx_tool_calls_session_id", "session_id"),
+        Index("idx_tool_calls_tool_name", "tool_name"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    session_id: str
+    call_id: str
+    tool_name: str
+    # BigInteger for the same reason as turns and dead_air_events: a millisecond
+    # epoch exceeds int32 and every insert fails on Postgres with "value out of
+    # int32 range", while SQLite hides it so the default test run cannot see it.
+    started_at_ms: int = Field(sa_column=Column(BigInteger(), nullable=False))
+    # Null while a call is in flight and for one that never reported an end.
+    # Absent is not zero: a zero duration would read as an instant tool.
+    duration_ms: int | None = Field(
+        default=None, sa_column=Column(BigInteger(), nullable=True)
+    )
+    # "completed" | "failed" | "cancelled". Null means no terminal event was
+    # seen, which is a different fact from any of the three.
+    outcome: str | None = None
+    # The turn this call belongs to, so tool time can be attributed to the wait
+    # a caller actually experienced rather than floating free in the session.
+    turn_index: int | None = None
+    created_at: str = Field(
+        sa_column_kwargs={"server_default": text("CURRENT_TIMESTAMP")}
+    )
+    tenant_id: str | None = None
+    # Agent configuration revision. Carried because #245's acceptance says the
+    # revision appears on every row type, and this row type was added after it.
+    revision: str | None = None

--- a/src/voicegateway/repository/tool_calls_repository.py
+++ b/src/voicegateway/repository/tool_calls_repository.py
@@ -1,0 +1,133 @@
+"""Async repo for the ``tool_calls`` table.
+
+Nothing here reads or writes a tool's arguments or results. There is no column
+for either and no parameter that could carry one: a name and a duration are a
+timing measurement, a payload is a disclosure, and that separation is what lets
+this capture default on.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import text
+
+from voicegateway.inference.session.context import current_tenant
+from voicegateway.models.tool_call_model import ToolCall
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+_INSERT = text(
+    "INSERT INTO tool_calls ("
+    "session_id, call_id, tool_name, started_at_ms, duration_ms, outcome, "
+    "turn_index, tenant_id, revision"
+    ") VALUES ("
+    ":session_id, :call_id, :tool_name, :started_at_ms, :duration_ms, :outcome, "
+    ":turn_index, :tenant_id, :revision"
+    ")"
+)
+
+
+async def create_tool_calls(
+    session: AsyncSession,
+    rows: list[ToolCall],
+    *,
+    tenant_id: str | None = None,
+) -> int:
+    """Insert tool-call rows. Commits the session. Returns how many landed."""
+    if not rows:
+        return 0
+    resolved = tenant_id if tenant_id is not None else current_tenant()
+    await session.execute(
+        _INSERT,
+        [
+            {
+                "session_id": r.session_id,
+                "call_id": r.call_id,
+                "tool_name": r.tool_name,
+                "started_at_ms": r.started_at_ms,
+                "duration_ms": r.duration_ms,
+                "outcome": r.outcome,
+                "turn_index": r.turn_index,
+                "tenant_id": r.tenant_id if r.tenant_id is not None else resolved,
+                "revision": r.revision,
+            }
+            for r in rows
+        ],
+    )
+    await session.commit()
+    return len(rows)
+
+
+async def list_by_session(session: AsyncSession, session_id: str) -> list[ToolCall]:
+    """All tool calls for one session, oldest first."""
+    result = await session.execute(
+        text(
+            "SELECT session_id, call_id, tool_name, started_at_ms, duration_ms, "
+            "outcome, turn_index, tenant_id, revision "
+            "FROM tool_calls WHERE session_id = :session_id "
+            "ORDER BY started_at_ms ASC"
+        ),
+        {"session_id": session_id},
+    )
+    return [
+        ToolCall(
+            session_id=r[0],
+            call_id=r[1],
+            tool_name=r[2],
+            started_at_ms=r[3],
+            duration_ms=r[4],
+            outcome=r[5],
+            turn_index=r[6],
+            tenant_id=r[7],
+            revision=r[8],
+        )
+        for r in result
+    ]
+
+
+async def aggregate_by_tool(
+    session: AsyncSession,
+    *,
+    session_id: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Per-tool call count, total and average duration, and failure counts.
+
+    Averaged over calls that REPORTED a duration. A call still in flight, or one
+    whose end was never seen, contributes to ``calls`` and not to ``avg_ms``:
+    counting it as zero would pull the average toward "instant" precisely when a
+    tool hung, which is the case somebody is looking for.
+    """
+    where = ""
+    params: dict[str, Any] = {}
+    if session_id is not None:
+        where = "WHERE session_id = :session_id"
+        params["session_id"] = session_id
+    result = await session.execute(
+        text(
+            f"""SELECT tool_name,
+                       COUNT(*) AS calls,
+                       SUM(CASE WHEN duration_ms IS NOT NULL THEN 1 ELSE 0 END) AS timed,
+                       SUM(COALESCE(duration_ms, 0)) AS total_ms,
+                       SUM(CASE WHEN outcome = 'failed' THEN 1 ELSE 0 END) AS failed,
+                       SUM(CASE WHEN outcome = 'cancelled' THEN 1 ELSE 0 END) AS cancelled
+                FROM tool_calls {where}
+                GROUP BY tool_name ORDER BY total_ms DESC"""
+        ),
+        params,
+    )
+    out: dict[str, dict[str, Any]] = {}
+    for name, calls, timed, total_ms, failed, cancelled in result:
+        out[name] = {
+            "calls": int(calls),
+            "total_ms": int(total_ms or 0),
+            "avg_ms": (int(total_ms) / int(timed)) if timed else None,
+            "failed": int(failed or 0),
+            "cancelled": int(cancelled or 0),
+        }
+    return out
+
+
+__all__ = ["aggregate_by_tool", "create_tool_calls", "list_by_session"]

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
     from voicegateway.middleware.turn_tracker_middleware import TurnRow
     from voicegateway.models.request_model import RequestRecord
+    from voicegateway.models.tool_call_model import ToolCall
     from voicegateway.services.storage_service import StorageService
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,8 @@ class Sink(Protocol):
 
     async def log_dead_air(self, events: list[DeadAirEvent]) -> None: ...
 
+    async def log_tool_calls(self, rows: list[ToolCall]) -> None: ...
+
     async def flush(self) -> None: ...
 
     async def aclose(self) -> None: ...
@@ -84,6 +87,9 @@ class LocalSqliteSink:
 
     async def log_dead_air(self, events: list[DeadAirEvent]) -> None:
         await self._storage.log_dead_air(events)
+
+    async def log_tool_calls(self, rows: list[ToolCall]) -> None:
+        await self._storage.log_tool_calls(rows)
 
     async def flush(self) -> None:
         return None
@@ -157,6 +163,7 @@ class RemoteCollectorSink:
         # cannot share /v1/ingest.
         self._turns_url = self._ingest_url + "/turns"
         self._dead_air_url = self._ingest_url + "/dead-air"
+        self._tool_calls_url = self._ingest_url + "/tool-calls"
         self._headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         self._batch_size = max(1, batch_size)
         self._flush_interval = flush_interval
@@ -180,6 +187,7 @@ class RemoteCollectorSink:
         # Same reasoning as turns: batched in memory, never in the durable
         # outbox, which exists to prove cost completeness for reconcile.
         self._dead_air_buffer: list[dict[str, Any]] = []
+        self._tool_call_buffer: list[dict[str, Any]] = []
         self._flusher: asyncio.Task[None] | None = None
         self._closed = False
         # Durable outbox (opt-in).
@@ -436,6 +444,50 @@ class RemoteCollectorSink:
         if not await self._post(batch, self._dead_air_url):
             self._dead_air_buffer = batch + self._dead_air_buffer
 
+    async def log_tool_calls(self, rows: list[ToolCall]) -> None:
+        """Buffer tool calls for the collector's ``/v1/ingest/tool-calls``.
+
+        Best-effort like the rest of this sink. Rows are serialised field by
+        field rather than by dumping the model, so a payload column added to
+        ``ToolCall`` in future cannot start leaving the agent by accident: the
+        wire shape here is a decision, not a reflection of the ORM.
+        """
+        if not rows:
+            return
+        self._tool_call_buffer.extend(
+            {
+                "session_id": r.session_id,
+                "call_id": r.call_id,
+                "tool_name": r.tool_name,
+                "started_at_ms": r.started_at_ms,
+                "duration_ms": r.duration_ms,
+                "outcome": r.outcome,
+                "turn_index": r.turn_index,
+                "tenant_id": r.tenant_id,
+                "revision": r.revision,
+            }
+            for r in rows
+        )
+        if len(self._tool_call_buffer) > self._max_buffer:
+            overflow = len(self._tool_call_buffer) - self._max_buffer
+            del self._tool_call_buffer[:overflow]
+            self._dropped += overflow
+            logger.warning(
+                "RemoteCollectorSink tool-call buffer full; dropped %d oldest", overflow
+            )
+        self._maybe_start_flusher()
+        if len(self._tool_call_buffer) >= self._batch_size:
+            await self._flush_tool_calls()
+
+    async def _flush_tool_calls(self) -> None:
+        """Drain the tool-call buffer to the collector. Requeues on failure."""
+        if not self._tool_call_buffer:
+            return
+        batch = self._tool_call_buffer
+        self._tool_call_buffer = []
+        if not await self._post(batch, self._tool_calls_url):
+            self._tool_call_buffer = batch + self._tool_call_buffer
+
     def _maybe_start_flusher(self) -> None:
         if not self._flush_interval or self._flusher is not None or self._closed:
             return
@@ -459,6 +511,7 @@ class RemoteCollectorSink:
         # runs regardless of which request path is taken below.
         await self._flush_turns()
         await self._flush_dead_air()
+        await self._flush_tool_calls()
         if self._spool_path is not None:
             if not self._spooled:
                 return

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -404,6 +404,28 @@ class StorageService:
         async with self._conn.session() as db:
             return await turns.create_turns_bulk(db, rows)
 
+    async def log_tool_calls(self, rows: list[Any]) -> int:
+        """Write per-tool-call rows. Returns the number inserted.
+
+        Bulk, unlike dead air: a single turn can dispatch several tools and the
+        capture hands them over together.
+        """
+        from voicegateway.repository import tool_calls_repository as tool_calls
+
+        if not rows:
+            return 0
+        await self._ensure_initialized()
+        async with self._conn.session() as db:
+            return await tool_calls.create_tool_calls(db, rows)
+
+    async def aggregate_tool_calls(self, session_id: str | None = None) -> dict:
+        """Per-tool call count, total and average duration, failures."""
+        from voicegateway.repository import tool_calls_repository as tool_calls
+
+        await self._ensure_initialized()
+        async with self._conn.session() as db:
+            return await tool_calls.aggregate_by_tool(db, session_id=session_id)
+
     async def log_dead_air(self, events: list[Any]) -> int:
         """Write observed dead-air events. Returns the number inserted.
 

--- a/src/voicegateway/tests/inference/test_tool_call_rows.py
+++ b/src/voicegateway/tests/inference/test_tool_call_rows.py
@@ -1,0 +1,217 @@
+"""One row per tool call, and no payload anywhere near it.
+
+Somebody could see that a turn was slow and could not see that a tool took most
+of it. On agents that call tools the tool is usually the largest term in a slow
+turn, and it was the one term the views could not show: `llm_ttft_ms` and
+`tts_ttfb_ms` are both small and both visible, and the multi-second external
+call sitting between them was neither.
+
+THE PAYLOAD RULE IS THE LOAD-BEARING ONE. A tool's arguments and results are the
+operator's data, and whatever their tools handle is not ours to store. A name
+and a duration are a timing measurement; the payload is a disclosure. That
+separation is the entire reason this capture can default on, so it is asserted
+here rather than promised in a comment.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from voicegateway.models.tool_call_model import ToolCall
+
+_ATTACH = Path(__file__).resolve().parents[2] / "inference" / "session" / "attach.py"
+
+
+# --------------------------------------------------------------------------
+# No payload, asserted three ways
+# --------------------------------------------------------------------------
+
+
+def test_the_row_has_no_field_that_could_hold_a_payload() -> None:
+    """The schema itself refuses it, so there is nowhere to put one."""
+    fields = set(ToolCall.model_fields)
+    forbidden = {"arguments", "args", "result", "results", "output", "payload", "value"}
+    assert not (fields & forbidden), f"payload-shaped field on ToolCall: {fields}"
+
+
+def test_the_capture_never_reads_the_arguments_attribute() -> None:
+    """`function_call.arguments` is right there on the SDK event.
+
+    Reading it would be one word, so this asserts the word is absent rather than
+    trusting that nobody adds it. The tool NAME is read from the same object,
+    which is what makes the omission a decision rather than an oversight.
+    """
+    src = _ATTACH.read_text()
+    handler_start = src.index("def _on_tool_execution_updated")
+    handler = src[handler_start : handler_start + 2000]
+    # Comments stripped first: the code carries a comment SAYING arguments are
+    # never read, and a naive grep matches its own explanation.
+    code = "\n".join(
+        line for line in handler.splitlines() if not line.strip().startswith("#")
+    )
+    assert ".arguments" not in code
+    assert 'getattr(call, "name"' in code
+
+
+def test_the_insert_binds_no_payload_column() -> None:
+    """The repository cannot write one even if a row somehow carried it."""
+    from voicegateway.repository import tool_calls_repository as repo
+
+    sql = str(repo._INSERT)
+    for word in ("arguments", "result", "payload", "output"):
+        assert word not in sql, f"{word!r} reachable from the insert"
+
+
+# --------------------------------------------------------------------------
+# Outcomes
+# --------------------------------------------------------------------------
+
+
+def _outcome_map() -> dict[str, str]:
+    """The SDK's status vocabulary mapped to ours, read from the source."""
+    src = _ATTACH.read_text()
+    line = next(ln for ln in src.splitlines() if "_OUTCOME = {" in ln)
+    return eval(line.split("=", 1)[1].strip())  # noqa: S307 - our own literal
+
+
+def test_completed_failed_and_cancelled_each_map_to_their_own_outcome() -> None:
+    """Three terminal states the SDK distinguishes, kept distinct here.
+
+    Collapsing error into cancelled would hide a tool that is broken behind one
+    that a caller interrupted, and those want different fixes.
+    """
+    mapping = _outcome_map()
+    assert mapping["done"] == "completed"
+    assert mapping["error"] == "failed"
+    assert mapping["cancelled"] == "cancelled"
+    assert len(set(mapping.values())) == 3
+
+
+# --------------------------------------------------------------------------
+# Aggregates
+# --------------------------------------------------------------------------
+
+
+async def _seeded(tmp_path):
+    from voicegateway.services.storage_service import StorageService
+
+    storage = StorageService(str(tmp_path / "tools.db"))
+    await storage._ensure_initialized()
+    await storage.log_tool_calls(
+        [
+            ToolCall(
+                session_id="s",
+                call_id="c1",
+                tool_name="lookup_order",
+                started_at_ms=1000,
+                duration_ms=2000,
+                outcome="completed",
+                turn_index=0,
+            ),
+            ToolCall(
+                session_id="s",
+                call_id="c2",
+                tool_name="lookup_order",
+                started_at_ms=5000,
+                duration_ms=4000,
+                outcome="failed",
+                turn_index=1,
+            ),
+            ToolCall(
+                session_id="s",
+                call_id="c3",
+                tool_name="send_sms",
+                started_at_ms=9000,
+                duration_ms=100,
+                outcome="completed",
+                turn_index=2,
+            ),
+            # In flight: no end was ever seen.
+            ToolCall(
+                session_id="s",
+                call_id="c4",
+                tool_name="send_sms",
+                started_at_ms=9500,
+                duration_ms=None,
+                outcome=None,
+                turn_index=2,
+            ),
+        ]
+    )
+    return storage
+
+
+async def test_aggregates_group_by_tool_name(tmp_path) -> None:
+    storage = await _seeded(tmp_path)
+    agg = await storage.aggregate_tool_calls()
+    await storage.aclose()
+    assert agg["lookup_order"]["calls"] == 2
+    assert agg["lookup_order"]["total_ms"] == 6000
+    assert agg["lookup_order"]["failed"] == 1
+    assert agg["send_sms"]["calls"] == 2
+
+
+async def test_an_unfinished_call_is_counted_but_not_averaged(tmp_path) -> None:
+    """Counting it as zero would pull the average toward "instant" exactly when
+    a tool hung, which is the case somebody went looking for."""
+    storage = await _seeded(tmp_path)
+    agg = await storage.aggregate_tool_calls()
+    await storage.aclose()
+    assert agg["send_sms"]["calls"] == 2
+    assert agg["send_sms"]["avg_ms"] == 100.0
+
+
+async def test_rows_correlate_to_the_turn_they_belong_to(tmp_path) -> None:
+    from voicegateway.repository import tool_calls_repository as repo
+
+    storage = await _seeded(tmp_path)
+    async with storage._conn.session() as db:
+        rows = await repo.list_by_session(db, "s")
+    await storage.aclose()
+    assert [r.turn_index for r in rows] == [0, 1, 2, 2]
+
+
+async def test_nothing_read_back_carries_a_payload(tmp_path) -> None:
+    """End to end: what goes in and comes out is timing only."""
+    from voicegateway.repository import tool_calls_repository as repo
+
+    storage = await _seeded(tmp_path)
+    async with storage._conn.session() as db:
+        rows = await repo.list_by_session(db, "s")
+    await storage.aclose()
+    for row in rows:
+        dumped = row.model_dump()
+        assert not any(
+            k in dumped for k in ("arguments", "result", "payload", "output")
+        )
+
+
+# --------------------------------------------------------------------------
+# Remote collector, not local storage only
+# --------------------------------------------------------------------------
+
+
+def test_the_collector_sink_implements_tool_calls() -> None:
+    """Acceptance says this must work against a remote collector.
+
+    Asserted structurally: the sink has the method, a dedicated buffer, its own
+    ingest URL, and drains on flush like turns and dead air do.
+    """
+    from voicegateway.services import sinks
+
+    src = inspect.getsource(sinks)
+    assert "async def log_tool_calls" in src
+    assert "_tool_call_buffer" in src
+    assert '"/tool-calls"' in src
+    assert "await self._flush_tool_calls()" in src
+
+
+def test_the_wire_shape_is_written_field_by_field() -> None:
+    """So a payload column added to ToolCall later cannot start leaving the
+    agent by accident. The wire shape is a decision, not a mirror of the ORM."""
+    from voicegateway.services import sinks
+
+    src = inspect.getsource(sinks.RemoteCollectorSink.log_tool_calls)
+    assert "asdict(" not in src
+    assert "model_dump" not in src


### PR DESCRIPTION
Somebody could see that a turn was slow and could not see that a tool took most of it. On agents that call tools the tool is usually the largest term in a slow turn, and it was **the one term the views could not show**: `llm_ttft_ms` and `tts_ttfb_ms` are both small and both visible, and the multi-second external call sitting between them was neither.

## No arguments and no results, enforced in three places

A tool's payload is the operator's data, and whatever their tools handle is not ours to store. A name and a duration are a *timing measurement*; the payload is a *disclosure*. Keeping them apart is exactly what lets this capture default on, so it is enforced rather than promised:

1. **The table has no column** that could hold one.
2. **The capture reads `function_call.name` and never `function_call.arguments`** — which is right there on the same object, one word away. That is what makes the omission a decision rather than an oversight.
3. **The collector wire shape is written field by field**, not `asdict`/`model_dump`, so a payload column added to `ToolCall` later cannot start leaving the agent by accident.

All three are asserted by tests. The arguments test strips comments first, because the code carries a comment *saying* arguments are never read and a naive grep matches its own explanation. Mutation-verified: swapping `name` for `arguments` in the capture turns it red.

## Decisions

**Three distinct outcomes.** `done` → completed, `error` → failed, `cancelled` → cancelled. Collapsing error into cancelled would hide a tool that is broken behind one a caller interrupted, and those want different fixes.

**An end with no matching start writes nothing.** Writing a row with an invented start would put a fabricated duration into the aggregate, and the case is real: the subscription can begin mid-call, or a terminal event can arrive twice.

**A call still in flight counts toward its tool's call count but not its average.** Treating a missing duration as zero would pull the average toward "instant" precisely when a tool hung, which is the case somebody went looking for.

**Turn correlation is a hint, not a measurement.** `current_turn_index` is read without the lock, because it is called from the synchronous handler that writes the row. The worst case is attributing a call to the turn either side of a boundary, and the docstring says so.

## Reuses #250's subscription

The issue says `tool_execution_updated` is "already observed for turn purposes". It was **not observed at all** until #250 an hour ago, which is now true, so this extends that handler rather than binding the event a second time with a second notion of when a tool is running.

## Also

Carries the #245 `revision`, because that acceptance says the revision appears on every row type and this row type was added after it merged.

Migration `b8e2f04a7d31` off the single head `a3f7d21c9b04`, verified to leave one head and to create no payload column.

Works against a remote collector, not local storage only: `log_tool_calls` on the protocol, both sinks, a dedicated buffer with overflow accounting, its own `/v1/ingest/tool-calls` URL, and drains on `flush()` alongside turns and dead air.

## Gates

ruff clean, mypy clean on 289 files, 3537 passed (+10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool-call telemetry with timing, outcomes, turn correlation, and per-tool summaries.
  * Added chronological call history and aggregate metrics, including counts, failures, cancellations, and average durations.
  * Added local and remote collection support with buffering, retry, and flush handling.
* **Privacy**
  * Tool arguments and results are never captured or stored.
  * In-progress calls count toward totals but are excluded from duration averages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-tool-call timing telemetry from LiveKit execution events, including a new database model and migration, local aggregation, and remote sink buffering.
- Records tool name, duration, outcome, turn correlation, tenant, and revision without arguments or results.
- Adds local persistence and per-tool aggregate queries.
- Adds remote collector serialization and buffering, but the corresponding server endpoint is absent.
- Extends tests around payload exclusion, outcomes, aggregation, and sink structure.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until remote ingestion is implemented and tool-call capture works when turn tracking is disabled.

Remote agents currently post every tool-call batch to a nonexistent server route, while supported configurations without a turn tracker silently skip capture altogether.

**Files Needing Attention:** src/voicegateway/services/sinks.py, src/voicegateway/server/api/ingest.py, src/voicegateway/inference/session/attach.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/inference/session/attach.py | Captures tool execution timing, but incorrectly couples capture to the optional turn tracker. |
| src/voicegateway/services/sinks.py | Adds field-wise remote buffering and flushing to a collector endpoint that the server does not expose. |
| src/voicegateway/repository/tool_calls_repository.py | Adds parameterized inserts, session listing, and static per-tool aggregation without exposing payload fields. |
| src/voicegateway/models/tool_call_model.py | Defines a timing-only tool-call schema with nullable terminal data and no argument or result columns. |
| alembic/versions/b8e2f04a7d31_tool_calls.py | Creates the tool_calls table and lookup indexes consistently with the new ORM model. |
| src/voicegateway/tests/inference/test_tool_call_rows.py | Covers privacy and local aggregation, but its structural remote-sink assertion does not verify the collector endpoint exists. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as LiveKit SDK
    participant Agent as Event handler
    participant Sink as RemoteCollectorSink
    participant Server as Voicegateway collector
    SDK->>Agent: tool_call_started
    SDK->>Agent: tool_call_ended
    Agent->>Sink: log_tool_calls([row])
    Sink->>Server: POST /v1/ingest/tool-calls
    Server-->>Sink: 404 (route absent)
    Sink->>Sink: Requeue in memory
    Note over Sink: Rows never persist remotely
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mahimailabs%2Fvoicegateway%20PR%20%23254%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mahimailabs%2Fvoicegateway&pr=254&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Fservices%2Fsinks.py%3A166%0A**Collector%20route%20is%20missing**%0A%0AWhen%20a%20remotely%20configured%20agent%20flushes%20a%20tool-call%20row%2C%20the%20sink%20posts%20it%20to%20%60%2Fv1%2Fingest%2Ftool-calls%60%2C%20but%20the%20server%20exposes%20no%20matching%20endpoint.%20The%20request%20returns%20404%2C%20leaving%20rows%20requeued%20only%20in%20memory%20until%20they%20are%20lost%20when%20the%20process%20exits.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%3A1247-1250%0A**Capture%20depends%20on%20turn%20tracking**%0A%0AWhen%20turn%20tracking%20is%20disabled%2C%20this%20guard%20either%20prevents%20the%20tool%20event%20handler%20from%20being%20registered%20or%20the%20handler%20exits%20because%20%60tracker%60%20is%20absent.%20Tool%20executions%20therefore%20produce%20no%20telemetry%20rows%20even%20though%20a%20sink%20is%20available.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fvoicegateway%2Fservices%2Fstorage_service.py%3A407-429%0A**Document%20the%20telemetry%20interface**%0A%0AThis%20adds%20public%20capture%2C%20persistence%2C%20aggregation%2C%20and%20remote%20collector%20behavior%20without%20updating%20the%20repository%20documentation.%20Operators%20consequently%20lack%20durable%20guidance%20for%20configuring%2C%20querying%2C%20and%20interpreting%20the%20new%20tool-call%20telemetry.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=254&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22mahimailabs%2Fvoicegateway%22%20on%20the%20existing%20branch%20%22feat%2Fper-tool-call-rows%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fper-tool-call-rows%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Fservices%2Fsinks.py%3A166%0A**Collector%20route%20is%20missing**%0A%0AWhen%20a%20remotely%20configured%20agent%20flushes%20a%20tool-call%20row%2C%20the%20sink%20posts%20it%20to%20%60%2Fv1%2Fingest%2Ftool-calls%60%2C%20but%20the%20server%20exposes%20no%20matching%20endpoint.%20The%20request%20returns%20404%2C%20leaving%20rows%20requeued%20only%20in%20memory%20until%20they%20are%20lost%20when%20the%20process%20exits.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fvoicegateway%2Finference%2Fsession%2Fattach.py%3A1247-1250%0A**Capture%20depends%20on%20turn%20tracking**%0A%0AWhen%20turn%20tracking%20is%20disabled%2C%20this%20guard%20either%20prevents%20the%20tool%20event%20handler%20from%20being%20registered%20or%20the%20handler%20exits%20because%20%60tracker%60%20is%20absent.%20Tool%20executions%20therefore%20produce%20no%20telemetry%20rows%20even%20though%20a%20sink%20is%20available.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fvoicegateway%2Fservices%2Fstorage_service.py%3A407-429%0A**Document%20the%20telemetry%20interface**%0A%0AThis%20adds%20public%20capture%2C%20persistence%2C%20aggregation%2C%20and%20remote%20collector%20behavior%20without%20updating%20the%20repository%20documentation.%20Operators%20consequently%20lack%20durable%20guidance%20for%20configuring%2C%20querying%2C%20and%20interpreting%20the%20new%20tool-call%20telemetry.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=254&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/voicegateway/services/sinks.py:166
**Collector route is missing**

When a remotely configured agent flushes a tool-call row, the sink posts it to `/v1/ingest/tool-calls`, but the server exposes no matching endpoint. The request returns 404, leaving rows requeued only in memory until they are lost when the process exits.

### Issue 2
src/voicegateway/inference/session/attach.py:1247-1250
**Capture depends on turn tracking**

When turn tracking is disabled, this guard either prevents the tool event handler from being registered or the handler exits because `tracker` is absent. Tool executions therefore produce no telemetry rows even though a sink is available.

### Issue 3
src/voicegateway/services/storage_service.py:407-429
**Document the telemetry interface**

This adds public capture, persistence, aggregation, and remote collector behavior without updating the repository documentation. Operators consequently lack durable guidance for configuring, querying, and interpreting the new tool-call telemetry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Capture per-tool-call rows from tool\_exe..."](https://github.com/mahimailabs/voicegateway/commit/e785a7d031105ba3d92efd8e6336e3b3202d05b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54640759)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/mahimailabs/voicegateway/blob/main/CLAUDE.md))

<!-- /greptile_comment -->