### PR TITLE
fix(pricing): stop reporting a rateless catalogue match as a priced zero

### DIFF
--- a/docs/architecture/cost-tracking.md
+++ b/docs/architecture/cost-tracking.md
@@ -66,6 +66,8 @@ pricing_source(modality: str) -> str
 
 All three modalities return `None` for unknown models (never silent zero), so callers can distinguish "free" from "unknown."
 
+A fourth case sits between them. A model can *match* the catalogue and still carry no rate for the units recorded, in which case `calc_price` applies nothing and returns a total of zero. `calculate_cost_detail` reports those units alongside the total, and `CostTracker` tags the row `voice-prices-unrated` instead of `voice-prices@<version>` so it never reads as a priced figure. Use `calculate_cost_detail` rather than `calculate_cost` anywhere the answer feeds a price display or a gate.
+
 ## Per-request flow
 
 Every wrapped request flows through `InstrumentationMixin._log_request` (`src/voicegateway/middleware/base_middleware.py`, the mixin behind `InstrumentedSTT`/`InstrumentedLLM`/`InstrumentedTTS`):
@@ -91,7 +93,7 @@ Each `RequestRecord` carries the same `pricing_source` string the catalog return
 | `output_units` | `float` | Output tokens (LLM only) |
 | `cached_input_units` | `float` | Cached prompt tokens (LLM only; 0 for STT/TTS) |
 | `cost_usd` | `float` | Recorded provider cost, from `calculate_cost()` |
-| `pricing_source` | `str` | `voice-prices@<version>` or `voicegateway-local` |
+| `pricing_source` | `str` | `voice-prices@<version>`, `voice-prices-unrated`, `voicegateway-local`, or `""` when the model is unknown |
 | `rated_price_usd` | `float` | Billable price the active rate card stamped at write time; see [Rating](/architecture/rating) |
 | `rate_rule` | `str` | Audit token for the rule applied, e.g. `"cost_plus:1.3"` |
 | `ttfb_ms` | `float \| None` | Time to first byte in milliseconds |

--- a/docs/reference/cloud-rows-not-appearing.md
+++ b/docs/reference/cloud-rows-not-appearing.md
@@ -23,15 +23,20 @@ See the [hosted quickstart](/hosted/quickstart) for the full setup.
 
 ## Rows arrive but every cost is `$0.00`
 
-A `$0.00` row is a real row. **Three different things produce one**, and they are not distinguished by the cost column, which is why the cost column is the wrong place to look:
+A `$0.00` row is a real row. **Four different things produce one**, and they are not distinguished by the cost column, which is why the cost column is the wrong place to look:
 
 | What happened | `cost_usd` | `pricing_source` |
 |---|---|---|
 | Self-hosted model (`local/*`, `ollama/*`) | `0.0` | `voicegateway-local` |
 | Model not in the pricing catalogue | `0.0` | `""` (empty) |
+| Model matched, but the catalogue has no rate for it | `0.0` | `voice-prices-unrated` |
 | Genuinely free or trivial usage | `0.0` | `voice-prices@<version>` |
 
 **`pricing_source` is what tells them apart.** An empty `pricing_source` means VoiceGateway priced nothing because it did not recognise the model, and it logs a warning when that happens: `No pricing data for <modality> model '<model>'; cost recorded as $0`.
+
+`voice-prices-unrated` is the subtle one. Some catalogue entries match a model and carry no rate at all: `deepgram/nova-general` matches the entry `nova`, whose price fields are all empty. The lookup succeeds, no rate is applied, and the total is zero. That zero is not a price, so the row is tagged `voice-prices-unrated` rather than `voice-prices@<version>` and logs `matched the catalog but it carries no rate for <units>`. The remedy differs from an unknown model: the entry exists already and needs a rate, rather than needing to be added.
+
+The tag makes no claim about *why* there is no rate. A deliberately free tier and a missing rate are identical in the catalogue data, so VoiceGateway reports what it observed instead of guessing which one you have.
 
 Self-hosted models are not a defect. They run on hardware you already pay for, and VoiceGateway records the usage without inventing a price for it.
 

