### PR TITLE
Add the tool-calls ingest route, and pin forward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Fixed
 
+- **Tool-call rows are no longer dropped by a remote collector.**
+  `/v1/ingest/tool-calls` did not exist, so every batch the agent posted was
+  answered 405 and discarded.
+
+  Reported by a consumer running against a collector. The sink is best-effort
+  and requeues quietly, so nothing surfaced anywhere: a collector deployment
+  simply had no tool rows and no error explaining why. Local-store deployments
+  were unaffected.
+
+  The route drops unknown keys and has no field for arguments or results, so a
+  payload cannot enter the store through it even if an agent sent one. That
+  keeps the guarantee on the collector side of the wire rather than trusting
+  every agent that posts. An agent-supplied `id` is ignored, since honouring it
+  would let one agent overwrite another's row.
+
+### Added
+
+- **A test that an older collector accepts a newer row shape.** Forward
+  compatibility across a version-skewed fleet was already true, because every
+  ingest parser drops unknown keys, but it held by accident rather than by
+  contract.
+
+  Agents and collectors upgrade at different times whether or not anyone intends
+  it, and if that ever tightened the failure would be total (every cost and
+  latency row rejected) rather than partial (one row type). `revision` is the
+  concrete case: 0.25 agents send it and 0.24 collectors have never heard of it.
+
+### Fixed
+
 - **The `attach()` docstring no longer contradicts its own signature.** Shipped
   in 0.25.0 and reported by a consumer who read the API rather than the release
   notes.

--- a/src/voicegateway/server/api/ingest.py
+++ b/src/voicegateway/server/api/ingest.py
@@ -22,6 +22,7 @@ from sqlalchemy.exc import IntegrityError
 from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
 from voicegateway.middleware.turn_tracker_middleware import TurnRow
 from voicegateway.models.request_model import RequestRecord
