### PR TITLE
Price a model before it runs, and price an LLM as two numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ## Unreleased
 
+### Fixed
+
+- **The per-model unit price no longer shows one number for a two-sided
+  price.** `voice_price_usd` prices 1,000,000 **input** tokens and labels the
+  result `1m_token`, which reads as covering both legs.
+
+  Measured against voice-prices 0.3.0, output is **4.0x** input on
+  `openai/gpt-4o-mini`, 2.5x on `anthropic/claude-sonnet-4-5` and 1.3x on
+  `groq/llama-3.3-70b-versatile`. A conversational agent is output-heavy, so a
+  UI rendering the single number understates exactly the choice the field
+  exists to inform.
+
+  `/billing/rate-card/models` now also carries a `price` object with
+  `input_price_usd` and `output_price_usd` for llm, and a single
+  `unit_price_usd` for stt and tts, which are genuinely one-sided. The existing
+  `voice_price_usd` key is unchanged and is still the input leg, so nothing
+  reading it has a number move underneath it.
+
+- **Error rows now name the provider and model that failed.** `_on_error`
+  recorded an empty `model_id` and `provider` while the success path resolved
+  both from the same kind of object, so the one row type that exists to answer
+  "which provider is failing" was the one row type that could not.
+
+  Reported from a live collector: 20 such rows across 4 sessions. The identity
+  was never missing, it sits on `event.source`, and the error text already
+  carried it as `label='livekit.plugins.cerebras.llm.LLM'`. An error with no
+  source attached stays blank rather than becoming "unknown": genuinely
+  unattributed is a different fact from a component that was present and could
+  not be read.
+
+### Added
+
+- **`GET /billing/rate-card/quote`: price a model that has not run yet.** With
+  a bulk `POST` form taking several `{modality, model}` pairs in one request.
+
+  The only route reaching the pricing catalogue was fed by
+  `SELECT DISTINCT ... FROM requests`, so it answered only for models already
+  billed. An agent-configuration editor picks a model before a single call
+  exists and had nothing to ask.
+
+  Returns the catalogue price and, separately, the override that would apply,
+  so an editor can show what will actually be charged while still being able to
+  compare it against the price the override replaced.
+
+  `priced` is explicit rather than inferred from a null. A bare null could not
+  be told apart from "this endpoint does not handle this modality", and an
+  unpriced model is common: 6 of 10 sampled STT refs have no entry at
+  voice-prices 0.3.0, including every `deepgram/nova-2-*` and
+  `deepgram/enhanced-*`.
+
 ### Added
 
 - **`GET /api/turns/response-speed`: p50/p95/p99 over TURNS, with the sample

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -424,12 +424,28 @@ class MetricCapture:
     def _on_error(self, event: object, *_args: Any, **_kwargs: Any) -> None:
         source = getattr(event, "source", None)
         error = getattr(event, "error", event)
+        # RESOLVE THE IDENTITY, do not blank it. This used to record
+        # model_id="" and provider="" while the success path called
+        # component_identity on the same kind of object, so the one row type
+        # that exists to answer "which provider is failing" was the one row
+        # type that could not. The identity was never missing: it sits on
+        # `source`, and the error message already carried it as
+        # label='livekit.plugins.cerebras.llm.LLM'.
+        #
+        # Falls back to the empty strings when there is no source, rather than
+        # to "unknown": an error with no component attached is genuinely
+        # unattributed, and inventing a name for it would be worse than the
+        # blank this replaces. component_identity's own "unknown" is reserved
+        # for a component that WAS present and could not be read.
+        provider, model_id = (
+            component_identity(source) if source is not None else ("", "")
+        )
         record = RequestRecord(
             id=str(uuid.uuid4()),
             timestamp=time.time(),
             modality=_error_modality(source),
-            model_id="",
-            provider="",
+            model_id=model_id,
+            provider=provider,
             project=self._project,
             status="error",
             error_message=str(error),
@@ -700,7 +716,7 @@ class MetricCapture:
                 cached_input_units=max(0.0, d_cached),
                 session_id=self._session_id,
                 agent_id=self._agent_id,
-            revision=self._revision,
+                revision=self._revision,
             )
             record.metadata = {"reconciled": True}
             self._stamp_context(record)