--- a/src/voicegateway/inference/pricing/_calc.py
+++ b/src/voicegateway/inference/pricing/_calc.py
@@ -1,0 +1,64 @@
+"""One place that asks voice-prices for a price and reports what came back.
+
+The three modality modules each split ``provider/model``, built a ``Usage``,
+called ``calc_price`` and collapsed the answer to ``Decimal | None``. That
+collapse threw away the distinction this module exists to keep.
+
+A model can MATCH the catalogue and still carry no rate for the units
+recorded. ``deepgram/nova-general`` matches the catalogue entry ``nova``,
+whose ``ModelPrice`` has every field ``None``. Nothing raises, no rate is
+applied, and the total is ``Decimal('0')``: a confident zero that is
+indistinguishable, downstream, from a model that genuinely costs nothing.
+
+voice-prices reports this as ``unpriced_usage``, a tuple naming the usage
+fields it could not price. ``getattr`` with a default because the attribute
+arrived in 0.6.0 and the floor pin still admits 0.3.0, where a rateless entry
+raises ``LookupError`` instead and takes the honest path anyway.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from voice_prices import calc_price
+
+if TYPE_CHECKING:
+    from voice_prices import Usage
+
+
+def split_ref(model: str) -> tuple[str, str]:
+    """``(provider, ref)`` from a ``provider/model`` string.
+
+    A bare model with no slash has no provider, and voice-prices is left to
+    match on the ref alone.
+    """
+    if "/" in model:
+        provider, _, ref = model.partition("/")
+        return provider, ref
+    return "", model
+
+
+def price_usage(usage: Usage, model: str) -> tuple[Decimal | None, tuple[str, ...]]:
+    """Return ``(total, unpriced_units)`` for ``usage`` against ``model``.
+
+    ``total`` is ``None`` when the model is unknown to the catalogue.
+
+    ``unpriced_units`` names the usage fields the catalogue matched but could
+    not put a rate to. Non-empty means the total is not fully rate-backed, and
+    the caller must not report it as a priced figure. It carries no claim
+    about WHY: a deliberate free tier and a missing rate look identical here,
+    because the catalogue does not distinguish them.
+    """
+    provider, ref = split_ref(model)
+    try:
+        price = calc_price(usage, model_ref=ref, provider_id=provider or None)
+    except LookupError:
+        return None, ()
+    if price is None:
+        return None, ()
+    unpriced = tuple(getattr(price, "unpriced_usage", ()) or ())
+    return Decimal(str(price.total_price)), unpriced
+
+
+__all__ = ["price_usage", "split_ref"]

--- a/src/voicegateway/inference/pricing/catalog.py
+++ b/src/voicegateway/inference/pricing/catalog.py
@@ -13,6 +13,21 @@ from voicegateway.inference.pricing import llm, stt, tts
 SELF_HOSTED_SOURCE = "voicegateway-local"
 _SELF_HOSTED_PREFIXES = ("local/", "ollama/")
 
+# A model can MATCH the catalogue and still carry no rate for the units
+# recorded: ``deepgram/nova-general`` matches the entry ``nova``, whose
+# ModelPrice has every field None. calc_price applies nothing, raises nothing,
+# and returns a total of 0. Stamping that row ``voice-prices@<version>`` claims
+# the catalogue priced it, which it did not, and the row then reads exactly
+# like a model that genuinely costs nothing.
+#
+# This source says only what is true: the catalogue matched the model and put
+# no rate to the units recorded. It deliberately does NOT claim to know why.
+# Of the 139 rateless entries in voice-prices 0.6.0, 131 are ``:free`` models
+# where zero is the right answer and 8 are not, and the catalogue records no
+# field distinguishing the two. Resolving that belongs upstream; until it is
+# resolved, a meter that cannot tell them apart must not pick one.
+UNRATED_SOURCE = "voice-prices-unrated"
+
 
 def calculate_cost(
     modality: str,
@@ -30,17 +45,44 @@ def calculate_cost(
     ``Decimal('0')``. Cloud models are priced by voice-prices; an unknown model
     returns ``None``.
     """
