### PR TITLE
feat(reconcile): name what a flagged row's disagreement is about

### DIFF
--- a/docs/cli/reconcile.md
+++ b/docs/cli/reconcile.md
@@ -40,7 +40,30 @@ voicegw reconcile --provider <name> --start <YYYY-MM-DD> --end <YYYY-MM-DD> \
 
 An aligned table with one row per model. Columns: model, VG units, provider units, units delta%, VG cost, provider cost, cost delta$, cost delta%. Rows whose absolute cost diff % exceeds `--threshold` are tagged with a trailing ` *` and rendered in ANSI yellow when stdout is a TTY (no color when piped or captured). Models present in only one side carry a `(no vg data)` or `(no provider data)` suffix instead.
 
-A Total row sums VG cost and provider cost across rows where both sides matched (missing-side rows are excluded so their `$0` placeholders do not skew the total). When any rows are flagged, a footer line `(N flagged row(s) marked with *)` follows.
+A Total row sums VG cost and provider cost across rows where both sides matched (missing-side rows are excluded so their `$0` placeholders do not skew the total). When any rows are flagged, a footer line `(N flagged row(s) marked with *)` follows, and then a **What to check** section naming what each disagreement is about.
+
+### What to check
+
+A diff on its own says something is wrong, not what. That matters most when rates are operator-entered: a rule typed as `0.008` instead of `0.08` produces a perfectly plausible bill, and the provider invoice is the only thing in the world that can catch it.
+
+Each flagged row is diagnosed as one of three causes, because they have three different fixes and only one is in your hands:
+
+| Cause | Meaning | Fix |
+|---|---|---|
+| `rate` | The unit counts agree and the money does not. | The per-unit rate is wrong. |
+| `units` | The two sides metered different amounts of work. | A metering gap. No rate change closes it. |
+| `coverage` | Only one side has the model at all. | Either VG never metered it, or the invoice does not itemise it. |
+
+For a `rate` disagreement the report names **which authority produced VG's figure** and what the invoice implies the rate should be:
+
+```
+What to check:
+  nova-3: units agree, cost does not. VG priced this from rate-card rule
+  'cost|*|*|stt|deepgram|nova-3'. Your rate implies $0.00000583/unit; the
+  invoice implies $0.00005833/unit (10.00x).
+```
+
+The rule is named by `rule_id` rather than by its price, because two rules at different scopes can carry the same rate and restating the number identifies nothing. When the catalogue produced the figure instead, the report says so: that is not a rule to edit, it means the published rate is stale or your contract differs from list, and the remedy is to [declare a cost rule](/configuration/voicegw-yaml) rather than to change one.
 
 The unit label adapts to the provider:
 
@@ -50,7 +73,7 @@ The unit label adapts to the provider:
 
 ### CSV
 
-Twelve columns: `model, vg_units, provider_units, units_diff_abs, units_diff_pct, vg_cost_usd, provider_cost_usd, cost_diff_abs, cost_diff_pct, matched_in_vg, matched_in_provider, flagged`. The `flagged` column is `True`/`False` so spreadsheets can filter on it without re-deriving the threshold comparison.
+Sixteen columns: `model, vg_units, provider_units, units_diff_abs, units_diff_pct, vg_cost_usd, provider_cost_usd, cost_diff_abs, cost_diff_pct, matched_in_vg, matched_in_provider, flagged, cause, pricing_sources, vg_rate, provider_rate`. The `flagged` column is `True`/`False` so spreadsheets can filter on it without re-deriving the threshold comparison, and `cause` carries the same diagnosis the text report explains, so a machine reader gets it too. `pricing_sources` is pipe-separated when a model was priced by more than one authority over the window.
 
 ### JSON
 

