### PR TITLE
Collapse the four capture flags into one named policy (closes #248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Added
 
+- **`attach(policy=...)`: one named capture policy instead of four booleans.**
+  `standard`, `timing_only`, `lean`, `debug`, `off`. The four flags stay and
+  behave identically, with no deprecation warning in this change.
+
+  The set was the interesting thing and there was no way to name it. An operator
+  who wanted "timing only, nothing the caller said" had to know that means three
+  of the four off, get each right, repeat it at every call site, and know which
+  environment variable overrides which. That is a policy expressed as four
+  independent booleans, which is how a wrong combination ships without anybody
+  deciding to ship it.
+
+  The flags also mixed two unrelated questions. **What it costs to run**: dead
+  air polls once a second for the life of every session, where turn capture
+  costs nothing between events, and `lean` is `timing_only` without that
+  standing cost. **What it discloses**: a transcript is what the caller said, a
+  snapshot is the operator's own prompt and every tool payload, and `debug` is
+  the only policy carrying snapshots.
+
+  An explicit argument overrides the policy, so the four parameters are now
+  tri-state: with plain boolean defaults there is no way to tell `transcript=True`
+  passed deliberately from the default that happens to be True. An unknown
+  policy name is refused rather than defaulted, because a typo that silently
+  selected `standard` would turn "nothing the caller said" into transcript
+  capture. Environment kill-switches still beat everything.
+
+### Fixed
+
+- **Tool-call rows now ride the `turns` flag.** They correlate to a turn and
+  their `turn_index` is meaningless without one, so capturing them for somebody
+  who asked not to capture turns wrote a row type they did not ask for and could
+  not join to anything.
+
 - **One row per tool call, from `tool_execution_updated`.** Tool name, start,
   duration and outcome (completed, failed, cancelled), correlated to the turn
   and session it belongs to, with per-tool aggregates on the read path.

--- a/docs/guide/attach.md
+++ b/docs/guide/attach.md
@@ -137,6 +137,35 @@ same async context inherits it too, with no argument needed.
 **Tenant** attribution is opt-in: pass `tenant_id=` when one deployment
 serves several customers. See [Tenant attribution](/guide/multi-tenant-quickstart).
 
+## policy: naming the set instead of spelling it out
+
+The four capture flags below are the mechanism. `policy=` is the way to say what you actually want, because the interesting thing is the **set** and four independent booleans cannot name one.
+
+```python
+vg.attach(session, policy="timing_only")   # nothing the caller said
+```
+
+| Policy | transcript | snapshots | turns | dead_air |
+|---|---|---|---|---|
+| `standard` (default) | on | off | on | on |
+| `timing_only` | off | off | on | on |
+| `lean` | off | off | on | off |
+| `debug` | on | **on** | on | on |
+| `off` | off | off | off | off |
+
+The flags mix two unrelated questions, and the policies separate them:
+
+- **What does it cost to run?** Dead air polls once a second for the life of every session. Turn capture costs nothing between events. `lean` is `timing_only` without that standing cost.
+- **What does it disclose?** A transcript is what the caller said. A snapshot is your own system prompt and every tool payload. `debug` is the only policy that carries snapshots, and it is named for when that trade is worth making.
+
+Tool-call rows ride `turns`: they correlate to a turn and their `turn_index` is meaningless without one. Both are timing-only and neither carries a payload.
+
+An **explicit argument overrides the policy**, so `attach(session, policy="timing_only", dead_air=False)` is `lean`. An unknown policy name is refused rather than defaulting, because a typo that silently selected `standard` would turn "nothing the caller said" into transcript capture.
+
+<Note>
+The environment kill-switches still beat everything, including a policy. A fleet-wide override that a policy could cancel would not be a kill-switch.
+</Note>
+
 ## room, heartbeat, transcript, snapshots, turns, dead_air (LiveKit)
 
 | Param | Behavior |

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -19,7 +19,8 @@ if TYPE_CHECKING:
     from voicegateway.middleware.cost_tracker_middleware import CostTracker
     from voicegateway.middleware.dead_air_detector_middleware import DeadAirDetector
     from voicegateway.middleware.turn_tracker_middleware import TurnTracker
-    from voicegateway.models.tool_call_model import ToolCall
+from voicegateway.inference.session.policy import resolve_policy
+from voicegateway.models.tool_call_model import ToolCall
 from voicegateway.services.sinks import Sink
 
 DEFAULT_DB_PATH = "~/.config/voicegateway/voicegw.db"
@@ -423,10 +424,11 @@ def attach(
     sink: Sink | None = None,
     room: str | None = None,
     heartbeat: bool = False,
-    transcript: bool = True,
-    snapshots: bool = False,
-    turns: bool = True,
-    dead_air: bool = True,
+    policy: str | None = None,
+    transcript: bool | None = None,
+    snapshots: bool | None = None,
+    turns: bool | None = None,
+    dead_air: bool | None = None,
 ) -> str:
     """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
 
@@ -523,6 +525,14 @@ def attach(
         The correlation session id stamped on every captured row.
     """
     resolved_project = project or os.environ.get("VOICEGW_PROJECT") or "default"
+    # Resolved BEFORE the framework dispatch, so Pipecat and LiveKit get the
+    # same answer. Resolving inside one branch would make `policy=` mean
+    # something on one framework and nothing on the other, silently.
+    capture = _resolve_capture(policy, transcript, snapshots, turns, dead_air)
+    transcript = capture["transcript"]
+    snapshots = capture["snapshots"]
+    turns = capture["turns"]
+    dead_air = capture["dead_air"]
 
     from voicegateway._frameworks import detect_framework
 
@@ -558,6 +568,42 @@ def attach(
         turns=turns,
         dead_air=dead_air,
     )
+
+
+def _resolve_capture(
+    policy: str | None,
+    transcript: bool | None,
+    snapshots: bool | None,
+    turns: bool | None,
+    dead_air: bool | None,
+) -> dict[str, bool]:
+    """The four capture switches, from a named policy and any explicit override.
+
+    Precedence is explicit argument > policy > the standard set. The four
+    parameters are tri-state for exactly this reason: with plain ``bool``
+    defaults there is no way to tell ``transcript=True`` passed deliberately
+    from the default that happens to be True, so a policy could not be
+    overridden in one place without silently ignoring it everywhere.
+
+    Passing NOTHING resolves to the standard set, which is the values the four
+    parameters used to default to. That is what makes every existing call site
+    behave identically.
+
+    The environment kill-switches are NOT applied here. They stay where they
+    are, downstream of this, so they keep beating both the policy and the
+    argument: a fleet-wide override that a policy could cancel would not be a
+    kill-switch.
+    """
+    resolved = resolve_policy(policy)
+    for name, value in (
+        ("transcript", transcript),
+        ("snapshots", snapshots),
+        ("turns", turns),
+        ("dead_air", dead_air),
+    ):
+        if value is not None:
+            resolved[name] = value
+    return resolved
 
 
 def _transcripts_enabled(param: bool) -> bool:
@@ -901,7 +947,12 @@ def _bind_turn_events(
     def _write_tool_call(call_id: str, status: str | None) -> None:
         """Emit one finished tool call, correlated to the turn it belongs to."""
         started = open_tools.pop(call_id, None)
-        if sink is None or started is None:
+        # TOOL ROWS RIDE THE TURN FLAG. They correlate to a turn and their
+        # turn_index is meaningless without one, so capturing them for somebody
+        # who asked not to capture turns would write a row type they did not ask
+        # for and could not join to anything. Both are timing-only and neither
+        # carries a payload, which is why one switch is right for the pair.
+        if sink is None or tracker is None or started is None:
             # An end with no start: the subscription began mid-call, or the SDK
             # reported a terminal event twice. Writing a row with an invented
             # start would put a fabricated duration into the aggregate.

--- a/src/voicegateway/inference/session/policy.py
+++ b/src/voicegateway/inference/session/policy.py
@@ -1,0 +1,99 @@
+"""Named capture policies: what to collect, said once instead of four times.
+
+Capture was four booleans on ``attach()``, each with its own default and its own
+environment kill-switch. The SET is the interesting thing and there was no way
+to name it. An operator who wanted "timing only, nothing the caller said" had to
+know that means three of the four off, get each one right, repeat it at every
+call site, and know which variable overrides which. That is a policy expressed
+as four independent booleans, which is how a wrong combination ships without
+anybody deciding to ship it.
+
+The flags also mix two unrelated questions, and the policy names separate them:
+
+* **What does it cost to run?** Dead air polls once a second for the life of
+  every session. Turn capture costs nothing between events.
+* **What does it disclose?** A transcript is what the caller said. A snapshot is
+  the operator's own system prompt and every tool payload.
+
+``lean`` and ``timing_only`` differ only on the first axis; ``timing_only`` and
+``standard`` differ only on the second. That is the distinction four booleans
+could express and could not NAME.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+#: What each policy turns on. Keys are the four capture switches; tool-call rows
+#: ride ``turns``, because they correlate to a turn and their ``turn_index`` is
+#: meaningless without one.
+CAPTURE_POLICIES: Final[dict[str, dict[str, bool]]] = {
+    # Today's defaults, so `policy="standard"` and passing nothing agree.
+    "standard": {
+        "transcript": True,
+        "snapshots": False,
+        "turns": True,
+        "dead_air": True,
+    },
+    # The intent the issue names outright: nothing the caller said.
+    "timing_only": {
+        "transcript": False,
+        "snapshots": False,
+        "turns": True,
+        "dead_air": True,
+    },
+    # timing_only minus the standing per-session cost. Dead air is the only
+    # capture that runs a task for the life of every call.
+    "lean": {
+        "transcript": False,
+        "snapshots": False,
+        "turns": True,
+        "dead_air": False,
+    },
+    # Everything, including the operator's own prompt and tool payloads. Named
+    # `debug` rather than `full` because that is when it is worth the
+    # disclosure, and the name should say so at the call site.
+    "debug": {
+        "transcript": True,
+        "snapshots": True,
+        "turns": True,
+        "dead_air": True,
+    },
+    # Meter cost and latency, capture nothing else.
+    "off": {
+        "transcript": False,
+        "snapshots": False,
+        "turns": False,
+        "dead_air": False,
+    },
+}
+
+#: The switch names a policy sets, in a stable order for error messages.
+CAPTURE_SWITCHES: Final[tuple[str, ...]] = (
+    "transcript",
+    "snapshots",
+    "turns",
+    "dead_air",
+)
+
+
+def resolve_policy(name: str | None) -> dict[str, bool]:
+    """The four switches a policy sets, or the standard set when unnamed.
+
+    An unknown name is REFUSED rather than falling back to a default. A typo
+    that silently selected ``standard`` would turn "nothing the caller said"
+    into transcript capture, which is the exact wrong-combination-nobody-decided
+    this whole change exists to prevent.
+    """
+    if name is None:
+        return dict(CAPTURE_POLICIES["standard"])
+    try:
+        return dict(CAPTURE_POLICIES[name])
+    except KeyError:
+        known = ", ".join(sorted(CAPTURE_POLICIES))
+        raise ValueError(
+            f"unknown capture policy {name!r}. Known policies: {known}."
+        ) from None
+
+
+__all__ = ["CAPTURE_POLICIES", "CAPTURE_SWITCHES", "resolve_policy"]

--- a/src/voicegateway/tests/inference/test_attach_state_snapshots.py
+++ b/src/voicegateway/tests/inference/test_attach_state_snapshots.py
@@ -250,12 +250,19 @@ async def test_a_storage_failure_does_not_raise_out_of_the_handler(wired) -> Non
 
 def test_snapshots_are_off_by_default() -> None:
     """A snapshot carries the system prompt and every tool payload, which is a
-    strictly larger disclosure than a transcript. It is asked for, not assumed."""
-    import inspect
+    strictly larger disclosure than a transcript. It is asked for, not assumed.
 
-    assert inspect.signature(attach_mod.attach).parameters["snapshots"].default is False
+    Asserted through the RESOLVER rather than the signature default. The four
+    capture parameters became tri-state so a named policy can be overridden in
+    one place without silently ignoring it everywhere, which makes their raw
+    default None. The guarantee did not move; where it is expressed did, and
+    reading the resolved value is the stronger check anyway because it is what
+    the capture actually uses.
+    """
+    resolved = attach_mod._resolve_capture(None, None, None, None, None)
+    assert resolved["snapshots"] is False
     # Non-vacuous: transcripts really are the other way round.
-    assert inspect.signature(attach_mod.attach).parameters["transcript"].default is True
+    assert resolved["transcript"] is True
 
 
 def test_the_kill_switch_beats_the_argument(monkeypatch) -> None:

--- a/src/voicegateway/tests/inference/test_capture_policy.py
+++ b/src/voicegateway/tests/inference/test_capture_policy.py
@@ -1,0 +1,168 @@
+"""One named policy instead of four booleans nobody can name together.
+
+Capture was four booleans on `attach()`, each with its own default and its own
+environment kill-switch. The SET is the interesting thing and there was no way
+to say it. An operator who wanted "timing only, nothing the caller said" had to
+know that means three of the four off, get each right, repeat it at every call
+site, and know which variable overrides which. That is a policy expressed as
+four independent booleans, which is how a wrong combination ships without
+anybody deciding to ship it.
+
+The mapping from policy to flags is asserted here rather than described in
+prose, which is the whole point of the change: prose about which booleans a
+policy sets is the thing that goes stale and was already spread across three
+places.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+from voicegateway.inference.session.policy import (
+    CAPTURE_POLICIES,
+    CAPTURE_SWITCHES,
+    resolve_policy,
+)
+
+# import_module, not `from ... import attach`: the package __init__ re-exports
+# the attach FUNCTION under that name and shadows the module.
+attach_mod = importlib.import_module("voicegateway.inference.session.attach")
+
+_resolve = attach_mod._resolve_capture
+
+
+# --------------------------------------------------------------------------
+# The mapping, asserted rather than described
+# --------------------------------------------------------------------------
+
+
+def test_every_policy_sets_every_switch() -> None:
+    """A policy that leaves one unset is a combination nobody decided."""
+    for name, mapping in CAPTURE_POLICIES.items():
+        assert set(mapping) == set(CAPTURE_SWITCHES), name
+
+
+def test_standard_is_exactly_todays_defaults() -> None:
+    """The compatibility claim, stated as an equality.
+
+    If this drifts, every existing `attach()` call changes behaviour silently,
+    which the acceptance explicitly forbids.
+    """
+    assert CAPTURE_POLICIES["standard"] == {
+        "transcript": True,
+        "snapshots": False,
+        "turns": True,
+        "dead_air": True,
+    }
+
+
+def test_timing_only_captures_nothing_the_caller_said() -> None:
+    """The intent the issue names outright."""
+    p = CAPTURE_POLICIES["timing_only"]
+    assert p["transcript"] is False and p["snapshots"] is False
+    assert p["turns"] is True
+
+
+def test_lean_differs_from_timing_only_on_cost_not_disclosure() -> None:
+    """The two axes the four booleans flattened.
+
+    Dead air polls once a second for the life of every session; turn capture
+    costs nothing between events. `lean` is the same disclosure as
+    `timing_only` and a different running cost, and that is a distinction the
+    booleans could express but could not name.
+    """
+    lean, timing = CAPTURE_POLICIES["lean"], CAPTURE_POLICIES["timing_only"]
+    differing = {k for k in CAPTURE_SWITCHES if lean[k] != timing[k]}
+    assert differing == {"dead_air"}
+
+
+def test_debug_is_the_only_policy_that_discloses_snapshots() -> None:
+    """A snapshot is the operator's own prompt and every tool payload.
+
+    Exactly one policy should carry that, and it should be the one whose name
+    says why you turned it on.
+    """
+    with_snapshots = {n for n, p in CAPTURE_POLICIES.items() if p["snapshots"]}
+    assert with_snapshots == {"debug"}
+
+
+def test_off_captures_nothing() -> None:
+    assert not any(CAPTURE_POLICIES["off"].values())
+
+
+# --------------------------------------------------------------------------
+# Precedence
+# --------------------------------------------------------------------------
+
+
+def test_passing_nothing_behaves_exactly_as_before() -> None:
+    """The acceptance criterion: existing calls are identical, no warning."""
+    assert _resolve(None, None, None, None, None) == CAPTURE_POLICIES["standard"]
+
+
+def test_the_four_booleans_still_work_on_their_own() -> None:
+    """No deprecation in this change, so they must keep behaving."""
+    resolved = _resolve(None, False, True, False, False)
+    assert resolved == {
+        "transcript": False,
+        "snapshots": True,
+        "turns": False,
+        "dead_air": False,
+    }
+
+
+def test_an_explicit_argument_overrides_the_policy() -> None:
+    """Which is why the four parameters are tri-state.
+
+    With plain bool defaults there is no way to tell `transcript=True` passed
+    deliberately from the default that happens to be True, so a policy could
+    not be overridden in one place without being ignored everywhere.
+    """
+    resolved = _resolve("timing_only", True, None, None, None)
+    assert resolved["transcript"] is True
+    # And the rest of the policy still applies.
+    assert resolved["snapshots"] is False
+    assert resolved["dead_air"] is True
+
+
+def test_an_unknown_policy_is_refused_not_defaulted() -> None:
+    """A typo that silently selected `standard` would turn "nothing the caller
+    said" into transcript capture: the exact wrong combination this prevents."""
+    with pytest.raises(ValueError) as excinfo:
+        resolve_policy("timing-only")  # underscores, not a hyphen
+    assert "timing_only" in str(excinfo.value)
+
+
+def test_resolving_returns_a_copy_not_the_shared_mapping() -> None:
+    """An override must not mutate the policy table for the whole process."""
+    first = _resolve("timing_only", True, None, None, None)
+    second = _resolve("timing_only", None, None, None, None)
+    assert first["transcript"] is True
+    assert second["transcript"] is False
+
+
+# --------------------------------------------------------------------------
+# The kill-switches keep beating everything
+# --------------------------------------------------------------------------
+
+
+def test_the_environment_still_beats_a_policy() -> None:
+    """A fleet-wide override a policy could cancel would not be a kill-switch.
+
+    The env vars are applied downstream of the resolver, so they survive both
+    the policy and an explicit argument.
+    """
+    before = os.environ.get("VOICEGW_TRANSCRIPTS")
+    os.environ["VOICEGW_TRANSCRIPTS"] = "0"
+    try:
+        resolved = _resolve("debug", None, None, None, None)
+        assert resolved["transcript"] is True  # the policy did ask for it
+        # ...and the kill-switch still wins where it is applied.
+        assert attach_mod._transcripts_enabled(resolved["transcript"]) is False
+    finally:
+        os.environ.pop("VOICEGW_TRANSCRIPTS", None)
+        if before is not None:
+            os.environ["VOICEGW_TRANSCRIPTS"] = before


### PR DESCRIPTION
Capture was four booleans on `attach()`, each with its own default and its own environment kill-switch. **The set is the interesting thing and there was no way to name it.**

An operator who wanted "timing only, nothing the caller said" had to know that means three of the four off, get each one right, repeat it at every call site, and know which variable overrides which. That is a policy expressed as four independent booleans, which is how a wrong combination ships without anybody deciding to ship it.

```python
vg.attach(session, policy="timing_only")
```

| Policy | transcript | snapshots | turns | dead_air |
|---|---|---|---|---|
| `standard` (default) | on | off | on | on |
| `timing_only` | off | off | on | on |
| `lean` | off | off | on | off |
| `debug` | on | **on** | on | on |
| `off` | off | off | off | off |

## The two axes the booleans flattened

**What does it cost to run?** Dead air polls once a second for the life of every session; turn capture costs nothing between events. `lean` is `timing_only` without that standing cost, and a test asserts those two differ on `dead_air` and nothing else.

**What does it disclose?** A transcript is what the caller said. A snapshot is the operator's own system prompt and every tool payload. `debug` is the only policy carrying snapshots, asserted as a set equality, and it is named for when that trade is worth making rather than `full`.

The mapping is **asserted in tests rather than described in prose**, which is the point of the change: prose about which booleans a policy sets is exactly what goes stale, and it was already spread across three places.

## Compatibility

The four flags stay and behave identically, with no deprecation warning, as the acceptance requires. `test_standard_is_exactly_todays_defaults` states that as an equality, so drift changes every existing call site loudly rather than silently.

**The four parameters become tri-state** so an explicit argument can override a policy. With plain `bool` defaults there is no way to tell `transcript=True` passed deliberately from the default that happens to be True, so a policy could not be overridden in one place without being silently ignored everywhere. Passing nothing resolves to the standard set — the values they used to default to.

**Resolved before the framework dispatch**, so Pipecat and LiveKit get the same answer. Resolving inside one branch would make `policy=` mean something on one framework and nothing on the other, silently. I had this wrong in the first draft and caught it reading the dispatch order.

**An unknown policy raises** rather than defaulting. A typo that quietly selected `standard` would turn "nothing the caller said" into transcript capture, which is the exact failure this exists to prevent.

**Environment kill-switches are untouched** and still beat both the policy and the argument, because a fleet-wide override a policy could cancel would not be a kill-switch. Asserted directly.

## A gap #247 left, fixed here

Tool-call rows were written whenever the turn events were bound, and that happens when `dead_air` is on even with `turns` off. So `turns=False, dead_air=True` wrote a row type the caller had not asked for and could not join to anything, since `turn_index` would always be null. They now ride the `turns` flag: both are timing-only, neither carries a payload, and one switch is right for the pair.

## One existing test changed

`test_snapshots_are_off_by_default` asserted the raw signature default is `False`, which the tri-state change makes `None`. **The guarantee did not move, only where it is expressed**, so it now asserts the *resolved* value — which is what capture actually reads, and is the stronger check. Flagging it because changing an existing test to make a change pass deserves to be seen rather than buried.

## Gates

ruff clean, mypy clean on 290 files, docs validator PASS (80 pages), 3549 passed (+12).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces named capture policies while preserving explicit per-flag overrides and existing environment kill-switch precedence. It also documents and tests the policy mappings and associates tool-call capture with turn tracking.

- Adds `standard`, `timing_only`, `lean`, `debug`, and `off` capture policies.
- Resolves policies and explicit overrides before framework dispatch.
- Retains the existing default capture behavior for callers that omit the new policy.
- Adds policy, precedence, disclosure, and compatibility tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The policy resolver preserves existing defaults, applies explicit overrides predictably, rejects unknown policies, and feeds the same resolved values into both framework paths before existing environment controls are applied.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/inference/session/policy.py | Defines complete named-policy mappings, rejects unknown names, and returns copies to prevent shared-state mutation. |
| src/voicegateway/inference/session/attach.py | Resolves policies and explicit overrides before framework dispatch while retaining downstream environment kill-switch behavior. |
| src/voicegateway/tests/inference/test_capture_policy.py | Covers policy completeness, compatibility defaults, override precedence, invalid names, mapping isolation, and environment precedence. |
| docs/guide/attach.md | Documents the policy sets, their cost and disclosure tradeoffs, explicit overrides, and kill-switch precedence. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[attach call] --> B[Resolve named policy]
    B --> C[Apply explicit flag overrides]
    C --> D[Detect framework]
    D --> E[LiveKit attachment]
    D --> F[Pipecat attachment]
    E --> G[Apply environment kill-switches]
    F --> G
    G --> H[Configure capture components]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Collapse the four capture flags into one..."](https://github.com/mahimailabs/voicegateway/commit/34812abe5112350306d4f194bae6abfbde482434) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54647297)</sub>

<!-- /greptile_comment -->