### PR TITLE
feat(billing): gate model enablement on a declared rate, and list the gaps

### DIFF
--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -425,6 +425,43 @@ Distinct models seen in telemetry, each with its `voice-prices` unit cost and th
 curl http://localhost:8080/v1/billing/rate-card/models
 ```
 
+### GET /v1/billing/rate-card/quote
+
+Price a model **before it has run**. `/rate-card/models` answers only for models already in telemetry, because it is fed by the requests table, and an agent-config editor picks a model before any call exists.
+
+Query: `modality`, `model` (`provider/model`), `tenant?`, `plan?`.
+
+```json
+{
+  "modality": "stt",
+  "provider": "deepgram",
+  "model": "deepgram/nova-3",
+  "serviceable": false,
+  "priced_by": "catalog",
+  "gate": "declared_only",
+  "catalog": { "priced": true, "unit": "minute", "unit_price_usd": 0.0043 },
+  "effective": null
+}
+```
+
+- **`serviceable`** — can this model be offered to end users. This is the field a consumer UI gates enablement on.
+- **`priced_by`** — `operator` (a rate someone declared), `catalog` (a published list price), or `none`.
+- **`gate`** — the policy that produced `serviceable`, from [`pricing.gate`](/configuration/voicegw-yaml). Echoed because `serviceable` is a policy answer rather than a fact: under the default `declared_only` a catalogue price does **not** make a model serviceable, and a consumer written against `permissive` would otherwise misread it.
+- **`catalog`** — what `voice-prices` says, for prefilling the operator's input. `priced` is `false` both for an unknown model and for one the catalogue matched but holds no rate for.
+- **`effective`** — the rate rule that would apply, or `null`.
+
+`POST /v1/billing/rate-card/quote` takes `{"models": [{modality, model, tenant?, plan?}, ...]}` (max 200) and returns the same shape per entry under `models`, so an editor prices a whole dropdown in one call and gets the same gate.
+
+### GET /v1/billing/rate-card/gaps
+
+Models that have run and cannot be priced, heaviest first. The work list for operator-declared pricing.
+
+Query: `tenant?`, `project?`, `since?` (ISO date). Each entry carries `requests`, `input_units`, `output_units`, `last_seen`, and the two gap kinds split apart: `unknown_requests` (the catalogue does not carry the model) and `unrated_requests` (it matched the model and holds no rate for it).
+
+Only billable rows count: non-error requests that moved units, so end-of-utterance timing rows do not appear.
+
+The response carries `caveat_before`, stating that rows which matched the catalogue with no rate were recorded as priced before v0.25.6, so a window spanning that release under-reports `unrated_requests`. A gap list that was ever silently short is one nobody trusts twice, and a reader cannot tell that from the numbers.
+
 ### GET /v1/billing/rate-card/rules
 
 Return the editable DB override rules, each with its `rule_id`. Use this to drive an editor (the seed rules in `GET /rate-card` have no `rule_id`; only DB overrides are mutable).

--- a/docs/cli/prices.md
+++ b/docs/cli/prices.md
@@ -8,6 +8,26 @@ Inspect and reconcile the billing rate card that turns recorded provider cost in
 
 `voicegw prices` is the command group for VoiceGateway's rating layer. The rate card maps recorded cost to a billable price and stamps that price immutably onto every request row (`rated_price_usd` + `rate_rule`). The card has two layers: the `rate_card:` seed in `voicegw.yaml` plus DB overrides you set at runtime with `set` (one store, both surfaces). `ls` prints the effective card (seed + overrides), `reconcile` rolls up rated revenue against recorded cost per tenant, `sync` checks fixed-price rules against the current base cost, and `set` / `rm` edit the DB overrides. The full model (cost-plus vs fixed, tenant->plan->global resolution, write-time immutability) lives at [Rating](/architecture/rating).
 
+## `voicegw prices gaps`
+
+```bash
+voicegw prices gaps [--tenant X] [--project Y] [--since 2026-08-01] [--limit 20]
+```
+
+Models that have run and cannot be priced, heaviest first. This is the work list for operator-declared pricing: which models still need a rate typed in, ordered by how much traffic is currently going unpriced, so the task is finite rather than discovered one dashboard row at a time.
+
+The `gap` column names which of two problems each row has, because the remedies differ:
+
+- **`not in catalog`** — `voice-prices` does not carry the model. It needs a catalogue entry, or an operator rate.
+- **`matched, no rate`** — the catalogue matched the model and holds no rate for it. `deepgram/nova-general` matches the entry `nova`, whose price fields are empty. The entry exists already and only needs a rate put on it, so these are usually the cheapest gaps to close.
+
+Only billable rows count: non-error requests that moved units. End-of-utterance rows carry no model and an empty pricing source, and would otherwise dominate the list with something nobody can put a price on.
+
+<Warning>
+Rows whose model matched the catalogue but carried no rate were recorded as priced before v0.25.6, so a window spanning that release under-reports the `matched, no rate` column.
+</Warning>
+
+
 ## Usage
 
 ```bash