+    return calculate_cost_detail(
+        modality,
+        model,
+        audio_seconds=audio_seconds,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=cached_input_tokens,
+        character_count=character_count,
+    )[0]
+
+
+def calculate_cost_detail(
+    modality: str,
+    model: str,
+    *,
+    audio_seconds: float = 0.0,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cached_input_tokens: int = 0,
+    character_count: int = 0,
+) -> tuple[Decimal | None, tuple[str, ...]]:
+    """As :func:`calculate_cost`, plus the units the catalogue put no rate to.
+
+    A non-empty second element means the returned total is NOT fully
+    rate-backed and must not be reported as a priced figure. See
+    :data:`UNRATED_SOURCE`.
+    """
     if model.startswith(_SELF_HOSTED_PREFIXES):
-        return Decimal("0")
+        return Decimal("0"), ()
     if modality == "llm":
-        return llm.calculate_llm_cost(
+        return llm.calculate_llm_cost_detail(
             model, input_tokens, output_tokens, cached_input_tokens
         )
     if modality == "stt":
-        return stt.calculate_stt_cost(model, audio_seconds)
+        return stt.calculate_stt_cost_detail(model, audio_seconds)
     if modality == "tts":
-        return tts.calculate_tts_cost(model, character_count)
-    return None
+        return tts.calculate_tts_cost_detail(model, character_count)
+    return None, ()
 
 
 def pricing_source(modality: str) -> str:

--- a/src/voicegateway/inference/pricing/llm.py
+++ b/src/voicegateway/inference/pricing/llm.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from decimal import Decimal
 
 import voice_prices
-from voice_prices import Usage, calc_price
+from voice_prices import Usage
+
+from voicegateway.inference.pricing._calc import price_usage
 
 PRICING_SOURCE = f"voice-prices@{voice_prices.__version__}"
 
@@ -25,11 +27,22 @@ def calculate_llm_cost(
     so we clamp it to the prompt total before constructing Usage. Most providers
     discount cached input significantly (OpenAI: 50%, Anthropic: ~10%).
     """
-    if "/" in model:
-        provider, _, ref = model.partition("/")
-    else:
-        provider, ref = "", model
+    return calculate_llm_cost_detail(
+        model, input_tokens, output_tokens, cached_input_tokens
+    )[0]
 
+
+def calculate_llm_cost_detail(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cached_input_tokens: int = 0,
+) -> tuple[Decimal | None, tuple[str, ...]]:
+    """As :func:`calculate_llm_cost`, plus the units that carry no rate.
+
+    See :func:`voicegateway.inference.pricing._calc.price_usage`: a non-empty
+    second element means the total is not fully rate-backed.
+    """
     # voice-prices expects ``input_tokens`` to carry the TOTAL prompt token
     # count (cached subset included) and computes uncached = input - cached
     # internally. Clamp cached to input to avoid the library's negative-uncached
@@ -41,15 +54,4 @@ def calculate_llm_cost(
         output_tokens=output_tokens,
         cache_read_tokens=cached or None,
     )
-    try:
-        price = calc_price(
-            usage,
-            model_ref=ref,
-            provider_id=provider or None,
-        )
-    except LookupError:
-        return None
-    if price is None:
-        return None
-
-    return Decimal(str(price.total_price))
+    return price_usage(usage, model)

--- a/src/voicegateway/inference/pricing/stt.py
+++ b/src/voicegateway/inference/pricing/stt.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from decimal import Decimal
 
 import voice_prices
-from voice_prices import Usage, calc_price
+from voice_prices import Usage
+
+from voicegateway.inference.pricing._calc import price_usage
 
 PRICING_SOURCE = f"voice-prices@{voice_prices.__version__}"
 
@@ -16,19 +18,18 @@ def calculate_stt_cost(model: str, audio_seconds: float) -> Decimal | None:
     Self-hosted ``local/*`` models are intercepted as free upstream in the
     catalog facade and never reach here.
     """
+    return calculate_stt_cost_detail(model, audio_seconds)[0]
+
+
+def calculate_stt_cost_detail(
+    model: str, audio_seconds: float
+) -> tuple[Decimal | None, tuple[str, ...]]:
+    """As :func:`calculate_stt_cost`, plus the units that carry no rate.
+
+    See :func:`voicegateway.inference.pricing._calc.price_usage`: a non-empty
+    second element means the total is not fully rate-backed.
+    """
     if audio_seconds < 0:
         raise ValueError(f"audio_seconds must be non-negative, got {audio_seconds}")
-    if "/" in model:
-        provider, _, ref = model.partition("/")
-    else:
-        provider, ref = "", model
-
     usage = Usage(audio_input_seconds=Decimal(str(audio_seconds)))
-    try:
-        price = calc_price(usage, model_ref=ref, provider_id=provider or None)
-    except LookupError:
-        return None
-    if price is None:
-        return None
-
-    return Decimal(str(price.total_price))
+    return price_usage(usage, model)

--- a/src/voicegateway/inference/pricing/tts.py
+++ b/src/voicegateway/inference/pricing/tts.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from decimal import Decimal
 
 import voice_prices
-from voice_prices import Usage, calc_price
+from voice_prices import Usage
+
+from voicegateway.inference.pricing._calc import price_usage
 
 PRICING_SOURCE = f"voice-prices@{voice_prices.__version__}"
 
@@ -16,19 +18,14 @@ def calculate_tts_cost(model: str, character_count: int) -> Decimal | None:
     Self-hosted ``local/*`` models are intercepted as free upstream in the
     catalog facade and never reach here.
     """
+    return calculate_tts_cost_detail(model, character_count)[0]
+
+
+def calculate_tts_cost_detail(
+    model: str, character_count: int
+) -> tuple[Decimal | None, tuple[str, ...]]:
+    """As :func:`calculate_tts_cost`, plus the units that carry no rate."""
     if character_count < 0:
         raise ValueError(f"character_count must be non-negative, got {character_count}")
-    if "/" in model:
-        provider, _, ref = model.partition("/")
-    else:
-        provider, ref = "", model
-
     usage = Usage(characters=character_count)
-    try:
-        price = calc_price(usage, model_ref=ref, provider_id=provider or None)
-    except LookupError:
-        return None
-    if price is None:
-        return None
-
-    return Decimal(str(price.total_price))
+    return price_usage(usage, model)

--- a/src/voicegateway/middleware/cost_tracker_middleware.py
+++ b/src/voicegateway/middleware/cost_tracker_middleware.py
@@ -102,14 +102,18 @@ class CostTracker:
         input_units: float,
         output_units: float,
         cached_input_units: float,
-    ) -> Decimal | None:
-        """Map recorded units onto the catalog call for ``modality``."""
+    ) -> tuple[Decimal | None, tuple[str, ...]]:
+        """Map recorded units onto the catalog call for ``modality``.
+
+        Returns the catalog's ``(total, unrated_units)`` pair: a non-empty
+        second element means the model matched but no rate was applied.
+        """
         if modality == "stt":
-            return catalog.calculate_cost(
+            return catalog.calculate_cost_detail(
                 "stt", model_id, audio_seconds=input_units * 60
             )
         if modality == "llm":
-            return catalog.calculate_cost(
+            return catalog.calculate_cost_detail(
                 "llm",
                 model_id,
                 input_tokens=int(input_units),
@@ -117,10 +121,10 @@ class CostTracker:
                 cached_input_tokens=int(cached_input_units),
             )
         if modality == "tts":
-            return catalog.calculate_cost(
+            return catalog.calculate_cost_detail(
                 "tts", model_id, character_count=int(input_units)
             )
-        return None
+        return None, ()
 
     def _resolve_cost(
         self,
@@ -129,14 +133,20 @@ class CostTracker:
         input_units: float,
         output_units: float,
         cached_input_units: float,
-    ) -> tuple[float, Decimal | None]:
-        """Return ``(float_cost, raw_decimal_or_None)`` for a request.
+    ) -> tuple[float, Decimal | None, tuple[str, ...]]:
+        """Return ``(float_cost, raw_decimal_or_None, unrated_units)``.
 
-        ``None`` means voice-prices did not recognize the model. A warning is
-        logged for unpriced cloud models; self-hosted ``local/``/``ollama/``
-        models are expected to be free and are not warned about.
+        ``None`` means voice-prices did not recognize the model. A non-empty
+        ``unrated_units`` means it DID recognize the model and applied no rate
+        to those units, so the total is a zero the catalogue never priced.
+        Both are warned about, in different words, because the remedies
+        differ: an unknown model needs a catalogue entry, a rateless match
+        needs a rate on an entry that already exists.
+
+        Self-hosted ``local/``/``ollama/`` models are expected to be free and
+        are not warned about.
         """
-        cost = self._catalog_cost(
+        cost, unrated = self._catalog_cost(
             model_id, modality, input_units, output_units, cached_input_units
         )
         if cost is None:
@@ -146,8 +156,18 @@ class CostTracker:
                     modality,
                     model_id,
                 )
-            return 0.0, None
-        return float(cost), cost
+            return 0.0, None, ()
+        if unrated:
+            logger.warning(
+                "%s model %r matched the catalog but it carries no rate for "
+                "%s; cost recorded as $%s and tagged %r rather than as priced.",
+                modality,
+                model_id,
+                ", ".join(unrated),
+                cost,
+                catalog.UNRATED_SOURCE,
+            )
+        return float(cost), cost, unrated
 
     def calculate_cost(
         self,
@@ -158,7 +178,7 @@ class CostTracker:
         cached_input_units: float = 0.0,
     ) -> float:
         """Calculate cost for a request."""
-        cost, _ = self._resolve_cost(
+        cost, _, _ = self._resolve_cost(
             model_id, modality, input_units, output_units, cached_input_units
         )
         return cost
@@ -183,12 +203,14 @@ class CostTracker:
         revision: str | None = None,
     ) -> RequestRecord:
         """Create a request record with cost calculated."""
-        cost, cost_dec = self._resolve_cost(
+        cost, cost_dec, unrated = self._resolve_cost(
             model_id, modality, input_units, output_units, cached_input_units
         )
         if not pricing_source:
             if model_id.startswith(("local/", "ollama/")):
                 pricing_source = catalog.SELF_HOSTED_SOURCE
+            elif unrated:
+                pricing_source = catalog.UNRATED_SOURCE
             elif cost_dec is not None:
                 pricing_source = catalog.pricing_source(modality)
         rated = self._rate(

--- a/src/voicegateway/server/api/billing.py
+++ b/src/voicegateway/server/api/billing.py
@@ -15,7 +15,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from voicegateway.billing.rate_card import RateCard
 from voicegateway.clickhouse import read_repository as ch_read
-from voicegateway.inference.pricing.catalog import calculate_cost
+from voicegateway.inference.pricing.catalog import (
+    calculate_cost,
+    calculate_cost_detail,
+)
 from voicegateway.inference.pricing.catalog import (
     pricing_source as catalog_pricing_source,
 )
@@ -221,6 +224,25 @@ def _voice_price(modality: str, model: str) -> float | None:
     return float(cost) if cost is not None else None
 
 
+def _unrated(unit: str, units: tuple[str, ...]) -> dict[str, Any]:
+    """The catalogue matched the model and put no rate to it.
+
+    Reported as unpriced rather than as ``$0.00``, because a zero the
+    catalogue never priced is indistinguishable downstream from a model that
+    genuinely costs nothing, and an editor gating on ``priced`` would let the
+    first one through as free. The reason names the units so the remedy is
+    obvious: the entry exists, it needs a rate.
+    """
+    return {
+        "priced": False,
+        "unit": unit,
+        "reason": (
+            f"matched the voice-prices catalog, which carries no rate for "
+            f"{', '.join(units)}"
+        ),
+    }
+
+
 def _voice_prices(modality: str, model: str) -> dict[str, Any]:
     """Unit prices for a model, split by leg where the modality has two.
 
@@ -243,27 +265,33 @@ def _voice_prices(modality: str, model: str) -> dict[str, Any]:
         return {"priced": False, "unit": None, "reason": "unknown modality"}
     unit = spec[0]
     if modality == "llm":
-        inp = calculate_cost(modality, model, input_tokens=1_000_000)
-        out = calculate_cost(modality, model, output_tokens=1_000_000)
+        inp, inp_unrated = calculate_cost_detail(
+            modality, model, input_tokens=1_000_000
+        )
+        out, _ = calculate_cost_detail(modality, model, output_tokens=1_000_000)
         if inp is None and out is None:
             return {
                 "priced": False,
                 "unit": unit,
                 "reason": "not in the voice-prices catalog",
             }
+        if inp_unrated:
+            return _unrated(unit, inp_unrated)
         return {
             "priced": True,
             "unit": unit,
             "input_price_usd": float(inp) if inp is not None else None,
             "output_price_usd": float(out) if out is not None else None,
         }
-    cost = calculate_cost(modality, model, **spec[1])
+    cost, unrated = calculate_cost_detail(modality, model, **spec[1])
     if cost is None:
         return {
             "priced": False,
             "unit": unit,
             "reason": "not in the voice-prices catalog",
         }
+    if unrated:
+        return _unrated(unit, unrated)
     return {"priced": True, "unit": unit, "unit_price_usd": float(cost)}
 
 

--- a/src/voicegateway/tests/pricing/test_rateless_match.py
+++ b/src/voicegateway/tests/pricing/test_rateless_match.py
@@ -1,0 +1,155 @@
+"""A model can match the catalogue and still carry no rate.
+
+``deepgram/nova-general`` matches the catalogue entry ``nova``, whose
+``ModelPrice`` has every field ``None``. ``calc_price`` raises nothing, applies
+nothing, and returns a total of ``Decimal('0')``. Before this change the row
+was stamped ``voice-prices@<version>``, which asserts the catalogue priced it.
+It did not. Downstream the row was indistinguishable from a model that
+genuinely costs nothing, and it was the only zero in the system that logged no
+warning.
+
+That is the fourth state the three-state design could not express:
+
+    voice-prices@<version>   priced, rate-backed
+    voicegateway-local       free because it runs on your hardware
+    ""                       unknown model, nothing to price it with
+    voice-prices-unrated     matched, and no rate was applied      <- this
+
+The tag deliberately makes no claim about WHY there is no rate. In
+voice-prices 0.6.0, 139 catalogue entries are rateless and 131 of them are
+``:free`` models where zero is correct; the catalogue records no field
+separating those from the 8 that are simply missing a rate. A meter that
+cannot tell them apart must not pick one, so it reports what it observed.
+
+These tests skip rather than fail when the installed catalogue has no rateless
+entry, because whether one exists is a fact about the catalogue rather than
+about this code. voice-prices 0.3.0 raises ``LookupError`` for these refs and
+takes the honest path already.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from voicegateway.inference.pricing import catalog
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
+
+# A rateless match if the installed catalogue has one, checked at runtime.
+_CANDIDATES = ("deepgram/nova-general", "deepgram/whisper-tiny")
+
+
+def _rateless_model() -> str | None:
+    for ref in _CANDIDATES:
+        _, unrated = catalog.calculate_cost_detail("stt", ref, audio_seconds=60)
+        if unrated:
+            return ref
+    return None
+
+
+@pytest.fixture
+def rateless() -> str:
+    model = _rateless_model()
+    if model is None:
+        pytest.skip("installed voice-prices has no rateless STT entry to exercise")
+    return model
+
+
+# --------------------------------------------------------------------------
+# The catalogue facade reports the distinction
+# --------------------------------------------------------------------------
+
+
+def test_a_rateless_match_reports_the_units_it_could_not_price(rateless) -> None:
+    cost, unrated = catalog.calculate_cost_detail("stt", rateless, audio_seconds=600)
+    assert cost == 0
+    assert unrated, "a rateless match must name the units it could not price"
+
+
+def test_a_rated_model_reports_nothing_unrated() -> None:
+    cost, unrated = catalog.calculate_cost_detail(
+        "stt", "deepgram/nova-3", audio_seconds=600
+    )
+    assert cost and cost > 0
+    assert unrated == ()
+
+
+def test_an_unknown_model_is_still_none_not_a_rateless_zero() -> None:
+    """The two must not collapse: they have different remedies.
+
+    An unknown model needs a catalogue entry. A rateless match has an entry
+    already and needs a rate on it.
+    """
+    cost, unrated = catalog.calculate_cost_detail(
+        "stt", "nobody/made-this-up", audio_seconds=600
+    )
+    assert cost is None
+    assert unrated == ()
+
+
+# --------------------------------------------------------------------------
+# The recorded row stops claiming provenance it does not have
+# --------------------------------------------------------------------------
+
+
+def test_the_row_is_tagged_unrated_rather_than_priced(rateless) -> None:
+    record = CostTracker().create_record(
+        model_id=rateless, modality="stt", provider="deepgram", input_units=10.0
+    )
+    assert record.cost_usd == 0.0
+    assert record.pricing_source == catalog.UNRATED_SOURCE
+    assert not record.pricing_source.startswith("voice-prices@"), (
+        "the tag must not read as a priced row to anything matching on the "
+        "voice-prices@ prefix"
+    )
+
+
+def test_the_four_states_are_all_distinguishable(rateless) -> None:
+    """The point of the change, stated as four different strings."""
+    tracker = CostTracker()
+
+    def source(model: str) -> str:
+        return tracker.create_record(
+            model_id=model,
+            modality="stt",
+            provider=model.split("/")[0],
+            input_units=10.0,
+        ).pricing_source
+
+    priced = source("deepgram/nova-3")
+    unrated = source(rateless)
+    unknown = source("nobody/made-this-up")
+    self_hosted = source("local/whisper")
+
+    assert len({priced, unrated, unknown, self_hosted}) == 4
+    assert priced.startswith("voice-prices@")
+    assert unrated == catalog.UNRATED_SOURCE
+    assert unknown == ""
+    assert self_hosted == catalog.SELF_HOSTED_SOURCE
+
+
+def test_a_rateless_match_warns(rateless, caplog) -> None:
+    """It was the only zero in the system that logged nothing.
+
+    The warning names the units, because the remedy is to put a rate on an
+    entry that already exists rather than to add the model.
+    """
+    with caplog.at_level(logging.WARNING):
+        CostTracker().create_record(
+            model_id=rateless, modality="stt", provider="deepgram", input_units=10.0
+        )
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("carries no rate" in m for m in messages), messages
+    assert any(rateless in m for m in messages), messages
+
+
+def test_a_priced_model_does_not_warn(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        CostTracker().create_record(
+            model_id="deepgram/nova-3",
+            modality="stt",
+            provider="deepgram",
+            input_units=10.0,
+        )
+    assert not caplog.records


### PR DESCRIPTION
Item 2 of the follow-ups. **Stacked on #266** (`base: fix/lock-pin-divergence`), because the bug is only reachable under voice-prices 0.6.0 and #266 is what makes that the tested version. Merge #266 first.

## The bug

A model can match the catalogue and still carry no rate. `deepgram/nova-general` matches the entry `nova`, whose `ModelPrice` has every field `None`:

```
calc_price(nova-general, deepgram) -> total=0, unpriced_usage=('audio_input_seconds',)
```

Nothing raises, no rate is applied, the total is zero. The row was stamped `voice-prices@0.6.0`, asserting the catalogue priced it. It did not.

Two consequences. Downstream that row is indistinguishable from a model that genuinely costs nothing, and it was **the only zero in the system that logged no warning**. On the read side `/rate-card/quote` returned `priced: true, unit_price_usd: 0.0`, so an editor gating on `priced` would have let it through as free.

**Reachable now, not latent.** Under 0.3.0 these refs raise `LookupError` and take the honest path. 0.6.0 rewrote the Deepgram matchers so `nova` and `whisper` became prefix catch-alls with empty prices, which is why this surfaces with #266.

## The fix, and what it deliberately does not do

A fourth `pricing_source`:

| value | meaning |
|---|---|
| `voice-prices@<version>` | priced, rate-backed |
| `voicegateway-local` | free because it runs on your hardware |
| `""` | unknown model, nothing to price it with |
| **`voice-prices-unrated`** | **matched, and no rate was applied** |

**The tag makes no claim about why there is no rate.** I checked all 1400 catalogue entries: 139 are rateless, and **131 of those are `:free` models where zero is the correct answer**. Only 8 are genuinely missing a rate:

```
cerebras/qwen-3-coder-480b   deepgram/nova    deepgram/whisper    google/gemma-3
google/gemma-3n              telnyx/us-tollfree-outbound
openrouter/gemini-2.5-pro-exp-03-25          huggingface_together/...Apriel-1.6-15b-Thinker
```

The catalogue records no field separating the two. So reporting all 139 as unpriced would break 131 correct answers to fix 8, and trusting all 139 is the bug. A meter that cannot tell them apart must not pick one: it reports what it observed and leaves the distinction to whoever knows the contract. Resolving it properly belongs upstream in voice-prices.

## Incidental cleanup that is actually the root

`llm.py`, `stt.py` and `tts.py` each duplicated split / build `Usage` / `calc_price` / collapse to `Decimal | None`, and it was that collapse that discarded the signal. They now share `_calc.price_usage`, which returns the total **and** the units no rate was put to. `getattr(price, "unpriced_usage", ())` because the attribute arrived in 0.6.0 and the floor pin still admits 0.3.0.

`calculate_cost` is unchanged in signature and behaviour; `calculate_cost_detail` is the new one, and the docs now say to prefer it anywhere the answer feeds a price display or a gate.

## Docs

`cost-tracking.md` claimed *"All three modalities return `None` for unknown models (never silent zero)"* — the exact belief this disproves. Corrected. The `$0.00` triage table in `cloud-rows-not-appearing.md` listed three causes; there are four.

## Verification

- `3601 passed, 23 skipped, 36 deselected`
- `mypy` clean on 291 files, `ruff` clean, docs validator PASS (81 pages)
- New tests skip rather than fail when the installed catalogue has no rateless entry, since that is a fact about the catalogue and not about this code. Under 0.3.0 they skip; under 0.6.0 they exercise the real path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves catalogue matches that lack applicable rates instead of collapsing them into confidently priced zeroes.
- Adds detailed pricing helpers that return both the calculated total and unrated usage fields.
- Tags tracked requests with `voice-prices-unrated` and emits a warning when no rate was applied.
- Updates rate-card quoting, tests, and documentation for the additional pricing state.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because LLM quotes can still classify an unrated output leg as fully priced.

The quote implementation checks unrated metadata only for the input calculation and discards the output calculation's metadata before returning the whole model as priced.

**Files Needing Attention:** src/voicegateway/server/api/billing.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/voicegateway/inference/pricing/_calc.py | Centralizes catalogue lookup and preserves the library's unrated-usage metadata alongside the total. |
| src/voicegateway/inference/pricing/catalog.py | Adds the detailed pricing facade and the `voice-prices-unrated` source classification while preserving existing cost APIs. |
| src/voicegateway/middleware/cost_tracker_middleware.py | Propagates unrated units into request provenance and emits a warning for matched catalogue entries without applicable rates. |
| src/voicegateway/server/api/billing.py | Updates rate-card catalogue quotes to represent rateless matches as unpriced. |
| src/voicegateway/tests/pricing/test_rateless_match.py | Covers detailed rateless pricing, request provenance, warning behavior, and separation of the four pricing states. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Recorded usage] --> B[calculate_cost_detail]
    B --> C{Catalogue match?}
    C -- No --> D[Unknown model]
    C -- Yes --> E{All recorded units rated?}
    E -- Yes --> F[Priced total]
    E -- No --> G[Unrated total and unit names]
    G --> H[voice-prices-unrated]
    G --> I[Quote priced false]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/mahimailabs/voicegateway/commit/e8bb51cf069dffa12f8c5da63cd02ab85875948a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55426549)</sub>

<!-- /greptile_comment -->