--- a/src/voicegateway/services/reconciliation_service.py
+++ b/src/voicegateway/services/reconciliation_service.py
@@ -18,6 +18,17 @@ _PROVIDER_MODALITY = {
 
 DEFAULT_DIFF_THRESHOLD_PCT = 5.0
 
+# Below this, the two sides are metering the same work and any cost gap is a
+# RATE disagreement rather than a measurement one. Deliberately tighter than
+# the cost threshold: unit counts are counts, so they should agree closely,
+# and a rounding difference in billable seconds is the only reason they would
+# not.
+UNITS_AGREE_PCT = 1.0
+
+# A rate-card rule produced the cost. Matches the ``pricing_source`` written
+# by CostTracker when an operator-declared rate applies.
+_RATE_CARD_PREFIX = "rate-card:"
+
 
 @dataclass
 class ReconcileLine:
@@ -35,6 +46,54 @@ class ReconcileLine:
     matched_in_vg: bool
     matched_in_provider: bool
     flagged: bool = False
+    # WHAT PRODUCED VG'S NUMBER. A flagged row used to say only that the two
+    # sides disagree, which leaves the operator to guess whether their own
+    # rate is wrong, the catalogue's is, or the two are metering different
+    # amounts of work. Those have different fixes and only one of them is in
+    # the operator's hands.
+    pricing_sources: tuple[str, ...] = ()
+    # The per-unit rates the two sides imply. When the units agree, these are
+    # what actually differ, and the invoice's rate is the number the operator
+    # should be typing into the rule.
+    vg_rate: float | None = None
+    provider_rate: float | None = None
+    cause: str = ""  # "" | "rate" | "units" | "coverage"
+
+
+def _rate(cost: float, units: float) -> float | None:
+    """Implied per-unit rate, or None when there are no units to divide by."""
+    return cost / units if units else None
+
+
+def _diagnose(
+    *,
+    units_diff_pct: float,
+    matched_both: bool,
+) -> str:
+    """Name what a flagged row's disagreement is ABOUT.
+
+    Three causes with three different fixes:
+
+    ``coverage``
+        One side has the model and the other does not. Nothing to compare;
+        either VG never metered it or the invoice does not itemise it.
+
+    ``units``
+        The two sides disagree about how much work happened. That is a
+        metering question (a dropped session, a different billable-duration
+        rounding), and no rate change will close it.
+
+    ``rate``
+        The unit counts agree and the money does not, so the per-unit rate is
+        wrong. This is the one an operator can fix directly, and with
+        operator-declared pricing it is the likely one: a hand-typed rate has
+        no other oracle than the invoice.
+    """
+    if not matched_both:
+        return "coverage"
+    if abs(units_diff_pct) > UNITS_AGREE_PCT:
+        return "units"
+    return "rate"
 
 
 def _pct(diff: float, base: float) -> float:
@@ -90,11 +149,18 @@ def parse_provider_file(provider: str, path: Path) -> dict[str, dict[str, float]
 
 def aggregate_vg_records(
     provider: str, records: list[dict[str, Any]]
-) -> dict[str, dict[str, float]]:
-    """Aggregate VG's per-request rows into per-model totals."""
+) -> dict[str, dict[str, Any]]:
+    """Aggregate VG's per-request rows into per-model totals.
+
+    Carries the distinct ``pricing_source`` values through, because when the
+    invoice disagrees the first useful question is which authority produced
+    VG's figure: a rate the operator typed, the catalogue, or nothing at all.
+    """
     prefix = f"{provider}/"
     expected_modality = _PROVIDER_MODALITY.get(provider)
-    out: dict[str, dict[str, float]] = {}
+    # ``Any`` because a bucket holds float totals plus the set of distinct
+    # pricing sources seen for the model, which is not a number.
+    out: dict[str, dict[str, Any]] = {}
     for r in records:
         model_id = r.get("model_id", "")
         if not model_id.startswith(prefix):
@@ -103,8 +169,12 @@ def aggregate_vg_records(
             continue
         bare_model = model_id[len(prefix) :]
         bucket = out.setdefault(
-            bare_model, {"units": 0.0, "cost": 0.0, "n_requests": 0.0}
+            bare_model,
+            {"units": 0.0, "cost": 0.0, "n_requests": 0.0, "sources": set()},
         )
+        source = str(r.get("pricing_source") or "")
+        if source:
+            bucket["sources"].add(source)
 
         input_units = float(r.get("input_units", 0) or 0)
         output_units = float(r.get("output_units", 0) or 0)
@@ -132,7 +202,7 @@ def reconcile(
     all_models = sorted(set(vg_agg) | set(provider_agg))
     lines: list[ReconcileLine] = []
     for model in all_models:
-        vg = vg_agg.get(model, {"units": 0.0, "cost": 0.0})
+        vg = vg_agg.get(model, {"units": 0.0, "cost": 0.0, "sources": set()})
         prov = provider_agg.get(model, {"units": 0.0, "cost": 0.0})
         units_diff = prov["units"] - vg["units"]
         cost_diff = prov["cost"] - vg["cost"]
@@ -143,13 +213,22 @@ def reconcile(
         flagged = matched_both and (
             abs(cost_diff_pct) > threshold_pct or zero_base_real_diff
         )
+        units_diff_pct = _pct(units_diff, prov["units"])
         lines.append(
             ReconcileLine(
+                pricing_sources=tuple(sorted(vg.get("sources") or ())),
+                vg_rate=_rate(vg["cost"], vg["units"]),
+                provider_rate=_rate(prov["cost"], prov["units"]),
+                cause=(
+                    _diagnose(units_diff_pct=units_diff_pct, matched_both=matched_both)
+                    if flagged or not matched_both
+                    else ""
+                ),
                 model=model,
                 vg_units=vg["units"],
                 provider_units=prov["units"],
                 units_diff_abs=units_diff,
-                units_diff_pct=_pct(units_diff, prov["units"]),
+                units_diff_pct=units_diff_pct,
                 vg_cost=vg["cost"],
                 provider_cost=prov["cost"],
                 cost_diff_abs=cost_diff,
@@ -228,7 +307,62 @@ def format_text(
     )
     if flagged_count:
         rows.append(f"  ({flagged_count} flagged row(s) marked with *)")
+        rows.extend(explain(lines))
     return "\n".join(rows) + "\n"
+
+
+def explain(lines: list[ReconcileLine]) -> list[str]:
+    """Per-flagged-row guidance naming the suspect and the number to change.
+
+    A diff on its own tells an operator that something is wrong, not what.
+    That gap matters more now that rates are hand-entered: a rule typed as
+    0.008 instead of 0.08 has no oracle inside the product, and the invoice is
+    the only thing that can catch it. So when the unit counts agree, this says
+    which rate produced VG's figure and what the invoice implies it should be,
+    which is the edit rather than a hint toward it.
+    """
+    out: list[str] = ["", "What to check:"]
+    for line in lines:
+        if not line.flagged and line.matched_in_vg and line.matched_in_provider:
+            continue
+        if line.cause == "coverage":
+            missing = "VG" if not line.matched_in_vg else "the provider export"
+            out.append(
+                f"  {line.model}: only one side has this model ({missing} has no rows)."
+            )
+            continue
+        if line.cause == "units":
+            out.append(
+                f"  {line.model}: the unit counts disagree by "
+                f"{line.units_diff_pct:+.2f}%, so this is a metering gap rather "
+                f"than a rate. No rate change closes it."
+            )
+            continue
+        # cause == "rate": the counts agree, so the per-unit rate is the fault.
+        declared = [s for s in line.pricing_sources if s.startswith(_RATE_CARD_PREFIX)]
+        if declared:
+            rule = declared[0][len(_RATE_CARD_PREFIX) :]
+            who = f"rate-card rule {rule!r}"
+        elif line.pricing_sources:
+            who = f"the catalog ({', '.join(line.pricing_sources)})"
+        else:
+            who = "nothing (these rows were never priced)"
+        detail = (
+            f"  {line.model}: units agree, cost does not. VG priced this from {who}."
+        )
+        if line.vg_rate is not None and line.provider_rate is not None:
+            factor = (
+                f" ({line.provider_rate / line.vg_rate:.2f}x)" if line.vg_rate else ""
+            )
+            detail += (
+                f" Your rate implies ${line.vg_rate:.8f}/unit; the invoice implies "
+                f"${line.provider_rate:.8f}/unit{factor}."
+            )
+        out.append(detail)
+    return out
+
+
+_EXTRA_FIELDS = ("cause", "pricing_sources", "vg_rate", "provider_rate")
 
 
 def format_csv(lines: list[ReconcileLine]) -> str:
@@ -251,6 +385,10 @@ def format_csv(lines: list[ReconcileLine]) -> str:
             "matched_in_vg",
             "matched_in_provider",
             "flagged",
+            "cause",
+            "pricing_sources",
+            "vg_rate",
+            "provider_rate",
         ]
     )
     for line in lines:
@@ -268,6 +406,10 @@ def format_csv(lines: list[ReconcileLine]) -> str:
                 line.matched_in_vg,
                 line.matched_in_provider,
                 line.flagged,
+                line.cause,
+                "|".join(line.pricing_sources),
+                "" if line.vg_rate is None else f"{line.vg_rate:.10f}",
+                "" if line.provider_rate is None else f"{line.provider_rate:.10f}",
             ]
         )
     return buf.getvalue()

--- a/src/voicegateway/tests/services/test_reconcile_names_the_cause.py
+++ b/src/voicegateway/tests/services/test_reconcile_names_the_cause.py
@@ -1,0 +1,217 @@
+"""A reconcile diff has to say what is wrong, not only that something is.
+
+``voicegw reconcile`` compared VG's per-model totals against a provider export
+and flagged rows past a threshold. That is enough when the cost came from a
+catalogue everyone can inspect. It stopped being enough once rates are
+operator-entered, because a hand-typed rule has NO oracle inside the product:
+a rate entered as 0.008 instead of 0.08 produces a perfectly plausible bill,
+and the invoice is the only thing that can catch it.
+
+A flagged row now names which of three things disagrees, because they have
+three different fixes and only one is in the operator's hands:
+
+    coverage   one side has the model and the other does not
+    units      the two sides metered different amounts of work
+    rate       the counts agree and the money does not
+
+For a rate disagreement it names the rule that produced VG's figure and the
+per-unit rate the invoice implies, which is the edit rather than a hint at it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from voicegateway.services import reconciliation_service as rs
+
+
+def _vg_row(model: str, *, units: float, cost: float, source: str) -> dict:
+    """One request as ``get_requests_in_window`` returns it (deepgram: minutes)."""
+    return {
+        "model_id": f"deepgram/{model}",
+        "modality": "stt",
+        "input_units": units,
+        "output_units": 0.0,
+        "cost_usd": cost,
+        "pricing_source": source,
+    }
+
+
+def _provider_file(tmp_path: Path, model: str, *, seconds: float, cost: float) -> Path:
+    path = tmp_path / "usage.json"
+    path.write_text(
+        json.dumps([{"model": model, "audio_seconds": seconds, "cost_usd": cost}])
+    )
+    return path
+
+
+def _line(lines: list[rs.ReconcileLine], model: str) -> rs.ReconcileLine:
+    return next(ln for ln in lines if ln.model == model)
+
+
+# --------------------------------------------------------------------------
+# The three causes
+# --------------------------------------------------------------------------
+
+
+def test_a_mistyped_rate_is_diagnosed_as_a_rate_problem(tmp_path) -> None:
+    """The failure operator-declared pricing introduces, and cannot self-catch.
+
+    10 minutes metered on both sides. The operator typed 0.00035 where they
+    meant 0.0035, so VG says $0.0035 and the invoice says $0.035. The units
+    agree exactly, which is what makes this a rate fault rather than a
+    metering one.
+    """
+    vg = [_vg_row("nova-3", units=10.0, cost=0.0035, source="rate-card:cost|mine")]
+    lines = rs.reconcile(
+        "deepgram", vg, _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035)
+    )
+    line = _line(lines, "nova-3")
+    assert line.flagged
+    assert line.cause == "rate"
+    assert line.units_diff_pct == pytest.approx(0.0)
+    # The rate the invoice implies is what the rule should have said.
+    assert line.vg_rate == pytest.approx(0.0035 / 600.0)
+    assert line.provider_rate == pytest.approx(0.035 / 600.0)
+
+
+def test_a_metering_gap_is_not_blamed_on_the_rate(tmp_path) -> None:
+    """Half the sessions never reached VG. No rate edit closes that.
+
+    Telling an operator to check their rate here would send them to change a
+    number that is correct.
+    """
+    vg = [_vg_row("nova-3", units=5.0, cost=0.0175, source="rate-card:cost|mine")]
+    lines = rs.reconcile(
+        "deepgram", vg, _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035)
+    )
+    line = _line(lines, "nova-3")
+    assert line.flagged
+    assert line.cause == "units"
+
+
+def test_a_model_on_only_one_side_is_a_coverage_problem(tmp_path) -> None:
+    lines = rs.reconcile(
+        "deepgram", [], _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035)
+    )
+    line = _line(lines, "nova-3")
+    assert line.cause == "coverage"
+    assert line.matched_in_vg is False
+
+
+def test_an_agreeing_row_is_not_diagnosed_at_all(tmp_path) -> None:
+    """No cause on a row that is fine, so the report stays quiet when it can."""
+    vg = [_vg_row("nova-3", units=10.0, cost=0.035, source="rate-card:cost|mine")]
+    lines = rs.reconcile(
+        "deepgram", vg, _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035)
+    )
+    line = _line(lines, "nova-3")
+    assert not line.flagged
+    assert line.cause == ""
+
+
+# --------------------------------------------------------------------------
+# Naming the suspect
+# --------------------------------------------------------------------------
+
+
+def test_the_report_names_the_rate_card_rule_that_produced_the_number(
+    tmp_path,
+) -> None:
+    """Point at the entry, not at the usage.
+
+    The operator needs to know WHICH rule to edit. Two rules at different
+    scopes can carry the same rate, so restating the price identifies nothing.
+    """
+    vg = [
+        _vg_row(
+            "nova-3",
+            units=10.0,
+            cost=0.0035,
+            source="rate-card:cost|*|*|stt|deepgram|nova-3",
+        )
+    ]
+    lines = rs.reconcile(
+        "deepgram", vg, _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035)
+    )
+    text = "\n".join(rs.explain(lines))
+    assert "rate-card rule 'cost|*|*|stt|deepgram|nova-3'" in text
+    assert "10.00x" in text, text  # the invoice is 10x what was typed
+
+
+def test_the_report_says_when_the_catalogue_produced_the_number(tmp_path) -> None:
+    """A catalogue disagreement is not the operator's rule to fix.
+
+    It means the published rate is stale or their contract differs from list,
+    and the remedy is to declare a cost rule rather than to edit one.
+    """
+    vg = [_vg_row("nova-3", units=10.0, cost=0.0035, source="voice-prices@0.6.0")]
+    lines = rs.reconcile(
+        "deepgram", vg, _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035)
+    )
+    text = "\n".join(rs.explain(lines))
+    assert "the catalog (voice-prices@0.6.0)" in text
+    assert "rate-card rule" not in text
+
+
+def test_the_report_says_when_nothing_priced_the_rows(tmp_path) -> None:
+    vg = [_vg_row("nova-3", units=10.0, cost=0.0, source="")]
+    lines = rs.reconcile(
+        "deepgram", vg, _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035)
+    )
+    text = "\n".join(rs.explain(lines))
+    assert "never priced" in text
+
+
+def test_a_units_disagreement_says_no_rate_change_will_close_it(tmp_path) -> None:
+    vg = [_vg_row("nova-3", units=5.0, cost=0.0175, source="rate-card:cost|mine")]
+    lines = rs.reconcile(
+        "deepgram", vg, _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035)
+    )
+    text = "\n".join(rs.explain(lines))
+    assert "metering gap" in text
+    assert "No rate change closes it" in text
+
+
+# --------------------------------------------------------------------------
+# The output surfaces carry it
+# --------------------------------------------------------------------------
+
+
+def test_the_text_report_appends_the_guidance_only_when_something_is_flagged(
+    tmp_path,
+) -> None:
+    clean = rs.reconcile(
+        "deepgram",
+        [_vg_row("nova-3", units=10.0, cost=0.035, source="voice-prices@0.6.0")],
+        _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035),
+    )
+    assert "What to check:" not in rs.format_text(clean, "deepgram")
+
+    dirty = rs.reconcile(
+        "deepgram",
+        [_vg_row("nova-3", units=10.0, cost=0.0035, source="rate-card:cost|mine")],
+        _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035),
+    )
+    assert "What to check:" in rs.format_text(dirty, "deepgram")
+
+
+def test_csv_and_json_carry_the_cause(tmp_path) -> None:
+    """A machine reader must get the diagnosis too, not just the terminal."""
+    lines = rs.reconcile(
+        "deepgram",
+        [_vg_row("nova-3", units=10.0, cost=0.0035, source="rate-card:cost|mine")],
+        _provider_file(tmp_path, "nova-3", seconds=600.0, cost=0.035),
+    )
+    csv_out = rs.format_csv(lines)
+    assert "cause" in csv_out.splitlines()[0]
+    assert "rate" in csv_out.splitlines()[1]
+
+    doc = json.loads(rs.format_json(lines, provider="deepgram"))
+    row = doc["rows"][0]
+    assert row["cause"] == "rate"
+    assert row["pricing_sources"] == ["rate-card:cost|mine"]
+    assert row["provider_rate"] > row["vg_rate"]


### PR DESCRIPTION
The third leg of operator-declared pricing, and the one that makes hand-entered rates *safe* rather than merely possible.

## Why now

`reconcile` flagged rows past a cost threshold and left the operator to work out what was wrong. Tolerable while every cost came from a catalogue anyone can inspect.

Not tolerable once rates are entered by hand. **A rule typed as `0.008` instead of `0.08` produces a perfectly plausible bill.** Nothing inside the product can tell — that is what #270 traded away in exchange for correct negotiated pricing. The provider invoice is the only oracle that exists, so pointing at "these two numbers differ" and stopping wastes the one signal that can catch it.

## What it does now

```
nova-3          600.0     600.0   +0.00%  $0.0035  $0.0350  $+0.0315  +90.00% *
  (1 flagged row(s) marked with *)

What to check:
  nova-3: units agree, cost does not. VG priced this from rate-card rule
  'cost|*|*|stt|deepgram|nova-3'. Your rate implies $0.00000583/unit; the
  invoice implies $0.00005833/unit (10.00x).
```

That is the edit rather than a hint toward it, and the **10.00x** is what makes a fat-fingered rate obvious rather than merely detectable.

## Three causes, because they have three different fixes

| Cause | Meaning | In the operator's hands? |
|---|---|---|
| `rate` | Unit counts agree, money does not | **Yes** — the rate is wrong |
| `units` | The two sides metered different work | No — a metering gap; no rate change closes it |
| `coverage` | Only one side has the model | No |

The `units` case matters as much as `rate`. Without it the report would send someone to change a rate that is correct, because half their sessions never reached the collector.

## Decisions worth flagging

**The rule is named by `rule_id`, not by its price.** Two rules at different scopes can carry the same rate, so restating the number identifies nothing. This is the whole reason `pricing_source` carries the id rather than the figure.

**A catalogue disagreement says so explicitly.** It is not a rule to edit: it means the published rate is stale or the contract differs from list, and the remedy is to *declare* a cost rule rather than change one. Blaming a nonexistent rule would be worse than saying nothing.

**Units-agree threshold is 1%, tighter than the 5% cost threshold.** Unit counts are counts; the only reason they should differ at all is billable-duration rounding. Reusing the cost threshold would let a real metering gap masquerade as a rate fault.

**CSV and JSON carry it too** (`cause`, `pricing_sources`, `vg_rate`, `provider_rate`), so a machine reader gets the diagnosis and not only the terminal.

## Verification

- `3661 passed, 23 skipped, 36 deselected`
- `mypy` clean on 291 files, `ruff` clean, docs validator PASS (81 pages)
- 10 new tests: all three causes, the quiet case (no diagnosis on a healthy row), the rule-vs-catalogue-vs-nothing attribution, and both machine formats

## Note

I broke the CSV writer mid-edit by inserting rows outside the list literal. Caught by an import error rather than by review, fixed, and the CSV shape is now covered by a test that reads the header and a data row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reconciliation results now identify rate, unit, and coverage discrepancies.
  - Reports include pricing sources, implied and invoiced rates, and actionable explanations.
  - CSV output now includes 16 columns with diagnostic and rate details.

- **Documentation**
  - Updated CLI documentation to describe diagnostic sections, discrepancy causes, pricing sources, and CSV fields.

- **Tests**
  - Added coverage for reconciliation diagnoses across text, CSV, and JSON outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->