### PR TITLE
Stop the attach docstring contradicting its own signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ## Unreleased
 
+### Fixed
+
+- **The `attach()` docstring no longer contradicts its own signature.** Shipped
+  in 0.25.0 and reported by a consumer who read the API rather than the release
+  notes.
+
+  `revision` and `policy` were in the signature and absent from `Args`, so a
+  reader checking the docstring concluded the release's two headline parameters
+  did not exist. Worse, the four capture flags became `bool | None = None` while
+  their entries still read "(default on)" and "(default OFF)", which were the
+  pre-0.25.0 values: somebody passing nothing and trusting the docstring would
+  believe transcript capture was on when the policy decides. A doc that is
+  merely absent is a gap; one that states the opposite of the code is a trap.
+
+  The three-layer precedence (environment kill-switch, then explicit flag, then
+  policy) is now stated once, in `policy`. Two tests pin it: every public
+  parameter is documented, and the docstring claims no default the signature
+  dropped.
+
 ### Added
 
 - **`attach(policy=...)`: one named capture policy instead of four booleans.**

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -453,6 +453,32 @@ def attach(
             variable, then ``"default"``.
         agent_id: fleet label; defaults to ``VOICEGW_AGENT_ID`` or hostname.
         tenant_id: optional tenant attribution.
+        revision: which build of THIS AGENT'S CONFIGURATION is running: the
+            prompt, the model ids, the voice, the interruption thresholds.
+            Stamped on every cost, latency, turn, dead-air and tool-call row, so
+            "this got slower last Tuesday" is answerable without joining deploy
+            logs by hand, and so two revisions live in one window separate
+            instead of blending into one p95 of two different agents. Opaque: a
+            content hash, a git sha, a semver string and a deploy id are all
+            valid, and nothing parses it. Falls back to
+            ``VOICEGW_AGENT_REVISION``; the ARGUMENT WINS, unlike the capture
+            kill-switches, because this is the agent reporting a fact about
+            itself rather than a fleet overriding what it asked for. Absent when
+            neither is set: no hostname, no timestamp, no invented default,
+            because a made-up revision splits aggregates that belong together.
+        policy: a named capture policy, which is how to say what you want
+            instead of spelling it out in four booleans. One of ``"standard"``
+            (today's defaults), ``"timing_only"`` (nothing the caller said),
+            ``"lean"`` (``timing_only`` without dead air's per-session polling
+            cost), ``"debug"`` (everything, including your own prompt and tool
+            payloads), or ``"off"``. An unknown name RAISES rather than falling
+            back to ``standard``: a typo that silently selected the default
+            would turn "nothing the caller said" into transcript capture.
+
+            PRECEDENCE, since there are three layers: an environment
+            kill-switch beats everything, then an explicitly passed flag, then
+            the policy. So ``policy="timing_only", dead_air=False`` is ``lean``,
+            and ``VOICEGW_TRANSCRIPTS=0`` still wins over ``policy="debug"``.
         channel: ``"telephony"`` | ``"web"``; auto-detected from the transport
             when omitted.
         collector_url / api_key: fleet push target (env fallbacks).
@@ -472,7 +498,8 @@ def attach(
             ``register_worker("agent", local=True)`` at your ``__main__`` boot
             instead, and do not also pass ``heartbeat=True`` there (the subprocess
             would become a second writer of the same roster row).
-        transcript: capture the call transcript (default on). On close, the
+        transcript: capture the call transcript. ``None`` (the default) means
+            the policy decides; an explicit value overrides it. On close, the
             user/agent text turns are read from the framework's conversation
             history and written to the local store, so the Calls page can show
             the conversation. Pass ``transcript=False`` to disable per attach, or
@@ -480,7 +507,9 @@ def attach(
             kill-switch wins over the argument). Captures to the local SQLite the
             co-located dashboard reads; currently LiveKit-only (the Pipecat path
             accepts the flag but does not capture transcripts yet).
-        snapshots: capture conversation-state snapshots (default OFF). When on,
+        snapshots: capture conversation-state snapshots. ``None`` (the default)
+            means the policy decides, and only ``debug`` turns this on; an
+            explicit value overrides it. When on,
             a snapshot is written at each completed message and each resolved
             tool call, carrying the system prompt, the message history, and the
             tool's arguments and result. ``voicegw replay`` and the dashboard's
@@ -494,7 +523,10 @@ def attach(
             local sink: a remote collector has no replay tables, so capture is
             skipped there rather than buffering rows nothing can flush.
             LiveKit-only, like transcripts.
-        turns: capture per-turn speech boundaries (default ON). One row per
+        turns: capture per-turn speech boundaries. ``None`` (the default) means
+            the policy decides; an explicit value overrides it. Tool-call rows
+            ride this flag, because their ``turn_index`` is meaningless without
+            a turn. One row per
             caller/agent exchange: the turn index and the four speech timestamps,
             from which ``response_speed_ms`` is derived. This is what
             ``e2e_ms`` and the ``turns`` list on ``/v1/rooms/{room}/latency``
@@ -507,7 +539,10 @@ def attach(
             ``VOICEGW_TURNS=0`` to force it off fleet-wide (the kill-switch wins
             over the argument). LiveKit-only: the Pipecat path accepts the flag
             but has no equivalent speech-boundary events yet.
-        dead_air: watch for silences longer than the threshold (default ON).
+        dead_air: watch for silences longer than the threshold. ``None`` (the
+            default) means the policy decides; an explicit value overrides it.
+            This is the only capture with a standing per-session cost, which is
+            what ``lean`` exists to drop.
             Writes one row per observed silence, which
             ``GET /api/sessions/{id}/dead_air`` and the dashboard read back.
             Driven by the same four speech events as ``turns``, but its own flag

--- a/src/voicegateway/tests/inference/test_capture_policy.py
+++ b/src/voicegateway/tests/inference/test_capture_policy.py
@@ -166,3 +166,52 @@ def test_the_environment_still_beats_a_policy() -> None:
         os.environ.pop("VOICEGW_TRANSCRIPTS", None)
         if before is not None:
             os.environ["VOICEGW_TRANSCRIPTS"] = before
+
+
+# --------------------------------------------------------------------------
+# The docstring must not contradict the signature
+# --------------------------------------------------------------------------
+
+
+def test_every_public_parameter_is_documented() -> None:
+    """`revision` and `policy` shipped in 0.25.0 undocumented.
+
+    They are the two headline parameters of that release, and a reader who
+    checked the docstring concluded they did not exist. Cheap to assert, and
+    the failure mode is silent.
+    """
+    import inspect
+
+    doc = inspect.getdoc(attach_mod.attach) or ""
+    params = inspect.signature(attach_mod.attach).parameters
+    # Names taken from the part of each Args line BEFORE the colon, so a
+    # combined entry ("collector_url / api_key: ...") counts for both. Matching
+    # on "\nname:" alone would report a documented pair as missing.
+    documented: set[str] = set()
+    for line in doc.splitlines():
+        head, sep, _ = line.partition(":")
+        if not sep or head != head.rstrip():
+            continue
+        documented.update(w.strip("`*, ") for w in head.replace("/", " ").split())
+    undocumented = sorted(
+        name for name in params if name != "session" and name not in documented
+    )
+    assert not undocumented, f"undocumented attach parameters: {undocumented}"
+
+
+def test_the_docstring_does_not_claim_a_default_the_signature_dropped() -> None:
+    """The four capture flags became tri-state and the prose did not follow.
+
+    It still read "(default on)" and "(default OFF)", which were the
+    pre-0.25.0 values. A reader who passed nothing and trusted it believed
+    transcript capture was on when the policy decides. A doc that is merely
+    absent is a gap; one that states the opposite of the code is a trap.
+    """
+    import inspect
+
+    doc = inspect.getdoc(attach_mod.attach) or ""
+    params = inspect.signature(attach_mod.attach).parameters
+    for flag in CAPTURE_SWITCHES:
+        assert params[flag].default is None, f"{flag} is no longer tri-state"
+    for claim in ("(default on)", "(default OFF)", "(default ON)"):
+        assert claim not in doc, f"docstring still claims {claim}"


### PR DESCRIPTION
Reported by a consumer that upgraded to 0.25.0 and read the shipped API rather than the release notes. **Verified: both halves are real, and both are mine**, from the capture-policy change in #248.

## What shipped wrong

`revision` and `policy` were in the signature and **absent from `Args`**. They are the two headline parameters of that release, so a reader who checked the docstring concluded they did not exist.

Worse, the four capture flags became `bool | None = None` while their entries still read:

```
transcript: capture the call transcript (default on).
snapshots:  capture conversation-state snapshots (default OFF).
```

Those were the pre-0.25.0 values. Somebody passing nothing and trusting the docstring would believe transcript capture is on **when the policy decides it**. A doc that is merely absent is a gap; one that states the opposite of the code is a trap, and this one shipped.

## What changed

- `Args` entries for `revision` and `policy`, naming the five built-ins and stating that an unknown name **raises** rather than defaulting, since that is the safety property of the change.
- The four flag entries now say `None` means the policy decides and an explicit value overrides it.
- **The three-layer precedence stated once**, under `policy`: environment kill-switch beats everything, then an explicitly passed flag, then the policy. The consumer said they could not tell from the docstring which of policy and an explicit flag wins and had to read `resolve_policy`. That is the question the entry now answers first.

## Two tests, so it cannot silently recur

- Every public parameter appears in `Args`.
- The docstring claims no default the signature dropped.

The first reads parameter names from the part of each `Args` line **before the colon**, so a combined entry (`collector_url / api_key: ...`) counts for both. Matching on `\nname:` alone reported that documented pair as missing — I found that by writing it the naive way first.

Verified by mutation: deleting the two new `Args` entries turns the first test red.

## Not included

The same report raised two more, both verified and neither included here because they are new scope rather than warranty on this one:

1. **`voicegw baseline check` cannot read a remote collector.** Confirmed: `baseline_cli` reads only the local store, so #246's drift gate does not work for any deployment that sets `VOICEGW_COLLECTOR_URL` — which is the normal production shape and the one that most needs a CI gate.
2. **No cost-to-turn join.** Confirmed: `tool_calls` carries `turn_index` and `requests` does not, so "which turns are expensive" is unanswerable.

Both are filed for a separate decision.

## Gates

ruff clean, mypy clean on 290 files, 3551 passed (+2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified capture configuration options and how policy settings, overrides, and environment controls determine behavior.
  * Documented revision attribution and updated descriptions for transcript, snapshot, turn, and dead-air capture settings.
  * Corrected option defaults and explained policy precedence.

* **Tests**
  * Added coverage to verify that all public parameters are documented and that configuration defaults are accurately described.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the `attach()` docstring to document `revision`, capture policies, precedence, and tri-state capture flags, and adds regression tests for documentation coverage and obsolete default claims.
- Documents the five built-in policies and environment/argument/policy precedence.
- Updates capture-flag descriptions to explain policy-controlled defaults.
- Adds signature-to-docstring and obsolete-default regression checks.
- Records the correction in the changelog.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking weakness in the new documentation-coverage test.

The runtime code is unchanged and the documentation corrections align with the inspected policy behavior, but the new parser can falsely pass when a parameter name appears in colon-bearing continuation prose.

**Files Needing Attention:** src/voicegateway/tests/inference/test_capture_policy.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/inference/session/attach.py | Expands the public API documentation with policy, revision, precedence, and tri-state capture semantics. |
| src/voicegateway/tests/inference/test_capture_policy.py | Adds useful documentation regression tests, but the parameter parser can mistake continuation prose for an `Args` entry. |
| CHANGELOG.md | Accurately records the corrected docstring and accompanying regression coverage. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mahimailabs%2Fvoicegateway%20PR%20%23256%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mahimailabs%2Fvoicegateway&pr=256&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Ftests%2Finference%2Ftest_capture_policy.py%3A191-195%0A**Args%20parser%20accepts%20continuation%20prose**%0A%0AThe%20parser%20scans%20the%20entire%20docstring%20rather%20than%20only%20parameter%20entries%20in%20%60Args%60%2C%20so%20the%20existing%20%60local%20sink%3A%60%20continuation%20text%20independently%20marks%20%60sink%60%20as%20documented.%20Removing%20the%20real%20%60sink%3A%60%20entry%20would%20therefore%20leave%20this%20regression%20test%20green.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=256&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22mahimailabs%2Fvoicegateway%22%20on%20the%20existing%20branch%20%22docs%2Fattach-docstring-post-policy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fattach-docstring-post-policy%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Ftests%2Finference%2Ftest_capture_policy.py%3A191-195%0A**Args%20parser%20accepts%20continuation%20prose**%0A%0AThe%20parser%20scans%20the%20entire%20docstring%20rather%20than%20only%20parameter%20entries%20in%20%60Args%60%2C%20so%20the%20existing%20%60local%20sink%3A%60%20continuation%20text%20independently%20marks%20%60sink%60%20as%20documented.%20Removing%20the%20real%20%60sink%3A%60%20entry%20would%20therefore%20leave%20this%20regression%20test%20green.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=256&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/voicegateway/tests/inference/test_capture_policy.py:191-195
**Args parser accepts continuation prose**

The parser scans the entire docstring rather than only parameter entries in `Args`, so the existing `local sink:` continuation text independently marks `sink` as documented. Removing the real `sink:` entry would therefore leave this regression test green.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Stop the attach docstring contradicting ..."](https://github.com/mahimailabs/voicegateway/commit/2a846df8059a4bc126e67368050e5c899caa8116) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54685285)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->