### PR TITLE
chore: align sample project names in fixtures and API docs

### DIFF
--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -248,7 +248,7 @@ curl -H "Authorization: Bearer vk_..." \
 ```json
 {
   "room": "demo-a1b2c3",
-  "project": "pixis-w1",
+  "project": "acme-w1",
   "turn_count": 7,
   "complete": true,
   "components": {

--- a/src/voicegateway/tests/livekit_diag/test_report_basis.py
+++ b/src/voicegateway/tests/livekit_diag/test_report_basis.py
@@ -101,8 +101,8 @@ def test_a_run_that_probed_nothing_reports_zero_not_null() -> None:
 
 
 def test_a_declared_environment_is_carried_and_labelled_as_declared() -> None:
-    basis = _payload(_run([]), environment="pixis-prod-iad")["basis"]
-    assert basis["environment"] == "pixis-prod-iad"
+    basis = _payload(_run([]), environment="acme-prod-iad")["basis"]
+    assert basis["environment"] == "acme-prod-iad"
     assert basis["environment_declared"] is True
     assert "declared" in basis["environment_source"]
 
@@ -155,9 +155,9 @@ def test_the_rendered_report_states_both_counts(monkeypatch) -> None:
 
 
 def test_the_rendered_report_names_the_declared_environment() -> None:
-    html = run_report.render_html(_payload(_run([]), environment="pixis-prod-iad"))
+    html = run_report.render_html(_payload(_run([]), environment="acme-prod-iad"))
     assert "Environment" in html
-    assert "pixis-prod-iad" in html
+    assert "acme-prod-iad" in html
 
 
 def test_an_undeclared_environment_is_not_left_blank(monkeypatch) -> None:

--- a/src/voicegateway/tests/server/test_room_latency_endpoint.py
+++ b/src/voicegateway/tests/server/test_room_latency_endpoint.py
@@ -48,7 +48,7 @@ def _req(
     *,
     ttfb_ms: float | None = None,
     eou: dict[str, Any] | None = None,
-    project: str = "pixis-w1",
+    project: str = "acme-w1",
 ) -> RequestRecord:
     """One request row as ``attach`` writes it: the room lives on metadata."""
     metadata: dict[str, Any] = {"room": room}
@@ -185,7 +185,7 @@ async def test_a_complete_split_returns_every_component(harness):
     body = r.json()
 
     assert body["room"] == ROOM
-    assert body["project"] == "pixis-w1"
+    assert body["project"] == "acme-w1"
     assert body["complete"] is True
     c = body["components"]
     # aggregate_components works in SECONDS; the wire is milliseconds.


### PR DESCRIPTION
Uses `acme` for the sample project and environment names in the per-room latency docs example and two test fixtures, matching the convention the rest of the suite already follows.

Superseded, closing unmerged.