### PR TITLE
Add a turn-percentile read endpoint so both baseline modes agree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Added
 
+- **`GET /api/turns/response-speed`: p50/p95/p99 over TURNS, with the sample
+  count.** So a drift gate reading a remote collector pins the same mathematics
+  a local one does.
+
+  `GET /api/metrics` reports `response_speed_ms` as the **mean of per-session
+  percentiles**, which is a different statistic from the percentile over all
+  turns that `voicegw baseline pin` computes. On two sessions with turn
+  latencies `[100,110,120,130,900]` and `[200,210,220]` the first is 662 and the
+  second is 482. Both are defensible numbers and only one is a p95.
+
+  Without this, collector mode would have had to read the per-session mean into
+  a field named for a percentile, and a baseline pinned locally then checked
+  remotely would have compared two different statistics under one name while
+  looking exactly like a comparison.
+
+  Windowed on `caller_speak_start_ms`, the turn's own instant, rather than on
+  `created_at`, which is when the row was written and lags by the buffer flush.
+
+  `aggregate_response_speed` gains a `samples` key, additively. A percentile
+  over three turns and one over two hundred are different claims.
+
+### Added
+
 - **A pinned baseline now records where its figures came from, and
   `voicegw baseline check` refuses when that does not match.** Exit code **3**,
   documented and stable.

