### PR TITLE
feat(cost): record which turn a metered call belongs to

### DIFF
--- a/alembic/versions/e5c9b41a72f8_requests_turn_index.py
+++ b/alembic/versions/e5c9b41a72f8_requests_turn_index.py
@@ -1,0 +1,54 @@
+"""requests: which turn a call belongs to
+
+Revision ID: e5c9b41a72f8
+Revises: d7a2f91c4b03
+Create Date: 2026-08-21 18:00:00.000000
+
+Cost could be totalled by model, project, session or agent, but not by TURN.
+So "that turn took four seconds" and "that turn cost this much" were two
+questions about the same moment that could not be asked together, and the
+expensive turn and the slow turn could never be shown to be the same one.
+
+Every input already existed. ``requests`` carried ``session_id`` and ``turns``
+carried ``session_id`` + ``turn_index``, but nothing tied a single call to a
+single turn, and nothing downstream can reconstruct it: the correlation exists
+only at the instant the metric fires, while the tracker still knows which turn
+is open.
+
+Nullable, and absent rather than zero. A Pipecat session, or any agent running
+with turn capture off, has no turn for a call to belong to, and defaulting to
+0 would claim the first turn for every one of them. The index is composite on
+(session_id, turn_index) because every question this enables is scoped to one
+session first.
+
+Mirrors ``tool_calls.turn_index``, which correlates the same way for the same
+reason.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e5c9b41a72f8"
+down_revision: str | None = "d7a2f91c4b03"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX = "idx_requests_session_turn"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "requests",
+        sa.Column("turn_index", sa.Integer(), nullable=True),
+    )
+    op.create_index(_INDEX, "requests", ["session_id", "turn_index"])
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX, table_name="requests")
+    op.drop_column("requests", "turn_index")

--- a/docs/architecture/cost-tracking.md
+++ b/docs/architecture/cost-tracking.md
@@ -68,6 +68,21 @@ All three modalities return `None` for unknown models (never silent zero), so ca
 
 A fourth case sits between them. A model can *match* the catalogue and still carry no rate for the units recorded, in which case `calc_price` applies nothing and returns a total of zero. `calculate_cost_detail` reports those units alongside the total, and `CostTracker` tags the row `voice-prices-unrated` instead of `voice-prices@<version>` so it never reads as a priced figure. Use `calculate_cost_detail` rather than `calculate_cost` anywhere the answer feeds a price display or a gate.
 
+
+## Per-turn cost
+
+`requests.turn_index` says which conversational turn a metered call belongs to, within its `session_id`. It exists so that "that turn took four seconds" and "that turn cost this much" can be asked together, which they could not be before: cost rolled up by model, project, session or agent, but never by turn, so an expensive turn and a slow turn could not be shown to be the same one.
+
+It is stamped in `capture.py` at the instant the metric fires, from the turn tracker, the same way `tool_calls.turn_index` is. **It cannot be reconstructed later.** Once the metric has been handled nothing knows which turn was open, so this is not a join that could have been deferred to read time.
+
+<Warning>
+`turn_index` is a **correlation hint, not a measurement.** The tracker's index is read without its lock, so a call landing on a turn boundary can be attributed to the turn either side. That is fine for "which turn was expensive" and wrong for anything requiring exactness.
+</Warning>
+
+**NULL means no turn, not turn zero.** A Pipecat session, or a LiveKit agent running with turn capture off, has no turn for a call to belong to. Defaulting to `0` would pile every such row onto the first turn.
+
+**Cost with no turn is reported, not dropped.** A session-close reconcile row spans the whole call by construction, so `get_cost_by_turn` excludes it and `get_unattributed_cost` reports it separately. Per-turn plus unattributed reconstructs the session total exactly; a per-turn view that presented itself as complete would understate the session in precisely the case worth noticing.
+
 ## Per-request flow
 
 Every wrapped request flows through `InstrumentationMixin._log_request` (`src/voicegateway/middleware/base_middleware.py`, the mixin behind `InstrumentedSTT`/`InstrumentedLLM`/`InstrumentedTTS`):

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -65,6 +65,7 @@ The primary table for every completed (or failed) inference request. ORM class `
 | `cached_input_units` | REAL | Prompt tokens served from the provider's cache (LLM only; 0 for STT/TTS) |
 | `cost_usd` | REAL | Recorded provider cost |
 | `pricing_source` | TEXT | `"rate-card:<rule_id>"` operator-declared, `"voice-prices@<version>"` catalogue-priced, `"voice-prices-unrated"` matched with no rate, `"voicegateway-local"` self-hosted, `""` unknown model |
+| `turn_index` | INTEGER | Which conversational turn within `session_id` this call belongs to. NULL when no turn was tracked, never `0`. A correlation hint, not a measurement: see below. |
 | `rated_price_usd` | REAL | Billable price the rate card stamped at write time; see [Rating](/architecture/rating) |
 | `rate_rule` | TEXT | Audit token for the rule applied, e.g. `"cost_plus:1.3"` |
 | `ttfb_ms` | REAL | Time to first byte in milliseconds |

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -1305,6 +1305,7 @@ def _attach_livekit(
         dispatch_name=resolved_dispatch_name,
         revision=resolved_revision,
         on_caller_end=_correct_caller_end if turn_tracker is not None else None,
+        turn_tracker=turn_tracker,
     )
     capture.bind(session)
 

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -299,6 +299,7 @@ class MetricCapture:
         channel: str | None = None,
         dispatch_name: str | None = None,
         on_caller_end: Callable[[int], None] | None = None,
+        turn_tracker: Any = None,
     ) -> None:
         self._cost_tracker = cost_tracker
         self._sink = sink
@@ -316,6 +317,12 @@ class MetricCapture:
         # milliseconds, whenever an EOU metric makes it recoverable. See
         # _caller_end_from_eou.
         self._on_caller_end = on_caller_end
+        # Read at metric time to say WHICH TURN a call belongs to. The
+        # correlation exists only at that instant: nothing downstream can
+        # reconstruct which turn was open when a metric fired, which is why
+        # the tracker has to be here rather than the join being done later.
+        # Same mechanism tool-call rows already use.
+        self._turn_tracker = turn_tracker
         self._pending: set[asyncio.Task[None]] = set()
         # Exception types already reported in full. A sink that cannot write
         # fails on every metric event, and one traceback per event buries the
@@ -388,6 +395,7 @@ class MetricCapture:
             current_guard_fallback_from,
         )
 
+        turn_index = self._current_turn_index()
         fallback_from = current_guard_fallback_from()
         if fallback_from is not None and fallback_from != provider:
             status = "fallback"
@@ -408,6 +416,7 @@ class MetricCapture:
             session_id=self._session_id,
             agent_id=self._agent_id,
             revision=self._revision,
+            turn_index=turn_index,
         )
         network = _network_meta(metric)
         if network:
@@ -632,6 +641,29 @@ class MetricCapture:
         if extra:
             record.metadata = {**record.metadata, **extra}
 
+    def _current_turn_index(self) -> int | None:
+        """Which turn is open right now, or None when nothing is tracked.
+
+        A CORRELATION HINT. ``current_turn_index`` reads without the lock, so a
+        metric landing on a turn boundary can be attributed to the turn either
+        side. Good enough to answer "which turn was expensive", not good
+        enough for anything requiring exactness, and the column's docstring
+        says so rather than leaving a reader to assume precision.
+
+        Absent rather than 0 when no tracker is wired (Pipecat, or turn
+        capture off), because 0 would claim the first turn for every row on
+        every agent that never tracks turns.
+        """
+        tracker = self._turn_tracker
+        if tracker is None:
+            return None
+        try:
+            index = tracker.current_turn_index(self._session_id)
+        except Exception:  # pragma: no cover - a hint must never break a write
+            logger.debug("turn index unavailable", exc_info=True)
+            return None
+        return int(index) if index is not None else None
+
     def _schedule(self, coro: Any) -> None:
         try:
             task = asyncio.ensure_future(coro)
@@ -706,6 +738,11 @@ class MetricCapture:
                 and d_cached <= _RECONCILE_EPSILON
             ):
                 continue
+            # NO turn_index on a reconcile row, deliberately. This is the
+            # close-time sweep for usage the per-metric path never saw, so the
+            # delta spans the whole session and belongs to no single turn.
+            # Stamping whichever turn happened to be open at close would
+            # attribute an entire session's missed usage to its last turn.
             record = self._cost_tracker.create_record(
                 model_id=model_id,
                 modality=modality,

--- a/src/voicegateway/middleware/cost_tracker_middleware.py
+++ b/src/voicegateway/middleware/cost_tracker_middleware.py
@@ -281,6 +281,7 @@ class CostTracker:
         session_id: str | None = None,
         agent_id: str | None = None,
         revision: str | None = None,
+        turn_index: int | None = None,
     ) -> RequestRecord:
         """Create a request record with cost calculated."""
         resolved = self._resolve_cost(
@@ -325,6 +326,7 @@ class CostTracker:
             fallback_from=fallback_from,
             error_message=error_message,
             revision=revision,
+            turn_index=turn_index,
             session_id=session_id,
             agent_id=agent_id,
         )

--- a/src/voicegateway/models/request_model.py
+++ b/src/voicegateway/models/request_model.py
@@ -53,6 +53,17 @@ class RequestRecord:
     # and a deploy id are all valid and the collector never parses it, it only
     # groups by it. Choosing between them is the operator's business.
     revision: str | None = None
+    # WHICH CONVERSATIONAL TURN THIS CALL BELONGS TO, within ``session_id``.
+    #
+    # A CORRELATION HINT, NOT A MEASUREMENT. It is read from the turn tracker
+    # at the instant the metric fires, without the lock, so a call landing on
+    # a turn boundary can be attributed to the turn either side. That is fine
+    # for "which turn was expensive" and wrong for anything needing exactness.
+    #
+    # None, never 0, when no turn is being tracked: Pipecat sessions and any
+    # agent with turn capture off have no turn to belong to, and 0 would claim
+    # the first one.
+    turn_index: int | None = None
     # Billing: the rate card in effect stamps a billable price + audit token
     # at write time. Immutable once written; defaults are a cost pass-through.
     rated_price_usd: float = 0.0
@@ -78,6 +89,8 @@ class Request(SQLModel, table=True):
         Index("idx_requests_session_id", "session_id"),
         Index("idx_requests_agent_id", "agent_id"),
         Index("idx_requests_agent_id_timestamp", "agent_id", "timestamp"),
+        # Every per-turn question is scoped to one session first.
+        Index("idx_requests_session_turn", "session_id", "turn_index"),
     )
 
     id: str = Field(primary_key=True)
@@ -131,3 +144,6 @@ class Request(SQLModel, table=True):
     agent_id: str | None = None
     # Agent configuration revision (opaque; grouped, never parsed).
     revision: str | None = None
+    # Which conversational turn within session_id produced this call. Nullable
+    # by design: absent means no turn was tracked, not turn zero.
+    turn_index: int | None = None

--- a/src/voicegateway/repository/cost_repository.py
+++ b/src/voicegateway/repository/cost_repository.py
@@ -393,7 +393,84 @@ async def get_project_stats(session: AsyncSession, project: str) -> dict[str, An
     }
 
 
+async def get_cost_by_turn(
+    session: AsyncSession,
+    *,
+    session_id: str,
+) -> list[dict[str, Any]]:
+    """Per-turn cost for one session, cheapest question this column enables.
+
+    "That turn took four seconds" and "that turn cost this much" were two
+    questions about the same moment that could not be asked together, so an
+    expensive turn and a slow turn could never be shown to be the same one.
+
+    Scoped to a single session because ``turn_index`` only means anything
+    inside one: turn 3 of two different calls are unrelated.
+
+    Rows with no ``turn_index`` are EXCLUDED rather than bucketed under a
+    null turn. They are real spend, and the caller is told how much via
+    ``unattributed`` from :func:`get_unattributed_cost`, so a total built from
+    this never silently under-counts.
+    """
+    result = await session.execute(
+        text("""
+            SELECT turn_index,
+                   COUNT(*) AS requests,
+                   SUM(COALESCE(cost_usd, 0)) AS cost_usd,
+                   SUM(COALESCE(rated_price_usd, 0)) AS rated_price_usd,
+                   GROUP_CONCAT(DISTINCT modality) AS modalities
+            FROM requests
+            WHERE session_id = :session_id AND turn_index IS NOT NULL
+            GROUP BY turn_index
+            ORDER BY turn_index ASC
+        """),
+        {"session_id": session_id},
+    )
+    return [
+        {
+            "turn_index": int(r["turn_index"]),
+            "requests": int(r["requests"]),
+            "cost_usd": float(r["cost_usd"] or 0.0),
+            "rated_price_usd": float(r["rated_price_usd"] or 0.0),
+            "modalities": sorted(str(r["modalities"] or "").split(","))
+            if r["modalities"]
+            else [],
+        }
+        for r in result.mappings()
+    ]
+
+
+async def get_unattributed_cost(
+    session: AsyncSession,
+    *,
+    session_id: str,
+) -> dict[str, Any]:
+    """Spend in this session that belongs to no turn.
+
+    Reported separately rather than folded in or dropped. A session-close
+    reconcile row spans the whole call by construction, and a Pipecat session
+    has no turns at all, so a per-turn view that pretended to be complete
+    would be wrong in exactly the cases the operator most needs to notice.
+    """
+    result = await session.execute(
+        text("""
+            SELECT COUNT(*) AS requests,
+                   SUM(COALESCE(cost_usd, 0)) AS cost_usd
+            FROM requests
+            WHERE session_id = :session_id AND turn_index IS NULL
+        """),
+        {"session_id": session_id},
+    )
+    row = result.mappings().first()
+    return {
+        "requests": int(row["requests"] or 0) if row else 0,
+        "cost_usd": float(row["cost_usd"] or 0.0) if row else 0.0,
+    }
+
+
 __all__ = [
+    "get_cost_by_turn",
+    "get_unattributed_cost",
     "get_cost_by_day",
     "get_cost_by_modality",
     "get_cost_by_project",

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -42,12 +42,14 @@ _INSERT_REQUEST = text(
     """INSERT INTO requests
        (id, timestamp, project, modality, model_id, provider,
         input_units, output_units, cached_input_units, cost_usd, pricing_source,
+        turn_index,
         rated_price_usd, rate_rule,
         ttfb_ms, total_latency_ms, status,
         fallback_from, error_message, metadata, session_id,
         tenant_id, agent_id, revision)
        VALUES (:id, :timestamp, :project, :modality, :model_id, :provider,
                :input_units, :output_units, :cached_input_units, :cost_usd, :pricing_source,
+               :turn_index,
                :rated_price_usd, :rate_rule,
                :ttfb_ms, :total_latency_ms, :status,
                :fallback_from, :error_message, :metadata, :session_id,
@@ -175,6 +177,7 @@ async def log_request(session: AsyncSession, record: RequestRecord) -> None:
             "cached_input_units": record.cached_input_units,
             "cost_usd": record.cost_usd,
             "pricing_source": record.pricing_source,
+            "turn_index": record.turn_index,
             "rated_price_usd": record.rated_price_usd,
             "rate_rule": record.rate_rule,
             "ttfb_ms": record.ttfb_ms,
@@ -338,6 +341,7 @@ _REQUEST_COLUMNS = (
     "session_id",
     "tenant_id",
     "agent_id",
+    "turn_index",
 )
 
 

--- a/src/voicegateway/tests/inference/test_attach_capture.py
+++ b/src/voicegateway/tests/inference/test_attach_capture.py
@@ -1027,3 +1027,111 @@ async def test_non_speaking_user_state_change_does_not_anchor_onset():
 
     eou = next(r for r in sink.records if r.modality == "eou")
     assert "time_to_first_partial_ms" not in eou.metadata["eou"]
+
+
+# --------------------------------------------------------------------------
+# Which turn a metered call belongs to
+# --------------------------------------------------------------------------
+
+
+class _FakeTracker:
+    """Stands in for TurnTracker.current_turn_index."""
+
+    def __init__(self, index: int | None) -> None:
+        self.index = index
+        self.asked_for: list[str | None] = []
+
+    def current_turn_index(self, session_id: str | None = None) -> int | None:
+        self.asked_for.append(session_id)
+        return self.index
+
+
+async def test_a_metered_call_records_the_turn_it_belongs_to(tmp_path):
+    """The wiring that makes per-turn cost possible at all.
+
+    The correlation exists only while the metric is firing: afterwards nothing
+    knows which turn was open, so this cannot be recovered by a later join.
+    """
+    storage = StorageService(str(tmp_path / "turn.db"))
+    sink = LocalSqliteSink(storage)
+    tracker = _FakeTracker(4)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=CostTracker(sink),
+        sink=sink,
+        project="fleet",
+        agent_id="agent-3",
+        session_id="vg-turn",
+        turn_tracker=tracker,
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    rows = await storage.get_recent_requests(limit=10)
+    assert rows[0]["turn_index"] == 4
+    # Scoped by session: turn 4 of another call is a different turn.
+    assert tracker.asked_for == ["vg-turn"]
+
+
+async def test_no_tracker_records_absent_rather_than_turn_zero(tmp_path):
+    """Pipecat, and any agent with turn capture off, has no turn to belong to.
+
+    0 would claim the first turn for every row those agents ever write, and a
+    per-turn view would then show all of their spend piled onto turn 0.
+    """
+    storage = StorageService(str(tmp_path / "noturn.db"))
+    sink = LocalSqliteSink(storage)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=CostTracker(sink),
+        sink=sink,
+        project="fleet",
+        agent_id="agent-3",
+        session_id="vg-noturn",
+        turn_tracker=None,
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    rows = await storage.get_recent_requests(limit=10)
+    assert rows[0]["turn_index"] is None
+
+
+async def test_a_broken_tracker_never_breaks_the_cost_write(tmp_path):
+    """A correlation hint must not be able to lose a cost row.
+
+    The turn index is a convenience; the cost is the measurement. If reading
+    the hint raises, the row still has to be written without it.
+    """
+
+    class _Exploding:
+        def current_turn_index(self, session_id=None):
+            raise RuntimeError("tracker is having a bad day")
+
+    storage = StorageService(str(tmp_path / "boom.db"))
+    sink = LocalSqliteSink(storage)
+    llm = _FakeEmitter(model="gpt-4o-mini", provider="openai")
+    session = _FakeSession(llm=llm)
+
+    capture = MetricCapture(
+        cost_tracker=CostTracker(sink),
+        sink=sink,
+        project="fleet",
+        agent_id="agent-3",
+        session_id="vg-boom",
+        turn_tracker=_Exploding(),
+    )
+    capture.bind(session)
+    llm.emit("metrics_collected", _LLMMetric())
+    await capture.drain()
+
+    rows = await storage.get_recent_requests(limit=10)
+    assert len(rows) == 1, "the cost row was lost to a failing hint"
+    assert rows[0]["turn_index"] is None
+    assert rows[0]["cost_usd"] > 0

--- a/src/voicegateway/tests/storage/test_cost_by_turn.py
+++ b/src/voicegateway/tests/storage/test_cost_by_turn.py
@@ -1,0 +1,157 @@
+"""Cost can be asked per TURN, not only per model, project or session.
+
+"That turn took four seconds" and "that turn cost this much" were two
+questions about the same moment that could not be asked together, so an
+expensive turn and a slow turn could never be shown to be the same one.
+
+Every input already existed: ``requests`` carried ``session_id`` and ``turns``
+carried ``session_id`` + ``turn_index``. What was missing is the tie between
+one CALL and one TURN, and nothing downstream can reconstruct it. The
+correlation exists only at the instant the metric fires, while the tracker
+still knows which turn is open, which is why the stamping has to happen in
+capture and cannot be a later join.
+
+TWO HONESTY PROPERTIES ARE PINNED HERE.
+
+``turn_index`` is absent, never 0, when no turn is tracked. Pipecat sessions
+and agents with turn capture off have no turn for a call to belong to, and 0
+would claim the first turn for every row they ever write.
+
+Cost that belongs to no turn is REPORTED, not dropped and not folded in. A
+session-close reconcile row spans the whole call by construction, so a
+per-turn view that presented itself as complete would understate the session
+in exactly the case an operator most needs to see.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.repository.cost_repository import (
+    get_cost_by_turn,
+    get_unattributed_cost,
+)
+
+
+def _record(session_id: str, *, turn: int | None, cost: float, modality: str = "llm"):
+    return RequestRecord(
+        id=str(uuid.uuid4()),
+        timestamp=time.time(),
+        project="default",
+        modality=modality,
+        model_id=f"openai/{modality}-model",
+        provider="openai",
+        input_units=100.0,
+        cost_usd=cost,
+        rated_price_usd=cost,
+        session_id=session_id,
+        turn_index=turn,
+    )
+
+
+@pytest.fixture
+async def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "turns.db"))
+    from voicegateway.services.storage_service import StorageService
+
+    storage = StorageService(db_path=str(tmp_path / "turns.db"))
+    await storage._ensure_initialized()
+    return storage
+
+
+async def _rows(storage, session_id: str):
+    async with storage._conn.session() as db:
+        return (
+            await get_cost_by_turn(db, session_id=session_id),
+            await get_unattributed_cost(db, session_id=session_id),
+        )
+
+
+async def test_cost_rolls_up_per_turn(store) -> None:
+    sid = "sess-a"
+    for rec in (
+        _record(sid, turn=0, cost=0.01, modality="stt"),
+        _record(sid, turn=0, cost=0.05, modality="llm"),
+        _record(sid, turn=1, cost=0.30, modality="llm"),
+    ):
+        await store.log_request(rec)
+
+    turns, _ = await _rows(store, sid)
+    assert [t["turn_index"] for t in turns] == [0, 1]
+    assert turns[0]["cost_usd"] == pytest.approx(0.06)
+    assert turns[0]["requests"] == 2
+    assert turns[1]["cost_usd"] == pytest.approx(0.30)
+    # Which turn was expensive is now answerable, which is the whole point.
+    assert max(turns, key=lambda t: t["cost_usd"])["turn_index"] == 1
+
+
+async def test_a_turn_reports_which_modalities_it_spent_on(store) -> None:
+    """A turn's cost is only actionable if you can see where it went."""
+    sid = "sess-b"
+    await store.log_request(_record(sid, turn=0, cost=0.01, modality="stt"))
+    await store.log_request(_record(sid, turn=0, cost=0.05, modality="llm"))
+    turns, _ = await _rows(store, sid)
+    assert turns[0]["modalities"] == ["llm", "stt"]
+
+
+async def test_untracked_calls_are_reported_not_dropped(store) -> None:
+    """The property that keeps a per-turn total from silently under-counting.
+
+    A session-close reconcile row has no turn by construction. Dropping it
+    would make the per-turn view disagree with the session total with nothing
+    saying why.
+    """
+    sid = "sess-c"
+    await store.log_request(_record(sid, turn=0, cost=0.05))
+    await store.log_request(_record(sid, turn=None, cost=0.02))
+
+    turns, unattributed = await _rows(store, sid)
+    assert [t["turn_index"] for t in turns] == [0]
+    assert unattributed["requests"] == 1
+    assert unattributed["cost_usd"] == pytest.approx(0.02)
+    # Per-turn plus unattributed reconstructs the session total exactly.
+    total = sum(t["cost_usd"] for t in turns) + unattributed["cost_usd"]
+    assert total == pytest.approx(0.07)
+
+
+async def test_an_untracked_call_is_null_rather_than_turn_zero(store) -> None:
+    """0 would claim the first turn for every Pipecat row ever written."""
+    sid = "sess-d"
+    await store.log_request(_record(sid, turn=None, cost=0.02))
+    turns, unattributed = await _rows(store, sid)
+    assert turns == []
+    assert unattributed["requests"] == 1
+
+
+async def test_turns_do_not_leak_across_sessions(store) -> None:
+    """``turn_index`` only means something inside one session.
+
+    Turn 3 of two different calls are unrelated, so a query that forgot to
+    scope by session would sum strangers together and report a plausible
+    number.
+    """
+    await store.log_request(_record("sess-e", turn=0, cost=0.05))
+    await store.log_request(_record("sess-f", turn=0, cost=0.99))
+    turns, _ = await _rows(store, "sess-e")
+    assert len(turns) == 1
+    assert turns[0]["cost_usd"] == pytest.approx(0.05)
+
+
+async def test_the_column_survives_the_write_and_read_round_trip(store) -> None:
+    """The failure mode this repo has already had once.
+
+    ``revision`` was added to the model and the migration and left out of
+    ``_INSERT_REQUEST``, so it was accepted everywhere and stored nowhere.
+    Only a read-back catches that, so this reads the row back rather than
+    trusting the write.
+    """
+    sid = "sess-g"
+    await store.log_request(_record(sid, turn=7, cost=0.05))
+    rows = await store.get_requests_in_window()
+    stored = [r for r in rows if r.get("session_id") == sid]
+    assert stored, "the row was not written at all"
+    assert stored[0]["turn_index"] == 7


### PR DESCRIPTION
Cost rolled up by model, project, session and agent, but never by **turn**. So *"that turn took four seconds"* and *"that turn cost this much"* were two questions about the same moment that could not be asked together, and an expensive turn and a slow turn could never be shown to be the same one.

## Why it had to go in capture

Every input already existed — `requests.session_id`, `turns.session_id`, `turns.turn_index` — and nothing tied one **call** to one **turn**.

That tie cannot be made later. The correlation exists only while the metric is firing and the tracker still knows which turn is open; afterwards nothing knows. So this is not a join that could have been deferred to read time, and it is also why no consumer could build it from outside no matter what the read API exposed.

Stamped from the turn tracker in `capture.py`, the same mechanism `tool_calls.turn_index` already uses.

## Three honesty properties, each with a test

**It is a correlation hint, not a measurement.** `current_turn_index` reads without the lock, so a call landing on a turn boundary can be attributed to the turn either side. Fine for "which turn was expensive", wrong for anything requiring exactness. The column and the docs say so rather than letting a reader assume precision it does not have.

**NULL means no turn, never turn zero.** A Pipecat session, or a LiveKit agent with turn capture off, has no turn for a call to belong to. Defaulting to `0` would pile all of their spend onto the first turn of every call they ever make.

**Cost with no turn is reported, not dropped.** The close-time reconcile row spans the whole session by construction, so it is deliberately left unstamped rather than attributed to whichever turn happened to be open at close. `get_unattributed_cost` surfaces it, and per-turn + unattributed reconstructs the session total exactly. A per-turn view presenting itself as complete would understate the session in precisely the case worth noticing.

Plus: **a failing tracker cannot lose a cost row.** The hint is a convenience, the cost is the measurement, so the read is guarded and the row is written without it.

## Scope

Engine only, no UI. One repository query (`get_cost_by_turn` / `get_unattributed_cost`) so the column ships proven, and no API endpoint or dashboard view — consistent with the line we drew on the admin page: the engine answers the question, whoever builds the screen owns the screen.

## Verification

- `3670 passed, 23 skipped, 36 deselected`
- `mypy` clean on 291 files, `ruff` clean, docs validator PASS (81 pages)
- Migration `e5c9b41a72f8` upgrade / downgrade / re-upgrade verified; single alembic head
- The round-trip is tested by **reading the row back**, because this repo has already shipped a column that the model and the migration accepted and `_INSERT_REQUEST` silently dropped. The existing "INSERT covers every column" guard also passes.

## One thing I noticed and did not fix

`revision` is written to `requests` but is **not** in `_REQUEST_COLUMNS`, so `get_requests_in_window` never returns it. That looks like the same class of omission, one step further along: stored correctly, unreadable through that path. Out of scope here; worth its own look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-turn cost attribution for recorded requests.
  - Added reporting of costs grouped by conversational turn, including request counts, totals, prices, and modalities.
  - Added separate reporting for costs that cannot be attributed to a turn.
  - Preserved cost recording when turn tracking is unavailable or fails.

- **Documentation**
  - Documented turn-based cost attribution, missing-turn handling, and storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->