### PR TITLE
docs: describe the fourth pricing state everywhere it is listed

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -64,7 +64,7 @@ The primary table for every completed (or failed) inference request. ORM class `
 | `output_units` | REAL | Output tokens (LLM only) |
 | `cached_input_units` | REAL | Prompt tokens served from the provider's cache (LLM only; 0 for STT/TTS) |
 | `cost_usd` | REAL | Recorded provider cost |
-| `pricing_source` | TEXT | e.g. `"voice-prices@0.1.0"` or `"voicegateway-local"` |
+| `pricing_source` | TEXT | `"voice-prices@<version>"` priced, `"voice-prices-unrated"` matched with no rate, `"voicegateway-local"` self-hosted, `""` unknown model |
 | `rated_price_usd` | REAL | Billable price the rate card stamped at write time; see [Rating](/architecture/rating) |
 | `rate_rule` | TEXT | Audit token for the rule applied, e.g. `"cost_plus:1.3"` |
 | `ttfb_ms` | REAL | Time to first byte in milliseconds |

--- a/docs/cli/export-costs.md
+++ b/docs/cli/export-costs.md
@@ -37,7 +37,7 @@ Both formats share this 10-column schema, rows ordered by timestamp ascending:
 | `input_units` | Tokens (LLM input), minutes (STT), or characters (TTS). |
 | `output_units` | Tokens (LLM output); `0` for STT/TTS. |
 | `calculated_cost_usd` | Fixed-point USD string, priced through `voice-prices`. |
-| `pricing_source` | `voice-prices@<version>` for cloud models, `voicegateway-local` for `local/*`/`ollama/*`, empty for unknown. |
+| `pricing_source` | `voice-prices@<version>` for priced cloud models, `voice-prices-unrated` when the catalogue matched the model but holds no rate for it, `voicegateway-local` for `local/*`/`ollama/*`, empty for unknown. |
 | `status` | `ok` or an error tag. |
 
 `--format json` writes JSONL (one object per line, no outer array).

--- a/docs/contributing/refreshing-pricing.md
+++ b/docs/contributing/refreshing-pricing.md
@@ -16,8 +16,15 @@ The pricing wrappers that call into it are:
 
 Each resolves a `provider/model` id against `voice-prices` and returns the
 computed cost. The per-request attribution string is `voice-prices@<version>`
-for priced models and `voicegateway-local` for self-hosted (`local/*`,
-`ollama/*`) models.
+for priced models, `voicegateway-local` for self-hosted (`local/*`, `ollama/*`)
+models, and empty when the model is unknown.
+
+A fourth value, `voice-prices-unrated`, means the catalogue matched the model
+and carries no rate for it, so the zero it returned is not a price. Some
+entries match by prefix and hold no rates at all: `deepgram/nova-general`
+matches the entry `nova`, whose price fields are empty. Those are the entries
+a refresh should prioritise, because unlike an unknown model they already have
+a home in the catalogue and only need a rate put on them.
 
 ## When a refresh is required
 

--- a/docs/guide/what-is-voicegateway.md
+++ b/docs/guide/what-is-voicegateway.md
@@ -109,7 +109,8 @@ emits, and the model id decides what happens next:
 | Model id | Cost | Pricing source |
 |---|---|---|
 | starts with `local/` or `ollama/` | always `0` | `voicegateway-local` |
-| known to `voice-prices` | the catalog rate | `voice-prices@<version>` |
+| known to `voice-prices`, with a rate | the catalog rate | `voice-prices@<version>` |
+| known to `voice-prices`, no rate recorded | `0`, but not a price | `voice-prices-unrated` |
 | anything else | none, the row is metered but unpriced | empty |
 
 The Costs page shows that source per row, so you can always tell which case you landed


### PR DESCRIPTION
Follow-through on #267, which was incomplete.

#267 added `voice-prices-unrated` and updated the two pages that explain `$0.00` triage. Four other pages enumerate the `pricing_source` values and still listed three:

| Page | Was |
|---|---|
| `guide/what-is-voicegateway.md` | 3-row table of model id to pricing source |
| `contributing/refreshing-pricing.md` | "`voice-prices@<version>` for priced models and `voicegateway-local` for self-hosted" |
| `architecture/storage.md` | `requests.pricing_source` column comment |
| `cli/export-costs.md` | the exported column's description |

A reader landing on any of them would conclude a zero is either self-hosted, catalogue-priced, or unknown, and would file a rateless match under the wrong one.

`refreshing-pricing.md` gets the version that is actually actionable: a rateless entry is the case a pricing refresh should **prioritise**, because unlike an unknown model it already has a catalogue entry and only needs a rate put on it. `deepgram/nova-general` matching the rateless `nova` entry is the worked example.

Docs only, no code. Validator PASS (81 pages).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consistently documents the fourth `pricing_source` state, `voice-prices-unrated`, across storage, export, contributor, and introductory documentation.
- Distinguishes catalogue matches without rates from priced, self-hosted, and unknown models.
- Adds actionable pricing-refresh guidance and a concrete rateless-model example.
- Aligns all four pages with the pricing attribution values emitted and persisted by the current implementation.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge, with the new pricing state described consistently with current runtime behavior.

The changed pages accurately distinguish priced catalogue matches, unrated catalogue matches, self-hosted models, and unknown models, and no actionable changed-code defect remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/architecture/storage.md | Expands the `requests.pricing_source` schema description to accurately enumerate all four persisted attribution states. |
| docs/cli/export-costs.md | Documents the unrated catalogue-match value in the exported `pricing_source` column without changing the export schema. |
| docs/contributing/refreshing-pricing.md | Explains the unrated state and why catalogue entries lacking rates should be prioritized during pricing refreshes. |
| docs/guide/what-is-voicegateway.md | Adds the unrated catalogue-match case to the introductory model-cost decision table. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: describe the fourth pricing state ..."](https://github.com/mahimailabs/voicegateway/commit/ee7bbedfd760687443d3f74caac68f8edadf721d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55434898)</sub>

<!-- /greptile_comment -->