### PR TITLE
fix(storage): return revision on request rows, and guard the read list

### DIFF
--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -21,7 +21,7 @@ Args: `period` (`"today"` default, `"week"`, `"month"`), `project`, `modality` (
 
 ### get_logs
 
-Args: `project`, `modality`, `model_id`, `status` (`"success"` | `"error"` | `"fallback"`), `limit` (1-1000, default 50). Returns up to `limit` request rows, newest first, each with `timestamp`, `project`, `modality`, `model_id`, `provider`, `cost_usd`, `pricing_source`, `ttfb_ms`, `total_latency_ms`, `status`, `error_message`, plus rating fields (`rated_price_usd`, `rate_rule`; see [Rating](/architecture/rating)) and `session_id`/`tenant_id`/`agent_id`.
+Args: `project`, `modality`, `model_id`, `status` (`"success"` | `"error"` | `"fallback"`), `limit` (1-1000, default 50). Returns up to `limit` request rows, newest first, each with `timestamp`, `project`, `modality`, `model_id`, `provider`, `cost_usd`, `pricing_source`, `ttfb_ms`, `total_latency_ms`, `status`, `error_message`, plus rating fields (`rated_price_usd`, `rate_rule`; see [Rating](/architecture/rating)), `session_id`/`tenant_id`/`agent_id`, `revision`, and `turn_index`.
 
 ## Models
 

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -342,6 +342,7 @@ _REQUEST_COLUMNS = (
     "tenant_id",
     "agent_id",
     "turn_index",
+    "revision",
 )
 
 

--- a/src/voicegateway/tests/repository/test_read_covers_every_column.py
+++ b/src/voicegateway/tests/repository/test_read_covers_every_column.py
@@ -1,0 +1,69 @@
+"""A table's columns and its SELECT are two things that must agree.
+
+The companion to ``test_insert_covers_every_column``, and it exists because
+the same drift happened at the other end of the same column.
+
+``revision`` was added to the model, the migration and (after a fix) the
+INSERT, so it stored correctly. It was never added to ``_REQUEST_COLUMNS``,
+which is the explicit column list all three row readers build their SELECT
+from. So the value was written to every row and returned by none of them:
+``get_recent_requests`` (the dashboard log view and the MCP request tool),
+``get_requests_for_room`` and ``get_requests_in_window`` all silently dropped
+it.
+
+That is worse than the INSERT bug in one respect. The INSERT bug wrote NULL,
+so a read-back caught it. This one writes correctly and reads back a dict that
+simply has no such key, which looks identical to a caller that never asked for
+it. The aggregate path worked the whole time -- ``get_cost_by_revision``
+groups on the column directly -- so revision totals were right while no
+individual row would tell you which revision it belonged to.
+
+The lesson is the same and so is the remedy: two producers of one truth drift
+silently, so compare them mechanically instead of hoping a reviewer notices a
+name missing from a twenty-four entry tuple.
+"""
+
+from __future__ import annotations
+
+from voicegateway.models.request_model import Request
+from voicegateway.repository.request_log_repository import _REQUEST_COLUMNS
+
+#: Columns a row reader is not expected to return, and why. This list is the
+#: only place a column may be excused, so excusing one is a visible edit in a
+#: diff rather than a silent omission in a tuple.
+_NOT_READ: dict[str, str] = {}
+
+
+def test_every_request_column_is_selected_by_the_row_readers() -> None:
+    """Nothing in the table may be invisible to the three row readers."""
+    table = {column.name for column in Request.__table__.columns}
+    selected = set(_REQUEST_COLUMNS)
+
+    missing = sorted(table - selected - set(_NOT_READ))
+    assert not missing, (
+        f"columns exist on `requests` but no row reader returns them: {missing}. "
+        f"Add them to _REQUEST_COLUMNS, or list them in _NOT_READ with the "
+        f"reason they are deliberately unreadable. A column that is written "
+        f"and never read is indistinguishable, to a caller, from one that was "
+        f"never added."
+    )
+
+
+def test_the_reader_does_not_select_columns_the_table_lacks() -> None:
+    """The other direction, which fails loudly at query time rather than quietly.
+
+    Included because the two lists drifting apart is the actual fault, and a
+    guard that only checks one direction lets half of it through.
+    """
+    table = {column.name for column in Request.__table__.columns}
+    phantom = sorted(set(_REQUEST_COLUMNS) - table)
+    assert not phantom, (
+        f"_REQUEST_COLUMNS names columns `requests` does not have: {phantom}"
+    )
+
+
+def test_the_excuse_list_only_names_real_columns() -> None:
+    """An excuse for a column that no longer exists is an excuse nobody reads."""
+    table = {column.name for column in Request.__table__.columns}
+    stale = sorted(set(_NOT_READ) - table)
+    assert not stale, f"_NOT_READ names columns that no longer exist: {stale}"

--- a/src/voicegateway/tests/storage/test_cost_by_turn.py
+++ b/src/voicegateway/tests/storage/test_cost_by_turn.py
@@ -155,3 +155,21 @@ async def test_the_column_survives_the_write_and_read_round_trip(store) -> None:
     stored = [r for r in rows if r.get("session_id") == sid]
     assert stored, "the row was not written at all"
     assert stored[0]["turn_index"] == 7
+
+
+async def test_revision_is_readable_on_a_row_not_only_in_aggregate(store) -> None:
+    """The gap the read-column guard was added for.
+
+    ``revision`` stored correctly and no row reader returned it, so
+    ``get_cost_by_revision`` could total two revisions apart while nothing
+    could tell you which individual requests belonged to either. Written and
+    unreadable looks, to a caller, exactly like never added.
+    """
+    rec = _record("sess-rev", turn=0, cost=0.05)
+    rec.revision = "deploy-42"
+    await store.log_request(rec)
+
+    rows = await store.get_requests_in_window()
+    stored = [r for r in rows if r.get("session_id") == "sess-rev"]
+    assert stored, "the row was not written at all"
+    assert stored[0]["revision"] == "deploy-42"


### PR DESCRIPTION
**Stacked on #272** — merge that first.

## The bug

`revision` was written to every row and returned by none of them.

It is missing from `_REQUEST_COLUMNS`, the explicit column list all three row readers build their SELECT from:

| Reader | Used by |
|---|---|
| `get_recent_requests` | dashboard log view, MCP `vg_list_requests` |
| `get_requests_for_room` | room latency |
| `get_requests_in_window` | `reconcile`, export |

All three silently dropped it. Verified mechanically: `revision` was the **only** column on `requests` that no reader returned.

## Why this is worse than the INSERT bug it rhymes with

The INSERT bug wrote `NULL`, so reading a row back caught it. **This one writes correctly and returns a dict with no such key**, which is indistinguishable — to a caller — from a column that was never added.

And it hid behind a working path. `get_cost_by_revision` groups on the column directly in SQL, so revision *totals* were right the whole time while nothing could tell you which individual requests belonged to either revision. Half the reason the column exists is answering "this got slower last Tuesday", and that needs the value on rows, not only in a sum.

## The guard

`test_read_covers_every_column`, the companion to `test_insert_covers_every_column`. Two producers of one truth drift silently, so compare them mechanically rather than hoping a reviewer spots a name missing from a twenty-four entry tuple.

Checked **both directions** — a guard that only checks one lets half the fault through — plus a staleness check on the excuse list, so excusing a column is a visible edit in a diff rather than a silent omission.

Verified it actually fires by deleting the line and watching it fail:

```
AssertionError: columns exist on `requests` but no row reader returns them: ['revision'].
```

## Also

`docs/mcp/tools.md` enumerated the fields the request tool returns and listed neither `revision` nor `turn_index`. Corrected.

## Verification

- `3674 passed, 23 skipped, 36 deselected`
- `mypy` clean on 291 files, `ruff` clean, docs validator PASS (81 pages)
- Round-trip test reads `revision` back out of storage rather than trusting the write