+from voicegateway.models.tool_call_model import ToolCall
 from voicegateway.server.api._deps import get_gateway, require_scope
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,15 @@ _TURN_FIELDS: frozenset[str] = frozenset(f.name for f in dataclasses.fields(Turn
 _DEAD_AIR_FIELDS: frozenset[str] = frozenset(
     f.name for f in dataclasses.fields(DeadAirEvent)
 )
+
+#: ToolCall is a SQLModel, not a dataclass, so its fields come from the model
+#: rather than ``dataclasses.fields``. ``id`` and ``created_at`` are excluded:
+#: they are the collector's to assign, and honouring an agent-supplied primary
+#: key would let one agent overwrite another's row.
+_TOOL_CALL_FIELDS: frozenset[str] = frozenset(ToolCall.model_fields) - {
+    "id",
+    "created_at",
+}
 
 
 def _record_from_payload(raw: dict[str, Any]) -> RequestRecord | None:
@@ -259,6 +269,89 @@ def _dead_air_from_payload(raw: dict[str, Any]) -> DeadAirEvent | None:
         return DeadAirEvent(**filtered)
     except TypeError:
         return None
+
+
+def _tool_call_from_payload(raw: dict[str, Any]) -> ToolCall | None:
+    """Build a ToolCall from a payload dict, ignoring unknown keys.
+
+    Unknown keys are DROPPED rather than rejected, exactly as turns and dead air
+    do, and that is what makes an agent newer than its collector keep working:
+    a field this build has never heard of costs the row nothing. The reverse
+    also holds, since every column is nullable.
+    """
+    filtered = {k: v for k, v in raw.items() if k in _TOOL_CALL_FIELDS}
+    try:
+        return ToolCall(**filtered)
+    except (TypeError, ValueError):
+        return None
+
+
+@router.post("/ingest/tool-calls")
+async def ingest_tool_calls(
+    rows: list[dict[str, Any]],
+    request: Request,
+    _auth: None = Depends(require_scope("write")),
+) -> dict[str, int]:
+    """Persist per-tool-call rows pushed by a fleet agent.
+
+    MISSING UNTIL NOW, which is the defect this fixes. ``RemoteCollectorSink``
+    has posted here since tool-call capture shipped, and with no route the
+    request fell through to the SPA fallback and came back 405, so every batch
+    was dropped. The sink is best-effort and requeues quietly, so nothing
+    surfaced anywhere: a collector deployment simply had no tool rows and no
+    error to explain why.
+
+    NO ARGUMENTS AND NO RESULTS are accepted, because ``_TOOL_CALL_FIELDS``
+    contains no such name and unknown keys are dropped. A payload cannot enter
+    the store through this route even if an agent sent one, which keeps the
+    guarantee on the collector side of the wire rather than trusting the agent
+    to have withheld it.
+
+    Always SQL, like turns and dead air, because the per-tool aggregates read
+    from SQL.
+    """
+    gateway = get_gateway(request)
+    storage = gateway.storage
+    if storage is None:
+        raise HTTPException(
+            status_code=503,
+            detail="cost tracking storage is disabled on this collector",
+        )
+
+    max_batch = gateway.config.ingest.max_batch_size
+    if len(rows) > max_batch:
+        raise HTTPException(
+            status_code=413,
+            detail=f"batch too large: {len(rows)} rows exceeds max {max_batch}",
+        )
+
+    parsed: list[ToolCall] = []
+    rejected = 0
+    for raw in rows:
+        row = _tool_call_from_payload(raw)
+        if row is None:
+            rejected += 1
+            continue
+        parsed.append(row)
+
+    accepted = 0
+    if parsed:
+        try:
+            accepted = await storage.log_tool_calls(parsed)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ingest/tool-calls: failed to persist %d row(s)",
+                len(parsed),
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="telemetry store temporarily unavailable",
+            ) from exc
+
+    if rejected:
+        logger.warning("ingest/tool-calls: skipped %d malformed row(s)", rejected)
+    return {"accepted": accepted}
 
 
 @router.post("/ingest/dead-air")

--- a/src/voicegateway/tests/server/test_ingest_tool_calls.py
+++ b/src/voicegateway/tests/server/test_ingest_tool_calls.py
@@ -1,0 +1,174 @@
+"""The collector accepts tool-call rows, and keeps accepting newer row shapes.
+
+Two separate guarantees, and the second is worth more than the first.
+
+THE ROUTE. `RemoteCollectorSink` has posted to `/v1/ingest/tool-calls` since
+tool-call capture shipped, and no route existed. The request fell through to the
+SPA fallback (`/{full_path:path}`, GET-only), so a POST matched the path, failed
+the method check, and came back 405. The sink is best-effort and requeues
+quietly, so nothing surfaced: a collector deployment simply had no tool rows and
+no error explaining why.
+
+Worth recording how that was misdiagnosed, because the reasoning looked sound. A
+405 on POST where GET gives 404 suggests something IS registered at the path,
+which points at a misregistered route rather than a missing one. The test that
+settles it is a request to a path that CANNOT exist: if that also gives 405, the
+405 is a fact about the server, not about the path. It does, because of the
+catch-all.
+
+FORWARD COMPATIBILITY. An agent upgraded ahead of its collector must keep
+delivering. That holds today because every ingest parser drops unknown keys, but
+it held by accident rather than by contract, and the failure mode if it ever
+tightens is total rather than partial: every row rejected instead of one kind.
+"""
+
+from __future__ import annotations
+
+import uuid
+import warnings
+
+import pytest
+from fastapi.testclient import TestClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.server.main import build_app
+
+
+@pytest.fixture
+def client():
+    warnings.filterwarnings("ignore")
+    return TestClient(build_app(Gateway(), enable_mcp_sse=False))
+
+
+# --------------------------------------------------------------------------
+# The route exists
+# --------------------------------------------------------------------------
+
+
+def test_the_tool_calls_route_accepts_a_post(client) -> None:
+    """It answered 405 before this route existed."""
+    result = client.post("/v1/ingest/tool-calls", json=[])
+    assert result.status_code == 200
+    assert result.json() == {"accepted": 0}
+
+
+def test_a_405_alone_never_proved_the_route_existed(client) -> None:
+    """The control that settles a 405, pinned so the reasoning is not lost.
+
+    A path that cannot exist in any version answers exactly as the tool-calls
+    path did before the fix. So 405-on-POST is a fact about this app having a
+    GET-only catch-all, not evidence that anything is registered at the path.
+    """
+    bogus = "/v1/ingest/definitely-not-a-route-" + uuid.uuid4().hex
+    assert client.get(bogus).status_code == 404
+    assert client.post(bogus, json=[]).status_code == 405
+
+
+# --------------------------------------------------------------------------
+# No payload can enter through this route
+# --------------------------------------------------------------------------
+
+
+def test_arguments_and_results_cannot_be_stored_even_if_an_agent_sends_them(
+    client,
+) -> None:
+    """The guarantee is enforced on the COLLECTOR side of the wire too.
+
+    The agent is written not to send a payload, but a collector that would
+    persist one if it arrived is trusting every agent that ever posts to it.
+    Unknown keys are dropped, and there is no column for them.
+    """
+    from voicegateway.server.api.ingest import _tool_call_from_payload
+
+    row = _tool_call_from_payload(
+        {
+            "session_id": "s",
+            "call_id": "c1",
+            "tool_name": "lookup_order",
+            "started_at_ms": 1000,
+            "duration_ms": 250,
+            "outcome": "completed",
+            "arguments": {"order_id": "SECRET"},
+            "result": "customer PII",
+        }
+    )
+    assert row is not None
+    dumped = row.model_dump()
+    assert not any(k in dumped for k in ("arguments", "result"))
+    assert "SECRET" not in str(dumped)
+    assert "PII" not in str(dumped)
+
+
+def test_an_agent_supplied_primary_key_is_ignored(client) -> None:
+    """Honouring it would let one agent overwrite another agent's row."""
+    from voicegateway.server.api.ingest import _tool_call_from_payload
+
+    row = _tool_call_from_payload(
+        {
+            "id": 999,
+            "session_id": "s",
+            "call_id": "c1",
+            "tool_name": "t",
+            "started_at_ms": 1,
+        }
+    )
+    assert row is not None and row.id is None
+
+
+# --------------------------------------------------------------------------
+# An agent newer than its collector keeps delivering
+# --------------------------------------------------------------------------
+
+
+def _record(**extra) -> dict:
+    """A cost row with a FRESH id: a reused one dedups and returns
+    accepted=0, which reads exactly like a rejection and is not one."""
+    base = {
+        "id": str(uuid.uuid4()),
+        "timestamp": 1_785_661_200.0,
+        "modality": "llm",
+        "model_id": "openai/gpt-4o-mini",
+        "provider": "openai",
+        "project": "default",
+    }
+    base.update(extra)
+    return base
+
+
+def test_a_row_carrying_an_unknown_field_is_still_accepted(client) -> None:
+    """THE CONTRACT THIS FILE EXISTS FOR.
+
+    A fleet upgrades agents and collectors at different times whether or not
+    anyone intends it to. If a newer row shape were rejected, the failure would
+    be total (every cost and latency row) rather than partial (one row type),
+    and it would arrive at whatever moment somebody rolled an agent forward.
+    """
+    result = client.post(
+        "/v1/ingest",
+        json=[_record(a_field_from_a_later_release="whatever", another=123)],
+    )
+    assert result.status_code == 200
+    assert result.json()["accepted"] == 1
+
+
+def test_the_revision_field_specifically_survives_an_older_parser(client) -> None:
+    """`revision` is the concrete case: 0.25 agents send it, 0.24 collectors
+    have never heard of it, and those pairings exist in the wild right now."""
+    result = client.post("/v1/ingest", json=[_record(revision="abc123")])
+    assert result.status_code == 200
+    assert result.json()["accepted"] == 1
+
+
+def test_the_same_row_twice_dedups_rather_than_rejecting(client) -> None:
+    """Guards the test above from a false green.
+
+    A reused id returns accepted=0, which is indistinguishable from a rejection
+    if you are not expecting it. Naming it here means a future reader of these
+    tests cannot mistake one for the other.
+    """
+    row = _record()
+    first = client.post("/v1/ingest", json=[row])
+    second = client.post("/v1/ingest", json=[row])
+    assert first.json()["accepted"] == 1
+    assert second.json()["accepted"] == 0
+    assert second.json().get("duplicates") == 1

--- a/src/voicegateway/tests/server/test_ingest_tool_calls.py
+++ b/src/voicegateway/tests/server/test_ingest_tool_calls.py
@@ -72,16 +72,30 @@ def test_the_tool_calls_route_accepts_a_post(client) -> None:
     assert result.json() == {"accepted": 0}
 
 
-def test_a_405_alone_never_proved_the_route_existed(client) -> None:
+def test_two_paths_that_cannot_exist_answer_identically(client) -> None:
     """The control that settles a 405, pinned so the reasoning is not lost.
 
-    A path that cannot exist in any version answers exactly as the tool-calls
-    path did before the fix. So 405-on-POST is a fact about this app having a
-    GET-only catch-all, not evidence that anything is registered at the path.
+    A 405 on POST where GET gives 404 looks like proof that SOMETHING is
+    registered at the path, which points at a misregistered route rather than a
+    missing one. It is neither. When the built SPA is present, its fallback
+    ``/{full_path:path}`` is registered GET-only, so any non-GET matches the
+    path, fails the method check, and gets 405.
+
+    THE ASSERTION IS THAT TWO IMPOSSIBLE PATHS AGREE, not that either returns a
+    particular code. The code itself depends on whether the SPA was built: 405
+    with it, 404 without, which is why a developer machine and CI disagree and
+    why two people probing different collectors reached opposite conclusions
+    about the same fault. Pinning 405 here would be asserting one deployment's
+    shape, which is the mistake this test exists to describe.
     """
-    bogus = "/v1/ingest/definitely-not-a-route-" + uuid.uuid4().hex
-    assert client.get(bogus).status_code == 404
-    assert client.post(bogus, json=[]).status_code == 405
+    one = "/v1/ingest/definitely-not-a-route-" + uuid.uuid4().hex
+    two = "/v1/ingest/also-not-a-route-" + uuid.uuid4().hex
+    assert (
+        client.post(one, json=[]).status_code == client.post(two, json=[]).status_code
+    )
+    # And whatever that is, it is NOT what a real route answers.
+    assert client.post(one, json=[]).status_code != 200
+    assert client.post("/v1/ingest/tool-calls", json=[]).status_code == 200
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/server/test_ingest_tool_calls.py
+++ b/src/voicegateway/tests/server/test_ingest_tool_calls.py
@@ -28,16 +28,36 @@ import uuid
 import warnings
 
 import pytest
+import yaml
 from fastapi.testclient import TestClient
 
 from voicegateway.core.gateway import Gateway
 from voicegateway.server.main import build_app
 
+_CFG = {
+    "providers": {},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
 
 @pytest.fixture
-def client():
+def client(tmp_path, monkeypatch):
+    """A collector built from an EXPLICIT config.
+
+    Not ``Gateway()``: that resolves a voicegw.yaml from the ambient
+    environment, which exists on a developer machine and does not in CI, so the
+    tests passed locally and failed on all three Python versions. A fixture that
+    depends on where it is run is not a fixture.
+    """
     warnings.filterwarnings("ignore")
-    return TestClient(build_app(Gateway(), enable_mcp_sse=False))
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "ingest.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    cfg = tmp_path / "voicegw.yaml"
+    cfg.write_text(yaml.dump(_CFG))
+    gateway = Gateway(config_path=str(cfg))
+    return TestClient(build_app(gateway, enable_mcp_sse=False))
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
`RemoteCollectorSink` has posted to `/v1/ingest/tool-calls` since tool-call capture shipped in 0.25.0, and **no route existed**. Every batch was discarded.

The sink is best-effort and requeues quietly, so nothing surfaced anywhere: a collector deployment simply had no tool rows and no error explaining why. Local-store deployments were unaffected. Reported by a consumer running 0.25.x against a remote collector.

**This is my defect.** #247's acceptance said *"works against a remote collector, not local storage only"*, and the test I wrote asserted the **sink** has the method, a buffer, and drains on flush. It never asserted the collector **accepts** the post. I tested one end of a wire and called it connected — the same shape as the `_INSERT_REQUEST` silent drop in #245.

## How the diagnosis almost went wrong

Worth recording, because the reasoning looked sound and the peer and I reached opposite conclusions from the same evidence.

Probing the path gives `GET → 404` but `POST → 405`. A 405 means the path matched *something*, which suggests a route registered without the method rather than a missing one. That inference is correct for a bare API and **inverted here**: the SPA fallback `/{full_path:path}` is GET-only, so any non-GET matches the path, fails the method check, and gets 405.

The test that settles it is a request to a path that **cannot exist**:

```
/v1/ingest/tool-calls                    GET=404  POST=405
/v1/ingest/definitely-not-a-route-<uuid> GET=404  POST=405
```

Identical. One probe tells you about the path; only the control tells you about the server. There is a test pinning that control so the reasoning survives the next time someone reads a 405 here.

I also checked the harness itself before trusting it — `POST /v1/ingest → 200` — because the app uses lazy router inclusion and an unbuilt app would have produced the same 405 for everything.

## The payload guarantee now holds on both sides

The field allowlist contains no `arguments` or `result`, and unknown keys are dropped, so a payload cannot enter the store through this route **even if an agent sent one**. Previously the guarantee lived only in the agent; a collector that would persist a payload if it arrived is trusting every agent that ever posts to it.

An agent-supplied `id` is ignored, since honouring it would let one agent overwrite another's row.

## The part worth more than the fix

**Forward compatibility is now tested.** An agent upgraded ahead of its collector keeps delivering, because every ingest parser drops unknown keys — but that held by accident and nothing asserted it.

A fleet upgrades agents and collectors at different times whether or not anyone intends it. If this ever tightened, the failure would be **total** (every cost and latency row rejected) rather than **partial** (one row type), and it would arrive whenever somebody rolled an agent forward. `revision` is the concrete case: 0.25 agents send it, 0.24 collectors have never heard of it, and those pairings exist in the wild now.

The **dedup case is tested beside it deliberately**: a reused id returns `accepted: 0`, which is indistinguishable from a rejection if you are not expecting it, and it has already produced one false finding this week.

Verified by mutation: renaming the route turns the route test red.

## Gates

ruff clean, mypy clean on 290 files, 3563 passed (+7). Branched off `main`, independent of #257.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated ingestion for tool-call records through the ingestion API.
  - Supports batched submissions and reports the number of accepted records.
  - Automatically ignores unsupported fields and agent-supplied identifiers.

- **Bug Fixes**
  - Improved compatibility with newer tool-call data sent by older collectors.
  - Malformed records are skipped safely, and duplicate submissions are deduplicated.
  - Storage failures now return an appropriate service-unavailable response.

- **Documentation**
  - Updated the unreleased changelog with tool-call ingestion and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the missing remote-collector endpoint for ingesting tool-call telemetry and pins forward compatibility for version-skewed deployments.
- Parses tool-call rows through an explicit allowlist and ignores collector-owned identifiers.
- Applies authentication and batch-size limits before writing accepted rows to storage.
- Adds route, payload-safety, compatibility, and deduplication coverage.
- Records the corrected remote-collector behavior in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/server/api/ingest.py | Adds the authenticated, batch-limited tool-call ingestion route and delegates validated rows to existing storage. |
| src/voicegateway/tests/server/test_ingest_tool_calls.py | Covers route registration, sensitive-field filtering, collector-owned IDs, forward compatibility, and deduplication. |
| CHANGELOG.md | Documents the remote-collector fix and the newly tested version-skew compatibility guarantee. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as Fleet agent
    participant API as Collector ingest API
    participant S as Tool-call storage
    A->>API: POST /v1/ingest/tool-calls
    API->>API: Authenticate write scope
    API->>API: Enforce batch limit
    API->>API: Drop unknown and collector-owned fields
    API->>S: log_tool_calls(parsed rows)
    S-->>API: Accepted row count
    API-->>A: "200 {accepted: count}"
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Assert the control&#39;s invariant, not one ..."](https://github.com/mahimailabs/voicegateway/commit/08d3a7173fa18af3c74b602fad7fefd583992f58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54827266)</sub>

<!-- /greptile_comment -->