### PR TITLE
fix(telemetry): walk FastAPI's included-router wrappers

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -49,9 +49,21 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install the project
-        run: |
-          uv venv --clear --seed
-          uv pip install -e ".[dev,dashboard]"
+        # `uv sync`, matching ci.yml. This job used to `uv pip install -e`,
+        # which resolves fresh against the pyproject ranges instead of the
+        # lock, so it silently tested a different dependency tree from every
+        # other job. ci.yml's install step carries the long-form rationale and
+        # the voice-prices war story that produced that rule; this job simply
+        # predates it.
+        #
+        # The drift was not theoretical here either. While ci.yml's matrix ran
+        # fastapi 0.136.1 from the lock, this job resolved 0.141.1, which
+        # replaced the included-route copies `include_router` used to leave on
+        # the parent router with a lazy wrapper. The authorization matrix's
+        # route walk saw 4 routes instead of 89 and this job failed on every
+        # commit while the test matrix stayed green. The walk now handles both
+        # shapes, but the jobs should still agree on what they are testing.
+        run: uv sync --extra dev --extra dashboard
 
       - name: Run tests with coverage.py
         run: |

--- a/docs/architecture/observability-contracts.md
+++ b/docs/architecture/observability-contracts.md
@@ -51,9 +51,22 @@ restores the exact prior context.
 
 `SpanAttributes.tenant_id` is internal-authoritative. It is set from a verified
 principal at an ingestion boundary; an arbitrary external attribute with the
-same name never overrides it. This contract does not carry prompt text,
-transcripts, tool arguments, tool results, or encrypted payload bytes. Those
-belong to the security content contract and a later encrypted content plane.
+same name never overrides it. `correlation` is a separate field from the
+free-form `attributes` collection, so that separation is structural rather than
+a convention a receiver has to remember.
+
+The half that is not yet structural is the boundary itself. No receiver exists,
+and this contract has a single tenant slot rather than one field for what the
+payload asserted and another for what the server derived. That is tracked as
+VG-SEC-015 in
+[observability security contracts](/architecture/observability-security), filed
+under the same threat as VG-SEC-001, which is the live defect where a payload
+`tenant_id` beats the tenant resolved from the API key on a route that already
+ships. Read that gap before writing the receiver.
+
+This contract does not carry prompt text, transcripts, tool arguments, tool
+results, or encrypted payload bytes. Those belong to the security content
+contract and a later encrypted content plane.
 
 | Existing field | Wave 0 mapping | Notes |
 | :--- | :--- | :--- |

--- a/docs/architecture/observability-security.md
+++ b/docs/architecture/observability-security.md
@@ -64,6 +64,22 @@ This also contradicts a published guarantee. See
 request bodies is advisory only and cannot override the key-derived tenant.
 For this one route, it can.
 
+**VG-SEC-015** (planned, Wave 1) is the same shape, one wave ahead of the code.
+The trace contract in
+[observability contracts](/architecture/observability-contracts) states that
+`SpanAttributes.tenant_id` is internal-authoritative, set from a verified
+principal at an ingestion boundary. No such boundary exists yet, and the
+contract carries a single tenant slot with no way to distinguish what a payload
+asserted from what the server decided. That is structurally the arrangement
+which produced VG-SEC-001, and the lesson of VG-SEC-001 is that writing the
+rule down is not enough: it was written down, in the security page above, while
+the code did the opposite.
+
+So the rule is recorded as data rather than prose. Each planned OTLP route
+carries `tenant_source: server_derived`, and a validator on `PlannedRoute`
+refuses any planned ingest route that does not. The receiver cannot be written
+without a row stating where its tenant comes from.
+
 ### VG-THREAT-002: cross-tenant and unauthenticated read
 
 **VG-SEC-004** (gap, Wave 1): 28 of the 89 routes resolve no auth dependency
@@ -271,9 +287,11 @@ Constants and helpers: `EXISTING_SCOPES`, `PLANNED_SCOPES`,
    roadmap named the same directory for both agents in the same wave. Two
    schemas in one directory is a collision with no upside.
 3. **No `voicegateway.telemetry` import exists, by design.** The binding map
-   is strings. When the trace contract lands, the binding test stops skipping
-   and starts gating. Field names it currently expects are `tenant_id`,
-   `session_id`, `trace_id`, `span_id` and `turn_index`.
+   is strings, and an AST guard enforces the rule. The trace contract has now
+   landed, so the binding test no longer skips: it resolves `tenant_id`,
+   `session_id` and `turn_index` on `SpanAttributes` and `trace_id`, `span_id`
+   on `SpanContext`, and fails if any of them moves. The zero-coupling
+   mechanism worked as intended, and the gate is live.
 4. **Planned routes are namespaced under `/v1/telemetry/`.** The conventional
    OTLP receiver mounts are `/v1/traces`, `/v1/metrics` and `/v1/logs`. Two of
    those already exist here as GET reads, so a bare OTLP mount would collide

--- a/src/voicegateway/schemas/telemetry/authorization_matrix.json
+++ b/src/voicegateway/schemas/telemetry/authorization_matrix.json
@@ -800,7 +800,8 @@
       "gap_id": "VG-SEC-003",
       "wave": 1,
       "required_scope": "ingest",
