### PR TITLE
feat(billing): let a rate rule set what the operator pays

### DIFF
--- a/alembic/versions/d7a2f91c4b03_rate_card_cost_basis.py
+++ b/alembic/versions/d7a2f91c4b03_rate_card_cost_basis.py
@@ -1,0 +1,56 @@
+"""rate card: which ledger side a rule sets
+
+Revision ID: d7a2f91c4b03
+Revises: c4d1e8b7a260
+Create Date: 2026-08-21 12:00:00.000000
+
+A rate rule could only ever set what a tenant is CHARGED. The cost it marked
+up was always the voice-prices catalogue figure, which is a published list
+price, and anyone at volume is on a negotiated contract that differs from it
+by a margin nobody outside the contract can see. So ``cost_plus`` multiplied a
+number that was never true and produced a margin the operator could not tell
+was wrong.
+
+``sets`` names the side: ``price`` (the historical behaviour, and the default
+for every existing row) or ``cost`` (what the operator actually pays,
+replacing the catalogue figure).
+
+NOT NULL with a server default rather than nullable, because "which side does
+this rule set" has no meaningful unknown state: a rule written before this
+column existed set the price, definitionally, since that was the only thing a
+rule could do.
+
+The primary key is unchanged for price rules. ``scope_key`` prefixes only cost
+rules, so every existing ``rule_id`` still addresses its row and an upsert
+against it updates rather than duplicating. That is also what lets a cost rule
+and a price rule coexist at one scope, which is the ordinary configuration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d7a2f91c4b03"
+down_revision: str | None = "c4d1e8b7a260"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "managed_rate_rules",
+        sa.Column(
+            "sets",
+            sa.String(),
+            nullable=False,
+            server_default="price",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("managed_rate_rules", "sets")

--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -448,7 +448,8 @@ Query: `modality`, `model` (`provider/model`), `tenant?`, `plan?`.
 - **`priced_by`** — `operator` (a rate someone declared), `catalog` (a published list price), or `none`.
 - **`gate`** — the policy that produced `serviceable`, from [`pricing.gate`](/configuration/voicegw-yaml). Echoed because `serviceable` is a policy answer rather than a fact: under the default `declared_only` a catalogue price does **not** make a model serviceable, and a consumer written against `permissive` would otherwise misread it.
 - **`catalog`** — what `voice-prices` says, for prefilling the operator's input. `priced` is `false` both for an unknown model and for one the catalogue matched but holds no rate for.
-- **`effective`** — the rate rule that would apply, or `null`.
+- **`effective`** — the price rule that would apply, or `null`.
+- **`cost_basis`** — the cost rule that would apply, or `null`. A declared cost alone makes a model serviceable: it is the number the operator is actually asked for.
 
 `POST /v1/billing/rate-card/quote` takes `{"models": [{modality, model, tenant?, plan?}, ...]}` (max 200) and returns the same shape per entry under `models`, so an editor prices a whole dropdown in one call and gets the same gate.
 
@@ -470,7 +471,7 @@ Return the editable DB override rules, each with its `rule_id`. Use this to driv
 
 Upsert a DB rate-card override for a scope (one rule per scope, keyed by `tenant|plan|modality|provider|model`). Requires the `write` scope. Takes effect on the next config refresh, which the call triggers.
 
-**Body:** a scope (`modality?`, `provider?`, `model?`, `tenant?`, `plan?`) plus one of:
+**Body:** a scope (`modality?`, `provider?`, `model?`, `tenant?`, `plan?`), an optional `sets` (`"price"` default, or `"cost"` for what the operator pays), plus one of:
 
 - `markup` (cost-plus), or
 - `fixed` + `unit` for a single-sided unit (`minute`, `second`, `char`, `1k_char`, `request`), or

--- a/docs/architecture/rating.md
+++ b/docs/architecture/rating.md
@@ -15,6 +15,10 @@ A rate card is a global `default_markup` fallback plus an ordered list of rules.
 
 **Rule kind** is one of two:
 
+Each rule also names **which side of the ledger it sets** via `sets`: `price` (the default, what the tenant is charged) or `cost` (what the operator pays, replacing the catalogue figure on the recorded row). The two resolve independently, so a model-specific cost and a global markup both apply rather than the more specific one winning outright. A cost rule must be `fixed`, because `cost_plus` multiplies a recorded cost and so cannot produce one. See [`rate_card`](/configuration/voicegw-yaml).
+
+A cost rule is what makes `cost_plus` honest. Without one, the number being marked up is always the `voice-prices` list price, so anyone on a negotiated contract has a margin computed against a figure they do not pay.
+
 - **cost_plus** (`markup`): the billable price is the recorded provider cost multiplied by `markup`. Because it multiplies the recorded cost, a cost-plus rule auto-follows voice-prices base movement: when the base price changes, the rated price tracks it with no edit.
 - **fixed** (`fixed` + `unit`): the billable price is an advertised `$/unit` multiplied by the request's billable quantity in that unit. A fixed rule is decoupled from the base cost, so it holds a stable advertised price even as the base moves. Single-sided units: `minute`, `second` (stt), `char`, `1k_char` (tts), `request` (any).
 - **fixed, per leg** (`input_price_usd` + `output_price_usd` + a token `unit`): the LLM form. Token units (`token`, `1k_token`, `1m_token`) carry a rate per leg, because input and output bill at different rates on every provider in the catalogue and one blended rate cannot express either. `cached_input_price_usd` is optional and defaults to the input rate. Cached prompt tokens are a **subset** of the prompt, so the uncached leg is `input - cached`. A fixed rule describes a flat contract and cannot express context-window tiers; use `cost_plus` to track a tiered list price.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -64,7 +64,7 @@ The primary table for every completed (or failed) inference request. ORM class `
 | `output_units` | REAL | Output tokens (LLM only) |
 | `cached_input_units` | REAL | Prompt tokens served from the provider's cache (LLM only; 0 for STT/TTS) |
 | `cost_usd` | REAL | Recorded provider cost |
-| `pricing_source` | TEXT | `"voice-prices@<version>"` priced, `"voice-prices-unrated"` matched with no rate, `"voicegateway-local"` self-hosted, `""` unknown model |
+| `pricing_source` | TEXT | `"rate-card:<rule_id>"` operator-declared, `"voice-prices@<version>"` catalogue-priced, `"voice-prices-unrated"` matched with no rate, `"voicegateway-local"` self-hosted, `""` unknown model |
 | `rated_price_usd` | REAL | Billable price the rate card stamped at write time; see [Rating](/architecture/rating) |
 | `rate_rule` | TEXT | Audit token for the rule applied, e.g. `"cost_plus:1.3"` |
 | `ttfb_ms` | REAL | Time to first byte in milliseconds |
@@ -98,6 +98,7 @@ DB-side rate-card overrides layered after the YAML `rate_card:` seed. See [Ratin
 | `rule_id` | TEXT PK | Deterministic key built from `(tenant, plan, modality, provider, model)`, so an upsert for the same scope updates rather than duplicates |
 | `modality`, `provider`, `model` | TEXT | Scope; `"*"` means "any" |
 | `tenant`, `plan` | TEXT, nullable | Scope; `NULL` means "any" |
+| `sets` | TEXT | `"price"` (what the tenant is charged) or `"cost"` (what the operator pays) |
 | `kind` | TEXT | `"cost_plus"` or `"fixed"` |
 | `input_price_usd` | REAL | LLM input leg, $/token-unit (fixed token rules only) |
 | `cached_input_price_usd` | REAL | LLM cached-input leg; NULL means "same as input" |

--- a/docs/configuration/voicegw-yaml.md
+++ b/docs/configuration/voicegw-yaml.md
@@ -250,7 +250,34 @@ rate_card:
 ```
 
 - `default_markup` (float, default `1.0`): cost-plus multiplier applied when no rule matches a request.
-- `rules` (list): ordered rate rules. Each rule is scoped, and carries exactly one kind of arithmetic.
+- `rules` (list): ordered rate rules. Each rule is scoped, names which side of the ledger it sets, and carries exactly one kind of arithmetic.
+
+### Which side a rule sets
+
+`sets` is `price` (default) or `cost`.
+
+- **`price`**: what the tenant is **charged**, computed from the recorded cost. Every rule written before this field existed sets the price, which is why that is the default.
+- **`cost`**: what the operator **pays**, replacing the `voice-prices` figure on the recorded row. A cost rule must carry a fixed price: `cost_plus` multiplies a recorded cost, so it cannot produce one.
+
+A cost rule exists because the catalogue holds published list prices, and anyone at volume is on a negotiated contract that differs from them by a margin nobody outside the contract can see. Marking up the catalogue number produces a margin that is wrong in a direction you cannot detect from the recorded row.
+
+```yaml
+rate_card:
+  rules:
+    # what you actually pay Deepgram
+    - {sets: cost, modality: stt, provider: deepgram, model: nova-3,
+       fixed: 0.0035, unit: minute}
+    # what you charge on top of it
+    - {sets: price, markup: 1.3}
+```
+
+**The two sides resolve independently.** The example above is the ordinary configuration: a model-specific cost plus a global markup. Resolving one merged list most-specific-wins would return the cost rule, apply it as the price, and bill at cost with no margin and nothing in the output saying so. So `cost` and `price` are two separate resolutions over the same list, and both apply.
+
+A cost rule and a price rule can share a scope, since "what I pay for nova-3" and "what I charge for nova-3" are different numbers about the same model. The stored `rule_id` carries the side, so one does not overwrite the other.
+
+When a cost rule applies, the row's `pricing_source` becomes `rate-card:<rule_id>` instead of `voice-prices@<version>`, so a row never claims the catalogue priced it when an operator did.
+
+The collector re-derives cost on ingest. Agents carry no rate card and record the catalogue figure; the collector holds the contract and is the source of truth, so an ingested row is corrected before the markup is applied.
 
 ### Scope fields
 

--- a/src/voicegateway/billing/rate_card.py
+++ b/src/voicegateway/billing/rate_card.py
@@ -25,6 +25,7 @@ This module is pure data + resolution; the arithmetic lives in
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 WILDCARD = "*"
 
@@ -103,6 +104,26 @@ def _model_matches(rule_model: str, model_id: str) -> bool:
     return rule_model == bare
 
 
+VALID_SETS = frozenset({"cost", "price"})
+
+
+def validate_sets(sets: str, kind: str) -> None:
+    """Raise unless the ledger side and the arithmetic are compatible.
+
+    A cost rule must be ``fixed``. ``cost_plus`` multiplies a recorded cost to
+    produce a price; asking it to produce the cost would be asking what to
+    multiply, and the only available answer is the catalogue figure the rule
+    exists to replace.
+    """
+    if sets not in VALID_SETS:
+        raise ValueError(f"a rate rule sets one of {sorted(VALID_SETS)}, got {sets!r}")
+    if sets == "cost" and kind != "fixed":
+        raise ValueError(
+            "a cost rule must carry a fixed price: cost_plus multiplies the "
+            "recorded cost, so it cannot produce one"
+        )
+
+
 def validate_fixed_pricing(
     *,
     modality: str,
@@ -176,6 +197,25 @@ class RateRule:
     model: str = WILDCARD
     tenant: str | None = None
     plan: str | None = None
+    # WHICH SIDE OF THE LEDGER THIS RULE SETS.
+    #
+    # ``price`` (the default, and what every rule was before this existed)
+    # sets what the tenant is CHARGED, starting from the recorded cost.
+    #
+    # ``cost`` sets what the operator PAYS, replacing the catalogue figure.
+    # It exists because a catalogue price is a public list price and every
+    # negotiated contract differs from it by an unknown margin, so marking up
+    # the catalogue number produces a margin nobody can see is wrong.
+    #
+    # The two resolve INDEPENDENTLY (see ``RateCard.resolve``). A model-level
+    # cost rule and a global markup are the ordinary configuration, and one
+    # resolution over a merged list would let the more specific cost rule win
+    # and silently drop the markup.
+    sets: str = "price"
+    # Set when the rule came from the DB override store, so a row can name the
+    # exact rule that priced it. Seed rules from YAML have no id and fall back
+    # to ``describe()``.
+    rule_id: str | None = None
     kind: str = "cost_plus"
     markup: float | None = None
     unit_price_usd: float | None = None
@@ -234,6 +274,10 @@ class RateRule:
             return False
         return _model_matches(self.model, model_id)
 
+    def audit_token(self) -> str:
+        """How a recorded row names the rule that set its number."""
+        return self.rule_id or self.describe()
+
     def specificity(self) -> int:
         """Higher means more specific. Tenant > plan > model > provider > modality."""
         score = 0
@@ -264,6 +308,11 @@ class RateRule:
         return f"cost_plus:{_fmt(self.markup)}"
 
 
+def _opt_float(value: Any) -> float | None:
+    """``float(value)`` unless it is absent."""
+    return None if value is None else float(value)
+
+
 def _fmt(value: float | None) -> str:
     """Format a float compactly (``1.30`` -> ``1.3``, ``0.0060`` -> ``0.006``)."""
     if value is None:
@@ -278,6 +327,8 @@ def rate_rule_from_row(row: dict) -> RateRule:
     (used when merging DB overrides onto the YAML seed).
     """
     return RateRule(
+        sets=row.get("sets") or "price",
+        rule_id=row.get("rule_id"),
         modality=row.get("modality", WILDCARD),
         provider=row.get("provider", WILDCARD),
         model=row.get("model", WILDCARD),
@@ -332,6 +383,7 @@ class RateCard:
         model = str(raw.get("model", WILDCARD))
         tenant = raw.get("tenant")
         plan = raw.get("plan")
+        sets = str(raw.get("sets", "price"))
         fixed = raw.get("fixed")
         legs = {
             "input_price_usd": raw.get("input_price_usd"),
@@ -340,6 +392,7 @@ class RateCard:
         }
         if fixed is not None or any(v is not None for v in legs.values()):
             unit = raw.get("unit")
+            validate_sets(sets, "fixed")
             validate_fixed_pricing(
                 modality=modality,
                 unit=unit,
@@ -347,6 +400,7 @@ class RateCard:
                 **{k: (None if v is None else float(v)) for k, v in legs.items()},
             )
             return RateRule(
+                sets=sets,
                 modality=modality,
                 provider=provider,
                 model=model,
@@ -355,10 +409,14 @@ class RateCard:
                 kind="fixed",
                 unit_price_usd=None if fixed is None else float(fixed),
                 unit=str(unit),
-                **{k: (None if v is None else float(v)) for k, v in legs.items()},
+                input_price_usd=_opt_float(legs["input_price_usd"]),
+                cached_input_price_usd=_opt_float(legs["cached_input_price_usd"]),
+                output_price_usd=_opt_float(legs["output_price_usd"]),
             )
         markup = float(raw.get("markup", default_markup))
+        validate_sets(sets, "cost_plus")
         return RateRule(
+            sets=sets,
             modality=modality,
             provider=provider,
             model=model,
@@ -387,15 +445,27 @@ class RateCard:
         model_id: str,
         tenant: str | None = None,
         plan: str | None = None,
+        sets: str = "price",
     ) -> RateRule | None:
         """Return the most specific matching rule, or ``None`` if none match.
 
         Ties on specificity are broken in favour of the rule that appears
         later in :attr:`rules` (DB overrides layered after the seed).
+
+        ``sets`` selects which ledger side to resolve, and the two are
+        SEPARATE resolutions over the same list rather than one resolution
+        over a merged one. That distinction is the whole design: the ordinary
+        configuration is a model-specific cost ("what I pay Deepgram for
+        nova-3") plus a global markup ("charge 1.3x"), and a single
+        most-specific-wins pass would let the cost rule win outright and drop
+        the markup, producing a bill at cost with no margin and nothing in the
+        output saying so.
         """
         best: RateRule | None = None
         best_score = -1
         for rule in self.rules:
+            if rule.sets != sets:
+                continue
             if not rule.matches(
                 modality=modality,
                 provider=provider,
@@ -414,6 +484,8 @@ class RateCard:
 __all__ = [
     "WILDCARD",
     "VALID_UNITS",
+    "VALID_SETS",
+    "validate_sets",
     "TOKEN_UNITS",
     "UNITS_BY_MODALITY",
     "unit_matches_modality",

--- a/src/voicegateway/billing/rating.py
+++ b/src/voicegateway/billing/rating.py
@@ -142,6 +142,57 @@ def apply_rule(
     return RatedResult(rated_price_usd=cost_usd * markup, rate_rule=rule.describe())
 
 
+def declared_cost(
+    card: RateCard,
+    *,
+    modality: str,
+    provider: str,
+    model_id: str,
+    input_units: float = 0.0,
+    output_units: float = 0.0,
+    cached_input_units: float = 0.0,
+    tenant: str | None = None,
+    plan: str | None = None,
+) -> tuple[float, RateRule] | None:
+    """The operator's own cost for this request, or None if none is declared.
+
+    This is the number the catalogue cannot know. A published rate is a list
+    price, and anyone at volume is on a negotiated contract that differs from
+    it by a margin nobody outside the contract can see, so a cost-plus markup
+    over the catalogue figure produces a margin that is wrong in a direction
+    the operator cannot detect.
+
+    Resolved on the ``cost`` side only, independently of whatever price rule
+    applies, so a model-specific cost and a global markup compose instead of
+    the more specific one winning outright.
+    """
+    rule = card.resolve(
+        modality=modality,
+        provider=provider,
+        model_id=model_id,
+        tenant=tenant,
+        plan=plan,
+        sets="cost",
+    )
+    if rule is None:
+        return None
+    if rule.unit in TOKEN_UNITS:
+        total = token_leg_price(
+            rule,
+            input_units=input_units,
+            output_units=output_units,
+            cached_input_units=cached_input_units,
+        )
+    else:
+        total = (rule.unit_price_usd or 0.0) * billable_quantity(
+            str(rule.unit),
+            modality=modality,
+            input_units=input_units,
+            output_units=output_units,
+        )
+    return total, rule
+
+
 def price(
     card: RateCard,
     *,
@@ -184,6 +235,7 @@ def price(
 
 __all__ = [
     "RatedResult",
+    "declared_cost",
     "apply_rule",
     "billable_quantity",
     "price",

--- a/src/voicegateway/middleware/cost_tracker_middleware.py
+++ b/src/voicegateway/middleware/cost_tracker_middleware.py
@@ -6,7 +6,7 @@ import logging
 import time
 import uuid
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from voicegateway.billing import rating
 from voicegateway.billing.rate_card import RateCard
@@ -18,6 +18,22 @@ if TYPE_CHECKING:
     from voicegateway.middleware.budget_enforcer_middleware import BudgetEnforcer
 
 logger = logging.getLogger(__name__)
+
+
+class ResolvedCost(NamedTuple):
+    """What a request cost, and which authority produced the number.
+
+    ``source`` is set only when an operator-declared rate produced the cost,
+    and becomes the row's ``pricing_source``. ``raw`` is None when nothing
+    could price the request at all. ``unrated`` names units the catalogue
+    matched and had no rate for, which is a zero that is not a price.
+    """
+
+    cost: float
+    raw: Decimal | None
+    unrated: tuple[str, ...]
+    source: str | None
+
 
 # When no rate card is wired in, rate every request as a cost pass-through
 # (default_markup 1.0 -> rated == cost, rule "default:1").
@@ -86,6 +102,28 @@ class CostTracker:
         resolved from the context var (ingest sets it from the verified key),
         matching the ``tenant_id`` stamped at write time.
         """
+        # The collector is the source of truth for what things cost: agents
+        # record the catalogue figure because they carry no card. If this
+        # collector declares a cost for the model, the ingested row is
+        # corrected to it before the markup is applied, so a margin is never
+        # computed against a list price the operator does not pay.
+        card = self._rate_card
+        if card is not None and not record.model_id.startswith(("local/", "ollama/")):
+            declared = rating.declared_cost(
+                card,
+                modality=record.modality,
+                provider=record.provider,
+                model_id=record.model_id,
+                input_units=record.input_units,
+                output_units=record.output_units,
+                cached_input_units=record.cached_input_units,
+                tenant=current_tenant(),
+            )
+            if declared is not None:
+                total, rule = declared
+                record.cost_usd = total
+                record.pricing_source = f"rate-card:{rule.audit_token()}"
+
         rated = self._rate(
             record.model_id,
             record.modality,
@@ -97,6 +135,17 @@ class CostTracker:
         )
         record.rated_price_usd = rated.rated_price_usd
         record.rate_rule = rated.rate_rule
+
+    @staticmethod
+    def _provider_of(model_id: str) -> str:
+        """Provider half of a ``provider/model`` id, for rule matching.
+
+        ``create_record`` takes the provider as its own argument, but
+        ``_resolve_cost`` is also reached from ``calculate_cost``, which does
+        not. Deriving it keeps both paths matching the same rules rather than
+        one of them silently missing every provider-scoped rule.
+        """
+        return model_id.split("/", 1)[0] if "/" in model_id else ""
 
     def _catalog_cost(
         self,
@@ -136,8 +185,8 @@ class CostTracker:
         input_units: float,
         output_units: float,
         cached_input_units: float,
-    ) -> tuple[float, Decimal | None, tuple[str, ...]]:
-        """Return ``(float_cost, raw_decimal_or_None, unrated_units)``.
+    ) -> ResolvedCost:
+        """Return the request's cost, and where the number came from.
 
         ``None`` means voice-prices did not recognize the model. A non-empty
         ``unrated_units`` means it DID recognize the model and applied no rate
@@ -148,7 +197,36 @@ class CostTracker:
 
         Self-hosted ``local/``/``ollama/`` models are expected to be free and
         are not warned about.
+
+        AN OPERATOR-DECLARED COST WINS OVER THE CATALOGUE, and is checked
+        first. The catalogue holds published list prices; anyone at volume is
+        on a negotiated contract that differs from them by a margin nobody
+        outside the contract can see. When a cost rule matches, the row records
+        what the operator actually pays and names the rule that said so, so
+        ``reconcile`` can point at the entry rather than at the usage when the
+        invoice disagrees.
         """
+        card = self._rate_card
+        if card is not None and not model_id.startswith(("local/", "ollama/")):
+            declared = rating.declared_cost(
+                card,
+                modality=modality,
+                provider=self._provider_of(model_id),
+                model_id=model_id,
+                input_units=input_units,
+                output_units=output_units,
+                cached_input_units=cached_input_units,
+                tenant=current_tenant(),
+            )
+            if declared is not None:
+                total, rule = declared
+                return ResolvedCost(
+                    cost=total,
+                    raw=Decimal(str(total)),
+                    unrated=(),
+                    source=f"rate-card:{rule.audit_token()}",
+                )
+
         cost, unrated = self._catalog_cost(
             model_id, modality, input_units, output_units, cached_input_units
         )
@@ -159,7 +237,7 @@ class CostTracker:
                     modality,
                     model_id,
                 )
-            return 0.0, None, ()
+            return ResolvedCost(cost=0.0, raw=None, unrated=(), source=None)
         if unrated:
             logger.warning(
                 "%s model %r matched the catalog but it carries no rate for "
@@ -170,7 +248,7 @@ class CostTracker:
                 cost,
                 catalog.UNRATED_SOURCE,
             )
-        return float(cost), cost, unrated
+        return ResolvedCost(cost=float(cost), raw=cost, unrated=unrated, source=None)
 
     def calculate_cost(
         self,
@@ -181,10 +259,9 @@ class CostTracker:
         cached_input_units: float = 0.0,
     ) -> float:
         """Calculate cost for a request."""
-        cost, _, _ = self._resolve_cost(
+        return self._resolve_cost(
             model_id, modality, input_units, output_units, cached_input_units
-        )
-        return cost
+        ).cost
 
     def create_record(
         self,
@@ -206,15 +283,18 @@ class CostTracker:
         revision: str | None = None,
     ) -> RequestRecord:
         """Create a request record with cost calculated."""
-        cost, cost_dec, unrated = self._resolve_cost(
+        resolved = self._resolve_cost(
             model_id, modality, input_units, output_units, cached_input_units
         )
+        cost = resolved.cost
         if not pricing_source:
-            if model_id.startswith(("local/", "ollama/")):
+            if resolved.source is not None:
+                pricing_source = resolved.source
+            elif model_id.startswith(("local/", "ollama/")):
                 pricing_source = catalog.SELF_HOSTED_SOURCE
-            elif unrated:
+            elif resolved.unrated:
                 pricing_source = catalog.UNRATED_SOURCE
-            elif cost_dec is not None:
+            elif resolved.raw is not None:
                 pricing_source = catalog.pricing_source(modality)
         rated = self._rate(
             model_id,

--- a/src/voicegateway/models/managed_rate_rule_model.py
+++ b/src/voicegateway/models/managed_rate_rule_model.py
@@ -28,6 +28,10 @@ class ManagedRateRule(SQLModel, table=True):
     model: str = Field(default="*", sa_column_kwargs={"server_default": "*"})
     tenant: str | None = None
     plan: str | None = None
+    # Which ledger side the rule sets: "price" (what the tenant is charged,
+    # the historical behaviour and the default) or "cost" (what the operator
+    # pays, replacing the catalogue figure).
+    sets: str = Field(default="price", sa_column_kwargs={"server_default": "price"})
     kind: str = Field(
         default="cost_plus", sa_column_kwargs={"server_default": "cost_plus"}
     )

--- a/src/voicegateway/repository/managed_rate_rule_repository.py
+++ b/src/voicegateway/repository/managed_rate_rule_repository.py
@@ -15,7 +15,11 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy import text
 from sqlmodel import delete, select
 
-from voicegateway.billing.rate_card import WILDCARD, validate_fixed_pricing
+from voicegateway.billing.rate_card import (
+    WILDCARD,
+    validate_fixed_pricing,
+    validate_sets,
+)
 from voicegateway.models.managed_rate_rule_model import ManagedRateRule
 
 if TYPE_CHECKING:
@@ -29,9 +33,20 @@ def scope_key(
     model: str,
     tenant: str | None,
     plan: str | None,
+    sets: str = "price",
 ) -> str:
-    """Deterministic primary key for a rule's scope (one row per scope)."""
-    return "|".join(
+    """Deterministic primary key for a rule's scope (one row per scope).
+
+    A cost rule and a price rule at the SAME scope are the ordinary
+    configuration ("this is what I pay for nova-3, and charge 1.3x on top"),
+    so the ledger side has to be part of the identity or the second write
+    would overwrite the first.
+
+    Price keys keep the historical format exactly. Only cost rules take the
+    prefix, so every row written before ``sets`` existed keeps its id and an
+    upsert against it still updates rather than duplicating.
+    """
+    scope = "|".join(
         [
             tenant or WILDCARD,
             plan or WILDCARD,
@@ -40,6 +55,7 @@ def scope_key(
             model,
         ]
     )
+    return scope if sets == "price" else f"{sets}|{scope}"
 
 
 def validate_rule(
@@ -48,6 +64,7 @@ def validate_rule(
     fixed: float | None,
     unit: str | None,
     modality: str = WILDCARD,
+    sets: str = "price",
     input_price_usd: float | None = None,
     cached_input_price_usd: float | None = None,
     output_price_usd: float | None = None,
@@ -62,6 +79,7 @@ def validate_rule(
     """
     legs = (input_price_usd, cached_input_price_usd, output_price_usd)
     has_fixed = fixed is not None or any(leg is not None for leg in legs)
+    validate_sets(sets, "fixed" if has_fixed else "cost_plus")
     if markup is not None and has_fixed:
         raise ValueError("a rate rule sets either markup or a fixed price, not both")
     if has_fixed:
@@ -85,16 +103,17 @@ _RULE_UPSERT = text(
     """
     INSERT INTO managed_rate_rules (
         rule_id, modality, provider, model, tenant, plan,
-        kind, markup, unit_price_usd, unit,
+        sets, kind, markup, unit_price_usd, unit,
         input_price_usd, cached_input_price_usd, output_price_usd,
         created_at, updated_at
     ) VALUES (
         :rule_id, :modality, :provider, :model, :tenant, :plan,
-        :kind, :markup, :unit_price_usd, :unit,
+        :sets, :kind, :markup, :unit_price_usd, :unit,
         :input_price_usd, :cached_input_price_usd, :output_price_usd,
         :now, :now
     )
     ON CONFLICT(rule_id) DO UPDATE SET
+        sets=excluded.sets,
         kind=excluded.kind,
         markup=excluded.markup,
         unit_price_usd=excluded.unit_price_usd,
@@ -116,6 +135,7 @@ def _row_to_dict(r: ManagedRateRule) -> dict[str, Any]:
         "model": r.model,
         "tenant": r.tenant,
         "plan": r.plan,
+        "sets": r.sets,
         "kind": r.kind,
         "markup": r.markup,
         "unit_price_usd": r.unit_price_usd,
@@ -150,6 +170,7 @@ async def upsert_rule(
     input_price_usd: float | None = None,
     cached_input_price_usd: float | None = None,
     output_price_usd: float | None = None,
+    sets: str = "price",
 ) -> str:
     """Insert or update one rule (keyed by scope). Returns the ``rule_id``."""
     kind = validate_rule(
@@ -157,12 +178,18 @@ async def upsert_rule(
         fixed=fixed,
         unit=unit,
         modality=modality,
+        sets=sets,
         input_price_usd=input_price_usd,
         cached_input_price_usd=cached_input_price_usd,
         output_price_usd=output_price_usd,
     )
     rid = scope_key(
-        modality=modality, provider=provider, model=model, tenant=tenant, plan=plan
+        modality=modality,
+        provider=provider,
+        model=model,
+        tenant=tenant,
+        plan=plan,
+        sets=sets,
     )
     await session.execute(
         _RULE_UPSERT,
@@ -173,6 +200,7 @@ async def upsert_rule(
             "model": model,
             "tenant": tenant,
             "plan": plan,
+            "sets": sets,
             "kind": kind,
             "markup": markup if kind == "cost_plus" else None,
             "unit_price_usd": fixed if kind == "fixed" else None,

--- a/src/voicegateway/server/api/billing.py
+++ b/src/voicegateway/server/api/billing.py
@@ -115,6 +115,7 @@ def _serialize_rule(rule: Any) -> dict[str, Any]:
         "model": rule.model,
         "tenant": rule.tenant,
         "plan": rule.plan,
+        "sets": rule.sets,
         "kind": rule.kind,
         "markup": rule.markup,
         "unit_price_usd": rule.unit_price_usd,
@@ -186,6 +187,7 @@ async def upsert_rate_card_rule(
             input_price_usd=body.get("input_price_usd"),
             cached_input_price_usd=body.get("cached_input_price_usd"),
             output_price_usd=body.get("output_price_usd"),
+            sets=body.get("sets", "price"),
         )
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
@@ -233,7 +235,9 @@ def _voice_price(modality: str, model: str) -> float | None:
     return float(cost) if cost is not None else None
 
 
-def _serviceability(catalog: dict[str, Any], rule: Any, gate: str) -> dict[str, Any]:
+def _serviceability(
+    catalog: dict[str, Any], rule: Any, gate: str, cost_rule: Any = None
+) -> dict[str, Any]:
     """Can this model be offered, on whose number, and under which rule?
 
     The gate a consumer UI needs before it lists a model. It was answerable
@@ -257,7 +261,11 @@ def _serviceability(catalog: dict[str, Any], rule: Any, gate: str) -> dict[str, 
     rate for, so a rateless match lands on ``none`` under either policy rather
     than being offered as free.
     """
-    if rule is not None:
+    if cost_rule is not None or rule is not None:
+        # Either declaration counts. A cost rule is the one this design asks
+        # the operator for ("what do you actually pay"), and it alone is
+        # enough: the row can be metered, costed and billed off it. A price
+        # rule alone also counts, since a number has been stated either way.
         return {"serviceable": True, "priced_by": "operator", "gate": gate}
     if catalog.get("priced"):
         return {
@@ -371,23 +379,36 @@ async def rate_card_quote(
     provider, _ = _split_ref(model)
     price = _voice_prices(modality, model)
     rule = None
+    cost_rule = None
     if gateway.storage is not None:
         card = await _effective_card(gateway)
+        # Two independent resolutions, never one over a merged list: a
+        # model-specific cost and a global markup must both apply.
         rule = card.resolve(
             modality=modality,
             provider=provider,
             model_id=model,
             tenant=tenant,
             plan=plan,
+            sets="price",
+        )
+        cost_rule = card.resolve(
+            modality=modality,
+            provider=provider,
+            model_id=model,
+            tenant=tenant,
+            plan=plan,
+            sets="cost",
         )
     return {
         "modality": modality,
         "provider": provider,
         "model": model,
         "pricing_source": catalog_pricing_source(modality),
-        **_serviceability(price, rule, gateway.config.pricing.gate),
+        **_serviceability(price, rule, gateway.config.pricing.gate, cost_rule),
         "catalog": price,
         "effective": _serialize_rule(rule) if rule is not None else None,
+        "cost_basis": _serialize_rule(cost_rule) if cost_rule is not None else None,
     }
 
 
@@ -415,17 +436,23 @@ async def rate_card_quote_bulk(
         modality = str(item.get("modality") or "")
         model = str(item.get("model") or "")
         provider, _ = _split_ref(model)
-        rule = (
-            card.resolve(
-                modality=modality,
-                provider=provider,
-                model_id=model,
-                tenant=item.get("tenant"),
-                plan=item.get("plan"),
-            )
-            if card is not None
-            else None
-        )
+        item_tenant = item.get("tenant")
+        item_plan = item.get("plan")
+        rule = cost_rule = None
+        if card is not None:
+            for side in ("price", "cost"):
+                resolved = card.resolve(
+                    modality=modality,
+                    provider=provider,
+                    model_id=model,
+                    tenant=item_tenant,
+                    plan=item_plan,
+                    sets=side,
+                )
+                if side == "price":
+                    rule = resolved
+                else:
+                    cost_rule = resolved
         catalog_price = _voice_prices(modality, model)
         out.append(
             {
@@ -433,9 +460,12 @@ async def rate_card_quote_bulk(
                 "provider": provider,
                 "model": model,
                 "pricing_source": catalog_pricing_source(modality),
-                **_serviceability(catalog_price, rule, gate),
+                **_serviceability(catalog_price, rule, gate, cost_rule),
                 "catalog": catalog_price,
                 "effective": _serialize_rule(rule) if rule is not None else None,
+                "cost_basis": (
+                    _serialize_rule(cost_rule) if cost_rule is not None else None
+                ),
             }
         )
     return {"models": out}

--- a/src/voicegateway/services/managed_config_service.py
+++ b/src/voicegateway/services/managed_config_service.py
@@ -171,6 +171,7 @@ class ManagedConfigService:
         input_price_usd: float | None = None,
         cached_input_price_usd: float | None = None,
         output_price_usd: float | None = None,
+        sets: str = "price",
     ) -> str:
         async with self._db.session() as s:
             return await rate_rule_repo.upsert_rule(
@@ -186,6 +187,7 @@ class ManagedConfigService:
                 input_price_usd=input_price_usd,
                 cached_input_price_usd=cached_input_price_usd,
                 output_price_usd=output_price_usd,
+                sets=sets,
             )
 
     async def delete_rate_rule(self, rule_id: str) -> bool:

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -1109,6 +1109,7 @@ class StorageService:
         input_price_usd: float | None = None,
         cached_input_price_usd: float | None = None,
         output_price_usd: float | None = None,
+        sets: str = "price",
     ) -> str:
         """Delegate to ManagedConfigService.upsert_rate_rule."""
         await self._ensure_initialized()
@@ -1124,6 +1125,7 @@ class StorageService:
             input_price_usd=input_price_usd,
             cached_input_price_usd=cached_input_price_usd,
             output_price_usd=output_price_usd,
+            sets=sets,
         )
 
     async def delete_rate_rule(self, rule_id: str) -> bool:

--- a/src/voicegateway/tests/billing/test_cost_basis.py
+++ b/src/voicegateway/tests/billing/test_cost_basis.py
@@ -1,0 +1,249 @@
+"""A rate rule can say what the operator PAYS, not only what they charge.
+
+Before this, ``rating.price()`` took ``cost_usd`` as an input and only ever
+turned it into ``rated_price_usd``. Nothing could replace ``cost_usd`` itself,
+so it was always the voice-prices catalogue figure: a published list price.
+Anyone at volume is on a negotiated contract that differs from it by a margin
+nobody outside the contract can see, so ``cost_plus`` marked up a number that
+was never true and produced a margin that was wrong in a direction the
+operator had no way to detect.
+
+The workaround was a ``fixed`` rule carrying the negotiated cost. That gives a
+correct total, and lands it in the SELL column while ``cost_usd`` keeps lying,
+so any report comparing the two is nonsense.
+
+THE DESIGN DECISION THIS FILE PINS is that cost and price resolve
+INDEPENDENTLY. The ordinary configuration is a model-specific cost ("this is
+what I pay for nova-3") plus a global markup ("charge 1.3x"). A single
+most-specific-wins pass over one merged list lets the cost rule win outright
+and silently drops the markup, producing a bill at cost with nothing in the
+output saying so. Two resolutions, one per side.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.billing.rate_card import RateCard, RateRule, validate_sets
+from voicegateway.billing.rating import declared_cost, price
+from voicegateway.middleware.cost_tracker_middleware import CostTracker
+
+_SCOPE = {"modality": "stt", "provider": "deepgram", "model_id": "deepgram/nova-3"}
+
+
+def _cost_rule(**kw) -> RateRule:
+    base = {
+        "sets": "cost",
+        "kind": "fixed",
+        "modality": "stt",
+        "provider": "deepgram",
+        "model": "nova-3",
+        "unit": "minute",
+        "unit_price_usd": 0.0035,
+    }
+    base.update(kw)
+    return RateRule(**base)
+
+
+# --------------------------------------------------------------------------
+# The two resolutions
+# --------------------------------------------------------------------------
+
+
+def test_a_model_cost_and_a_global_markup_both_apply() -> None:
+    """The case a single resolution silently breaks.
+
+    Deepgram list is $0.0048/min. The operator negotiated $0.0035 and charges
+    1.3x. Correct is 10 min at $0.035 cost and $0.0455 billed. A merged
+    resolution returns the model-specific COST rule as most specific, applies
+    it as though it were the price rule, and bills $0.035: cost exactly, no
+    margin, no error.
+    """
+    card = RateCard(
+        rules=[_cost_rule(), RateRule(sets="price", kind="cost_plus", markup=1.3)]
+    )
+    cost, cost_rule = declared_cost(card, **_SCOPE, input_units=10.0)
+    assert cost == pytest.approx(0.035)
+    assert cost_rule.sets == "cost"
+
+    rated = price(card, **_SCOPE, cost_usd=cost, input_units=10.0)
+    assert rated.rated_price_usd == pytest.approx(0.0455)
+    assert rated.rate_rule == "cost_plus:1.3"
+
+
+def test_resolving_one_side_never_returns_the_other() -> None:
+    card = RateCard(rules=[_cost_rule()])
+    assert card.resolve(**_SCOPE, sets="cost") is not None
+    assert card.resolve(**_SCOPE, sets="price") is None
+
+
+def test_no_cost_rule_means_no_declared_cost() -> None:
+    card = RateCard(rules=[RateRule(sets="price", kind="cost_plus", markup=1.3)])
+    assert declared_cost(card, **_SCOPE, input_units=10.0) is None
+
+
+def test_a_cost_rule_can_price_an_llm_by_leg() -> None:
+    """The negotiated LLM contract, which is three numbers, not one."""
+    card = RateCard(
+        rules=[
+            RateRule(
+                sets="cost",
+                kind="fixed",
+                modality="llm",
+                provider="openai",
+                model="gpt-4o",
+                unit="1m_token",
+                input_price_usd=2.0,
+                cached_input_price_usd=1.0,
+                output_price_usd=8.0,
+            )
+        ]
+    )
+    cost, _ = declared_cost(
+        card,
+        modality="llm",
+        provider="openai",
+        model_id="openai/gpt-4o",
+        input_units=1_000_000,
+        output_units=100_000,
+        cached_input_units=800_000,
+    )
+    # 200k uncached @ $2/M + 800k cached @ $1/M + 100k output @ $8/M
+    assert cost == pytest.approx(0.4 + 0.8 + 0.8)
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+
+
+def test_a_cost_rule_cannot_be_cost_plus() -> None:
+    """``cost_plus`` multiplies a recorded cost, so it cannot produce one.
+
+    The only number available to multiply would be the catalogue figure this
+    rule exists to replace, so the result would be a markup on a list price
+    wearing the label of a negotiated cost.
+    """
+    with pytest.raises(ValueError, match="cannot produce one"):
+        validate_sets("cost", "cost_plus")
+
+
+def test_an_unknown_side_is_rejected() -> None:
+    with pytest.raises(ValueError, match="sets one of"):
+        validate_sets("revenue", "fixed")
+
+
+def test_yaml_rejects_a_cost_rule_with_a_markup() -> None:
+    with pytest.raises(ValueError, match="cannot produce one"):
+        RateCard.from_config(
+            {"rules": [{"sets": "cost", "provider": "deepgram", "markup": 1.2}]}
+        )
+
+
+def test_rules_default_to_setting_the_price() -> None:
+    """Every rule written before ``sets`` existed set the price, definitionally."""
+    card = RateCard.from_config({"rules": [{"provider": "openai", "markup": 1.5}]})
+    assert card.rules[0].sets == "price"
+    assert RateRule().sets == "price"
+
+
+# --------------------------------------------------------------------------
+# The recorded row
+# --------------------------------------------------------------------------
+
+
+def test_the_row_records_the_declared_cost_and_names_the_rule() -> None:
+    """``cost_usd`` stops being the catalogue's number, and says so.
+
+    Without this the operator's negotiated rate could only reach the sell
+    column, leaving ``cost_usd`` at list price and any cost-vs-revenue report
+    comparing a real number against an invented one.
+    """
+    card = RateCard(
+        rules=[_cost_rule(), RateRule(sets="price", kind="cost_plus", markup=1.3)]
+    )
+    record = CostTracker(rate_card=card).create_record(
+        model_id="deepgram/nova-3",
+        modality="stt",
+        provider="deepgram",
+        input_units=10.0,
+    )
+    assert record.cost_usd == pytest.approx(0.035)
+    assert record.pricing_source.startswith("rate-card:")
+    assert record.rated_price_usd == pytest.approx(0.0455)
+
+
+def test_without_a_cost_rule_the_catalogue_still_prices_the_row() -> None:
+    """The override is additive: nothing changes for anyone not using it."""
+    record = CostTracker().create_record(
+        model_id="deepgram/nova-3",
+        modality="stt",
+        provider="deepgram",
+        input_units=10.0,
+    )
+    assert record.cost_usd == pytest.approx(0.048)
+    assert record.pricing_source.startswith("voice-prices@")
+
+
+def test_a_self_hosted_model_is_never_overridden_by_a_wildcard_cost_rule() -> None:
+    """``local/*`` runs on hardware already paid for; a cloud rate is not it.
+
+    A broad cost rule is easy to write, and silently attaching a per-minute
+    cloud rate to a local model would invent spend that never happened.
+    """
+    card = RateCard(
+        rules=[
+            RateRule(
+                sets="cost",
+                kind="fixed",
+                modality="stt",
+                unit="minute",
+                unit_price_usd=0.01,
+            )
+        ]
+    )
+    record = CostTracker(rate_card=card).create_record(
+        model_id="local/whisper", modality="stt", provider="local", input_units=10.0
+    )
+    assert record.cost_usd == 0.0
+    assert record.pricing_source == "voicegateway-local"
+
+
+def test_the_collector_re_derives_cost_on_ingest() -> None:
+    """Agents record the catalogue figure; the collector holds the contract.
+
+    An agent carries no rate card, so it writes the list price. The collector
+    is the source of truth for what things cost, so an ingested row is
+    corrected before the markup is applied, and a margin is never computed
+    against a price the operator does not pay.
+    """
+    agent = CostTracker()
+    record = agent.create_record(
+        model_id="deepgram/nova-3",
+        modality="stt",
+        provider="deepgram",
+        input_units=10.0,
+    )
+    assert record.cost_usd == pytest.approx(0.048)  # list price, as the agent saw it
+
+    collector = CostTracker(
+        rate_card=RateCard(
+            rules=[_cost_rule(), RateRule(sets="price", kind="cost_plus", markup=1.3)]
+        )
+    )
+    collector.rate_record(record)
+    assert record.cost_usd == pytest.approx(0.035)
+    assert record.pricing_source.startswith("rate-card:")
+    assert record.rated_price_usd == pytest.approx(0.0455)
+
+
+def test_a_db_rule_names_itself_by_id_rather_than_by_its_price() -> None:
+    """The audit trail has to identify the RULE, not restate its number.
+
+    Two rules at different scopes can carry the same rate, so a row stamped
+    only with the price cannot say which entry produced it, which is exactly
+    what reconcile needs when an invoice disagrees.
+    """
+    rule = _cost_rule(rule_id="cost|*|*|stt|deepgram|nova-3")
+    assert rule.audit_token() == "cost|*|*|stt|deepgram|nova-3"
+    assert _cost_rule().audit_token() == "fixed:0.0035/minute"

--- a/src/voicegateway/tests/server/test_pricing_gate_and_gaps.py
+++ b/src/voicegateway/tests/server/test_pricing_gate_and_gaps.py
@@ -241,3 +241,88 @@ async def test_gaps_is_empty_when_every_metered_model_has_a_rate(
     await gw.storage._ensure_initialized()
     await _record(gw, "deepgram/nova-3")
     assert client.get("/v1/billing/rate-card/gaps").json()["gaps"] == []
+
+
+# --------------------------------------------------------------------------
+# A declared COST is the declaration the design actually asks for
+# --------------------------------------------------------------------------
+
+
+def test_a_declared_cost_alone_makes_a_model_offerable(tmp_path, monkeypatch) -> None:
+    """What the operator enters on the config page is what they PAY.
+
+    The platform asks "how much does this plugin cost you per model", so a
+    cost rule with no sell-side rule is the ordinary state of a freshly
+    configured model. It has to open the gate on its own, or the page the
+    design describes produces nothing offerable.
+    """
+    client, _ = _client(tmp_path, monkeypatch)
+    r = client.post(
+        "/v1/billing/rate-card/rules",
+        json={
+            "sets": "cost",
+            "modality": "stt",
+            "provider": "deepgram",
+            "model": "nova-3",
+            "fixed": 0.0035,
+            "unit": "minute",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    body = _quote(client, "stt", "deepgram/nova-3")
+    assert body["serviceable"] is True
+    assert body["priced_by"] == "operator"
+    assert body["cost_basis"]["unit_price_usd"] == pytest.approx(0.0035)
+    assert body["cost_basis"]["sets"] == "cost"
+    # No sell-side rule was declared, so that side stays empty.
+    assert body["effective"] is None
+    # The catalogue answer is still carried, so a UI can show the operator
+    # their negotiated rate against the published one. Asserted structurally:
+    # the published number moves with the catalogue version, and pinning it
+    # would make this a test of voice-prices rather than of the endpoint.
+    assert body["catalog"]["priced"] is True
+    assert body["catalog"]["unit_price_usd"] > 0
+    assert body["catalog"]["unit_price_usd"] != body["cost_basis"]["unit_price_usd"]
+
+
+def test_a_cost_rule_and_a_price_rule_coexist_at_one_scope(
+    tmp_path, monkeypatch
+) -> None:
+    """ "What I pay" and "what I charge" for the same model are both storable.
+
+    They share every scope field, so without the ledger side in the key the
+    second write would overwrite the first and the operator would silently
+    lose one of the two numbers they entered.
+    """
+    client, _ = _client(tmp_path, monkeypatch)
+    scope = {"modality": "stt", "provider": "deepgram", "model": "nova-3"}
+    cost = client.post(
+        "/v1/billing/rate-card/rules",
+        json={**scope, "sets": "cost", "fixed": 0.0035, "unit": "minute"},
+    )
+    sell = client.post(
+        "/v1/billing/rate-card/rules",
+        json={**scope, "sets": "price", "fixed": 0.0060, "unit": "minute"},
+    )
+    assert cost.status_code == 200 and sell.status_code == 200
+    assert cost.json()["rule_id"] != sell.json()["rule_id"]
+
+    rules = client.get("/v1/billing/rate-card/rules").json()["rules"]
+    assert sorted(r["sets"] for r in rules) == ["cost", "price"]
+
+    body = _quote(client, "stt", "deepgram/nova-3")
+    assert body["cost_basis"]["unit_price_usd"] == pytest.approx(0.0035)
+    assert body["effective"]["unit_price_usd"] == pytest.approx(0.0060)
+
+
+def test_a_cost_rule_with_a_markup_is_rejected_by_the_api(
+    tmp_path, monkeypatch
+) -> None:
+    client, _ = _client(tmp_path, monkeypatch)
+    r = client.post(
+        "/v1/billing/rate-card/rules",
+        json={"sets": "cost", "provider": "deepgram", "markup": 1.2},
+    )
+    assert r.status_code == 400
+    assert "cannot produce one" in r.json()["detail"]


### PR DESCRIPTION
Phase 2 of operator-declared pricing, and the half that makes a declared rate mean anything. **Stacked on #269** — merge that first.

## The defect

`rating.price()` took `cost_usd` as an **input** and only ever turned it into `rated_price_usd`. Nothing could replace `cost_usd` itself, so it was always the voice-prices catalogue figure — a published list price.

Anyone at volume is on a negotiated contract that differs from list by a margin nobody outside the contract can see. So `cost_plus` marked up a number that was never true, and produced a margin wrong in a direction the operator had no way to detect from the row.

The available workaround was a `fixed` rule carrying the negotiated cost. That gives a correct total and puts it in the **sell** column while `cost_usd` keeps lying, so any cost-vs-revenue report compares a real number against an invented one.

## The load-bearing decision

A rule now names which side it sets: `price` (default, unchanged behaviour) or `cost`.

**The two sides resolve independently.** This is the part that would have shipped broken:

```yaml
- {sets: cost,  modality: stt, provider: deepgram, model: nova-3, fixed: 0.0035, unit: minute}
- {sets: price, markup: 1.3}
```

That is the ordinary configuration. One most-specific-wins pass over a merged list returns the **cost** rule as most specific, applies it as the price, and bills at cost — no margin, no error, nothing in the output saying so. So `resolve()` takes `sets` and the two are separate passes. Verified: cost `$0.035`, billed `$0.0455`.

Credit to Pixis for catching this: they proposed a single discriminated field and then identified that a single resolution over it silently drops the markup.

## Details that took a decision

**A cost rule must be `fixed`.** `cost_plus` multiplies a recorded cost, so asking it to *produce* one leaves the catalogue figure as the only thing to multiply — exactly what this exists to stop. Rejected at load.

**The ledger side is part of `rule_id`.** A cost rule and a price rule share every scope field, so without it the second write overwrites the first and the operator silently loses one of the two numbers they typed. Only cost rules take the prefix, so every existing `rule_id` still addresses its row.

**`pricing_source` becomes `rate-card:<rule_id>`.** A row must never claim the catalogue priced it when an operator did, and `reconcile` needs to point at the *entry* rather than at the usage when an invoice disagrees.

**The collector re-derives cost on ingest.** Agents carry no card and record the catalogue figure; the collector holds the contract. Tested both directions.

**Self-hosted is excluded.** A broad cost rule is easy to write, and attaching a per-minute cloud rate to `local/whisper` would invent spend that never happened.

**A declared cost alone opens the gate.** It is the number the design asks the operator for, so a model with a cost and no sell-side rule is the ordinary state of a freshly configured one. `cost_basis` is returned alongside `effective` on the quote endpoints.

## Migration

`d7a2f91c4b03` adds `sets` NOT NULL DEFAULT `'price'`. Not nullable, because "which side does this rule set" has no meaningful unknown state: a rule written before the column existed set the price definitionally, since that was the only thing a rule could do. Upgrade, downgrade and re-upgrade verified; single alembic head.

## Verification

- `3651 passed, 23 skipped, 36 deselected`
- `mypy` clean on 291 files, `ruff` clean, docs validator PASS (81 pages)
- 13 new tests covering both resolutions, validation, the recorded row, the collector path, self-hosted exclusion, and the audit token

One test caught me hardcoding a catalogue price again (`0.0043`, a 0.3.0 value). Now asserted structurally, so it does not become a test of voice-prices.