### PR TITLE
fix(ci): resolve dependencies from the lock, not from two sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,27 @@ jobs:
           # broke this workflow, which is why mcp is capped in pyproject.toml.
           # Revisit when livekit ships packaging mypy 2.x resolves, then drop
           # the cap here and in the local gate command.
-          uv pip install -e ".[dev,dashboard]" ruff 'mypy<2' types-PyYAML
+          #
+          # `uv sync`, NOT `uv pip install -e`. The two resolve differently and
+          # the job used to do both: `uv pip install -e` resolved fresh against
+          # the pyproject pins, then every `uv run` below re-synced the project
+          # environment from uv.lock. So the install step and the test step
+          # could run against different dependency trees in the same job.
+          #
+          # That is not theoretical. `voice-prices>=0.3.0,<1` resolves to 0.6.0
+          # while uv.lock pinned 0.3.0, and 0.6.0 rewrote the Deepgram matchers
+          # so a model that was unpriced became priced. A test asserting that
+          # model was unpriced then passed or failed depending on which command
+          # had touched the environment last, with no code change between.
+          #
+          # Tools that are not project dependencies come in as `--with`
+          # overlays on the step that needs them, so nothing outside the lock
+          # is ever installed into the synced environment.
+          uv sync --extra dev --extra dashboard
       - name: Ruff
-        run: uv run ruff check src
+        run: uv run --with ruff ruff check src
       - name: Mypy
-        run: uv run mypy
+        run: uv run --with 'mypy<2' --with types-PyYAML mypy
       - name: Pytest
         # Integration tests (testcontainers ClickHouse, real Postgres) run in
         # their dedicated jobs; the unit matrix deselects them by marker.

--- a/src/voicegateway/tests/server/test_rate_card_quote.py
+++ b/src/voicegateway/tests/server/test_rate_card_quote.py
@@ -98,11 +98,28 @@ def test_an_unknown_model_says_it_is_not_priced_and_why(client) -> None:
     """A bare null could not be told apart from "this endpoint does not handle
     this modality", and those want different UI.
 
-    deepgram/nova-2-phonecall is a real model that voice-prices 0.3.0 does not
-    carry, which is the common case: 6 of 10 sampled STT refs are unpriced.
+    THIS TEST USED TO NAME A REAL UNPRICED MODEL, deepgram/nova-2-phonecall,
+    and that made it a test of the catalogue rather than of this endpoint. The
+    catalogue matches by prefix clause, not by exact id, so what the choice
+    actually encoded was the SHAPE of one version's Deepgram matchers. When
+    voice-prices went 0.3.0 -> 0.6.0 those matchers were rewritten and the
+    domain-suffixed forms began resolving to their tier: nova-2-phonecall now
+    matches nova-2 and prices at 0.00583332/minute. The test then failed with
+    no code change, on a machine where the only difference was which version
+    a resolve had landed on.
+
+    The contract under test is that an unpriced answer is EXPLICIT: it carries
+    a reason and still names the unit, so a UI can render "unpriced, per
+    minute" rather than a blank. That contract does not need a real model, so
+    the ref below is under a real provider and cannot be claimed by any
+    matcher in any catalogue build.
     """
-    catalog = _quote(client, "stt", "deepgram/nova-2-phonecall")["catalog"]
-    assert catalog["priced"] is False
+    catalog = _quote(client, "stt", "deepgram/not-a-real-model-xyzzy")["catalog"]
+    assert catalog["priced"] is False, (
+        "a ref no matcher can claim must report unpriced; if this fails the "
+        "catalogue has started matching arbitrary strings, which is a "
+        "catalogue bug rather than an endpoint one"
+    )
     assert catalog["reason"]
     assert catalog["unit"] == "minute"
 