-      "note": "OTLP trace receiver. Namespaced under /v1/telemetry/ deliberately: the conventional OTLP paths /v1/metrics and /v1/logs already exist here as GET reads, so a bare OTLP mount would differ from them by method alone."
+      "note": "OTLP trace receiver. Namespaced under /v1/telemetry/ deliberately: the conventional OTLP paths /v1/metrics and /v1/logs already exist here as GET reads, so a bare OTLP mount would differ from them by method alone. Tenant must come from the verified principal, never from correlation.tenant_id in the payload (VG-SEC-015).",
+      "tenant_source": "server_derived"
     },
     {
       "method": "POST",
@@ -808,7 +809,8 @@
       "gap_id": "VG-SEC-003",
       "wave": 1,
       "required_scope": "ingest",
-      "note": "OTLP metric receiver. See the traces row on the path collision."
+      "note": "OTLP metric receiver. See the traces row on the path collision. Tenant must come from the verified principal, never from correlation.tenant_id in the payload (VG-SEC-015).",
+      "tenant_source": "server_derived"
     },
     {
       "method": "POST",
@@ -816,7 +818,8 @@
       "gap_id": "VG-SEC-003",
       "wave": 1,
       "required_scope": "ingest",
-      "note": "OTLP log receiver. See the traces row on the path collision."
+      "note": "OTLP log receiver. See the traces row on the path collision. Tenant must come from the verified principal, never from correlation.tenant_id in the payload (VG-SEC-015).",
+      "tenant_source": "server_derived"
     },
     {
       "method": "GET",
@@ -824,7 +827,8 @@
       "gap_id": "VG-SEC-013",
       "wave": 3,
       "required_scope": "admin",
-      "note": "Read-side audit trail of SensitiveAccessEvent. Nothing audits reads today."
+      "note": "Read-side audit trail of SensitiveAccessEvent. Nothing audits reads today.",
+      "tenant_source": "not_applicable"
     }
   ]
 }

--- a/src/voicegateway/schemas/telemetry/security_schema.py
+++ b/src/voicegateway/schemas/telemetry/security_schema.py
@@ -189,7 +189,26 @@ class PlannedRoute(BaseModel):
     wave: int = Field(ge=1)
     #: The scope this route must require the day it is written.
     required_scope: ScopeName
+    #: Where the tenant on a written row must come from. ``server_derived``
+    #: means the authenticated principal wins and any tenant in the payload is
+    #: discarded, never merged. This is a field rather than a sentence in a
+    #: note because VG-SEC-001 is what a prose-only version of this rule looks
+    #: like after it has been ignored once: the guarantee was written down in
+    #: docs/architecture/security.md and the code did the opposite.
+    tenant_source: Literal["server_derived", "not_applicable"]
     note: str = ""
+
+    @model_validator(mode="after")
+    def _writes_must_derive_their_tenant(self) -> PlannedRoute:
+        """Any planned route that ingests rows must derive its own tenant."""
+        if self.required_scope is ScopeName.INGEST and (
+            self.tenant_source != "server_derived"
+        ):
+            raise ValueError(
+                f"{self.method} {self.path}: an ingest route writes rows, so "
+                "tenant_source must be 'server_derived' (see VG-SEC-015)"
+            )
+        return self
 
     @property
     def key(self) -> tuple[str, str]:

--- a/src/voicegateway/schemas/telemetry/threat_model.json
+++ b/src/voicegateway/schemas/telemetry/threat_model.json
@@ -138,5 +138,15 @@
     "wave": 2,
     "evidence": "src/voicegateway/repository/request_log_repository.py:268",
     "fixture": null
+  },
+  {
+    "gap_id": "VG-SEC-015",
+    "threat": "VG-THREAT-001",
+    "title": "The trace contract has one tenant slot and no boundary to fill it",
+    "description": "SpanAttributes.tenant_id is documented as internal-authoritative, set from a verified principal at an ingestion boundary, and the observability-contracts page repeats that it must be server-derived at ingest. No such boundary exists yet, and nothing makes the rule executable: no receiver, no test, and no field distinguishing what a payload asserted from what the server decided. The single slot serves both roles, which is structurally the same arrangement that produced VG-SEC-001, where a payload tenant_id won over the tenant resolved from the key on a route that already ships. The trace contract is right to state the rule; Wave 0 records that stating it is all that has happened so far.",
+    "status": "planned",
+    "wave": 1,
+    "evidence": "src/voicegateway/telemetry/trace_schema.py:237",
+    "fixture": null
   }
 ]

--- a/src/voicegateway/tests/server/_telemetry_harness.py
+++ b/src/voicegateway/tests/server/_telemetry_harness.py
@@ -151,29 +151,36 @@ def canonical_route_auth() -> dict[tuple[str, str], str]:
     reconfigure them, so the inventory is taken in a clean child interpreter
     rather than trusting the parent test process's mutable state.
 
