### PR TITLE
Assert every telemetry INSERT writes every column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ follows [Semantic Versioning](https://semver.org/) and
 
 ### Added
 
+- **A test asserting every telemetry table's INSERT writes every one of its
+  columns.** The differential form of the `revision` defect.
+
+  `revision` was added to the model, added to the migration, and accepted by
+  both. `_INSERT_REQUEST` names its 23 columns explicitly and nobody added it
+  there, so every row wrote NULL. The field existed in the model, existed in
+  the schema, was in the changelog, and was never once stored. Every test
+  asserting on the in-memory record passed the whole time.
+
+  A schema and an INSERT are two producers of one truth, and they drift
+  silently, so something has to compare them mechanically rather than rely on a
+  reviewer noticing a missing name in a twenty-three column list.
+
+  `requests`, `turns`, `tool_calls` and `dead_air_events` get no exemptions at
+  all. Columns filled by a later UPDATE are listed per table with a reason, and
+  that list is the only place a column may be excused, so excusing one is a
+  visible edit. A second test fails if an excuse names a column that no longer
+  exists, since a stale excuse would pre-excuse the next column to take that
+  name.
+
+  Verified by reproducing the original defect: removing `revision` from
+  `_INSERT_REQUEST` fails this test by name.
+
+### Added
+
 - **The cost summary now reports `billable_requests` beside `requests`.**
   Divide `total` by the first for a cost per call; the second counts every
   stored row.

--- a/src/voicegateway/tests/repository/test_insert_covers_every_column.py
+++ b/src/voicegateway/tests/repository/test_insert_covers_every_column.py
@@ -1,0 +1,136 @@
+"""A table's columns and its INSERT are two things that must agree.
+
+`revision` was added to `RequestRecord`, added to the migration, and accepted by
+both. `_INSERT_REQUEST` names its columns explicitly and nobody added it there,
+so every row wrote NULL. The field existed in the model, existed in the schema,
+was documented in the changelog, and was never once stored.
+
+Every test asserting on the in-memory record passed the whole time. It surfaced
+only when a later test read the value back out of storage, which is the same
+shape as a sink test that checks one end of a wire.
+
+THIS IS THE DIFFERENTIAL FORM OF THAT LESSON. Two producers of one truth (the
+schema and the INSERT) drift silently, so something has to compare them
+mechanically rather than rely on a reviewer noticing a missing line in a
+twenty-three column statement.
+
+Columns filled by the database or by a later UPDATE are listed per table with a
+reason. That list is the only place a column may be excused, so excusing one is
+a visible edit rather than a silent omission.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from sqlalchemy import text
+
+from voicegateway.services.storage_service import StorageService
+
+_REPO_DIR = Path(__file__).resolve().parents[2] / "repository"
+
+#: Columns an INSERT is not expected to write, and why. Anything not listed
+#: here must appear in its table's INSERT statement.
+_WRITTEN_ELSEWHERE: dict[str, dict[str, str]] = {
+    "api_keys": {
+        "last_used_at": "stamped by an UPDATE when the key is used",
+        "revoked_at": "stamped by an UPDATE on revocation",
+    },
+    "sessions": {
+        "call_id": "resolved from room_name after the call row exists",
+        "talk_time_seconds": "computed by finalize_session_metrics",
+        "per_minute_cost_usd": "computed by finalize_session_metrics",
+        "response_speed_p50_ms": "computed by finalize_session_metrics",
+        "response_speed_p95_ms": "computed by finalize_session_metrics",
+        "talk_over_rate": "computed by finalize_session_metrics",
+        "budget_ms_used": "accumulated across the session, not known at insert",
+        "replay_size_bytes": "computed when replay artifacts are written",
+    },
+}
+
+#: Filled by the database itself on every table that has them.
+_DB_ASSIGNED = frozenset({"id", "created_at", "updated_at"})
+
+#: The telemetry tables. A dropped column here loses measurement silently,
+#: which is what happened, so they are named rather than discovered.
+_TELEMETRY_TABLES = ("requests", "turns", "tool_calls", "dead_air_events")
+
+
+def _insert_columns(table: str) -> set[str] | None:
+    """The column list of the INSERT that writes ``table``, if there is one."""
+    for path in sorted(_REPO_DIR.glob("*.py")):
+        match = re.search(
+            rf"INSERT INTO {re.escape(table)}\s*\(([^)]*)\)",
+            path.read_text(),
+            re.S,
+        )
+        if match:
+            raw = match.group(1).replace('"', "").replace("'", "")
+            return {
+                c.strip() for c in re.split(r"[,\s]+", raw) if c.strip().isidentifier()
+            }
+    return None
+
+
+async def _table_columns(tmp_path: Path, table: str) -> set[str]:
+    storage = StorageService(str(tmp_path / "schema.db"))
+    await storage._ensure_initialized()
+    async with storage._conn.session() as db:
+        result = await db.execute(
+            text("SELECT name FROM pragma_table_info(:t)"), {"t": table}
+        )
+        cols = {row[0] for row in result}
+    await storage.aclose()
+    return cols
+
+
+async def test_every_telemetry_insert_writes_every_column(tmp_path: Path) -> None:
+    """The one that would have caught the `revision` drop.
+
+    A column present in the schema and absent from the INSERT writes NULL on
+    every row, forever, with nothing raising.
+    """
+    for table in _TELEMETRY_TABLES:
+        columns = await _table_columns(tmp_path, table)
+        assert columns, f"{table} does not exist"
+        insert = _insert_columns(table)
+        assert insert is not None, f"no INSERT INTO {table} found in the repository"
+        excused = set(_WRITTEN_ELSEWHERE.get(table, {}))
+        missing = columns - insert - _DB_ASSIGNED - excused
+        assert not missing, (
+            f"{table}: these columns exist in the schema and are never written "
+            f"by its INSERT, so they are NULL on every row: {sorted(missing)}. "
+            f"Add them to the INSERT, or list them in _WRITTEN_ELSEWHERE with "
+            f"the reason they are filled elsewhere."
+        )
+
+
+async def test_the_excuse_list_names_only_real_columns(tmp_path: Path) -> None:
+    """An excuse for a column that no longer exists is a stale excuse.
+
+    Without this, deleting a column would leave its entry behind, and the next
+    column added with that name would be silently pre-excused.
+    """
+    for table, excuses in _WRITTEN_ELSEWHERE.items():
+        columns = await _table_columns(tmp_path, table)
+        if not columns:
+            continue
+        unknown = set(excuses) - columns
+        assert not unknown, (
+            f"{table}: excuses for columns that do not exist: {sorted(unknown)}"
+        )
+
+
+async def test_no_telemetry_column_is_excused(tmp_path: Path) -> None:
+    """The telemetry tables get no exemptions at all.
+
+    Every column on a measurement row is written at insert. If one ever needs
+    an exemption that is a design change worth arguing for explicitly, not a
+    line quietly added to a dictionary.
+    """
+    for table in _TELEMETRY_TABLES:
+        assert table not in _WRITTEN_ELSEWHERE, (
+            f"{table} is a telemetry table and should write every column at "
+            f"insert; an exemption here hides a measurement that is never stored"
+        )


### PR DESCRIPTION
The differential form of the `revision` defect, and the fourth instance this session of one underlying failure: **two producers of one truth drifting with nothing comparing them.**

## What it would have caught

`revision` was added to `RequestRecord`, added to the migration, and accepted by both. `_INSERT_REQUEST` names its 23 columns explicitly and nobody added it there, so **every row wrote NULL**.

The field existed in the model, existed in the schema, was documented in the changelog, and was never once stored. Every test asserting on the in-memory record passed the whole time. It surfaced only when a later test read the value back out of storage.

## The audit found no other instance

All nine explicit-column INSERTs checked against their tables. The only columns any INSERT omits:

| Table | Omitted | Why it is correct |
|---|---|---|
| `api_keys` | `last_used_at`, `revoked_at` | stamped by a later UPDATE |
| `sessions` | the rollup columns, `call_id`, `budget_ms_used`, `replay_size_bytes` | computed by `finalize_session_metrics` |

So this **pins a property that currently holds** rather than repairing one that is broken, which is the same reason the reader-parity tests in #261 were worth adding.

## The telemetry tables get no exemptions

`requests`, `turns`, `tool_calls` and `dead_air_events` must write every column. A dropped column there loses measurement silently, which is exactly what happened, and an exemption would hide it again. A third test fails if any of those four is ever added to the excuse list.

Columns written elsewhere are listed **per table with a reason**, and that list is the only place a column may be excused, so excusing one is a visible edit in a diff rather than an omission nobody sees. A second test fails when an excuse names a column that no longer exists, because a stale excuse silently pre-excuses the next column to take that name.

## Verified by reproducing the original defect

Not by inventing a new one. Removing `revision` from `_INSERT_REQUEST`:

```
AssertionError: requests: these columns exist in the schema and are never
written by its INSERT, so they are NULL on every row: ['revision'].
```

## Why this shape

Four defects this session were caught by a second reader rather than by a test: a sink test that checked one end of a wire, a docs test that passed by matching its own explanation, this silent INSERT drop, and a stub that asserted the keys of zero entries. Each was inside work already reported as verified.

A differential test does not depend on a second reader. It fails mechanically when two things that must agree stop agreeing, which is the only mechanism in this session that catches the class rather than an instance.

## Gates

ruff clean, mypy clean on 290 files, 3595 passed (+3).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds differential repository tests that compare telemetry INSERT column lists with initialized SQLite schemas, validate column exemptions, and prohibit telemetry exemptions.

- Documents the previously missed `revision` persistence defect and the new invariant in the changelog.
- Adds explicit exemptions for database-assigned and subsequently updated columns.
- Introduces a duplicate Added heading in the Unreleased changelog section.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only the non-blocking duplicate Added heading in the changelog needing cleanup.

The new tests cover the current telemetry INSERT producers and exemption lists without an established behavioral failure; the sole accepted issue is confusing changelog structure.

**Files Needing Attention:** CHANGELOG.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/tests/repository/test_insert_covers_every_column.py | Adds schema-to-INSERT parity checks and validates that exemptions remain current and exclude telemetry tables; no current behavioral defect was established. |
| CHANGELOG.md | Documents the new parity test but duplicates the existing Added subsection heading. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20mahimailabs%2Fvoicegateway%20PR%20%23262%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=mahimailabs%2Fvoicegateway&pr=262&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ACHANGELOG.md%3A34%0A**Duplicate%20Added%20subsection%20heading**%0A%0AThe%20new%20entry%20leaves%20two%20adjacent%20%60%23%23%23%20Added%60%20headings%20within%20the%20same%20Unreleased%20section%2C%20splitting%20one%20category%20into%20a%20confusing%20duplicate%20section.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=262&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22mahimailabs%2Fvoicegateway%22%20on%20the%20existing%20branch%20%22test%2Finsert-covers-every-column%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2Finsert-covers-every-column%22.%0A%0A%23%23%23%20Issue%201%0ACHANGELOG.md%3A34%0A**Duplicate%20Added%20subsection%20heading**%0A%0AThe%20new%20entry%20leaves%20two%20adjacent%20%60%23%23%23%20Added%60%20headings%20within%20the%20same%20Unreleased%20section%2C%20splitting%20one%20category%20into%20a%20confusing%20duplicate%20section.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=mahimailabs%2Fvoicegateway&pr=262&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
CHANGELOG.md:34
**Duplicate Added subsection heading**

The new entry leaves two adjacent `### Added` headings within the same Unreleased section, splitting one category into a confusing duplicate section.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Assert every telemetry INSERT writes eve..."](https://github.com/mahimailabs/voicegateway/commit/cf2d9d695751a1e573b63fdad3dfe41c0864e18c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54990300)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->