### PR TITLE
Count billable requests apart from every stored row, across all three readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,25 @@ follows [Semantic Versioning](https://semver.org/) and
   aggregate was what lied, and it took a raw-row pull to unwind.
 
   `total` is unchanged. Summing cost over rows that contribute zero is
-  harmless; only the denominator was ever wrong. Mirrored in the DuckDB reader,
-  which is the same contract with a second implementation.
+  harmless; only the denominator was ever wrong.
+
+  Mirrored in **all three** readers: SQLite, DuckDB and ClickHouse. Which one
+  answers depends on how a deployment is configured and a caller cannot tell
+  them apart, so a field in one and not another is the same endpoint giving
+  different operators different answers.
+
+- **A contract test pinning that the three cost-summary readers agree**, and it
+  needs no ClickHouse server.
+
+  The DuckDB reader already had equivalence tests, and they caught this change
+  when only SQLite was updated. Nothing covered ClickHouse, which is the
+  collector path, so that reader would have kept the old shape silently.
+
+  Written without a container on purpose: no CI workflow provides ClickHouse,
+  so the existing container-based tests error rather than run, and a guard that
+  never executes is not a guard. This asserts the response contract, which is
+  what drifted, and separately asserts the count query still carries its
+  predicate so it cannot be wired up while meaning nothing.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ## Unreleased
 
+### Added
+
+- **The cost summary now reports `billable_requests` beside `requests`.**
+  Divide `total` by the first for a cost per call; the second counts every
+  stored row.
+
+  `requests` holds three kinds of row and only one can cost anything: billable
+  calls, error rows where nothing was billed, and end-of-utterance rows which
+  are local timing with no vendor call at all. Counting all three as one
+  population gives a cost per call whose denominator is padded with rows that
+  could never contribute to the numerator, and the padding always makes it read
+  LOW.
+
+  This is the failure that bit a careful reader. A consumer read `/v1/costs` on
+  a live collector, saw 151 rows in 1,000 with no model and no price, and
+  reported 15% of traffic as unattributable spend. Every individual row was
+  honest: 131 were end-of-utterance records that correctly carry no model. The
+  aggregate was what lied, and it took a raw-row pull to unwind.
+
+  `total` is unchanged. Summing cost over rows that contribute zero is
+  harmless; only the denominator was ever wrong. Mirrored in the DuckDB reader,
+  which is the same contract with a second implementation.
+
 ### Fixed
 
 - **The per-model unit price no longer shows one number for a two-sided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ follows [Semantic Versioning](https://semver.org/) and
   what drifted, and separately asserts the count query still carries its
   predicate so it cannot be wired up while meaning nothing.
 
+  Extended to the other two multi-producer numbers, `cost_by_day` and
+  `latency_stats`. Those agree across all three readers today, checked field by
+  field, so nothing needed repairing. Nothing pinned that agreement either,
+  which is precisely the state `cost_summary` was in before it drifted.
+
 ### Fixed
 
 - **The per-model unit price no longer shows one number for a two-sided

--- a/src/voicegateway/analytics/duckdb_reader.py
+++ b/src/voicegateway/analytics/duckdb_reader.py
@@ -136,6 +136,21 @@ def cost_summary(
             f"SELECT COALESCE(SUM(cost_usd), 0) FROM vg.requests {where}", params
         ).fetchone()
         total = row[0] if row else 0.0
+        # Mirrors cost_repository.get_cost_summary. The two readers are one
+        # contract with two implementations, and tests assert they agree; a
+        # field added to only one means a DuckDB-backed deployment silently
+        # loses the honest denominator.
+        counts = con.execute(
+            "SELECT COUNT(*), "
+            "SUM(CASE WHEN status != 'error' "
+            "          AND (COALESCE(input_units, 0) "
+            "               + COALESCE(output_units, 0)) > 0 "
+            "         THEN 1 ELSE 0 END) "
+            f"FROM vg.requests {where}",
+            params,
+        ).fetchone()
+        request_count = int(counts[0]) if counts else 0
+        billable_count = int(counts[1] or 0) if counts else 0
         by_provider = {
             r[0]: {"cost": r[1], "requests": r[2]}
             for r in con.execute(
@@ -171,6 +186,8 @@ def cost_summary(
         "period": period,
         "project": project,
         "total": total,
+        "requests": request_count,
+        "billable_requests": billable_count,
         "by_provider": by_provider,
         "by_model": by_model,
     }

--- a/src/voicegateway/clickhouse/read_repository.py
+++ b/src/voicegateway/clickhouse/read_repository.py
@@ -59,6 +59,23 @@ WHERE tenant_id = {tenant:String}
   __PROJECT__
 """
 
+# Two counts, mirroring cost_repository.get_cost_summary. `requests` holds
+# billable calls, error rows and end-of-utterance telemetry, and only the first
+# can cost anything, so a cost per call divided by count() has a denominator
+# padded with rows that could never contribute to the numerator.
+_SQL_COST_SUMMARY_COUNTS = """\
+SELECT
+    count() AS request_count,
+    countIf(status != 'error'
+            AND (ifNull(input_units, 0) + ifNull(output_units, 0)) > 0)
+        AS billable_count
+FROM telemetry.requests
+WHERE tenant_id = {tenant:String}
+  AND timestamp >= fromUnixTimestamp64Milli({since_ms:Int64})
+  __UNTIL__
+  __PROJECT__
+"""
+
 _SQL_COST_BY_PROVIDER = """\
 SELECT
     provider,
@@ -365,6 +382,15 @@ async def get_cost_summary(
         raw_total = total_result.result_rows[0][0]
         total = float(raw_total) if raw_total is not None else 0.0
 
+    counts_sql = _render(_SQL_COST_SUMMARY_COUNTS, until=until, project=project)
+    counts_result = await client.query(counts_sql, parameters=params)
+    request_count = 0
+    billable_count = 0
+    if counts_result.result_rows:
+        row = counts_result.result_rows[0]
+        request_count = int(row[0] or 0)
+        billable_count = int(row[1] or 0)
+
     prov_sql = _render(_SQL_COST_BY_PROVIDER, until=until, project=project)
     prov_result = await client.query(prov_sql, parameters=params)
     by_provider: dict[str, dict[str, Any]] = {
@@ -391,6 +417,8 @@ async def get_cost_summary(
         "period": period_label,
         "project": project,
         "total": total,
+        "requests": request_count,
+        "billable_requests": billable_count,
         "by_provider": by_provider,
         "by_model": by_model,
         "by_project": by_project,

--- a/src/voicegateway/repository/cost_repository.py
+++ b/src/voicegateway/repository/cost_repository.py
@@ -127,6 +127,37 @@ async def get_cost_summary(
     row = result.fetchone()
     total = row[0] if row else 0.0
 
+    # TWO COUNTS, BECAUSE `requests` HOLDS THREE KINDS OF ROW and only one of
+    # them can cost anything:
+    #
+    #   * billable calls, where a vendor charged us,
+    #   * error rows, where the call failed and nothing was billed,
+    #   * end-of-utterance rows, which are local timing and involve no vendor
+    #     call at all.
+    #
+    # Dividing `total` by the count of ALL of them produces a cost-per-call with
+    # a denominator padded by rows that could never contribute to the numerator.
+    # On one real collector that was 151 rows in 1,000, and it read as 15% of
+    # traffic being "unpriced" when nothing was wrong: a wrong conclusion built
+    # in minutes on a dataset where every individual row was honest.
+    #
+    # `total` is unchanged. Summing cost over rows that contribute zero is
+    # harmless; it is the DENOMINATOR that was never right.
+    result = await session.execute(
+        text(
+            f"""SELECT COUNT(*),
+                       SUM(CASE WHEN status != 'error'
+                                 AND (COALESCE(input_units, 0)
+                                      + COALESCE(output_units, 0)) > 0
+                                THEN 1 ELSE 0 END)
+                FROM requests {where}"""
+        ),
+        params,
+    )
+    counts = result.fetchone()
+    request_count = int(counts[0]) if counts else 0
+    billable_count = int(counts[1] or 0) if counts else 0
+
     result = await session.execute(
         text(
             f"""SELECT provider, SUM(cost_usd) as cost, COUNT(*) as count
@@ -181,6 +212,12 @@ async def get_cost_summary(
         "period": period,
         "project": project,
         "total": total,
+        # Every row stored in the window, which is what `requests` has always
+        # meant here. Kept so nothing reading it changes.
+        "requests": request_count,
+        # The rows that could cost money. Divide `total` by THIS for a
+        # cost per call; dividing by `requests` counts telemetry as traffic.
+        "billable_requests": billable_count,
         "by_provider": by_provider,
         "by_model": by_model,
     }

--- a/src/voicegateway/tests/clickhouse/test_reader_contract_parity.py
+++ b/src/voicegateway/tests/clickhouse/test_reader_contract_parity.py
@@ -29,6 +29,7 @@ from typing import Any
 import pytest
 
 from voicegateway.clickhouse import read_repository as ch_read
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
 from voicegateway.repository import cost_repository
 from voicegateway.services.storage_service import StorageService
 
@@ -46,19 +47,36 @@ COST_SUMMARY_CONTRACT = frozenset(
     }
 )
 
+#: One entry of the day-bucketed cost series.
+COST_BY_DAY_CONTRACT = frozenset({"day", "cost", "requests"})
+
+#: One per-model entry of the latency rollup.
+LATENCY_ENTRY_CONTRACT = frozenset(
+    {
+        "avg_ttfb_ms",
+        "avg_latency_ms",
+        "request_count",
+        "ttfb_percentiles",
+        "latency_percentiles",
+    }
+)
+
 
 class _Row:
-    """A query result carrying no rows, which is all the shape check needs."""
+    """A query result carrying whatever rows the stub decided to hand back."""
 
-    result_rows: list[Any] = []
+    def __init__(self, rows: list[Any] | None = None) -> None:
+        self.result_rows = rows or []
 
 
 class _StubClient:
-    """Answers every query with nothing, and remembers what it was asked.
+    """Answers each query with a row shaped like what that query selects.
 
     The readers only call ``await client.query(sql, parameters=...)`` and read
-    ``.result_rows``, so an empty answer exercises every branch that builds the
-    response dict without needing ClickHouse running.
+    ``.result_rows``, so no ClickHouse is needed. Rows are NOT empty for the
+    per-entry queries: an empty result builds an empty dict, and an empty dict
+    has no entry whose keys can be checked, so the shape that actually drifts
+    would go unexamined. The values are arbitrary; only the arity matters.
     """
 
     def __init__(self) -> None:
@@ -66,6 +84,22 @@ class _StubClient:
 
     async def query(self, sql: str, parameters: Any = None) -> _Row:
         self.queries.append(sql)
+        if "quantilesTDigest" in sql:
+            # model_id, avg_ttfb, avg_latency, count, ttfb_pcts, lat_pcts
+            return _Row(
+                [
+                    (
+                        "openai/gpt-4o-mini",
+                        120.0,
+                        300.0,
+                        7,
+                        (1.0, 2.0, 3.0),
+                        (4.0, 5.0, 6.0),
+                    )
+                ]
+            )
+        if "toStartOfDay" in sql or "day" in sql.lower():
+            return _Row([(1_785_661_200, 0.42, 7)])
         return _Row()
 
 
@@ -139,3 +173,71 @@ async def test_neither_reader_reports_more_billable_than_total(
             result = await cost_repository.get_cost_summary(db, period="all")
         await storage.aclose()
     assert result["billable_requests"] <= result["requests"]
+
+
+# --------------------------------------------------------------------------
+# The other two multi-producer numbers
+# --------------------------------------------------------------------------
+#
+# cost_by_day and latency_stats also have three implementations each. They
+# AGREE today, checked field by field. Nothing pinned that, which is exactly
+# the state cost_summary was in before it drifted, so these exist to keep an
+# agreement that currently holds rather than to repair one that broke.
+
+
+async def test_clickhouse_cost_by_day_entries_match_the_contract() -> None:
+    client = _StubClient()
+    series = await ch_read.get_cost_by_day(
+        client, tenant="t1", since=0.0, until=None, project=None
+    )
+    assert series, "the stub returned no row, so no entry shape was checked"
+    assert COST_BY_DAY_CONTRACT <= set(series[0])
+
+
+async def test_sqlite_cost_by_day_entries_match_the_contract(tmp_path: Path) -> None:
+    storage = StorageService(str(tmp_path / "byday.db"))
+    await storage._ensure_initialized()
+    tracker = CostTracker()
+    rec = tracker.create_record(
+        model_id="openai/gpt-4o-mini",
+        modality="llm",
+        provider="openai",
+        project="default",
+        input_units=100.0,
+        output_units=10.0,
+    )
+    rec.cost_usd = 0.05
+    await storage.log_request(rec)
+    async with storage._conn.session() as db:
+        series = await cost_repository.get_cost_by_day(db, period="all")
+    await storage.aclose()
+    assert series, "seeded one request, expected one day bucket"
+    assert COST_BY_DAY_CONTRACT <= set(series[0])
+
+
+async def test_clickhouse_latency_entries_match_the_contract() -> None:
+    client = _StubClient()
+    stats = await ch_read.get_latency_stats(
+        client, tenant="t1", since=0.0, until=None, project=None
+    )
+    assert stats, "the stub returned no row, so no entry shape was checked"
+    entry = next(iter(stats.values()))
+    assert LATENCY_ENTRY_CONTRACT <= set(entry)
+
+
+def test_duckdb_entries_match_the_contract() -> None:
+    """Asserted on the source: the DuckDB reader needs a real database file.
+
+    Its VALUES are already compared against SQLite by the equivalence tests in
+    tests/analytics. This only pins that the same entry keys are constructed.
+    """
+    import inspect
+
+    from voicegateway.analytics import duckdb_reader
+
+    day_src = inspect.getsource(duckdb_reader.cost_by_day)
+    for key in COST_BY_DAY_CONTRACT:
+        assert f'"{key}"' in day_src, f"DuckDB cost_by_day is missing {key!r}"
+    lat_src = inspect.getsource(duckdb_reader.latency_stats)
+    for key in LATENCY_ENTRY_CONTRACT:
+        assert f'"{key}"' in lat_src, f"DuckDB latency_stats is missing {key!r}"

--- a/src/voicegateway/tests/clickhouse/test_reader_contract_parity.py
+++ b/src/voicegateway/tests/clickhouse/test_reader_contract_parity.py
@@ -1,0 +1,141 @@
+"""Three readers, one contract. A field added to one must be added to all.
+
+`get_cost_summary` has three implementations: SQLite (`cost_repository`),
+DuckDB (`analytics/duckdb_reader`) and ClickHouse (`clickhouse/read_repository`).
+Which one answers depends on how the deployment is configured, and a caller
+cannot tell them apart. So a field present in one and missing from another is
+not a gap, it is the same endpoint returning different answers to different
+operators.
+
+THIS ALREADY HAPPENED. `billable_requests` was added to the SQLite reader and
+three existing DuckDB equivalence tests went red, which is exactly what they are
+for. Nothing covered ClickHouse, so that reader silently kept the old shape, and
+ClickHouse is the collector path: the deployment where a fleet's numbers
+actually live.
+
+NO SERVER REQUIRED, deliberately. The existing ClickHouse tests spin a
+container, and no CI workflow provides one, so they error rather than run. A
+guard that never executes is not a guard, and this repository has produced two
+of those already. This asserts the CONTRACT, which is what drifted, using a
+stub client that records the SQL it was handed. It cannot catch a value
+disagreement; it catches the shape disagreement that actually occurred.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from voicegateway.clickhouse import read_repository as ch_read
+from voicegateway.repository import cost_repository
+from voicegateway.services.storage_service import StorageService
+
+#: What every implementation of the cost summary must return, whatever backs it.
+#: Adding a key here without adding it to all three readers fails this file.
+COST_SUMMARY_CONTRACT = frozenset(
+    {
+        "period",
+        "project",
+        "total",
+        "requests",
+        "billable_requests",
+        "by_provider",
+        "by_model",
+    }
+)
+
+
+class _Row:
+    """A query result carrying no rows, which is all the shape check needs."""
+
+    result_rows: list[Any] = []
+
+
+class _StubClient:
+    """Answers every query with nothing, and remembers what it was asked.
+
+    The readers only call ``await client.query(sql, parameters=...)`` and read
+    ``.result_rows``, so an empty answer exercises every branch that builds the
+    response dict without needing ClickHouse running.
+    """
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    async def query(self, sql: str, parameters: Any = None) -> _Row:
+        self.queries.append(sql)
+        return _Row()
+
+
+async def test_clickhouse_summary_satisfies_the_contract() -> None:
+    """The reader that had drifted."""
+    client = _StubClient()
+    result = await ch_read.get_cost_summary(
+        client, tenant="t1", since=0.0, until=None, project=None
+    )
+    missing = COST_SUMMARY_CONTRACT - set(result)
+    assert not missing, f"ClickHouse cost summary is missing {sorted(missing)}"
+
+
+async def test_sqlite_summary_satisfies_the_contract(tmp_path: Path) -> None:
+    storage = StorageService(str(tmp_path / "contract.db"))
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        result = await cost_repository.get_cost_summary(db, period="all")
+    await storage.aclose()
+    missing = COST_SUMMARY_CONTRACT - set(result)
+    assert not missing, f"SQLite cost summary is missing {sorted(missing)}"
+
+
+def test_duckdb_summary_satisfies_the_contract() -> None:
+    """Asserted on the source, because the DuckDB reader needs a real file.
+
+    The three equivalence tests in tests/analytics already compare its VALUES
+    against SQLite on seeded data. This only pins that the two contract keys
+    exist there too, so all three readers are covered by one list.
+    """
+    import inspect
+
+    from voicegateway.analytics import duckdb_reader
+
+    src = inspect.getsource(duckdb_reader.cost_summary)
+    for key in ("requests", "billable_requests"):
+        assert f'"{key}"' in src, f"DuckDB cost summary is missing {key!r}"
+
+
+async def test_the_counts_query_actually_filters_rather_than_counting_all() -> None:
+    """Guards against the count being wired up but meaning nothing.
+
+    A `count()` with no predicate would satisfy the contract check above while
+    reporting every stored row as billable, which is the exact defect this
+    whole change exists to remove.
+    """
+    client = _StubClient()
+    await ch_read.get_cost_summary(
+        client, tenant="t1", since=0.0, until=None, project=None
+    )
+    counts_sql = next((q for q in client.queries if "billable_count" in q), None)
+    assert counts_sql is not None, "no billable count query was issued"
+    assert "countIf" in counts_sql
+    assert "status != 'error'" in counts_sql
+    assert "input_units" in counts_sql and "output_units" in counts_sql
+
+
+@pytest.mark.parametrize("reader", ["clickhouse", "sqlite"])
+async def test_neither_reader_reports_more_billable_than_total(
+    reader: str, tmp_path: Path
+) -> None:
+    """A subset count cannot exceed the population it is drawn from."""
+    if reader == "clickhouse":
+        result = await ch_read.get_cost_summary(
+            _StubClient(), tenant="t1", since=0.0, until=None, project=None
+        )
+    else:
+        storage = StorageService(str(tmp_path / "bounds.db"))
+        await storage._ensure_initialized()
+        async with storage._conn.session() as db:
+            result = await cost_repository.get_cost_summary(db, period="all")
+        await storage.aclose()
+    assert result["billable_requests"] <= result["requests"]

--- a/src/voicegateway/tests/repository/test_billable_request_count.py
+++ b/src/voicegateway/tests/repository/test_billable_request_count.py
@@ -1,0 +1,124 @@
+"""A cost total and a row count are not the same population.
+
+`requests` holds three kinds of row and only one of them can cost anything:
+
+* billable calls, where a vendor charged us,
+* error rows, where the call failed and nothing was billed,
+* end-of-utterance rows, which are local timing with no vendor call at all.
+
+The cost summary counted all three as one population, so a cost per call
+divided real money by a denominator padded with rows that could never
+contribute to the numerator.
+
+This is the failure mode that bit a careful reader rather than a careless one.
+A consumer read `/v1/costs` on a live collector, saw 151 rows in 1,000 with no
+model and no price, and reported 15% of traffic as unattributable spend. Every
+individual row was honest: 131 were end-of-utterance records, which correctly
+carry no model because no vendor call happened. The aggregate was what lied,
+and it took a raw-row pull to unwind.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
+from voicegateway.services.storage_service import StorageService
+
+
+async def _seeded(tmp_path: Path) -> StorageService:
+    """One window holding all three row kinds."""
+    storage = StorageService(str(tmp_path / "counts.db"))
+    await storage._ensure_initialized()
+    tracker = CostTracker()
+
+    # Two billable calls.
+    for cost in (0.10, 0.20):
+        rec = tracker.create_record(
+            model_id="openai/gpt-4o-mini",
+            modality="llm",
+            provider="openai",
+            project="default",
+            input_units=1000.0,
+            output_units=100.0,
+        )
+        rec.cost_usd = cost
+        await storage.log_request(rec)
+
+    # One failed call: no units, no cost, and it is not a call anyone was billed
+    # for. Counting it would make the agent look cheaper per call the more it
+    # broke.
+    err = tracker.create_record(
+        model_id="openai/gpt-4o-mini",
+        modality="llm",
+        provider="openai",
+        project="default",
+    )
+    err.status = "error"
+    err.error_message = "429 queue_exceeded"
+    await storage.log_request(err)
+
+    # One end-of-utterance timing row: no vendor call happened at all.
+    eou = tracker.create_record(
+        model_id="",
+        modality="eou",
+        provider="",
+        project="default",
+    )
+    await storage.log_request(eou)
+    return storage
+
+
+async def test_billable_requests_excludes_errors_and_local_telemetry(
+    tmp_path,
+) -> None:
+    """The count you divide money by."""
+    storage = await _seeded(tmp_path)
+    summary = await storage.get_cost_summary("all")
+    await storage.aclose()
+    assert summary["requests"] == 4
+    assert summary["billable_requests"] == 2
+
+
+async def test_the_total_is_unchanged(tmp_path) -> None:
+    """Only the DENOMINATOR was ever wrong.
+
+    Summing cost over rows that contribute zero is harmless, so `total` keeps
+    its exact meaning and nobody comparing it across releases sees it move.
+    """
+    storage = await _seeded(tmp_path)
+    summary = await storage.get_cost_summary("all")
+    await storage.aclose()
+    assert round(summary["total"], 4) == 0.30
+
+
+async def test_cost_per_call_differs_by_a_third_between_the_two_counts(
+    tmp_path,
+) -> None:
+    """Why this is worth a field rather than a docs note.
+
+    Four rows against two billable ones is a 2x error on this fixture, and the
+    reported real-world case was 1,000 against 849. The wrong denominator is
+    always the larger one, so cost per call always reads LOW, which is the
+    flattering direction and the one nobody questions.
+    """
+    storage = await _seeded(tmp_path)
+    s = await storage.get_cost_summary("all")
+    await storage.aclose()
+    naive = s["total"] / s["requests"]
+    honest = s["total"] / s["billable_requests"]
+    assert naive < honest
+    assert round(honest, 4) == 0.15
+    assert round(naive, 4) == 0.075
+
+
+async def test_a_window_with_no_billable_rows_reports_zero_not_a_crash(
+    tmp_path,
+) -> None:
+    """A caller dividing by this must get a zero to guard on, not a None."""
+    storage = StorageService(str(tmp_path / "empty.db"))
+    await storage._ensure_initialized()
+    summary = await storage.get_cost_summary("all")
+    await storage.aclose()
+    assert summary["requests"] == 0
+    assert summary["billable_requests"] == 0


### PR DESCRIPTION
`requests` holds three kinds of row and only one of them can cost anything:

- **billable calls**, where a vendor charged us
- **error rows**, where the call failed and nothing was billed
- **end-of-utterance rows**, which are local timing with no vendor call at all

The cost summary counted all three as one population, so a cost per call divided real money by a denominator padded with rows that could never contribute to the numerator. The padding is always additive, so the figure always reads **low** — the flattering direction, and the one nobody questions.

## This bit a careful reader, not a careless one

A consumer read `/v1/costs` on a live collector, saw 151 rows in 1,000 carrying no model and no price, and reported 15% of traffic as unattributable spend.

Every individual row was honest. 131 were end-of-utterance records that correctly carry no model, because no vendor call happened. **The aggregate was what lied.** It cost them a raw-row pull and me a verification round to unwind, and neither of us was being sloppy.

That is the argument for a field rather than a docs note: nobody reads documentation to find out why a number is better than they hoped.

## What changed

```json
{ "total": 0.30, "requests": 4, "billable_requests": 2 }
```

`total` is unchanged and `requests` keeps its existing meaning. Summing cost over rows that contribute zero is harmless; **only the denominator was ever wrong**, so no published number moves.

## Three readers, one contract

`get_cost_summary` has three implementations — SQLite, DuckDB and ClickHouse — and which one answers depends on how a deployment is configured. A caller cannot tell them apart, so a field in one and not another is the same endpoint giving different operators different answers.

Adding the counts to SQLite alone turned **three existing DuckDB equivalence tests red**, which is exactly what they are for. **Nothing covered ClickHouse**, so that reader would have silently kept the old shape — and ClickHouse is the collector path, the deployment where a fleet's numbers actually live.

All three now carry the counts, and a new test pins the contract across them.

## The guard needs no ClickHouse server, deliberately

The existing ClickHouse tests spin a container, and **no workflow provides one**, so they error rather than run. A guard that never executes is not a guard, and this repo has produced two of those already: a sink test that asserted one end of a wire, and a docs test that passed by matching its own explanation.

So this asserts the response **contract** — which is what drifted — using a stub client that answers every query with nothing. It cannot catch a value disagreement and does not claim to; the DuckDB equivalence tests already compare values on seeded data, and what was missing was anything at all on the ClickHouse side.

A second test asserts the count query still carries its predicate, so a bare `count()` cannot satisfy the contract while reporting every stored row as billable.

Verified by mutation both ways: dropping the field from the ClickHouse response turns two tests red; stripping the predicate from its count query turns a third red.

## Why this shape

The consumer's suggestion, and it is better than the naming rule I proposed: look for numbers with two producers and assert they agree, rather than inventing a rule about names. **A careful person can satisfy a naming rule and still be wrong. A differential test fails mechanically.**

## Gates

ruff clean, mypy clean on 290 files, 3588 passed (+10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost summaries now consistently include total requests and billable requests across SQLite, DuckDB, and ClickHouse.
  * Billable requests count only successful requests with recorded usage.
* **Bug Fixes**
  * Cost summary metrics now accurately distinguish total request volume from billable activity.
  * Cost-by-day and latency summary fields remain consistent across supported data sources.
* **Tests**
  * Added cross-database contract coverage for cost summaries, daily costs, latency statistics, and billable request filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds separate total-row and billable-request counts to the SQLite, DuckDB, and ClickHouse cost-summary readers while preserving the existing cost total.
- Adds `requests` and `billable_requests` consistently across all three reader implementations.
- Adds value tests for SQLite and contract-parity checks covering ClickHouse and the other readers.
- Documents the new response field and its intended use in cost-per-call calculations.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because nullable positive-cost request rows can still be omitted from `billable_requests`.

The new SQLite predicate compares nullable status directly with `'error'`; SQL NULL therefore fails the predicate even though the same row can contribute units and cost to the total, leaving the previously reported denominator mismatch unresolved.

**Files Needing Attention:** src/voicegateway/repository/cost_repository.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/repository/cost_repository.py | Adds both count fields to the SQLite summary, but the billable predicate still excludes nullable non-error statuses. |
| src/voicegateway/analytics/duckdb_reader.py | Mirrors the new request counts in DuckDB using the same filtered-count contract. |
| src/voicegateway/clickhouse/read_repository.py | Fixes the previously reported ClickHouse response-shape drift by querying and returning both counts. |
| src/voicegateway/tests/repository/test_billable_request_count.py | Covers billable, error, telemetry, total-cost, and empty-window behavior, but does not exercise nullable status. |
| src/voicegateway/tests/clickhouse/test_reader_contract_parity.py | Adds serverless response-contract checks and verifies that the ClickHouse billable count retains its filtering predicate. |
| CHANGELOG.md | Documents the new denominator and cross-reader response contract. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API["Cost summary request"] --> Backend{"Configured reader"}
  Backend --> SQLite["SQLite reader"]
  Backend --> DuckDB["DuckDB reader"]
  Backend --> ClickHouse["ClickHouse reader"]
  SQLite --> Contract["total + requests + billable_requests"]
  DuckDB --> Contract
  ClickHouse --> Contract
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Pin the other two multi-producer numbers..."](https://github.com/mahimailabs/voicegateway/commit/84b53fd8a7ce628c1bb6761acebf1b6b28b3db3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54941110)</sub>

<!-- /greptile_comment -->