-    The child builds the application rather than reading the four routers.
-    That is not a detail. ``include_router`` can attach dependencies at include
-    time, and those land on the app's route objects, never on the router's, so
-    a router-level read reports the pre-inclusion gating. Demonstrated: mount
-    ``api_router`` with ``dependencies=[Depends(require_scope("admin"))]`` and
-    a router-level read still calls ``GET /v1/costs`` open while the app calls
-    it admin-gated. The matrix would then record a live gate as an open route,
-    or the reverse, which inverts what this suite exists to detect.
-
-    ``main.py`` attaches no such dependencies today, so the two agree, and
-    that is exactly why the weaker form survives review until it does not.
-    Building the app designs the failure out instead of leaving a comment.
+    The child reads the four routers ApplicationBuilder registers. Its
+    app-level ``routes`` inventory is not portable: on Linux under coverage it
+    can be empty despite those routers containing every endpoint. Main attaches
+    no dependencies at ``include_router`` time, so these resolved router routes
+    are the production inventory today. If that changes, make the dependency
+    explicit on the relevant router rather than relying on app-level state.
     """
     script = """
 import json
+from itertools import chain
 
-from voicegateway.tests.server._telemetry_harness import _Harness, live_route_auth
+from voicegateway.server.api.openorca.routes import router as openorca_router
+from voicegateway.server.routes import api_router, dashboard_router, system_router
+from voicegateway.tests.server._telemetry_harness import live_route_auth
 
-harness = _Harness()
-try:
-    auth = live_route_auth(harness.app)
-finally:
-    harness.cleanup()
+inventory = type(
+    "_RouteInventory",
+    (),
+    {
+        "routes": list(
+            chain(
+                system_router.routes,
+                api_router.routes,
+                dashboard_router.routes,
+                openorca_router.routes,
+            )
+        )
+    },
+)()
+auth = live_route_auth(inventory)
 print(json.dumps([[method, path, value] for (method, path), value in auth.items()]))
 """
     result = subprocess.run(

--- a/src/voicegateway/tests/server/_telemetry_harness.py
+++ b/src/voicegateway/tests/server/_telemetry_harness.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterator
 
 import yaml
 from fastapi.routing import APIRoute
@@ -97,6 +99,9 @@ async def _make_key(gateway, *, tenant_id=None, role="tenant"):
 
 _SCOPE_QUALNAME = "require_scope.<locals>._dep"
 
+#: ``{name:converter}`` -> ``{name}``, matching OpenAPI's normalisation.
+_CONVERTER_RE = re.compile(r":[^{}]+\}")
+
 
 def _collect_dependencies(dependant, out: list) -> None:
     """Collect every callable in the resolved dependency tree."""
@@ -123,25 +128,74 @@ def classify_dependency(fn) -> str | None:
     return None
 
 
+def iter_api_routes(routes) -> Iterator[tuple[str, APIRoute]]:
+    """Yield ``(resolved_path, APIRoute)``, flattening FastAPI's wrappers.
+
+    FastAPI changed how ``include_router`` stores routes, and this project's
+    CI runs both shapes, so both have to work:
+
+    - **<= 0.136** copies each included route onto the parent as a real
+      ``APIRoute`` with its full path already resolved.
+    - **0.141** stores one lazy ``_IncludedRouter`` per inclusion instead. It
+      is not an ``APIRoute``, and it has no ``path``, ``methods`` or
+      ``dependant``, so a check for any of those skips it and everything
+      underneath it. The resolved routes come from
+      ``effective_route_contexts()``, whose entries carry the fully-prefixed
+      ``path`` alongside the ``original_route``.
+
+    This is why Test Coverage failed while the test matrix passed: the two
+    jobs resolved different FastAPI versions, and under 0.141 the inventory
+    collapsed to the four routes declared by decorator rather than by
+    inclusion. A route this function fails to yield vanishes from the
+    authorization matrix, so breadth here is deliberate.
+    """
+    for route in routes:
+        if isinstance(route, APIRoute):
+            yield route.path, route
+        elif hasattr(route, "effective_route_contexts"):
+            for context in route.effective_route_contexts():
+                original = getattr(context, "original_route", None)
+                if isinstance(original, APIRoute):
+                    yield context.path, original
+        elif hasattr(route, "routes"):
+            yield from iter_api_routes(route.routes)
+
+
 def live_route_auth(app) -> dict[tuple[str, str], str]:
     """Map every live ``(method, path)`` to its recovered gating."""
     found: dict[tuple[str, str], str] = {}
-    for route in app.routes:
-        # isinstance rather than a structural hasattr check. A duck-typed
-        # check was tried and reverted: it was introduced to tolerate a
-        # "compatible route subclass from a different import boundary", but
-        # measured against this app no route disagrees between the two, so it
-        # bought nothing and admitted more. Being tight here matters, because
-        # anything this loop skips silently vanishes from the matrix.
-        if not isinstance(route, APIRoute):
-            continue
+    for path, route in iter_api_routes(app.routes):
         calls: list = []
         _collect_dependencies(route.dependant, calls)
         marks = sorted({m for m in (classify_dependency(f) for f in calls) if m})
         auth = "+".join(marks) if marks else "open"
         for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
-            found[(method, route.path)] = auth
+            found[(method, path)] = auth
     return found
+
+
+def normalize_route_key(key: tuple[str, str]) -> tuple[str, str]:
+    """Strip a path converter so a route key can be compared to OpenAPI."""
+    method, path = key
+    return (method, _CONVERTER_RE.sub("}", path))
+
+
+def openapi_route_keys(app) -> set[tuple[str, str]]:
+    """Return ``(method, path)`` for every route in the OpenAPI schema.
+
+    A version-stable second opinion on :func:`iter_api_routes`. The schema is
+    public API and survives the internal restructuring above, so comparing the
+    two catches the next such change as a named failure rather than as a
+    silently short inventory. Path converters are stripped because the schema
+    normalises ``{id:path}`` to ``{id}``.
+    """
+    schema = app.openapi()
+    return {
+        (method.upper(), _CONVERTER_RE.sub("}", path))
+        for path, operations in schema.get("paths", {}).items()
+        for method in operations
+        if method.upper() not in {"HEAD", "OPTIONS"}
+    }
 
 
 def canonical_route_auth() -> dict[tuple[str, str], str]:

--- a/src/voicegateway/tests/server/_telemetry_harness.py
+++ b/src/voicegateway/tests/server/_telemetry_harness.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from itertools import chain
 
 import yaml
 from httpx import ASGITransport, AsyncClient
@@ -135,3 +136,26 @@ def live_route_auth(app) -> dict[tuple[str, str], str]:
         for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
             found[(method, route.path)] = auth
     return found
+
+
+def canonical_route_auth() -> dict[tuple[str, str], str]:
+    """Map the route inventory the application builder includes.
+
+    ``ApplicationBuilder`` includes these four routers directly. Inspecting
+    their resolved routes avoids relying on FastAPI's app-level route list,
+    which is intentionally not a stable inventory surface for this project.
+    """
+    from voicegateway.server.api.openorca.routes import router as openorca_router
+    from voicegateway.server.routes import api_router, dashboard_router, system_router
+
+    class _RouteInventory:
+        routes = list(
+            chain(
+                system_router.routes,
+                api_router.routes,
+                dashboard_router.routes,
+                openorca_router.routes,
+            )
+        )
+
+    return live_route_auth(_RouteInventory())

--- a/src/voicegateway/tests/server/_telemetry_harness.py
+++ b/src/voicegateway/tests/server/_telemetry_harness.py
@@ -14,11 +14,14 @@ harness is safe to run alongside the rest of the suite.
 
 from __future__ import annotations
 
+import json
 import os
+import subprocess
+import sys
 import tempfile
-from itertools import chain
 
 import yaml
+from fastapi.routing import APIRoute
 from httpx import ASGITransport, AsyncClient
 
 from voicegateway.core.gateway import Gateway
@@ -124,10 +127,13 @@ def live_route_auth(app) -> dict[tuple[str, str], str]:
     """Map every live ``(method, path)`` to its recovered gating."""
     found: dict[tuple[str, str], str] = {}
     for route in app.routes:
-        # FastAPI can expose a compatible route subclass from a different
-        # import boundary. The API contract we need is structural: a route
-        # with a path, methods, and a resolved dependency graph.
-        if not all(hasattr(route, field) for field in ("path", "methods", "dependant")):
+        # isinstance rather than a structural hasattr check. A duck-typed
+        # check was tried and reverted: it was introduced to tolerate a
+        # "compatible route subclass from a different import boundary", but
+        # measured against this app no route disagrees between the two, so it
+        # bought nothing and admitted more. Being tight here matters, because
+        # anything this loop skips silently vanishes from the matrix.
+        if not isinstance(route, APIRoute):
             continue
         calls: list = []
         _collect_dependencies(route.dependant, calls)
@@ -141,21 +147,48 @@ def live_route_auth(app) -> dict[tuple[str, str], str]:
 def canonical_route_auth() -> dict[tuple[str, str], str]:
     """Map the route inventory the application builder includes.
 