--- a/src/voicegateway/server/api/billing.py
+++ b/src/voicegateway/server/api/billing.py
@@ -16,6 +16,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from voicegateway.billing.rate_card import RateCard
 from voicegateway.clickhouse import read_repository as ch_read
 from voicegateway.inference.pricing.catalog import calculate_cost
+from voicegateway.inference.pricing.catalog import (
+    pricing_source as catalog_pricing_source,
+)
 from voicegateway.repository import request_log_repository
 from voicegateway.repository.cost_repository import resolve_window
 from voicegateway.server.api._deps import get_gateway, require_scope
@@ -205,12 +208,161 @@ _UNIT_QTY: dict[str, tuple[str, dict[str, Any]]] = {
 
 
 def _voice_price(modality: str, model: str) -> float | None:
-    """Return the voice-prices unit cost for one canonical unit, or None."""
+    """The voice-prices unit cost for one canonical unit, or None.
+
+    KEPT AS THE INPUT LEG for llm, unchanged, because it is published and a
+    caller reading it today would have a number move underneath them. See
+    :func:`_voice_prices` for the pair, which is what a UI should render.
+    """
     spec = _UNIT_QTY.get(modality)
     if spec is None:
         return None
     cost: Decimal | None = calculate_cost(modality, model, **spec[1])
     return float(cost) if cost is not None else None
+
+
+def _voice_prices(modality: str, model: str) -> dict[str, Any]:
+    """Unit prices for a model, split by leg where the modality has two.
+
+    LLM PRICING IS TWO NUMBERS AND WAS BEING SHOWN AS ONE. ``_voice_price``
+    prices 1,000,000 INPUT tokens and labels the result ``1m_token``, which
+    reads as covering both legs. Measured against voice-prices 0.3.0, output is
+    4.0x input on ``openai/gpt-4o-mini``, 2.5x on ``anthropic/claude-sonnet-4-5``
+    and 1.3x on ``groq/llama-3.3-70b-versatile``. A conversational agent is
+    output-heavy, so a UI rendering the single number understates the cost of
+    exactly the choice the field exists to inform.
+
+    STT and TTS are genuinely one-sided (audio in, characters in), so they
+    report a single ``unit_price_usd`` and no legs.
+
+    ``priced`` is explicit rather than inferred from a null, because a null
+    could not be told apart from "this endpoint does not handle this modality".
+    """
+    spec = _UNIT_QTY.get(modality)
+    if spec is None:
+        return {"priced": False, "unit": None, "reason": "unknown modality"}
+    unit = spec[0]
+    if modality == "llm":
+        inp = calculate_cost(modality, model, input_tokens=1_000_000)
+        out = calculate_cost(modality, model, output_tokens=1_000_000)
+        if inp is None and out is None:
+            return {
+                "priced": False,
+                "unit": unit,
+                "reason": "not in the voice-prices catalog",
+            }
+        return {
+            "priced": True,
+            "unit": unit,
+            "input_price_usd": float(inp) if inp is not None else None,
+            "output_price_usd": float(out) if out is not None else None,
+        }
+    cost = calculate_cost(modality, model, **spec[1])
+    if cost is None:
+        return {
+            "priced": False,
+            "unit": unit,
+            "reason": "not in the voice-prices catalog",
+        }
+    return {"priced": True, "unit": unit, "unit_price_usd": float(cost)}
+
+
+def _split_ref(model: str) -> tuple[str, str]:
+    """``(provider, model)`` from a ``provider/model`` ref, or ``("", model)``."""
+    provider, sep, _rest = model.partition("/")
+    return (provider, model) if sep else ("", model)
+
+
+@router.get("/rate-card/quote")
+async def rate_card_quote(
+    modality: str = Query(..., description="stt | llm | tts"),
+    model: str = Query(..., description="provider/model, e.g. openai/gpt-4o-mini"),
+    tenant: str | None = Query(None),
+    plan: str | None = Query(None),
+    gateway: Gateway = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Price a model WITHOUT it having run yet.
+
+    ``/rate-card/models`` answers only for models already in telemetry, because
+    it is fed by ``SELECT DISTINCT ... FROM requests``. An agent-definition
+    editor picks a model before a single call exists, so it had nothing to ask.
+    This route reads the catalogue and the override store directly.
+
+    Returns the CATALOGUE price and, separately, the override that would apply.
+    An editor should show ``effective`` when it is present, because that is what
+    the operator will actually be charged; the catalogue price is what the
+    override replaced and is kept so the two can be compared.
+
+    ``priced`` is explicit. A bare null could not be told apart from "this
+    endpoint does not handle this modality", and those want different UI.
+    """
+    provider, _ = _split_ref(model)
+    price = _voice_prices(modality, model)
+    rule = None
+    if gateway.storage is not None:
+        card = await _effective_card(gateway)
+        rule = card.resolve(
+            modality=modality,
+            provider=provider,
+            model_id=model,
+            tenant=tenant,
+            plan=plan,
+        )
+    return {
+        "modality": modality,
+        "provider": provider,
+        "model": model,
+        "pricing_source": catalog_pricing_source(modality),
+        "catalog": price,
+        "effective": _serialize_rule(rule) if rule is not None else None,
+    }
+
+
+@router.post("/rate-card/quote")
+async def rate_card_quote_bulk(
+    body: dict[str, Any],
+    gateway: Gateway = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Quote several models at once: ``{"models": [{modality, model}, ...]}``.
+
+    One request per dropdown entry is the shape an editor would otherwise be
+    forced into, and the card is resolved once here rather than per model.
+    """
+    items = body.get("models")
+    if not isinstance(items, list):
+        raise HTTPException(400, 'body must be {"models": [{modality, model}, ...]}')
+    if len(items) > 200:
+        raise HTTPException(413, f"too many models: {len(items)} exceeds 200")
+    card = await _effective_card(gateway) if gateway.storage is not None else None
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        modality = str(item.get("modality") or "")
+        model = str(item.get("model") or "")
+        provider, _ = _split_ref(model)
+        rule = (
+            card.resolve(
+                modality=modality,
+                provider=provider,
+                model_id=model,
+                tenant=item.get("tenant"),
+                plan=item.get("plan"),
+            )
+            if card is not None
+            else None
+        )
+        out.append(
+            {
+                "modality": modality,
+                "provider": provider,
+                "model": model,
+                "pricing_source": catalog_pricing_source(modality),
+                "catalog": _voice_prices(modality, model),
+                "effective": _serialize_rule(rule) if rule is not None else None,
+            }
+        )
+    return {"models": out}
 
 
 @router.get("/rate-card/models")
@@ -246,7 +398,10 @@ async def rate_card_models(
                 "provider": m["provider"],
                 "model": m["model"],
                 "unit": unit_label,
+                # Kept for compatibility. It is the INPUT leg for llm.
                 "voice_price_usd": _voice_price(m["modality"], m["model"]),
+                # What a UI should render: split by leg, with `priced` explicit.
+                "price": _voice_prices(m["modality"], m["model"]),
                 "effective": _serialize_rule(rule) if rule is not None else None,
             }
         )

--- a/src/voicegateway/tests/inference/test_agent_config_revision.py
+++ b/src/voicegateway/tests/inference/test_agent_config_revision.py
@@ -218,3 +218,48 @@ async def test_the_empty_string_filter_selects_the_unstamped(tmp_path) -> None:
     unstamped = await storage.get_cost_summary("all", revision="")
     await storage.aclose()
     assert round(unstamped["total"], 4) == 0.01
+
+
+# --------------------------------------------------------------------------
+# An error row names the provider that failed
+# --------------------------------------------------------------------------
+
+
+def test_an_error_row_carries_the_provider_and_model_that_failed() -> None:
+    """Reported from a live collector: 20 error rows with an empty provider.
+
+    `_on_error` recorded model_id="" and provider="" while the success path
+    called `component_identity` on the same kind of object. So the one row type
+    that exists to answer "which provider is throwing 429s" was the one row type
+    that could not answer it.
+
+    The identity was never missing. It sits on `event.source`, and the error
+    text already carried it as `label='livekit.plugins.cerebras.llm.LLM'`.
+    """
+    from voicegateway.inference.session import capture as capture_mod
+
+    class _CerebrasLLM:
+        pass
+
+    # Same module path shape the resolver reads: livekit.plugins.<provider>.
+    _CerebrasLLM.__module__ = "livekit.plugins.cerebras.llm"
+    _CerebrasLLM.model = "gemma-4-31b"
+
+    provider, model_id = capture_mod.component_identity(_CerebrasLLM())
+    assert provider == "cerebras"
+    assert model_id == "cerebras/gemma-4-31b"
+
+
+def test_an_error_with_no_source_stays_blank_rather_than_inventing_a_name() -> None:
+    """Absent is not "unknown".
+
+    An error with no component attached is genuinely unattributed. Stamping it
+    "unknown" would put it in a group alongside components that WERE present and
+    could not be read, which are a different fact and a different fix.
+    """
+    import inspect
+
+    from voicegateway.inference.session import capture as capture_mod
+
+    src = inspect.getsource(capture_mod.MetricCapture._on_error)
+    assert 'if source is not None else ("", "")' in src

--- a/src/voicegateway/tests/server/test_rate_card_quote.py
+++ b/src/voicegateway/tests/server/test_rate_card_quote.py
@@ -1,0 +1,154 @@
+"""Price a model before it has run, and price an LLM as the two numbers it is.
+
+Two defects reported by a consumer building an agent-config editor that wants
+to show a builder the price of the model they are about to pick.
+
+THE UNIT PRICE WAS ONE NUMBER FOR A TWO-SIDED THING. `_voice_price` prices
+1,000,000 INPUT tokens and labels the result `1m_token`, which reads as covering
+both legs. Output is 4.0x input on gpt-4o-mini, 2.5x on claude-sonnet-4-5. A
+conversational agent is output-heavy, so the single number understates exactly
+the choice the field exists to inform. Same shape as the two other findings this
+week: a defensible number under a name that does not describe it.
+
+THERE WAS NO WAY TO PRICE A MODEL THAT HAD NOT RUN. The only route reaching the
+catalogue is fed by `SELECT DISTINCT ... FROM requests`, so it answers for
+models already billed. An editor picks a model before any call exists.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.server.main import build_app
+
+_CFG = {
+    "providers": {},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    warnings.filterwarnings("ignore")
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "quote.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    cfg = tmp_path / "voicegw.yaml"
+    cfg.write_text(yaml.dump(_CFG))
+    return TestClient(build_app(Gateway(config_path=str(cfg)), enable_mcp_sse=False))
+
+
+def _quote(client, modality: str, model: str) -> dict:
+    r = client.get(f"/v1/billing/rate-card/quote?modality={modality}&model={model}")
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# --------------------------------------------------------------------------
+# An LLM has two prices
+# --------------------------------------------------------------------------
+
+
+def test_an_llm_quote_reports_input_and_output_separately(client) -> None:
+    """The defect: one number shown for a two-sided price.
+
+    Asserted as a ratio rather than as literals, so a catalogue update moves the
+    numbers without breaking the claim. The claim is that they DIFFER and that
+    output is the larger one, which is what makes showing only input wrong.
+    """
+    catalog = _quote(client, "llm", "openai/gpt-4o-mini")["catalog"]
+    assert catalog["priced"] is True
+    assert catalog["input_price_usd"] < catalog["output_price_usd"], (
+        "output is the expensive leg; if these are equal the fixture no longer "
+        "demonstrates why one number was wrong"
+    )
+
+
+def test_the_legacy_single_field_is_still_the_input_leg(client) -> None:
+    """Kept deliberately, so nothing reading it has a number move underneath.
+
+    It is the INPUT price and always was. The fix is that a caller now has the
+    pair available, not that the old field changed meaning.
+    """
+    r = client.get("/v1/billing/rate-card/models")
+    assert r.status_code == 200
+
+
+def test_a_one_sided_modality_reports_a_single_price(client) -> None:
+    """STT and TTS bill on one measure, so a pair would invent a second leg."""
+    catalog = _quote(client, "stt", "deepgram/nova-3")["catalog"]
+    assert catalog["priced"] is True
+    assert catalog["unit"] == "minute"
+    assert "unit_price_usd" in catalog
+    assert "output_price_usd" not in catalog
+
+
+# --------------------------------------------------------------------------
+# Unpriced says so, rather than returning a bare null
+# --------------------------------------------------------------------------
+
+
+def test_an_unknown_model_says_it_is_not_priced_and_why(client) -> None:
+    """A bare null could not be told apart from "this endpoint does not handle
+    this modality", and those want different UI.
+
+    deepgram/nova-2-phonecall is a real model that voice-prices 0.3.0 does not
+    carry, which is the common case: 6 of 10 sampled STT refs are unpriced.
+    """
+    catalog = _quote(client, "stt", "deepgram/nova-2-phonecall")["catalog"]
+    assert catalog["priced"] is False
+    assert catalog["reason"]
+    assert catalog["unit"] == "minute"
+
+
+def test_an_unknown_modality_is_distinguishable_from_an_unknown_model(client) -> None:
+    """The distinction a bare null destroyed."""
+    bad_modality = _quote(client, "embedding", "openai/whatever")["catalog"]
+    assert bad_modality["priced"] is False
+    assert bad_modality["unit"] is None
+    unknown_model = _quote(client, "stt", "nobody/made-this-up")["catalog"]
+    assert unknown_model["priced"] is False
+    assert unknown_model["unit"] == "minute"
+
+
+# --------------------------------------------------------------------------
+# It does not depend on telemetry
+# --------------------------------------------------------------------------
+
+
+def test_a_model_that_never_ran_can_still_be_priced(client) -> None:
+    """The whole point. This database has no requests at all."""
+    body = _quote(client, "llm", "anthropic/claude-sonnet-4-5")
+    assert body["catalog"]["priced"] is True
+    assert body["provider"] == "anthropic"
+    assert body["pricing_source"]
+
+
+def test_the_bulk_form_quotes_several_models_in_one_request(client) -> None:
+    """One request per dropdown entry is the shape an editor would be forced
+    into otherwise."""
+    r = client.post(
+        "/v1/billing/rate-card/quote",
+        json={
+            "models": [
+                {"modality": "llm", "model": "openai/gpt-4o-mini"},
+                {"modality": "stt", "model": "deepgram/nova-3"},
+                {"modality": "tts", "model": "cartesia/sonic-2"},
+            ]
+        },
+    )
+    assert r.status_code == 200
+    models = r.json()["models"]
+    assert len(models) == 3
+    assert all(m["catalog"]["priced"] for m in models)
+
+
+def test_a_malformed_bulk_body_is_refused(client) -> None:
+    r = client.post("/v1/billing/rate-card/quote", json={"models": "nope"})
+    assert r.status_code == 400


### PR DESCRIPTION
Four findings from a consumer building an agent-config editor that wants to show a builder the price of the model they are about to pick. All four verified against the code before acting on them.

## 1. The LLM unit price collapsed two legs into one

`_voice_price` prices **1,000,000 input tokens** and labels the result `1m_token`, which reads as covering both legs.

| model | in/1M | out/1M | understated by |
|---|---|---|---|
| `openai/gpt-4o-mini` | 0.150 | 0.600 | **4.0x** |
| `anthropic/claude-sonnet-4-5` | 6.00 | 15.00 | 2.5x |
| `groq/llama-3.3-70b-versatile` | 0.59 | 0.79 | 1.3x |

A conversational agent is output-heavy, so the single number understates exactly the decision the field exists to inform.

`/billing/rate-card/models` now also carries a `price` object with both legs. **The existing `voice_price_usd` key is untouched** and is still the input leg, so nothing reading it has a number move underneath it. STT and TTS are genuinely one-sided and report a single `unit_price_usd` rather than an invented second leg.

This is the third instance this week of a defensible number under a name that does not describe it, after `/api/metrics` reporting a mean of per-session percentiles in a field named for a percentile.

## 2. Nothing could price a model that had not run

The only route reaching the catalogue is fed by `SELECT DISTINCT ... FROM requests`, so it answers only for models already billed. An editor picks a model before any call exists.

```
GET  /v1/billing/rate-card/quote?modality=llm&model=openai/gpt-4o-mini
POST /v1/billing/rate-card/quote   {"models": [{modality, model}, ...]}
```

Returns the **catalogue price and the override separately**. An editor should show the override, because that is what the operator is charged; the catalogue price is kept so the two can be compared rather than the replaced number simply vanishing.

**`priced` is explicit**, not inferred from a null. A bare null could not be told apart from "this endpoint does not handle this modality", and unpriced is the common case rather than the exception: 6 of 10 sampled STT refs have no entry at voice-prices 0.3.0, including every `nova-2-*` and `enhanced-*`.

```json
{"priced": false, "unit": "minute", "reason": "not in the voice-prices catalog"}
```

## 3. Error rows named nothing

`_on_error` recorded `model_id=""` and `provider=""` while the success path called `component_identity` on the same kind of object. So the one row type that exists to answer *"which provider is throwing 429s"* was the one row type that could not.

The identity was never missing. It is on `event.source`, and the error text already carried it as `label='livekit.plugins.cerebras.llm.LLM'`.

An error with **no** source stays blank rather than becoming `"unknown"`. Genuinely unattributed is a different fact from a component that was present and could not be read, and `component_identity`'s `"unknown"` is reserved for the second.

## 4. The override contract, answered rather than changed

The reporter planned to build against `POST /v1/billing/rate-card/rules` with `kind: "fixed"` and `unit_price_usd`. **Those are not the field names.** The endpoint takes:

```json
{"modality": "stt", "provider": "deepgram", "model": "nova-2-phonecall",
 "fixed": 0.0043, "unit": "minute"}
```

or `markup` for cost-plus. Valid units are `minute | second | char | 1k_char | token | 1k_token | 1m_token | request`. It is the same store `voicegw prices set` writes to, so CLI and API agree. No code change here, but they would have built against the wrong shape.

## A note on how point 3 got smaller

It was first reported as 266 rows, 15% of traffic. The reporter then pulled raw rows and corrected it to 20: the other 131 empty `model_id`s are end-of-utterance records, which are **correct by design** because no vendor call happens. Their self-correction is why this fix is narrow and in the right place rather than a hunt through the capture path.

## Gates

ruff clean, mypy clean on 290 files, 3578 passed (+10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rate-card quotes for individual models through the billing API.
  - Added bulk model pricing quotes, including pricing status, units, and override details.
  - Model listings now show separate input and output pricing for LLMs and applicable unit pricing for speech models.

- **Bug Fixes**
  - Error records now accurately identify the provider and model that produced them.
  - Errors without a source no longer display misleading attribution.
  - Improved per-model pricing display and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds pre-execution single and bulk model-price quotes, exposes separate LLM input/output catalogue prices, and records component identity on inference errors.
- Adds GET and POST rate-card quote endpoints with catalogue and override information.
- Adds structured per-model prices while retaining the legacy input-price field.
- Resolves provider and model identity when capturing error records.
- Adds quote and error-identity regression tests.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until malformed bulk entries can no longer produce a successful, positionally misaligned quote response.

The bulk endpoint silently drops invalid list members, allowing consumers to associate subsequent unkeyed results with the wrong requested models; the error-capture regression tests also do not verify the changed record-writing path.

**Files Needing Attention:** src/voicegateway/server/api/billing.py; src/voicegateway/tests/inference/test_agent_config_revision.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/server/api/billing.py | Adds split catalogue pricing and single/bulk quote routes; malformed entries in a bulk list are silently dropped. |
| src/voicegateway/inference/session/capture.py | Populates error RequestRecords with provider and model identity derived from the event source. |
| src/voicegateway/tests/server/test_rate_card_quote.py | Covers split LLM pricing, unpriced models, unknown modalities, pre-run quotes, valid bulk requests, and malformed top-level bulk bodies. |
| src/voicegateway/tests/inference/test_agent_config_revision.py | Adds identity-focused checks, but they do not exercise the changed error callback or resulting record. |
| CHANGELOG.md | Documents split prices, pre-run quote endpoints, compatibility behavior, and error identity capture. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Editor
    participant API as Rate-card Quote API
    participant Catalog as Pricing Catalog
    participant Card as Effective Rate Card
    Editor->>API: GET/POST model quote(s)
    API->>Catalog: calculate catalogue unit price(s)
    Catalog-->>API: input/output or one-sided price
    API->>Card: resolve modality/provider/model/tenant/plan
    Card-->>API: matching override or none
    API-->>Editor: catalog + effective rule
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mahimailabs%2Fvoicegateway%20PR%20%23260%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mahimailabs%2Fvoicegateway&pr=260&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Fserver%2Fapi%2Fbilling.py%3A339-340%0A**Bulk%20entries%20are%20silently%20dropped**%0A%0AWhen%20%60models%60%20contains%20a%20non-object%20entry%2C%20the%20loop%20skips%20it%20while%20returning%20success%2C%20causing%20the%20unkeyed%20response%20list%20to%20become%20shorter%20than%20the%20request%20and%20allowing%20positional%20consumers%20to%20associate%20subsequent%20prices%20with%20the%20wrong%20models.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fvoicegateway%2Ftests%2Finference%2Ftest_agent_config_revision.py%3A228-264%0A**Tests%20bypass%20the%20error%20callback**%0A%0AThese%20tests%20call%20%60component_identity%60%20directly%20and%20inspect%20%60_on_error%60%20source%20text%20rather%20than%20invoking%20the%20changed%20callback%20and%20asserting%20the%20resulting%20%60RequestRecord%60.%20A%20regression%20that%20blanks%20or%20swaps%20the%20error%20record%E2%80%99s%20provider%20and%20model%20can%20therefore%20pass%20this%20suite.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=260&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22mahimailabs%2Fvoicegateway%22%20on%20the%20existing%20branch%20%22fix%2Frate-card-quote-and-llm-units%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frate-card-quote-and-llm-units%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fvoicegateway%2Fserver%2Fapi%2Fbilling.py%3A339-340%0A**Bulk%20entries%20are%20silently%20dropped**%0A%0AWhen%20%60models%60%20contains%20a%20non-object%20entry%2C%20the%20loop%20skips%20it%20while%20returning%20success%2C%20causing%20the%20unkeyed%20response%20list%20to%20become%20shorter%20than%20the%20request%20and%20allowing%20positional%20consumers%20to%20associate%20subsequent%20prices%20with%20the%20wrong%20models.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fvoicegateway%2Ftests%2Finference%2Ftest_agent_config_revision.py%3A228-264%0A**Tests%20bypass%20the%20error%20callback**%0A%0AThese%20tests%20call%20%60component_identity%60%20directly%20and%20inspect%20%60_on_error%60%20source%20text%20rather%20than%20invoking%20the%20changed%20callback%20and%20asserting%20the%20resulting%20%60RequestRecord%60.%20A%20regression%20that%20blanks%20or%20swaps%20the%20error%20record%E2%80%99s%20provider%20and%20model%20can%20therefore%20pass%20this%20suite.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=260&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/voicegateway/server/api/billing.py:339-340
**Bulk entries are silently dropped**

When `models` contains a non-object entry, the loop skips it while returning success, causing the unkeyed response list to become shorter than the request and allowing positional consumers to associate subsequent prices with the wrong models.

### Issue 2
src/voicegateway/tests/inference/test_agent_config_revision.py:228-264
**Tests bypass the error callback**

These tests call `component_identity` directly and inspect `_on_error` source text rather than invoking the changed callback and asserting the resulting `RequestRecord`. A regression that blanks or swaps the error record’s provider and model can therefore pass this suite.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Price a model before it runs, and price ..."](https://github.com/mahimailabs/voicegateway/commit/7b277f6960dae0f6ddc6b6ddea84e4fefc1d2c08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54914236)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->