--- a/src/voicegateway/cli/baseline_cli.py
+++ b/src/voicegateway/cli/baseline_cli.py
@@ -85,11 +85,11 @@ async def _collect(storage: Any, period: str, project: str | None) -> dict[str, 
 
     async with storage._conn.session() as db:
         speed = await turns.aggregate_response_speed(db)
-        result = await db.execute(
-            turns.text("SELECT COUNT(*) FROM turns WHERE response_speed_ms IS NOT NULL")
-        )
-        row = result.fetchone()
-        turn_samples = int(row[0]) if row else 0
+    # The count comes from the aggregate itself rather than a second query.
+    # Two statements counting the same rows are two things that can disagree,
+    # and the one place they would show it is a baseline claiming a sample count
+    # that does not match the percentile it sits beside.
+    turn_samples = int(speed.get("samples") or 0)
     metrics["response_speed_p50_ms"] = {
         "value": speed.get("p50_ms"),
         "samples": turn_samples,

--- a/src/voicegateway/repository/turns_repository.py
+++ b/src/voicegateway/repository/turns_repository.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import statistics
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import text
 
@@ -96,35 +96,76 @@ async def list_turns_by_session(
 async def aggregate_response_speed(
     session: AsyncSession,
     session_id: str | None = None,
+    *,
+    since_ms: int | None = None,
+    until_ms: int | None = None,
+    project: str | None = None,
+    tenant: str | None = None,
 ) -> dict[str, int | None]:
-    """Compute p50/p95/p99 of ``response_speed_ms`` over the filtered turns."""
+    """p50/p95/p99 of ``response_speed_ms`` over the filtered turns, and the count.
+
+    A PERCENTILE OVER TURNS, which is not the same statistic as the mean of
+    per-session percentiles that ``GET /api/metrics`` reports. On two sessions
+    with turn latencies [100,110,120,130,900] and [200,210,220] this returns 662
+    where that returns 482. Both are defensible numbers and only one of them is
+    a p95, so they must not be read into the same field: a baseline pinned from
+    one and checked against the other would compare two different mathematics
+    under one name.
+
+    Windowed on ``caller_speak_start_ms``, the turn's own epoch instant, rather
+    than on ``created_at``. The latter is when the row was WRITTEN, which lags by
+    the buffer flush and would move a turn between windows depending on when the
+    agent got round to sending it.
+
+    ``samples`` travels with the values because a percentile over three turns and
+    one over two hundred are different claims, and a caller reading only the
+    number cannot tell them apart.
+    """
+    where = ["response_speed_ms IS NOT NULL"]
+    params: dict[str, Any] = {}
     if session_id is not None:
-        result = await session.execute(
-            text(
-                "SELECT response_speed_ms FROM turns "
-                "WHERE session_id = :session_id AND response_speed_ms IS NOT NULL"
-            ),
-            {"session_id": session_id},
-        )
-    else:
-        result = await session.execute(
-            text(
-                "SELECT response_speed_ms FROM turns "
-                "WHERE response_speed_ms IS NOT NULL"
-            )
-        )
+        where.append("t.session_id = :session_id")
+        params["session_id"] = session_id
+    if since_ms is not None:
+        where.append("t.caller_speak_start_ms >= :since_ms")
+        params["since_ms"] = since_ms
+    if until_ms is not None:
+        where.append("t.caller_speak_start_ms < :until_ms")
+        params["until_ms"] = until_ms
+    if tenant is not None:
+        if tenant == "":
+            where.append("t.tenant_id IS NULL")
+        else:
+            where.append("t.tenant_id = :tenant")
+            params["tenant"] = tenant
+    # Project lives on sessions, not on turns, so it needs the join. Only taken
+    # when asked for: an unconditional join would make every unfiltered read pay
+    # for a column it does not use.
+    join = ""
+    if project is not None:
+        join = " JOIN sessions s ON s.id = t.session_id"
+        where.append("s.project = :project")
+        params["project"] = project
+
+    result = await session.execute(
+        text(
+            f"SELECT t.response_speed_ms FROM turns t{join} WHERE {' AND '.join(where)}"
+        ),
+        params,
+    )
     values = [int(row[0]) for row in result]
     if not values:
-        return {"p50_ms": None, "p95_ms": None, "p99_ms": None}
+        return {"p50_ms": None, "p95_ms": None, "p99_ms": None, "samples": 0}
     if len(values) == 1:
         v = values[0]
-        return {"p50_ms": v, "p95_ms": v, "p99_ms": v}
+        return {"p50_ms": v, "p95_ms": v, "p99_ms": v, "samples": 1}
     cuts = statistics.quantiles(values, n=100, method="inclusive")
     # cuts[49] = p50, cuts[94] = p95, cuts[98] = p99
     return {
         "p50_ms": int(cuts[49]),
         "p95_ms": int(cuts[94]),
         "p99_ms": int(cuts[98]),
+        "samples": len(values),
     }
 
 

--- a/src/voicegateway/server/api/dashboard/costs.py
+++ b/src/voicegateway/server/api/dashboard/costs.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from voicegateway.clickhouse import read_repository as ch_read
+from voicegateway.repository import turns_repository as turns_repo
 from voicegateway.repository.cost_repository import resolve_window
 from voicegateway.server.api._deps import (
     Principal,
@@ -134,6 +135,49 @@ async def get_costs_by_day(
     )
 
 
+@router.get("/turns/response-speed")
+async def get_turn_response_speed(
+    request: Request,
+    period: str = Query("week", enum=["today", "week", "month", "all"]),
+    project: str | None = Query(None),
+    tenant: str | None = Query(None),
+    gateway: Gateway = Depends(get_gateway),
+    principal: Principal = Depends(require_principal),
+) -> dict:
+    """p50/p95/p99 of ``response_speed_ms`` OVER TURNS, with the sample count.
+
+    Deliberately not the same statistic as ``response_speed_ms`` on
+    ``GET /api/metrics``, which is the MEAN OF PER-SESSION PERCENTILES. On two
+    sessions with turn latencies [100,110,120,130,900] and [200,210,220] this
+    returns 662 where that returns 482, and only one of them is a p95.
+
+    It exists so a drift gate reading a remote collector pins the same
+    mathematics a local one does. Without it, collector mode would have to read
+    the per-session mean into a field named for a percentile, and a baseline
+    pinned locally and checked remotely would compare two different statistics
+    under one name while looking exactly like a comparison.
+    """
+    resolved = resolve_read_tenant(principal, tenant)
+    if gateway.storage is None:
+        return {"p50_ms": None, "p95_ms": None, "p99_ms": None, "samples": 0}
+    since, until = resolve_window(period)
+    # SECONDS -> MILLISECONDS. resolve_window speaks epoch seconds, because
+    # `requests.timestamp` is seconds; turns are windowed on
+    # `caller_speak_start_ms`, which is epoch MILLISECONDS. Passing the seconds
+    # straight through would put every window in 1970 and return every turn ever
+    # recorded, which reads as a healthy sample count rather than as an error.
+    since_ms = int(since * 1000)
+    until_ms = int(until * 1000) if until is not None else None
+    async with gateway.storage._conn.session() as db:
+        return await turns_repo.aggregate_response_speed(
+            db,
+            since_ms=since_ms,
+            until_ms=until_ms,
+            project=project,
+            tenant=resolved,
+        )
+
+
 @router.get("/latency")
 async def get_latency(
     request: Request,
@@ -160,5 +204,3 @@ async def get_latency(
     return await gateway.storage.get_latency_stats(
         period, project=project, percentiles=pcts, tenant=resolved, agent=agent
     )
-
-

--- a/src/voicegateway/tests/server/test_turn_percentile_endpoint.py
+++ b/src/voicegateway/tests/server/test_turn_percentile_endpoint.py
@@ -1,0 +1,173 @@
+"""A percentile over turns, so a remote drift gate pins the same mathematics.
+
+`GET /api/metrics` reports `response_speed_ms` as the MEAN OF PER-SESSION
+PERCENTILES. `voicegw baseline pin` computes a percentile over all turns. Those
+are different statistics wearing one name, and a baseline pinned locally and
+checked against a collector would have compared them while looking exactly like
+a comparison.
+
+The concrete divergence, which is the whole reason this endpoint exists: on two
+sessions with turn latencies [100,110,120,130,900] and [200,210,220], a p95 over
+turns is 662 and the mean of per-session p95s is 482. Both are defensible
+numbers. Only one of them is a p95.
+"""
+
+from __future__ import annotations
+
+import statistics
+import warnings
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.middleware.turn_tracker_middleware import TurnRow
+from voicegateway.repository import turns_repository as turns
+from voicegateway.server.main import build_app
+from voicegateway.services.storage_service import StorageService
+
+_CFG = {
+    "providers": {},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+# Epoch-ms instants inside a "today" window, since turns are windowed on
+# caller_speak_start_ms rather than on write time.
+_NOW_MS = 1_785_661_200_000
+
+
+def _turn(session_id: str, index: int, at_ms: int, speed: int) -> TurnRow:
+    return TurnRow(
+        session_id=session_id,
+        turn_index=index,
+        caller_speak_start_ms=at_ms,
+        caller_speak_end_ms=at_ms + 500,
+        agent_speak_start_ms=at_ms + 500 + speed,
+        response_speed_ms=speed,
+    )
+
+
+@pytest.fixture
+def storage(tmp_path):
+    warnings.filterwarnings("ignore")
+    return StorageService(str(tmp_path / "turns.db"))
+
+
+async def _seed(storage, rows: list[TurnRow]) -> None:
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        await turns.create_turns_bulk(db, rows)
+
+
+# --------------------------------------------------------------------------
+# The statistic
+# --------------------------------------------------------------------------
+
+
+async def test_it_is_a_percentile_over_turns_not_a_mean_of_session_percentiles(
+    storage,
+) -> None:
+    """The divergence that motivated the endpoint, asserted numerically.
+
+    If these two ever agree the test is not proving anything, so the fixture is
+    chosen to make them differ by a wide margin.
+    """
+    a = [100, 110, 120, 130, 900]
+    b = [200, 210, 220]
+    rows = [_turn("a", i, _NOW_MS + i * 1000, v) for i, v in enumerate(a)]
+    rows += [_turn("b", i, _NOW_MS + i * 1000, v) for i, v in enumerate(b)]
+    await _seed(storage, rows)
+
+    async with storage._conn.session() as db:
+        agg = await turns.aggregate_response_speed(db)
+    await storage.aclose()
+
+    def p95(vals):
+        return statistics.quantiles(vals, n=100, method="inclusive")[94]
+
+    over_turns = int(p95(a + b))
+    mean_of_session_p95s = int((p95(a) + p95(b)) / 2)
+    assert over_turns != mean_of_session_p95s, "fixture no longer distinguishes them"
+    assert agg["p95_ms"] == over_turns
+    assert agg["p95_ms"] != mean_of_session_p95s
+    assert agg["samples"] == len(a) + len(b)
+
+
+async def test_the_sample_count_travels_with_the_values(storage) -> None:
+    """A percentile over three turns and one over two hundred are different
+    claims, and a caller reading only the number cannot tell them apart."""
+    await _seed(storage, [_turn("a", i, _NOW_MS + i * 1000, 100 + i) for i in range(3)])
+    async with storage._conn.session() as db:
+        agg = await turns.aggregate_response_speed(db)
+    await storage.aclose()
+    assert agg["samples"] == 3
+
+
+# --------------------------------------------------------------------------
+# The window, which is where a unit error hides
+# --------------------------------------------------------------------------
+
+
+async def test_the_window_excludes_turns_outside_it(storage) -> None:
+    """Windowed on the turn's own instant, not on when the row was written.
+
+    `created_at` lags by the buffer flush, which would move a turn between
+    windows depending on when the agent got round to sending it.
+    """
+    old = _NOW_MS - 40 * 86_400_000
+    await _seed(
+        storage,
+        [_turn("a", 0, old, 5000), _turn("a", 1, _NOW_MS, 100)],
+    )
+    async with storage._conn.session() as db:
+        recent = await turns.aggregate_response_speed(db, since_ms=_NOW_MS - 1000)
+        everything = await turns.aggregate_response_speed(db)
+    await storage.aclose()
+    assert recent["samples"] == 1
+    assert recent["p95_ms"] == 100
+    assert everything["samples"] == 2
+
+
+async def test_seconds_passed_as_milliseconds_would_not_go_unnoticed(storage) -> None:
+    """The unit trap, pinned.
+
+    `resolve_window` speaks epoch SECONDS because `requests.timestamp` is
+    seconds; turns are windowed on epoch MILLISECONDS. Passing seconds straight
+    through puts the window in 1970 and returns every turn ever recorded, which
+    reads as a healthy sample count rather than as an error.
+    """
+    await _seed(storage, [_turn("a", 0, _NOW_MS - 40 * 86_400_000, 5000)])
+    async with storage._conn.session() as db:
+        correct = await turns.aggregate_response_speed(
+            db, since_ms=_NOW_MS - 86_400_000
+        )
+        as_if_seconds = await turns.aggregate_response_speed(
+            db, since_ms=int((_NOW_MS - 86_400_000) / 1000)
+        )
+    await storage.aclose()
+    assert correct["samples"] == 0, "the old turn should be outside a one-day window"
+    assert as_if_seconds["samples"] == 1, "seconds-as-ms silently widens the window"
+
+
+# --------------------------------------------------------------------------
+# The route
+# --------------------------------------------------------------------------
+
+
+def test_the_endpoint_is_reachable_and_carries_the_sample_count(
+    tmp_path, monkeypatch
+) -> None:
+    warnings.filterwarnings("ignore")
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "api.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    cfg = tmp_path / "voicegw.yaml"
+    cfg.write_text(yaml.dump(_CFG))
+    client = TestClient(build_app(Gateway(config_path=str(cfg)), enable_mcp_sse=False))
+    result = client.get("/api/turns/response-speed?period=all")
+    assert result.status_code == 200
+    body = result.json()
+    assert set(body) >= {"p50_ms", "p95_ms", "p99_ms", "samples"}
+    assert body["samples"] == 0

--- a/src/voicegateway/tests/storage/test_turns_repo.py
+++ b/src/voicegateway/tests/storage/test_turns_repo.py
@@ -83,7 +83,14 @@ async def test_aggregate_response_speed_empty_returns_nulls(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
         agg = await turns.aggregate_response_speed(db, "no-such-session")
-        assert agg == {"p50_ms": None, "p95_ms": None, "p99_ms": None}
+        # Not exact-dict: the aggregate also carries `samples`, because a
+        # percentile over three turns and one over two hundred are different
+        # claims. Asserting the shape rather than the values would break on
+        # every additive field.
+        assert agg["p50_ms"] is None
+        assert agg["p95_ms"] is None
+        assert agg["p99_ms"] is None
+        assert agg["samples"] == 0
 
 
 async def test_aggregate_response_speed_single_value(tmp_path) -> None:
@@ -91,7 +98,10 @@ async def test_aggregate_response_speed_single_value(tmp_path) -> None:
     async with storage._conn.session() as db:
         await turns.create_turn(db, _row("s1", 0, 0, 0, 0, 0, response_speed=250))
         agg = await turns.aggregate_response_speed(db, "s1")
-        assert agg == {"p50_ms": 250, "p95_ms": 250, "p99_ms": 250}
+        assert agg["p50_ms"] == 250
+        assert agg["p95_ms"] == 250
+        assert agg["p99_ms"] == 250
+        assert agg["samples"] == 1
 
 
 async def test_count_overlap_turns(tmp_path) -> None:


### PR DESCRIPTION
Option 1 of the three: give the collector the **same statistic** the local store computes, rather than renaming the remote metrics or pinning fewer of them.

## The problem this removes

`GET /api/metrics` reports `response_speed_ms` as the **mean of per-session percentiles**. `voicegw baseline pin` computes a **percentile over all turns**. On two sessions with turn latencies `[100,110,120,130,900]` and `[200,210,220]`:

| | value |
|---|---|
| p95 over all turns (what `pin` computes) | **662** |
| mean of per-session p95s (what `/api/metrics` returns) | **482** |

Both are defensible numbers. Only one is a p95, and the remote one flatters by 27%.

Without this endpoint, collector mode would have had to read the per-session mean into a field named for a percentile. A baseline pinned locally and checked remotely would then compare two different mathematics under one name **while looking exactly like a comparison** — which is the failure the drift gate exists to prevent, so building it on that substitution would invert the point of the command.

## `GET /api/turns/response-speed`

Returns `p50_ms`, `p95_ms`, `p99_ms` and `samples`, filterable by period, project and tenant.

**Windowed on `caller_speak_start_ms`**, the turn's own epoch instant, not on `created_at`. The latter is when the row was *written* and lags by the buffer flush, so a turn would move between windows depending on when the agent got round to sending it.

## The trap, named and tested

`resolve_window` speaks epoch **seconds**, because `requests.timestamp` is seconds. Turns are windowed in **milliseconds**. Passing seconds straight through puts the window in 1970 and returns **every turn ever recorded** — which reads as a healthy sample count rather than as an error, and would make a drift gate confidently compare the wrong population.

There is a test that fails if that substitution is made, rather than a comment asking the next person not to make it.

## Additive change to `aggregate_response_speed`

It now returns `samples` alongside the percentiles, because a percentile over three turns and one over two hundred are different claims and a caller reading only the number cannot tell them apart. That is also what makes `--min-samples` meaningful remotely, where a collector aggregates many agents.

Two existing tests asserted exact dict equality and now assert the values they care about. **The percentile numbers are unchanged**; only the shape grew.

## Next

This unblocks the collector read path for `baseline pin` / `baseline check`. #257 already landed the half that makes it safe: the pinned file records its source and `check` refuses a mismatch, so the two statistics cannot be silently compared even by accident.

## Gates

ruff clean, mypy clean on 290 files, 3568 passed (+5). The ClickHouse integration errors in the local run predate this branch and need a live CH server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added response-speed percentile metrics for turns, including p50, p95, p99, and sample counts.
  * Added filtering by time period, project, tenant, and session.
  * Added the `GET /turns/response-speed` dashboard endpoint.
  * Empty and single-sample results now report clear sample counts and percentile values.

* **Documentation**
  * Documented response-speed percentile calculations, sample counts, statistic differences, and caller-speech time windows.

* **Tests**
  * Added coverage for percentile accuracy, filtering, timestamp handling, endpoint responses, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a turn-level response-speed percentile endpoint so remote and local baseline calculations use the same statistic.
- Extends turn aggregation with time, project, and tenant filters plus sample counts.
- Adds the authenticated dashboard route and converts resolved epoch-second windows to milliseconds.
- Reuses the aggregate’s sample count in local baseline collection and adds endpoint and repository coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/repository/turns_repository.py | Extends response-speed aggregation with fixed-fragment, parameter-bound filtering and an accompanying sample count. |
| src/voicegateway/server/api/dashboard/costs.py | Adds the authenticated turn-percentile route with tenant resolution and explicit seconds-to-milliseconds window conversion. |
| src/voicegateway/cli/baseline_cli.py | Uses the aggregate’s own sample count so percentile values and counts come from the same query. |
| src/voicegateway/tests/server/test_turn_percentile_endpoint.py | Covers turn-level percentile semantics, sample counts, time-window units, and endpoint reachability. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as GET /api/turns/response-speed
    participant Window as resolve_window
    participant Repo as aggregate_response_speed
    participant DB as turns/session tables
    Client->>API: period, project, tenant
    API->>Window: resolve period
    Window-->>API: since/until in seconds
    API->>API: convert seconds to milliseconds
    API->>Repo: filters and tenant scope
    Repo->>DB: parameterized turn query
    DB-->>Repo: response_speed_ms values
    Repo-->>API: p50, p95, p99, samples
    API-->>Client: percentile response
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Take the baseline&#39;s sample count from th..."](https://github.com/mahimailabs/voicegateway/commit/c58fff632a96ecc5d297976aa92419eb88029a8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54852164)</sub>

<!-- /greptile_comment -->