--- a/docs/configuration/voicegw-yaml.md
+++ b/docs/configuration/voicegw-yaml.md
@@ -288,7 +288,24 @@ The single most specific matching rule wins. Precedence is `tenant > plan > glob
 
 Rating happens once, at write time, on the server (`voicegw serve`). The `rated_price_usd` and `rate_rule` audit token (for example `cost_plus:1.3`, `fixed:0.006/minute`, `fixed:in=2.5,cached=1.25,out=10/1m_token`, or `default:1`) are stamped onto the row and never rewritten: editing the card later never changes historical rows. Inspect and reconcile the card with the [`voicegw prices`](/cli/prices) commands.
 
+
 ---
+
+## `pricing`
+
+```yaml
+pricing:
+  gate: declared_only   # or: permissive
+```
+
+Controls what `serviceable` means on `GET`/`POST /v1/billing/rate-card/quote`, which is the single field a consumer UI gates model enablement on.
+
+- **`declared_only`** (default): only a rate an operator entered counts. A model nobody has priced is not offerable, even when the catalogue carries a published price for it.
+- **`permissive`**: any rate counts, including the catalogue's.
+
+The default is strict because a catalogue price is a public list price, wrong by an unknown margin for anyone on a negotiated contract. Treating one as sufficient means nobody ever has to declare theirs, which is the thing the rate card exists to collect. The cost is an empty slate on day one; [`voicegw prices gaps`](/cli/prices) and the catalogue prefill on the quote endpoint exist to make that short.
+
+The quote response echoes `gate` alongside `serviceable`, because `serviceable` is a policy answer rather than a fact, and a consumer written against the other setting would otherwise misread it. `priced_by` (`operator` / `catalog` / `none`) reports where the rate came from under either policy, so a UI can badge list-priced models rather than presenting them as declared.
 
 ## `latency`
 

--- a/src/voicegateway/cli/prices_cli.py
+++ b/src/voicegateway/cli/prices_cli.py
@@ -7,9 +7,12 @@ Subcommands:
                   thin or negative margins.
 * ``sync``      - check each fixed ($/unit) rule against the current
                   voice-prices base cost; cost-plus rules auto-follow.
+* ``gaps``      - models that have run and cannot be priced, heaviest first.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import typer
 from rich.table import Table
@@ -19,6 +22,7 @@ from voicegateway.billing.reconcile import margin_reconcile, sync_fixed_rules
 from voicegateway.cli._app import app, console
 from voicegateway.cli.base_cli import BaseCli
 from voicegateway.inference.pricing import catalog
+from voicegateway.repository import request_log_repository
 from voicegateway.repository.managed_rate_rule_repository import scope_key
 from voicegateway.utils.cli._shared import _parse_iso_date_arg
 
@@ -252,3 +256,69 @@ def rm_cmd(
         console.print(f"[green]removed[/green] rule [bold]{rid}[/bold]")
     else:
         _cli.fail(f"no DB override for scope {rid!r}", code=2)
+
+
+@prices_app.command("gaps")
+def gaps_cmd(
+    config: str | None = typer.Option(
+        None, "--config", "-c", help="Path to voicegw.yaml."
+    ),
+    tenant: str | None = typer.Option(None, "--tenant", help="Limit to one tenant."),
+    project: str | None = typer.Option(None, "--project", help="Limit to one project."),
+    since: str | None = typer.Option(
+        None, "--since", help="ISO date; only count rows at or after it."
+    ),
+    limit: int = typer.Option(20, "--limit", help="Rows to show."),
+) -> None:
+    """Models that have run and cannot be priced, heaviest first.
+
+    The work list for operator-declared pricing: which models still need a
+    rate typed in, ordered by how much traffic is going unpriced, so the job
+    is finite instead of discovered one dashboard row at a time.
+    """
+    gw = _cli.require_gateway(config)
+    storage = gw.storage
+    if storage is None:
+        console.print("Storage is not enabled; there is nothing to report.")
+        return
+    since_ts = _parse_iso_date_arg(since, end_of_day=False) if since else None
+
+    async def _read() -> list[dict[str, Any]]:
+        await storage._ensure_initialized()
+        async with storage._conn.session() as db:
+            return await request_log_repository.read_pricing_gaps(
+                db, tenant=tenant, project=project, since_ts=since_ts
+            )
+
+    rows = _cli.async_run(_read())
+    if not rows:
+        console.print("[bold]No pricing gaps.[/bold] Every metered model has a rate.")
+        return
+
+    table = Table(title="Pricing gaps (heaviest first)")
+    for col in ("model", "modality", "requests", "units in/out", "gap"):
+        table.add_column(col)
+    for row in rows[:limit]:
+        # The two gaps have different remedies, so the table names which one
+        # rather than collapsing both into "unpriced".
+        if row["unknown_requests"] and row["unrated_requests"]:
+            gap = "not in catalog + no rate"
+        elif row["unrated_requests"]:
+            gap = "matched, no rate"
+        else:
+            gap = "not in catalog"
+        table.add_row(
+            row["model"],
+            row["modality"],
+            str(row["requests"]),
+            f"{row['input_units']:.0f}/{row['output_units']:.0f}",
+            gap,
+        )
+    console.print(table)
+    if len(rows) > limit:
+        console.print(f"... and {len(rows) - limit} more; raise --limit to see them.")
+    console.print(
+        "\n[dim]Rows whose model matched the catalog but carried no rate were "
+        "recorded as priced before v0.25.6, so a window spanning that release "
+        "under-reports the 'matched, no rate' column.[/dim]"
+    )

--- a/src/voicegateway/core/config.py
+++ b/src/voicegateway/core/config.py
@@ -14,6 +14,7 @@ import yaml
 from voicegateway.schemas.config_schema import (
     ClickHouseConfig,
     IngestConfig,
+    PricingConfig,
     RetentionConfig,
     VoiceGatewayConfig,
     WorkersConfig,
@@ -166,6 +167,10 @@ class GatewayConfig:
     # Billing: the ``rate_card:`` seed (default_markup + rules). Kept as a raw
     # dict; the gateway builds a RateCard via RateCard.from_config at wiring.
     rate_card: dict[str, Any] = field(default_factory=dict)
+    # Whether a model is offerable before an operator has declared its rate.
+    # See PricingConfig: the default is strict because it propagates to every
+    # consumer that gates on ``serviceable``.
+    pricing: PricingConfig = field(default_factory=PricingConfig)
 
     @classmethod
     def load(
@@ -387,6 +392,7 @@ class GatewayConfig:
             workers=WorkersConfig.model_validate(raw.get("workers") or {}),
             clickhouse=ClickHouseConfig.model_validate(raw.get("clickhouse") or {}),
             rate_card=raw.get("rate_card", {}) or {},
+            pricing=PricingConfig.model_validate(raw.get("pricing") or {}),
         )
 
     def get_provider_config(self, provider_name: str) -> dict[str, Any]:

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -667,8 +667,94 @@ async def read_models_in_use(session: AsyncSession) -> list[dict[str, str]]:
     return rows
 
 
+async def read_pricing_gaps(
+    session: AsyncSession,
+    *,
+    tenant: str | None = None,
+    project: str | None = None,
+    since_ts: float | None = None,
+) -> list[dict[str, Any]]:
+    """Models that have run and cannot be priced, heaviest first.
+
+    The operator-declared-pricing design asks a person to type a rate per
+    model. This is the list telling them WHICH models, ordered by how much
+    traffic is currently going unpriced, so the work is finite and prioritised
+    rather than discovered one dashboard row at a time.
+
+    Two distinct gaps, reported separately because the remedies differ:
+
+    * ``unknown_requests`` - the catalogue does not carry the model at all.
+    * ``unrated_requests`` - the catalogue MATCHED the model and holds no rate
+      for it (``deepgram/nova-general`` matching the rateless ``nova`` entry).
+
+    The second kind was invisible before ``voice-prices-unrated`` existed: those
+    rows carried full ``voice-prices@<version>`` provenance, so a gap report
+    would have counted them as priced and under-reported exactly the prefix
+    catch-alls that swallow the most traffic.
+
+    Filtered to BILLABLE rows, using the same predicate as the billable count
+    in ``cost_repository``: a non-error row that moved units. Without it the
+    list is dominated by ``eou`` timing rows, which carry no model and an empty
+    ``pricing_source`` and are not something anyone can put a price on.
+    """
+    where = [
+        "pricing_source IN ('', 'voice-prices-unrated')",
+        "modality IN ('stt', 'llm', 'tts')",
+        "model_id != ''",
+        "status != 'error'",
+        "(COALESCE(input_units, 0) + COALESCE(output_units, 0)) > 0",
+    ]
+    params: dict[str, Any] = {}
+    if tenant is not None:
+        where.append("tenant_id = :tenant")
+        params["tenant"] = tenant
+    if project is not None:
+        where.append("project = :project")
+        params["project"] = project
+    if since_ts is not None:
+        where.append("timestamp >= :since_ts")
+        params["since_ts"] = since_ts
+
+    sql = text(f"""
+        SELECT modality, provider, model_id,
+               COUNT(*) AS requests,
+               SUM(COALESCE(input_units, 0)) AS input_units,
+               SUM(COALESCE(output_units, 0)) AS output_units,
+               MAX(timestamp) AS last_seen,
+               SUM(CASE WHEN pricing_source = '' THEN 1 ELSE 0 END)
+                   AS unknown_requests,
+               SUM(CASE WHEN pricing_source = 'voice-prices-unrated'
+                        THEN 1 ELSE 0 END) AS unrated_requests
+        FROM requests
+        WHERE {" AND ".join(where)}
+        GROUP BY modality, provider, model_id
+        ORDER BY requests DESC, last_seen DESC
+    """)
+    result = await session.execute(sql, params)
+    rows: list[dict[str, Any]] = []
+    for r in result.mappings():
+        model = r["model_id"]
+        if r["provider"] and "/" not in model:
+            model = f"{r['provider']}/{model}"
+        rows.append(
+            {
+                "modality": r["modality"],
+                "provider": r["provider"] or "",
+                "model": model,
+                "requests": int(r["requests"]),
+                "input_units": float(r["input_units"] or 0.0),
+                "output_units": float(r["output_units"] or 0.0),
+                "last_seen": float(r["last_seen"] or 0.0),
+                "unknown_requests": int(r["unknown_requests"] or 0),
+                "unrated_requests": int(r["unrated_requests"] or 0),
+            }
+        )
+    return rows
+
+
 __all__ = [
     "get_audit_log",
+    "read_pricing_gaps",
     "get_recent_requests",
     "get_requests_for_room",
     "get_requests_in_window",

--- a/src/voicegateway/schemas/config_schema.py
+++ b/src/voicegateway/schemas/config_schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import difflib
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -77,6 +77,35 @@ class TenantConfig(_StrictBase):
     """Multi-tenant attribution knobs."""
 
     api_key_stale_days: int = Field(default=90, ge=1)
+
+
+class PricingConfig(_StrictBase):
+    """Whether a model can be offered before someone has declared its rate.
+
+    ``gate`` decides what ``serviceable`` means on the rate-card quote
+    endpoints, which is the single field a consumer UI will gate enablement
+    on. The two values encode a product decision, not a preference:
+
+    ``declared_only`` (default)
+        Only a rate an operator entered counts. A model nobody has priced is
+        not offerable. This is the design's actual claim: a catalogue list
+        price is wrong by an unknown margin for anyone on a negotiated
+        contract, so treating one as sufficient defeats the purpose of asking.
+        The cost is a blank slate on day one, which ``voicegw prices gaps``
+        and catalogue prefill exist to make short.
+
+    ``permissive``
+        Any rate counts, including the catalogue's. Everything works
+        immediately, and an operator who declares nothing bills off list
+        prices without being stopped. ``priced_by`` still reports which rows
+        came from the catalogue so a UI can badge them.
+
+    The default is strict because the default propagates: every consumer that
+    gates on ``serviceable`` inherits it, and a permissive default would ship
+    list-price billing to all of them unless each independently noticed.
+    """
+
+    gate: Literal["declared_only", "permissive"] = "declared_only"
 
 
 class IngestConfig(_StrictBase):
@@ -319,6 +348,7 @@ _VALID_TOP_LEVEL_KEYS = {
     "workers",
     "clickhouse",
     "rate_card",
+    "pricing",
 }
 
 
@@ -346,6 +376,7 @@ class VoiceGatewayConfig(BaseModel):
     workers: WorkersConfig = Field(default_factory=WorkersConfig)
     clickhouse: ClickHouseConfig = Field(default_factory=ClickHouseConfig)
     rate_card: RateCardConfig = Field(default_factory=RateCardConfig)
+    pricing: PricingConfig = Field(default_factory=PricingConfig)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/voicegateway/server/api/billing.py
+++ b/src/voicegateway/server/api/billing.py
@@ -233,6 +233,41 @@ def _voice_price(modality: str, model: str) -> float | None:
     return float(cost) if cost is not None else None
 
 
+def _serviceability(catalog: dict[str, Any], rule: Any, gate: str) -> dict[str, Any]:
+    """Can this model be offered, on whose number, and under which rule?
+
+    The gate a consumer UI needs before it lists a model. It was answerable
+    already, by checking ``effective is not None`` and falling back to reading
+    ``catalog.priced``, but every caller had to reconstruct it and each one
+    could reconstruct it differently.
+
+    ``priced_by`` matters as much as ``serviceable``. A rate the operator
+    declared is what they actually pay; a catalogue rate is a public list
+    price that is wrong by an unknown margin for anyone on a negotiated
+    contract. A UI that cannot tell them apart cannot tell the operator which
+    models still need their attention.
+
+    ``gate`` is echoed back because ``serviceable`` is a policy answer, not a
+    fact, and a boolean whose meaning is configurable is a boolean that gets
+    misread. Under ``declared_only`` a catalogue price does NOT make a model
+    serviceable; under ``permissive`` it does. Returning the policy alongside
+    the verdict means a consumer can never mistake one for the other.
+
+    ``catalog.priced`` is false for a model the catalogue matched but holds no
+    rate for, so a rateless match lands on ``none`` under either policy rather
+    than being offered as free.
+    """
+    if rule is not None:
+        return {"serviceable": True, "priced_by": "operator", "gate": gate}
+    if catalog.get("priced"):
+        return {
+            "serviceable": gate == "permissive",
+            "priced_by": "catalog",
+            "gate": gate,
+        }
+    return {"serviceable": False, "priced_by": "none", "gate": gate}
+
+
 def _unrated(unit: str, units: tuple[str, ...]) -> dict[str, Any]:
     """The catalogue matched the model and put no rate to it.
 
@@ -350,6 +385,7 @@ async def rate_card_quote(
         "provider": provider,
         "model": model,
         "pricing_source": catalog_pricing_source(modality),
+        **_serviceability(price, rule, gateway.config.pricing.gate),
         "catalog": price,
         "effective": _serialize_rule(rule) if rule is not None else None,
     }
@@ -371,6 +407,7 @@ async def rate_card_quote_bulk(
     if len(items) > 200:
         raise HTTPException(413, f"too many models: {len(items)} exceeds 200")
     card = await _effective_card(gateway) if gateway.storage is not None else None
+    gate = gateway.config.pricing.gate
     out: list[dict[str, Any]] = []
     for item in items:
         if not isinstance(item, dict):
@@ -389,17 +426,60 @@ async def rate_card_quote_bulk(
             if card is not None
             else None
         )
+        catalog_price = _voice_prices(modality, model)
         out.append(
             {
                 "modality": modality,
                 "provider": provider,
                 "model": model,
                 "pricing_source": catalog_pricing_source(modality),
-                "catalog": _voice_prices(modality, model),
+                **_serviceability(catalog_price, rule, gate),
+                "catalog": catalog_price,
                 "effective": _serialize_rule(rule) if rule is not None else None,
             }
         )
     return {"models": out}
+
+
+@router.get("/rate-card/gaps")
+async def rate_card_gaps(
+    tenant: str | None = Query(None),
+    project: str | None = Query(None),
+    since: str | None = Query(None, description="ISO date; only rows at or after"),
+    gateway: Gateway = Depends(get_gateway),
+) -> dict[str, Any]:
+    """Models that have run and cannot be priced, heaviest first.
+
+    The work list for operator-declared pricing. Someone has to type a rate per
+    model; this says which models, ordered by how much traffic is currently
+    going unpriced, so the task is finite and prioritised instead of being
+    discovered one dashboard row at a time.
+
+    Each entry splits the two kinds of gap, because the remedies differ:
+    ``unknown_requests`` means the catalogue does not carry the model at all,
+    ``unrated_requests`` means it matched the model and holds no rate for it.
+
+    ``caveat_before`` is part of the response on purpose. Rateless matches used
+    to be stamped with full catalogue provenance, so this report would have
+    counted them as priced. A gap list that was ever silently short is one
+    nobody trusts twice, and the reader cannot know that from the numbers.
+    """
+    if gateway.storage is None:
+        return {"gaps": [], "unpriced_source_version": None}
+    await gateway.storage._ensure_initialized()
+    since_ts = parse_iso_date(since, end_of_day=False) if since else None
+    async with gateway.storage._conn.session() as db:
+        gaps = await request_log_repository.read_pricing_gaps(
+            db, tenant=tenant, project=project, since_ts=since_ts
+        )
+    return {
+        "gaps": gaps,
+        "caveat_before": (
+            "Rows whose model matched the catalog but carried no rate were "
+            "recorded as priced before voicegateway 0.25.6, so a window "
+            "spanning that release under-reports unrated_requests."
+        ),
+    }
 
 
 @router.get("/rate-card/models")

--- a/src/voicegateway/tests/server/test_pricing_gate_and_gaps.py
+++ b/src/voicegateway/tests/server/test_pricing_gate_and_gaps.py
@@ -1,0 +1,243 @@
+"""The two API surfaces operator-declared pricing needs.
+
+The design: an operator declares what they actually pay per model, the
+catalogue only prefills the field, and a model is not offered to end users
+until a rate exists for it. VoiceGateway ships no admin page for that. It
+ships the mechanism, and every consumer UI asks it the same two questions.
+
+**Can I offer this model?** ``serviceable`` on the quote endpoints. The trap
+this pins is that ``serviceable`` is the single boolean, so it is what
+everyone will gate on, and "a rate exists by any means" includes the
+catalogue's list price. That is the number the whole design exists because it
+is wrong. Under the default ``declared_only`` gate a catalogue price does NOT
+make a model serviceable, so an operator who has declared nothing offers
+nothing, rather than silently offering everything at list price.
+
+**What do I still need to price?** ``/rate-card/gaps``. Someone has to type a
+rate per model; this is the ranked list of which ones, so the job is finite.
+"""
+
+from __future__ import annotations
+
+import time
+import warnings
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
+from voicegateway.server.main import build_app
+
+_CFG = {
+    "providers": {},
+    "projects": {},
+    "fallbacks": {"stt": [], "llm": [], "tts": []},
+    "cost_tracking": {"enabled": True},
+}
+
+
+def _client(tmp_path, monkeypatch, *, gate: str | None = None):
+    warnings.filterwarnings("ignore")
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "gate.db"))
+    cfg = dict(_CFG)
+    if gate is not None:
+        cfg = {**cfg, "pricing": {"gate": gate}}
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    gw = Gateway(config_path=str(path))
+    return TestClient(build_app(gw, enable_dashboard=False)), gw
+
+
+def _quote(client, modality: str, model: str, **params):
+    r = client.get(
+        "/v1/billing/rate-card/quote",
+        params={"modality": modality, "model": model, **params},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# --------------------------------------------------------------------------
+# The gate
+# --------------------------------------------------------------------------
+
+
+def test_a_catalogue_price_alone_does_not_make_a_model_offerable(
+    tmp_path, monkeypatch
+) -> None:
+    """The default, and the whole point of the design.
+
+    deepgram/nova-3 has a published list price, so the catalogue can answer.
+    That answer is wrong by an unknown margin for anyone on a negotiated
+    contract, which is why the operator is asked to declare theirs. Treating
+    the list price as sufficient would mean nobody ever has to.
+    """
+    client, _ = _client(tmp_path, monkeypatch)
+    body = _quote(client, "stt", "deepgram/nova-3")
+    assert body["catalog"]["priced"] is True
+    assert body["priced_by"] == "catalog"
+    assert body["serviceable"] is False
+    assert body["gate"] == "declared_only"
+
+
+def test_permissive_offers_the_catalogue_price_and_still_says_where_it_came_from(
+    tmp_path, monkeypatch
+) -> None:
+    """The knowing opt-out. ``priced_by`` stays honest either way."""
+    client, _ = _client(tmp_path, monkeypatch, gate="permissive")
+    body = _quote(client, "stt", "deepgram/nova-3")
+    assert body["serviceable"] is True
+    assert body["priced_by"] == "catalog"
+    assert body["gate"] == "permissive"
+
+
+def test_an_unknown_model_is_never_offerable_under_either_gate(
+    tmp_path, monkeypatch
+) -> None:
+    for gate in ("declared_only", "permissive"):
+        client, _ = _client(tmp_path, monkeypatch, gate=gate)
+        body = _quote(client, "stt", "nobody/made-this-up")
+        assert body["serviceable"] is False, gate
+        assert body["priced_by"] == "none", gate
+
+
+def test_a_declared_rate_makes_a_model_offerable_under_the_strict_gate(
+    tmp_path, monkeypatch
+) -> None:
+    client, _ = _client(tmp_path, monkeypatch)
+    r = client.post(
+        "/v1/billing/rate-card/rules",
+        json={
+            "modality": "stt",
+            "provider": "deepgram",
+            "model": "nova-3",
+            "fixed": 0.0055,
+            "unit": "minute",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = _quote(client, "stt", "deepgram/nova-3")
+    assert body["serviceable"] is True
+    assert body["priced_by"] == "operator"
+    assert body["effective"]["unit_price_usd"] == pytest.approx(0.0055)
+    # The catalogue answer is still reported, so a UI can show the operator
+    # what they are paying against the published rate.
+    assert body["catalog"]["priced"] is True
+
+
+def test_the_gate_is_echoed_so_a_policy_answer_is_not_read_as_a_fact(
+    tmp_path, monkeypatch
+) -> None:
+    """``serviceable`` means different things under different config.
+
+    A boolean whose meaning is configurable is one that gets misread by a
+    consumer written against the other setting, so the policy travels with it.
+    """
+    strict, _ = _client(tmp_path, monkeypatch)
+    assert _quote(strict, "stt", "deepgram/nova-3")["gate"] == "declared_only"
+
+
+def test_the_bulk_quote_applies_the_same_gate(tmp_path, monkeypatch) -> None:
+    """An editor prices a dropdown in one call; it must not get a laxer answer."""
+    client, _ = _client(tmp_path, monkeypatch)
+    r = client.post(
+        "/v1/billing/rate-card/quote",
+        json={
+            "models": [
+                {"modality": "stt", "model": "deepgram/nova-3"},
+                {"modality": "stt", "model": "nobody/made-this-up"},
+            ]
+        },
+    )
+    assert r.status_code == 200, r.text
+    rows = r.json()["models"]
+    assert [row["serviceable"] for row in rows] == [False, False]
+    assert [row["priced_by"] for row in rows] == ["catalog", "none"]
+    assert {row["gate"] for row in rows} == {"declared_only"}
+
+
+# --------------------------------------------------------------------------
+# The gap list
+# --------------------------------------------------------------------------
+
+
+async def _record(gw, model: str, modality: str = "stt", units: float = 5.0) -> None:
+    tracker = CostTracker(storage=gw.storage)
+    record = tracker.create_record(
+        model_id=model,
+        modality=modality,
+        provider=model.split("/")[0],
+        input_units=units,
+    )
+    await gw.storage.log_request(record)
+
+
+@pytest.mark.asyncio
+async def test_gaps_ranks_unpriceable_models_by_traffic(tmp_path, monkeypatch) -> None:
+    client, gw = _client(tmp_path, monkeypatch)
+    await gw.storage._ensure_initialized()
+    for _ in range(3):
+        await _record(gw, "rime/mistv2")
+    await _record(gw, "lmnt/blizzard")
+    await _record(gw, "deepgram/nova-3")  # priced, must not appear
+
+    r = client.get("/v1/billing/rate-card/gaps")
+    assert r.status_code == 200, r.text
+    gaps = r.json()["gaps"]
+    models = [g["model"] for g in gaps]
+    assert models == ["rime/mistv2", "lmnt/blizzard"], models
+    assert "deepgram/nova-3" not in models
+    assert gaps[0]["requests"] == 3
+    assert gaps[0]["unknown_requests"] == 3
+
+
+@pytest.mark.asyncio
+async def test_gaps_excludes_eou_rows_which_nobody_can_price(
+    tmp_path, monkeypatch
+) -> None:
+    """End-of-utterance rows carry no model and an empty pricing_source.
+
+    They look exactly like an unpriced request to a naive query, and there are
+    a lot of them, so without the billable filter they dominate the list and
+    the report tells the operator to go price a timing measurement.
+    """
+    client, gw = _client(tmp_path, monkeypatch)
+    await gw.storage._ensure_initialized()
+    tracker = CostTracker(storage=gw.storage)
+    eou = tracker.create_record(
+        model_id="", modality="eou", provider="", input_units=0.0
+    )
+    eou.timestamp = time.time()
+    await gw.storage.log_request(eou)
+    await _record(gw, "rime/mistv2")
+
+    gaps = client.get("/v1/billing/rate-card/gaps").json()["gaps"]
+    assert [g["model"] for g in gaps] == ["rime/mistv2"]
+
+
+@pytest.mark.asyncio
+async def test_gaps_reports_the_window_caveat_in_the_response(
+    tmp_path, monkeypatch
+) -> None:
+    """A gap list that was ever silently short is one nobody trusts twice.
+
+    Before ``voice-prices-unrated`` existed, a model that matched the catalogue
+    with no rate was stamped as priced, so this report would have counted it as
+    covered. A reader cannot tell that from the numbers, so the response says
+    it rather than leaving it in a changelog.
+    """
+    client, _ = _client(tmp_path, monkeypatch)
+    body = client.get("/v1/billing/rate-card/gaps").json()
+    assert "under-report" in body["caveat_before"]
+
+
+@pytest.mark.asyncio
+async def test_gaps_is_empty_when_every_metered_model_has_a_rate(
+    tmp_path, monkeypatch
+) -> None:
+    client, gw = _client(tmp_path, monkeypatch)
+    await gw.storage._ensure_initialized()
+    await _record(gw, "deepgram/nova-3")
+    assert client.get("/v1/billing/rate-card/gaps").json()["gaps"] == []


### PR DESCRIPTION
Phase 1 of operator-declared pricing. VoiceGateway ships **no admin page** for entering rates and is not going to: consumers build their own against these endpoints. What VoiceGateway owns is the mechanism, and the defaults it picks propagate to every consumer.

## The gate

`/rate-card/quote` already returned `catalog` + `effective`, so "can I offer this model" was answerable by inference. Every caller had to reconstruct it, and each could reconstruct it differently. It now answers directly:

```json
{ "serviceable": false, "priced_by": "catalog", "gate": "declared_only",
  "catalog": { "priced": true, "unit_price_usd": 0.0043 }, "effective": null }
