### PR TITLE
Add a Cloud rows-not-appearing page, corrected (closes #174)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -221,6 +221,7 @@
             "pages": [
               "reference/faq",
               "reference/troubleshooting",
+              "reference/cloud-rows-not-appearing",
               "reference/reconcile-formats"
             ]
           },

--- a/docs/reference/cloud-rows-not-appearing.md
+++ b/docs/reference/cloud-rows-not-appearing.md
@@ -1,0 +1,46 @@
+---
+title: "Cloud: rows not appearing"
+description: Why telemetry rows do not show up on a hosted collector, and why a $0.00 row is usually not the problem you think it is.
+---
+
+Telemetry is missing from the dashboard, or every row reads `$0.00`. These are different problems with different causes.
+
+## Nothing is arriving at all
+
+Export all three variables in the same process that runs your agent:
+
+```bash
+export VOICEGW_COLLECTOR_URL="https://<your-collector-host>"
+export VOICEGW_API_KEY="vk_your_ingest_key"
+export VOICEGW_PROJECT="my-agent"
+```
+
+`attach()` reads `VOICEGW_COLLECTOR_URL` and `VOICEGW_API_KEY` at call time. If either name is misspelled, nothing is sent and **nothing raises**: the sink is best-effort by design, so it buffers, fails, and retries quietly rather than taking your agent down over a telemetry problem.
+
+That silence is deliberate, and it means a missing row is never reported as an error. Check the variable names first.
+
+See the [hosted quickstart](/hosted/quickstart) for the full setup.
+
+## Rows arrive but every cost is `$0.00`
+
+A `$0.00` row is a real row. **Three different things produce one**, and they are not distinguished by the cost column, which is why the cost column is the wrong place to look:
+
+| What happened | `cost_usd` | `pricing_source` |
+|---|---|---|
+| Self-hosted model (`local/*`, `ollama/*`) | `0.0` | `voicegateway-local` |
+| Model not in the pricing catalogue | `0.0` | `""` (empty) |
+| Genuinely free or trivial usage | `0.0` | `voice-prices@<version>` |
+
+**`pricing_source` is what tells them apart.** An empty `pricing_source` means VoiceGateway priced nothing because it did not recognise the model, and it logs a warning when that happens: `No pricing data for <modality> model '<model>'; cost recorded as $0`.
+
+Self-hosted models are not a defect. They run on hardware you already pay for, and VoiceGateway records the usage without inventing a price for it.
+
+An unrecognised model usually means one of two things. Either your collector is pinned to an older `voice-prices` than your agent, so a model your agent knows is one the collector has never heard of, or the model genuinely has no catalogue entry yet. Check the collector's `pricing_source` version before assuming the second.
+
+## A row with no model at all
+
+Rows with an empty `model_id` and modality `eou` are end-of-utterance timing records. No provider call happened, so no model and no cost is the correct answer rather than a gap. They carry their measurements in `metadata.eou`.
+
+Use `billable_requests` rather than `requests` when dividing cost by a call count: `requests` counts every stored row, including these and failed calls, and a cost per call built on it reads low.
+
+See [cost tracking](/architecture/cost-tracking) for how request costs are calculated.


### PR DESCRIPTION
Based on **#174 by @BossAlexWhite**. The page is a good idea and the shape is right. Three things needed fixing before it could ship, and one of them was a factual error in the section the page exists for.

## The wrong claim

> "Models with unknown pricing resolve to `None`, so their cost may appear blank instead of `$0.00`."

They do not. Verified:

```
local/kokoro           cost=0.0       source='voicegateway-local'
nobody/unknown-model   cost=0.0       source=''
openai/gpt-4o-mini     cost=2.1e-05   source='voice-prices@0.3.0'
```

An unrecognised model records `cost_usd = 0.0` with an empty `pricing_source`, and logs `No pricing data for <modality> model '<model>'; cost recorded as $0`.

So a troubleshooting page about `$0.00` rows told the reader that unknown-pricing rows look **different** from free ones, when they look **identical** — and sent them hunting for a blank cell that never appears.

**`pricing_source` is the distinguisher, not cost.** The page now leads with that table, because the cost column genuinely cannot answer the question the page exists to answer.

## Added: the cause this actually has in practice

An empty `pricing_source` is usually **version skew**, not a missing catalogue entry: a collector pinned to an older `voice-prices` than the agent will not recognise models the agent does.

A consumer hit exactly this last week and read 445 unpriced rows as a normalisation problem. Worth naming so the next person checks the collector's version before going looking for a bug.

## Also corrected

- **H1 duplicating the frontmatter title.** Sibling pages under `reference/` go straight from frontmatter into prose.
- **Missing trailing newlines** on both files, and `docs.json` lost the one it had.

## Also added while here

- The `eou` row case: empty `model_id` with modality `eou` is an end-of-utterance record, correct by design because no provider call happened.
- `requests` versus `billable_requests`, since "why is my cost per call so low" is the same question this page is for.
- Why nothing raises when the env vars are wrong: the sink is best-effort by design, so a missing row is never reported as an error. That silence is the reason to check variable names first.

## Gates

docs validator PASS (81 pages, 81 nav refs). No code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a troubleshooting guide for missing cloud telemetry rows and `$0.00` costs.
  - Documented collector configuration requirements, silent sink failures, pricing source distinctions, unrecognized models, and end-of-utterance rows.
  - Added guidance for calculating per-call costs using `billable_requests`.
  - Linked related setup and cost-tracking documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a navigable troubleshooting page for missing cloud telemetry and zero-cost rows. Two factual diagnostics previously reported in review remain unresolved.
- Adds the page to the Reference → Help navigation.
- Documents collector configuration, zero-cost row categories, EOU records, and billable request counts.
- Still directs pricing-version troubleshooting to the wrong component and treats an empty pricing source as uniquely identifying an unknown model.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because the new troubleshooting page still sends users to the wrong component for pricing-version problems and misclassifies valid EOU rows.

Pricing is performed and stamped by the agent before export, while the collector only applies separate rating fields, so checking the collector cannot resolve the documented unpriced-row condition. EOU records also legitimately retain an empty pricing source, contradicting the page’s claim that this value identifies an unrecognized model.

**Files Needing Attention:** docs/reference/cloud-rows-not-appearing.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/reference/cloud-rows-not-appearing.md | Adds the troubleshooting guide, but its collector-version advice and absolute empty-`pricing_source` diagnostic remain inconsistent with the telemetry data flow. |
| docs/docs.json | Adds the new troubleshooting page to the Help navigation with no identified issue. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Add a Cloud rows-not-appearing page, cor..."](https://github.com/mahimailabs/voicegateway/commit/2e3e293abedc4c71625f5574f527db0934dc0409) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55012063)</sub>

<!-- /greptile_comment -->