--- a/src/voicegateway/tests/test_lock_matches_environment.py
+++ b/src/voicegateway/tests/test_lock_matches_environment.py
@@ -1,0 +1,88 @@
+"""The tests must run against the dependency tree ``uv.lock`` describes.
+
+A CI job installed with ``uv pip install -e ".[dev,dashboard]"``, which
+resolves fresh against the pyproject pins, and then ran every later step with
+``uv run``, which re-syncs the project environment from ``uv.lock``. Those two
+can disagree, and did: ``voice-prices>=0.3.0,<1`` resolves to 0.6.0 while the
+lock pinned 0.3.0.
+
+That is not a packaging nicety. ``voice-prices`` ships the price catalogue, so
+its version decides what a model costs and whether a model is priced at all.
+0.6.0 rewrote the Deepgram matchers and ``deepgram/nova-2-phonecall`` went from
+unpriced to $0.00583332/minute. A test asserting it was unpriced then passed or
+failed depending on which uv command had touched the environment last, which
+reads exactly like flakiness and is not: each version is perfectly
+deterministic on its own.
+
+The structural fix is in ``ci.yml`` (sync from the lock, never pip-install
+alongside it). This is the guard for that fix, because the structural fix is
+one line someone can reasonably-looking undo.
+
+Scoped deliberately to the catalogue dependency rather than the whole lock.
+Asserting every pinned version matches would fail on any local venv that is
+merely a little stale, which is noise; this one package is the one whose
+version silently changes what the assertions in this suite mean.
+
+Set ``VOICEGW_ALLOW_DEP_DRIFT=1`` to run the suite against a deliberately
+different version, which is a legitimate thing to do when checking that a
+change survives a dependency bump.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+import pytest
+import voice_prices
+
+_TRACKED = "voice-prices"
+
+
+def _repo_root() -> Path | None:
+    """Walk up for the directory holding ``uv.lock``.
+
+    Returns None for an installed-package checkout with no lock beside it (a
+    wheel install, or a source tree the lock was not shipped with), where
+    there is nothing to compare against.
+    """
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "uv.lock").is_file():
+            return parent
+    return None
+
+
+def _locked_version(lock: Path, name: str) -> str | None:
+    data = tomllib.loads(lock.read_text())
+    for package in data.get("package", []):
+        if package.get("name") == name:
+            version = package.get("version")
+            return str(version) if version is not None else None
+    return None
+
+
+def test_the_installed_catalogue_matches_the_lock() -> None:
+    """Fail loudly when the environment is not the one the lock describes."""
+    if os.environ.get("VOICEGW_ALLOW_DEP_DRIFT"):
+        pytest.skip("VOICEGW_ALLOW_DEP_DRIFT set: deliberate cross-version run")
+
+    root = _repo_root()
+    if root is None:
+        pytest.skip("no uv.lock beside the package; nothing to compare against")
+
+    locked = _locked_version(root / "uv.lock", _TRACKED)
+    if locked is None:
+        pytest.skip(f"{_TRACKED} is not pinned in uv.lock")
+
+    installed = voice_prices.__version__
+    assert installed == locked, (
+        f"{_TRACKED} {installed} is installed but uv.lock pins {locked}. "
+        f"The suite is running against a different price catalogue than the "
+        f"lock describes, so any assertion about what a model costs, or about "
+        f"whether it is priced at all, may pass or fail for reasons unrelated "
+        f"to the code under test. Run `uv sync --extra dev --extra dashboard` "
+        f"to match the lock, `uv lock --upgrade-package {_TRACKED}` to move "
+        f"the lock forward on purpose, or set VOICEGW_ALLOW_DEP_DRIFT=1 if "
+        f"you are deliberately testing against another version."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3835,15 +3835,15 @@ wheels = [
 
 [[package]]
 name = "voice-prices"
-version = "0.3.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/db/d619c99888c08eec6decdc0b72967f9fb70ade814f156f2de66e81921ba9/voice_prices-0.3.0.tar.gz", hash = "sha256:2a8059ea694e5f237dcbbad8d1b06bb76503ed12b764e4daee239d5ec458e069", size = 84882, upload-time = "2026-08-08T17:00:25.282Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/44/373d130c8cbcecf6af78978ee115dc172a996ad15ac20039d82f8a96c484/voice_prices-0.6.0.tar.gz", hash = "sha256:eb21b5df70fd8608dcc5832d764c92f36fb807a6ff8b0c0c896727a746f49965", size = 99268, upload-time = "2026-08-21T00:29:17.132Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/1b/1cd363519500da90ea98a5442ce9f31015260aafbeb44b27a4aeff2d248a/voice_prices-0.3.0-py3-none-any.whl", hash = "sha256:0e7d1430123623596c4a9265ec1dbbe8eded9ceddf6f69a5e1abc8ee31f3bbcc", size = 89439, upload-time = "2026-08-08T17:00:23.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6a/23ed98f399f0bdd1bc2a4953cc1531ae86829ee28d2a48a4619804734c51/voice_prices-0.6.0-py3-none-any.whl", hash = "sha256:5bd86b6cb5cb9243a3aa984dc20fbb5c9c62bf3761e0f8cd6f16ae345d572540", size = 104161, upload-time = "2026-08-21T00:29:15.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Item 1 and item 3 from the rate-card follow-ups. They ship together because bumping the lock is what makes the test fail.

## The bug

The unit job did both of these:

```yaml
uv pip install -e ".[dev,dashboard]" ruff 'mypy<2' types-PyYAML   # fresh resolve
uv run pytest ...                                                 # syncs from uv.lock
```

`uv pip install -e` resolves against the pyproject pins; `uv run` re-syncs the project environment from `uv.lock`. When those disagree, **the install step and the test step run against different dependency trees in the same job.**

They disagreed. `voice-prices>=0.3.0,<1` resolves to **0.6.0**; `uv.lock` pinned **0.3.0**.

## Why that is not a packaging nicety

`voice-prices` ships the price catalogue, so its version decides what a model costs and whether it is priced at all. Matching is by prefix clause, not exact id, and 0.6.0 rewrote the Deepgram matchers:

```
0.3.0: calc_price(nova-2-phonecall, deepgram) -> LookupError, unpriced
0.6.0: calc_price(nova-2-phonecall, deepgram) -> 0.00583332, matched nova-2
```

`test_an_unknown_model_says_it_is_not_priced_and_why` asserts that model is unpriced, so it passed or failed depending on which uv command last touched the environment. That reads as flakiness and is not: each version is perfectly deterministic on its own. I chased it as a network refresh first, which was wrong; `get_snapshot()` returns a `@cache`d bundled snapshot and never refreshes unless something starts the updater, and nothing here does.

## Changes

**`uv sync` instead of `uv pip install -e`.** Tools that are not project dependencies come in as `--with` overlays on the step that needs them. One resolution, so the steps cannot disagree.

**`uv.lock` moves to voice-prices 0.6.0.** The lock should describe what a user gets, and `pip install voicegateway` resolves 0.6.0 today because that is what the published pin allows. Testing against 0.3.0 while shipping 0.6.0 is the gap that hid this.

**The quote test asserts its contract, not a catalogue fact.** It named one real model and asserted its absence, which really encoded the shape of one version's matchers. It now uses a ref no matcher can claim and asserts what it was written for: an unpriced answer is explicit and still names its unit, so a UI can render "unpriced, per minute" rather than a blank.

**A guard**, because the ci.yml fix is one line someone can plausibly undo. The suite fails if the installed catalogue version is not the one `uv.lock` pins, with a message naming the three ways to resolve it. `VOICEGW_ALLOW_DEP_DRIFT=1` opts out for a deliberate cross-version run. Verified it passes when matched and fails when drifted.

## Verification

- Full suite run against **both** 0.3.0 and 0.6.0 beforehand: the quote test was the **only** version-dependent failure out of 3616.
- `3594 passed, 23 skipped, 36 deselected` under the synced environment.
- `voice-prices` stayed at 0.6.0 across sync, ruff, mypy and pytest, so the divergence is gone in practice as well as by construction.
- `ruff check src`: clean. `mypy`: clean on 290 files.
- The new CI commands were run locally exactly as written.

## Not in this PR

The silent-zero finding (item 2): under 0.6.0, `deepgram/nova` and `deepgram/whisper` are catalogue entries with **no rates at all**, so `deepgram/nova-general` records `cost_usd=0.0` with `pricing_source="voice-prices@0.6.0"` and no warning, claiming provenance it does not have. Note this PR makes 0.6.0 the tested version, so that behaviour is now reachable in CI rather than only for users. It needs its own change and care: of 139 rateless catalogue entries, 131 are `:free` models where `$0.00` is correct, so the blunt fix would be worse than the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Improved build consistency by ensuring development and dashboard environments use the locked dependency set.
  * Added safeguards to detect mismatches between installed packages and their locked versions.

* **Bug Fixes**
  * Stabilized unknown-model speech-to-text pricing checks so results remain consistent across catalogue updates.
  * Continued validating that unsupported models are clearly identified as unpriced with the correct billing unit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes CI install project dependencies exclusively from `uv.lock`, updates the locked pricing catalogue, and prevents the unknown-model test from depending on catalogue-specific matcher behavior.
- Replaces the editable fresh resolve with `uv sync` and supplies lint/type-check tools as per-command overlays.
- Updates `voice-prices` from 0.3.0 to 0.6.0.
- Uses an intentionally nonexistent model reference for the unpriced quote contract.
- Adds a test ensuring the installed catalogue version matches the lock unless dependency-drift testing is explicitly enabled.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the CI dependency tree, pricing catalogue lock, and related tests aligned.

The changed workflow consistently synchronizes project dependencies from the lock, while the new guard detects catalogue drift and the revised quote test no longer relies on version-specific matcher coverage.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Synchronizes project dependencies from the lock and isolates unpinned CI tools in command-specific overlays. |
| src/voicegateway/tests/server/test_rate_card_quote.py | Decouples the unpriced-response contract test from real catalogue entries and matcher evolution. |
| src/voicegateway/tests/test_lock_matches_environment.py | Adds a focused lock-versus-installed-version guard with an explicit opt-out for cross-version testing. |
| uv.lock | Updates only voice-prices from 0.3.0 to 0.6.0 and refreshes its artifact metadata. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[uv sync with dev and dashboard extras] --> B[Environment synchronized from uv.lock]
    B --> C[uv run with Ruff overlay]
    B --> D[uv run with mypy overlays]
    B --> E[uv run pytest]
    E --> F[Guard compares installed voice-prices version with uv.lock]
    E --> G[Quote contract uses an intentionally unknown model]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): resolve dependencies from the l..."](https://github.com/mahimailabs/voicegateway/commit/7eaf200692d16702a2d3e07666083853b2de4582) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55424952)</sub>

<!-- /greptile_comment -->