```

**The trap, which Pixis caught before this shipped:** a single boolean is what everyone will gate on, and "a rate exists by any means" includes the catalogue list price — the number this whole design exists because it is wrong for anyone on a negotiated contract. Gate on it naively and an operator who has declared nothing still offers every model, billed off list, silently.

So `serviceable` is policy-driven. `pricing.gate` defaults to **`declared_only`**: a catalogue price does not make a model offerable. `permissive` is the knowing opt-out. Strict by default because **the default propagates** — a permissive default ships list-price billing to every consumer unless each one independently notices.

The response echoes `gate`, because a boolean whose meaning is configurable is one that a consumer written against the other setting will misread.

## The gap list

`GET /v1/billing/rate-card/gaps` and `voicegw prices gaps`. A strict gate is only tolerable if the operator can see what to type, so this is the ranked work list instead of a blank screen. Run against a real local DB it immediately found one:

```
┃ model                  ┃ modality ┃ requests ┃ units in/out ┃ gap            ┃
│ livekit/google/gemma-… │ llm      │ 17       │ 6644/258     │ not in catalog │
```

Two gap kinds, reported separately because the remedies differ: **not in the catalogue at all**, versus **matched with no rate recorded** (the entry exists and only needs a rate, usually the cheaper fix).

The second kind was invisible before `voice-prices-unrated` shipped in v0.25.6, since those rows carried full catalogue provenance and this report would have counted them as covered. **Both the API response and the CLI say so**, rather than leaving it in a changelog — a gap list that was ever silently short is one nobody trusts twice.

Filtered to billable rows using the same predicate as the billable request count. Without it, `eou` timing rows dominate and the report tells the operator to go price a latency measurement.

## Naming

`priced_by`, not `basis`, so it cannot collide with the cost-basis discriminator the rate rule will need in phase 2.

## Also documented

`GET`/`POST /rate-card/quote` had **no docs entry at all** — it shipped in 0.25.4 undocumented. Written up now, since this extends it.

## Verification

- `3635 passed, 23 skipped, 36 deselected`
- `mypy` clean on 291 files, `ruff` clean, docs validator PASS (81 pages)
- CLI exercised against a real DB, not only fixtures

## What comes next, and a correction

Phase 2 is the **cost basis**: a rate rule that sets what you *pay*, not only what you *charge*. Today `rating.price()` only ever transforms `cost_usd` into `rated_price_usd`, so `cost_usd` is always the voice-prices list figure and `cost_plus` marks up a number that was never true.

I had recorded that as owned by a peer session. That was a misread on my part — they were requesting it, not implementing it, and they have no access to this repo. It is unowned and unstarted, and it is the half of the design that makes the declared rate actually mean anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rate-card quote APIs for individual and bulk pricing estimates.
  - Quote results now show serviceability, pricing source, and the active pricing policy.
  - Added pricing-gap reporting with tenant, project, and date filters.
  - Added the `prices gaps` command to identify unknown catalog models and missing rates.
  - Added configurable strict or permissive pricing policies, defaulting to declared rates only.

- **Documentation**
  - Documented rate-card quotes, pricing gaps, CLI usage, configuration, classifications, and historical data limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->