-    ``ApplicationBuilder`` includes these four routers directly. Inspecting
-    their resolved routes avoids relying on FastAPI's app-level route list,
-    which is intentionally not a stable inventory surface for this project.
+    The route aggregators are module-level singletons. Other test modules may
+    reconfigure them, so the inventory is taken in a clean child interpreter
+    rather than trusting the parent test process's mutable state.
+
+    The child builds the application rather than reading the four routers.
+    That is not a detail. ``include_router`` can attach dependencies at include
+    time, and those land on the app's route objects, never on the router's, so
+    a router-level read reports the pre-inclusion gating. Demonstrated: mount
+    ``api_router`` with ``dependencies=[Depends(require_scope("admin"))]`` and
+    a router-level read still calls ``GET /v1/costs`` open while the app calls
+    it admin-gated. The matrix would then record a live gate as an open route,
+    or the reverse, which inverts what this suite exists to detect.
+
+    ``main.py`` attaches no such dependencies today, so the two agree, and
+    that is exactly why the weaker form survives review until it does not.
+    Building the app designs the failure out instead of leaving a comment.
     """
-    from voicegateway.server.api.openorca.routes import router as openorca_router
-    from voicegateway.server.routes import api_router, dashboard_router, system_router
+    script = """
+import json
 
-    class _RouteInventory:
-        routes = list(
-            chain(
-                system_router.routes,
-                api_router.routes,
-                dashboard_router.routes,
-                openorca_router.routes,
-            )
+from voicegateway.tests.server._telemetry_harness import _Harness, live_route_auth
+
+harness = _Harness()
+try:
+    auth = live_route_auth(harness.app)
+finally:
+    harness.cleanup()
+print(json.dumps([[method, path, value] for (method, path), value in auth.items()]))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        # check=True would raise CalledProcessError with the child's stderr
+        # captured and unshown, at collection time, which reads as "the module
+        # failed to import" and hides the cause. Surface it instead.
+        raise RuntimeError(
+            "route inventory child process failed "
+            f"(exit {result.returncode}):\n{result.stderr.strip()}"
         )
-
-    return live_route_auth(_RouteInventory())
+    rows = json.loads(result.stdout)
+    return {(method, path): auth for method, path, auth in rows}

--- a/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
+++ b/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
@@ -15,20 +15,30 @@ threat model without something going red.
 
 from __future__ import annotations
 
+import importlib.util
+
 import pytest
 
 from voicegateway.schemas.telemetry.security_schema import (
     ContractStatus,
     RouteAuth,
+    ScopeName,
     load_authorization_matrix,
     load_threat_model,
 )
-from voicegateway.tests.server._telemetry_harness import canonical_route_auth
+from voicegateway.tests.server._telemetry_harness import (
+    canonical_route_auth,
+)
 
-# Route modules are intentionally shared process-wide fixtures in this test
-# suite. Take the canonical inventory during collection, before tests that
-# temporarily alter router wiring execute. ApplicationBuilder's ``app.routes``
-# is not a stable inventory surface, so the snapshot comes from its routers.
+# Snapshot the served route inventory once at collection and share it across
+# every test below. The child interpreter that produces it builds the
+# application rather than reading the four routers, because dependencies
+# attached at ``include_router`` time exist only on the app's routes. See
+# canonical_route_auth's docstring for the demonstration.
+#
+# No test in this suite is known to mutate router wiring: the full suite passes
+# with the app built per module. The isolation is belt and braces, kept because
+# it is nearly free, not because a specific polluter was identified.
 _LIVE_ROUTE_AUTH = canonical_route_auth()
 
 
@@ -100,6 +110,21 @@ def test_bijection_is_exact(matrix, live):
     assert matrix.keys() == set(live)
 
 
+def test_canonical_inventory_ignores_parent_router_mutation(live):
+    """The child-process inventory must not inherit altered parent routers."""
+    from voicegateway.server.routes import api_router, dashboard_router, system_router
+
+    routers = (system_router, api_router, dashboard_router)
+    saved = [list(router.routes) for router in routers]
+    try:
+        for router in routers:
+            router.routes.clear()
+        assert canonical_route_auth() == live
+    finally:
+        for router, routes in zip(routers, saved, strict=True):
+            router.routes[:] = routes
+
+
 # --------------------------------------------------------------------------
 # Classification conformance
 # --------------------------------------------------------------------------
@@ -142,9 +167,18 @@ def test_open_routes_are_gap_unless_explicitly_open_by_design(matrix):
 
 
 def test_write_scope_spans_ingest_and_config(matrix):
-    """Evidence for VG-SEC-003: splitting write is semantic, not a rename."""
+    """Evidence for VG-SEC-003: splitting write is semantic, not a rename.
+
+    The count is pinned rather than merely non-empty because 18 is quoted as a
+    fact in the VG-SEC-003 threat entry and on the docs page. A looser
+    assertion lets the code drift away from a number the prose still claims.
+    """
     write_rows = [r for r in matrix.routes if r.auth is RouteAuth.SCOPE_WRITE]
-    assert write_rows, "no route is gated by the write scope"
+    assert len(write_rows) == 18, (
+        f"{len(write_rows)} routes are gated by the write scope, but "
+        "VG-SEC-003 and docs/architecture/observability-security.md both say "
+        "18. Update the count in all three places together."
+    )
     ingest = {r.path for r in write_rows if r.path.startswith("/v1/ingest")}
     config = {
         r.path
@@ -184,6 +218,50 @@ def test_planned_routes_name_a_scope_that_must_exist_first(matrix):
     for planned in matrix.planned_routes:
         assert planned.gap_id in minted
         assert planned.required_scope.value
+
+
+def test_planned_ingest_routes_derive_their_tenant_server_side(matrix):
+    """VG-SEC-015: the trace receiver must not trust a payload tenant.
+
+    The rule is stated in ``SpanAttributes``'s docstring and again on the
+    observability-contracts page, but prose is exactly what VG-SEC-001 already
+    defeated once: docs/architecture/security.md promised the payload could not
+    override the key-derived tenant while the tool-call writer did precisely
+    that. Asserting it against the data means the receiver cannot be written
+    without a row that says where its tenant comes from.
+    """
+    ingest = [
+        planned
+        for planned in matrix.planned_routes
+        if planned.required_scope is ScopeName.INGEST
+    ]
+    assert ingest, "no planned ingest route: VG-SEC-015 has nothing to bind to"
+    for planned in ingest:
+        assert planned.tenant_source == "server_derived", (
+            f"{planned.method} {planned.path} may not accept a payload tenant"
+        )
+
+
+def test_the_trace_contract_can_carry_a_payload_tenant(matrix):
+    """Why VG-SEC-015 exists: the risk is real, not hypothetical.
+
+    ``SpanRecord`` has a single tenant slot and no way to distinguish what a
+    payload asserted from what the server decided, so a receiver that simply
+    validates and stores an incoming span inherits the caller's tenant. Skips
+    until the trace contract exists, then stands as the standing argument for
+    the rule above.
+    """
+    if importlib.util.find_spec("voicegateway.telemetry") is None:
+        pytest.skip("voicegateway.telemetry does not exist yet")
+
+    from voicegateway.telemetry.trace_schema import SpanAttributes
+
+    attacker_controlled = SpanAttributes(tenant_id="victim-tenant")
+    assert attacker_controlled.tenant_id == "victim-tenant", (
+        "SpanAttributes now rejects a caller-supplied tenant. If the contract "
+        "gained a server-derived-only slot, VG-SEC-015 may be closable."
+    )
+    assert "VG-SEC-015" in load_threat_model().gap_ids()
 
 
 @pytest.mark.parametrize(

--- a/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
+++ b/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
@@ -27,7 +27,11 @@ from voicegateway.schemas.telemetry.security_schema import (
     load_threat_model,
 )
 from voicegateway.tests.server._telemetry_harness import (
+    _Harness,
     canonical_route_auth,
+    live_route_auth,
+    normalize_route_key,
+    openapi_route_keys,
 )
 
 # Snapshot the served route inventory once at collection and share it across
@@ -108,6 +112,40 @@ def test_bijection_is_exact(matrix, live):
     """State the cardinality directly, so an off-by-one cannot hide."""
     assert len(matrix.routes) == len(live)
     assert matrix.keys() == set(live)
+
+
+def test_inventory_agrees_with_the_openapi_schema(live):
+    """Cross-check the route walk against a version-stable public source.
+
+    This is the test that would have caught the Test Coverage failure at its
+    cause instead of six confusing symptoms. FastAPI 0.141 replaced the
+    included-route copies that ``include_router`` used to leave on the parent
+    with a lazy wrapper, so a walk that only recognised ``APIRoute`` collapsed
+    an 89-route inventory to 4. The matrix then reported 85 rows as dead
+    routes, which reads like the matrix rotted rather than like the walk
+    broke.
+
+    The OpenAPI schema survived that change untouched, so comparing the two
+    turns the next internal restructuring into one named failure here.
+    """
+    harness = _Harness()
+    try:
+        walked = {normalize_route_key(key) for key in live_route_auth(harness.app)}
+        schema = openapi_route_keys(harness.app)
+    finally:
+        harness.cleanup()
+
+    assert walked == schema, (
+        "the route walk disagrees with the OpenAPI schema, so "
+        "iter_api_routes no longer understands this FastAPI version. "
+        f"missing from the walk: {sorted(schema - walked)}; "
+        f"walked but absent from the schema: {sorted(walked - schema)}"
+    )
+    assert {normalize_route_key(key) for key in live} == schema, (
+        "the collection-time snapshot disagrees with the schema even though "
+        "the walk agrees, so the snapshot is stale or was taken against a "
+        "different application"
+    )
 
 
 def test_canonical_inventory_ignores_parent_router_mutation(live):

--- a/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
+++ b/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
@@ -25,6 +25,12 @@ from voicegateway.schemas.telemetry.security_schema import (
 )
 from voicegateway.tests.server._telemetry_harness import canonical_route_auth
 
+# Route modules are intentionally shared process-wide fixtures in this test
+# suite. Take the canonical inventory during collection, before tests that
+# temporarily alter router wiring execute. ApplicationBuilder's ``app.routes``
+# is not a stable inventory surface, so the snapshot comes from its routers.
+_LIVE_ROUTE_AUTH = canonical_route_auth()
+
 
 @pytest.fixture(scope="module")
 def matrix():
@@ -33,8 +39,8 @@ def matrix():
 
 @pytest.fixture(scope="module")
 def live():
-    """Return the canonical route inventory used by the app builder."""
-    return canonical_route_auth()
+    """Return the collection-time canonical route inventory."""
+    return _LIVE_ROUTE_AUTH
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
+++ b/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
@@ -23,17 +23,7 @@ from voicegateway.schemas.telemetry.security_schema import (
     load_authorization_matrix,
     load_threat_model,
 )
-from voicegateway.tests.server._telemetry_harness import _Harness, live_route_auth
-
-# This is intentionally evaluated while pytest collects this module, before
-# the test suite starts exercising mutable router wiring. The authorization
-# matrix describes a newly built production app, not an app altered by another
-# test's temporary router configuration.
-_snapshot_harness = _Harness()
-try:
-    _LIVE_ROUTE_AUTH = live_route_auth(_snapshot_harness.app)
-finally:
-    _snapshot_harness.cleanup()
+from voicegateway.tests.server._telemetry_harness import canonical_route_auth
 
 
 @pytest.fixture(scope="module")
@@ -43,8 +33,8 @@ def matrix():
 
 @pytest.fixture(scope="module")
 def live():
-    """Return the collection-time production route snapshot."""
-    return _LIVE_ROUTE_AUTH
+    """Return the canonical route inventory used by the app builder."""
+    return canonical_route_auth()
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/server/test_telemetry_gap_ids.py
+++ b/src/voicegateway/tests/server/test_telemetry_gap_ids.py
@@ -64,9 +64,14 @@ def _minted() -> set[str]:
 
 
 def test_gap_ids_are_contiguous_and_well_formed():
-    """A hole in the numbering usually means a gap was dropped, not renamed."""
+    """A hole in the numbering usually means a gap was dropped, not renamed.
+
+    The count is pinned deliberately. Adding a gap should be a decision, so
+    minting one and bumping this number is meant to be a two-line change made
+    on purpose rather than something that happens by accident.
+    """
     minted = sorted(_minted())
-    assert len(minted) == 14
+    assert len(minted) == 15
     for index, gap_id in enumerate(minted, start=1):
         assert re.fullmatch(GAP_ID_PATTERN, gap_id), gap_id
         assert gap_id == f"VG-SEC-{index:03d}", (

--- a/tools/scripts/gen_authorization_matrix.py
+++ b/tools/scripts/gen_authorization_matrix.py
@@ -67,14 +67,35 @@ def classify(fn) -> str | None:
     return None
 
 
-def inspect_routes() -> list[dict]:
-    """Return one dict per ``(method, path)`` with its recovered gating."""
+def _iter_api_routes(routes):
+    """Yield ``(resolved_path, APIRoute)``, flattening FastAPI's wrappers.
+
+    Mirrors ``iter_api_routes`` in tests/server/_telemetry_harness.py, and for
+    the same reason: FastAPI <= 0.136 leaves included routes on the parent as
+    real ``APIRoute`` copies, while 0.141 leaves one lazy wrapper per
+    inclusion that exposes them through ``effective_route_contexts()``.
+    Recognising only ``APIRoute`` collapses this project's 89-route inventory
+    to 4 under 0.141, which would make this generator print a skeleton for
+    every route the matrix already covers.
+    """
     from fastapi.routing import APIRoute
 
+    for route in routes:
+        if isinstance(route, APIRoute):
+            yield route.path, route
+        elif hasattr(route, "effective_route_contexts"):
+            for context in route.effective_route_contexts():
+                original = getattr(context, "original_route", None)
+                if isinstance(original, APIRoute):
+                    yield context.path, original
+        elif hasattr(route, "routes"):
+            yield from _iter_api_routes(route.routes)
+
+
+def inspect_routes() -> list[dict]:
+    """Return one dict per ``(method, path)`` with its recovered gating."""
     rows: list[dict] = []
-    for route in _canonical_routes():
-        if not isinstance(route, APIRoute):
-            continue
+    for path, route in _iter_api_routes(_canonical_routes()):
         calls: list = []
         _walk(route.dependant, calls)
         marks = sorted({m for m in (classify(f) for f in calls) if m})
@@ -82,12 +103,12 @@ def inspect_routes() -> list[dict]:
         # the pair rather than silently picking the first.
         auth = "+".join(marks) if marks else "open"
         params = {p.name for p in route.dependant.query_params}
-        takes_project = "project" in params or "{project_id}" in route.path
+        takes_project = "project" in params or "{project_id}" in path
         for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
             rows.append(
                 {
                     "method": method,
-                    "path": route.path,
+                    "path": path,
                     "auth": auth,
                     "takes_project": takes_project,
                 }

--- a/tools/scripts/gen_authorization_matrix.py
+++ b/tools/scripts/gen_authorization_matrix.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Print skeleton authorization-matrix rows for routes the matrix is missing.
 
-Read-only. Builds the FastAPI app in-process, enumerates every ``APIRoute``,
-recovers how each one is gated by walking the resolved dependency graph, and
-emits JSON rows for any ``(method, path)`` that ``authorization_matrix.json``
-does not already cover.
+Read-only. Enumerates the canonical routers registered by the application
+builder, recovers how each route is gated by walking the resolved dependency
+graph, and emits JSON rows for any ``(method, path)`` that
+``authorization_matrix.json`` does not already cover.
 
 This exists so the bijection test in
 ``tests/server/test_telemetry_authorization_matrix.py`` never becomes a tax:
@@ -19,37 +19,24 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
-import tempfile
-
-import yaml
+from itertools import chain
 
 # Scope literal recovered from require_scope's closure. Asserted, not assumed:
 # if the helper's shape changes this fails loudly rather than mislabelling.
 _SCOPE_QUALNAME = "require_scope.<locals>._dep"
 
 
-def _build_app():
-    """Build the app over a throwaway SQLite db and a minimal config."""
-    tmp = tempfile.mkdtemp(prefix="vg-matrix-")
-    os.environ["VOICEGW_DB_PATH"] = os.path.join(tmp, "matrix.db")
-    cfg = {
-        "providers": {"openai": {"api_key": "test-key"}},
-        "models": {"stt": {}, "llm": {}, "tts": {}},
-        "projects": {},
-        "fallbacks": {"stt": [], "llm": [], "tts": []},
-        "cost_tracking": {"enabled": True},
-    }
-    cfg_path = os.path.join(tmp, "voicegw.yaml")
-    with open(cfg_path, "w") as handle:
-        yaml.dump(cfg, handle)
+def _canonical_routes():
+    """Return the routers ApplicationBuilder registers on every API app."""
+    from voicegateway.server.api.openorca.routes import router as openorca_router
+    from voicegateway.server.routes import api_router, dashboard_router, system_router
 
-    from voicegateway.core.gateway import Gateway
-    from voicegateway.server import build_app
-
-    return build_app(
-        Gateway(config_path=cfg_path), enable_mcp_sse=False, enable_dashboard=False
+    return chain(
+        system_router.routes,
+        api_router.routes,
+        dashboard_router.routes,
+        openorca_router.routes,
     )
 
 
@@ -84,9 +71,8 @@ def inspect_routes() -> list[dict]:
     """Return one dict per ``(method, path)`` with its recovered gating."""
     from fastapi.routing import APIRoute
 
-    app = _build_app()
     rows: list[dict] = []
-    for route in app.routes:
+    for route in _canonical_routes():
         if not isinstance(route, APIRoute):
             continue
         calls: list = []


### PR DESCRIPTION
**This unbreaks `main`.** #274 landed the Wave 0 contracts before the FastAPI
incompatibility below was understood, so `main`'s Test Coverage job is failing
on `40c36359` right now. Merging this turns it green.

## Root cause of the red build

The two CI jobs were installing different dependency trees, and the route walk
behind the authorization matrix only understood one of them.

`ci.yml` syncs from `uv.lock` and gets **fastapi 0.136.1**, where
`include_router` leaves a real `APIRoute` copy on the parent for every included
route. `test-coverage.yml` used `uv pip install -e`, which resolves fresh
against the pyproject range and got **fastapi 0.141.1**, where `include_router`
instead leaves one lazy `_IncludedRouter` per inclusion. That wrapper is not an
`APIRoute` and exposes none of `path`, `methods` or `dependant`.

So the walk skipped it and everything beneath it. The 89-route inventory
collapsed to the 4 routes this app declares by decorator rather than by
inclusion, and the matrix reported 85 rows as dead routes. That reads like the
matrix rotted rather than like the walk broke, which is why the first three
commits here fix the wrong layer. Reproduced in a Linux container on 0.141.1.

Worth noting: neither an `isinstance` check nor a duck-typed
`hasattr(path/methods/dependant)` check can work, because the wrapper has none
of those three attributes. That is why swapping between them changed nothing.

## What is in this PR

**The fix.** `iter_api_routes` now handles both layouts, taking the resolved
path and original route from `effective_route_contexts()` when the wrapper is
present. Verified on 0.141.1: 89 routes with the same classification the matrix
records (28 open, 18 write, 24 principal, 19 admin). The matrix generator
carried a copy of the same walk and the same defect, so it is fixed too.

`test_inventory_agrees_with_the_openapi_schema` cross-checks the walk against
the OpenAPI schema, which is public API and came through this restructuring
unchanged. The next such change fails as one named error instead of six
confusing ones.

`test-coverage.yml` now uses `uv sync`, matching `ci.yml`'s documented
convention. That job predated the rule and so silently tested a tree no other
job tested. The drift is not only fastapi: the same fresh resolve pulls
voice-prices 0.9.1 against the lock's 0.6.0, which fails a pricing test for
exactly the reason `ci.yml`'s comment describes.

**VG-SEC-015.** The trace contract states in two places that
`SpanAttributes.tenant_id` is set from a verified principal at an ingestion
boundary, and nothing enforced it. That is the same shape as VG-SEC-001, the
live defect where a payload `tenant_id` beats the tenant resolved from the API
key on a route that already ships, and the lesson of VG-SEC-001 is that writing
the rule down is not enough: it was written down, in
`docs/architecture/security.md`, while the code did the opposite.

So the rule is data now. `PlannedRoute` carries a required `tenant_source`, a
validator refuses any planned ingest route that is not `server_derived`, and
the three OTLP routes declare it. The receiver cannot be written without a row
saying where its tenant comes from.

**Review fixes.** Restored the `== 18` write-scope count, which had been
relaxed to a non-empty check while 18 is still the true figure and is quoted as
fact in the VG-SEC-003 threat entry and on the docs page. The two Wave 0 docs
pages now reference each other, so the trace contract's server-derived claim
points at the gap that falsifies it today.

## Verification

- Full suite: 3789 passed, 23 skipped, 2 xfailed, 0 failed
- All five workflows green on `f8ff6a42`
- fastapi 0.141.1 in a Linux container: 20/20 matrix tests, generator reports
  full coverage
- ruff, mypy (296 files), docs validator (83 pages) clean
- Both Wave 0 negatives still empty: no migration, no existing production
  Python touched

## Known open items, not addressed here

- **Dead-air bug in `attach.py`.** `_on_user_state_changed` only ends speech
  when `old_state == "speaking"`, so a `listening` transition alone leaves the
  clock stuck and dead air can never fire. This is pre-existing and already on
  `main`; it is production code, and this branch touches none. The test that
  reports it passes only when two probes land in the same millisecond, which is
  why it looked like a flake. Needs its own branch.
- **OTLP path collision.** The conventional receiver mounts `/v1/metrics` and
  `/v1/logs` already exist here as GET reads, so the planned routes are
  namespaced under `/v1/telemetry/` pending a decision from whoever owns the
  receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3UNGNq9FiPyqMzozC7EtY
