### PR TITLE
feat(accounting): immutable pricing and reliable usage accounting

### DIFF
--- a/.github/workflows/postgres-collector.yml
+++ b/.github/workflows/postgres-collector.yml
@@ -39,7 +39,11 @@ jobs:
           uv venv --seed --python 3.12
           uv pip install -e ".[dev,collector]"
       - name: Run the Postgres collector integration test
-        run: uv run pytest src/voicegateway/tests/integration/test_postgres_collector.py -v
+        run: >-
+          uv run pytest
+          src/voicegateway/tests/integration/test_postgres_collector.py
+          src/voicegateway/tests/integration/test_accounting_postgres_release.py
+          -v
 
   image-smoke:
     name: Image smoke (collector stack on Postgres)

--- a/.gitignore
+++ b/.gitignore
@@ -471,3 +471,7 @@ qa/
 # .log by NAME, and that mismatch is the bug the fixture reproduces: renaming it
 # to .csv to get it past this rule would delete the only thing it proves.
 !src/voicegateway/tests/fixtures/loadtest/**/*.log
+
+# Working documents for superpowers skills stay local; never committed.
+docs/superpowers/plans/
+docs/superpowers/specs/

--- a/alembic/versions/a6c9e2f4b817_immutable_accounting_ledger.py
+++ b/alembic/versions/a6c9e2f4b817_immutable_accounting_ledger.py
@@ -47,6 +47,14 @@ def upgrade() -> None:
     op.create_index(
         "ix_pricing_revisions_scope_key", "pricing_revisions", ["scope_key"]
     )
+    op.create_index(
+        "uq_pricing_revisions_active_scope",
+        "pricing_revisions",
+        ["tenant_id", "side", "scope_key"],
+        unique=True,
+        sqlite_where=sa.text("active = 1"),
+        postgresql_where=sa.text("active"),
+    )
     op.create_table(
         "accounting_usage",
         sa.Column("id", sa.Integer(), primary_key=True),
@@ -76,7 +84,7 @@ def upgrade() -> None:
         sa.Column("receipt_id", sa.String(), nullable=False),
         sa.Column("created_at_ns", sa.BigInteger(), nullable=False),
         sa.UniqueConstraint("tenant_id", "project_id", "event_id"),
-        sa.UniqueConstraint("tenant_id", "project_id", "component", "attempt_id"),
+        sa.UniqueConstraint("tenant_id", "project_id", "attempt_id"),
     )
     for column in ("tenant_id", "project_id", "event_id", "session_id", "status"):
         op.create_index(f"ix_accounting_usage_{column}", "accounting_usage", [column])
@@ -157,10 +165,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("prepared_pricing_bindings")
-    op.drop_table("accounting_ownership")
-    op.drop_table("accounting_rejections")
-    op.drop_table("accounting_projection_outbox")
-    op.drop_table("accounting_usage")
-    op.drop_table("pricing_revisions")
-    op.drop_column("api_keys", "project_ids")
+    raise RuntimeError(
+        "This additive accounting migration has no destructive downgrade. "
+        "Roll back the application while retaining ledger tables and project allowlists."
+    )

--- a/alembic/versions/a6c9e2f4b817_immutable_accounting_ledger.py
+++ b/alembic/versions/a6c9e2f4b817_immutable_accounting_ledger.py
@@ -20,6 +20,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    op.add_column("api_keys", sa.Column("project_ids", sa.Text(), nullable=True))
     op.create_table(
         "pricing_revisions",
         sa.Column("id", sa.Integer(), primary_key=True),
@@ -27,6 +28,7 @@ def upgrade() -> None:
         sa.Column("revision_id", sa.String(), nullable=False),
         sa.Column("side", sa.String(), nullable=False),
         sa.Column("scope_json", sa.Text(), nullable=False),
+        sa.Column("scope_key", sa.String(), nullable=False),
         sa.Column("content_json", sa.Text(), nullable=False),
         sa.Column("content_hash", sa.String(64), nullable=False),
         sa.Column("contract_version", sa.Integer(), nullable=False),
@@ -42,6 +44,9 @@ def upgrade() -> None:
         "ix_pricing_revisions_revision_id", "pricing_revisions", ["revision_id"]
     )
     op.create_index("ix_pricing_revisions_active", "pricing_revisions", ["active"])
+    op.create_index(
+        "ix_pricing_revisions_scope_key", "pricing_revisions", ["scope_key"]
+    )
     op.create_table(
         "accounting_usage",
         sa.Column("id", sa.Integer(), primary_key=True),
@@ -57,6 +62,7 @@ def upgrade() -> None:
         sa.Column("turn_id", sa.String(), nullable=True),
         sa.Column("producer_id", sa.String(), nullable=False),
         sa.Column("ownership_mode", sa.String(), nullable=False),
+        sa.Column("pricing_binding_id", sa.String(), nullable=True),
         sa.Column("acquisition_revision_id", sa.String(), nullable=True),
         sa.Column("selling_revision_id", sa.String(), nullable=True),
         sa.Column("occurred_at_ns", sa.BigInteger(), nullable=False),
@@ -76,15 +82,85 @@ def upgrade() -> None:
         op.create_index(f"ix_accounting_usage_{column}", "accounting_usage", [column])
     op.create_table(
         "accounting_projection_outbox",
-        sa.Column("event_id", sa.String(), primary_key=True),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("event_id", sa.String(), nullable=False),
         sa.Column("payload_json", sa.Text(), nullable=False),
         sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("last_error_code", sa.String(), nullable=True),
         sa.Column("projected_at_ns", sa.BigInteger(), nullable=True),
+        sa.UniqueConstraint("tenant_id", "project_id", "event_id"),
+    )
+    for column in ("tenant_id", "project_id", "event_id"):
+        op.create_index(
+            f"ix_accounting_projection_outbox_{column}",
+            "accounting_projection_outbox",
+            [column],
+        )
+    op.create_table(
+        "accounting_rejections",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.Column("payload_hash", sa.String(64), nullable=False),
+        sa.Column("code", sa.String(), nullable=False),
+        sa.Column("receipt_id", sa.String(), nullable=False),
+        sa.Column("created_at_ns", sa.BigInteger(), nullable=False),
+        sa.UniqueConstraint("tenant_id", "project_id", "event_id", "payload_hash"),
+    )
+    op.create_index(
+        "ix_accounting_rejections_tenant_id", "accounting_rejections", ["tenant_id"]
+    )
+    op.create_index(
+        "ix_accounting_rejections_project_id", "accounting_rejections", ["project_id"]
+    )
+    op.create_table(
+        "accounting_ownership",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("component", sa.String(), nullable=False),
+        sa.Column("mode", sa.String(), nullable=False),
+        sa.Column("updated_at_ns", sa.BigInteger(), nullable=False),
+        sa.UniqueConstraint("tenant_id", "project_id", "component"),
+    )
+    op.create_index(
+        "ix_accounting_ownership_tenant_id", "accounting_ownership", ["tenant_id"]
+    )
+    op.create_index(
+        "ix_accounting_ownership_project_id", "accounting_ownership", ["project_id"]
+    )
+    op.create_table(
+        "prepared_pricing_bindings",
+        sa.Column("binding_id", sa.String(), primary_key=True),
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("component", sa.String(), nullable=False),
+        sa.Column("offering", sa.String(), nullable=False),
+        sa.Column("acquisition_revision_id", sa.String(), nullable=True),
+        sa.Column("selling_revision_id", sa.String(), nullable=True),
+        sa.Column("ownership_mode", sa.String(), nullable=False),
+        sa.Column("prepared_at_ns", sa.BigInteger(), nullable=False),
+    )
+    op.create_index(
+        "ix_prepared_pricing_bindings_tenant_id",
+        "prepared_pricing_bindings",
+        ["tenant_id"],
+    )
+    op.create_index(
+        "ix_prepared_pricing_bindings_project_id",
+        "prepared_pricing_bindings",
+        ["project_id"],
     )
 
 
 def downgrade() -> None:
+    op.drop_table("prepared_pricing_bindings")
+    op.drop_table("accounting_ownership")
+    op.drop_table("accounting_rejections")
     op.drop_table("accounting_projection_outbox")
     op.drop_table("accounting_usage")
     op.drop_table("pricing_revisions")
+    op.drop_column("api_keys", "project_ids")

--- a/alembic/versions/a6c9e2f4b817_immutable_accounting_ledger.py
+++ b/alembic/versions/a6c9e2f4b817_immutable_accounting_ledger.py
@@ -1,0 +1,90 @@
+"""immutable pricing revisions and exact usage ledger
+
+Revision ID: a6c9e2f4b817
+Revises: e5c9b41a72f8
+Create Date: 2026-09-05
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a6c9e2f4b817"
+down_revision: str | None = "e5c9b41a72f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pricing_revisions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.Column("revision_id", sa.String(), nullable=False),
+        sa.Column("side", sa.String(), nullable=False),
+        sa.Column("scope_json", sa.Text(), nullable=False),
+        sa.Column("content_json", sa.Text(), nullable=False),
+        sa.Column("content_hash", sa.String(64), nullable=False),
+        sa.Column("contract_version", sa.Integer(), nullable=False),
+        sa.Column("currency", sa.String(3), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at_ns", sa.BigInteger(), nullable=False),
+        sa.UniqueConstraint("tenant_id", "side", "revision_id"),
+    )
+    op.create_index(
+        "ix_pricing_revisions_tenant_id", "pricing_revisions", ["tenant_id"]
+    )
+    op.create_index(
+        "ix_pricing_revisions_revision_id", "pricing_revisions", ["revision_id"]
+    )
+    op.create_index("ix_pricing_revisions_active", "pricing_revisions", ["active"])
+    op.create_table(
+        "accounting_usage",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.Column("attempt_id", sa.String(), nullable=False),
+        sa.Column("component", sa.String(), nullable=False),
+        sa.Column("modality", sa.String(), nullable=False),
+        sa.Column("offering", sa.String(), nullable=False),
+        sa.Column("model_id", sa.String(), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("turn_id", sa.String(), nullable=True),
+        sa.Column("producer_id", sa.String(), nullable=False),
+        sa.Column("ownership_mode", sa.String(), nullable=False),
+        sa.Column("acquisition_revision_id", sa.String(), nullable=True),
+        sa.Column("selling_revision_id", sa.String(), nullable=True),
+        sa.Column("occurred_at_ns", sa.BigInteger(), nullable=False),
+        sa.Column("payload_hash", sa.String(64), nullable=False),
+        sa.Column("envelope_json", sa.Text(), nullable=False),
+        sa.Column("acquisition_total_usd", sa.String(), nullable=True),
+        sa.Column("selling_total_usd", sa.String(), nullable=True),
+        sa.Column("acquisition_complete", sa.Boolean(), nullable=False),
+        sa.Column("selling_complete", sa.Boolean(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("receipt_id", sa.String(), nullable=False),
+        sa.Column("created_at_ns", sa.BigInteger(), nullable=False),
+        sa.UniqueConstraint("tenant_id", "project_id", "event_id"),
+        sa.UniqueConstraint("tenant_id", "project_id", "component", "attempt_id"),
+    )
+    for column in ("tenant_id", "project_id", "event_id", "session_id", "status"):
+        op.create_index(f"ix_accounting_usage_{column}", "accounting_usage", [column])
+    op.create_table(
+        "accounting_projection_outbox",
+        sa.Column("event_id", sa.String(), primary_key=True),
+        sa.Column("payload_json", sa.Text(), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_error_code", sa.String(), nullable=True),
+        sa.Column("projected_at_ns", sa.BigInteger(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("accounting_projection_outbox")
+    op.drop_table("accounting_usage")
+    op.drop_table("pricing_revisions")

--- a/docs/architecture/accounting-release-candidate.md
+++ b/docs/architecture/accounting-release-candidate.md
@@ -78,6 +78,35 @@ uv build
 The final release record must attach the exact pass counts, skip/xfail
 classification, built artifact name, and SHA-256 digest from the candidate run.
 
+The 2026-09-05 candidate rehearsal produced this sanitized result:
+
+| Gate | Result | Release effect |
+| --- | --- | --- |
+| Complete Python suite with Pipecat installed | 4,001 passed, 33 skipped, 3 expected failures | pass |
+| Disposable PostgreSQL 16 collector + accounting matrix | 3 passed | pass |
+| Additional PostgreSQL dialect round trip | 1 passed | pass |
+| Ruff over `src` and `examples` | clean | pass |
+| Mypy over 310 source files | clean | pass |
+| Documentation | 85 pages validated | pass |
+| Dashboard production build | built successfully | pass; existing bundle-size advisory only |
+
+Skipped tests are classified by prerequisite and capability:
+
+| Count | Reason | Affected capability | Blocks accounting v1? |
+| ---: | --- | --- | --- |
+| 9 | optional load-test fixture bundle absent | load-generator report replay | no |
+| 15 | local node/exporter services not running | live infrastructure scrape | no |
+| 4 | provider-recorded streaming fixture bundle deferred | legacy provider replay fixtures | no; representative native SDK streaming is covered |
+| 4 | PostgreSQL environment variables absent from the all-tests process | PostgreSQL collector/accounting/dialect | no; all four passed separately on PostgreSQL 16 |
+| 1 | optional local-model plugin absent | local-model provider smoke | no |
+
+The three expected failures are pre-existing contracts outside the accounting
+v1 boundary: one storage-architecture reach-through and two open telemetry
+security gaps (unauthenticated audit-log read and an unscoped legacy project
+parameter). They do not affect the principal-aware `/v1/accounting/*`,
+dashboard accounting, or tenant-bound MCP accounting paths verified here. They
+do block claiming those separate architecture/security items complete.
+
 ## Deployment and forward recovery
 
 Deployment order:

--- a/docs/architecture/accounting-release-candidate.md
+++ b/docs/architecture/accounting-release-candidate.md
@@ -1,0 +1,102 @@
+---
+title: Accounting release candidate
+description: "Supported boundary, compatibility, verification commands, deployment, and forward recovery for accounting v1"
+---
+
+This is the release boundary for immutable pricing and exact accounting
+contract version 1. The authoritative store is SQL: SQLite for a single-node
+deployment and PostgreSQL for a collector deployment. All supported accounting
+write and read paths (`/v1/accounting/*`, `/api/accounting`, and
+`get_accounting_status`) use that SQL ledger.
+
+## Storage boundary
+
+ClickHouse continues to support legacy request telemetry and cost dashboards.
+An exact-accounting ClickHouse projection is not part of this release. No
+supported accounting endpoint reads ClickHouse, the reserved SQL projection
+table has no producer, and no `pending_delivery` field is exposed. Projection
+schema, consumer, replay, deduplication, recovery, and central projection-health
+reporting are deferred together so the product never reports a queue that no
+worker maintains.
+
+The producer-side SQLite outbox is different from that deferred projection. It
+is supported and exposes `pending`, `rejected`, `failed_delivery`, oldest age,
+memory depth, and capture failures through `AccountingOutbox.health()`.
+
+## Compatibility matrix
+
+| Surface | Release status | Verified combination |
+| --- | --- | --- |
+| Python | supported | project minimum 3.11; release tests on 3.12 |
+| Embedded SQL ledger | supported | SQLite through the complete suite |
+| Collector SQL ledger | supported | PostgreSQL 16 with asyncpg |
+| Native LiveKit capture | supported | livekit-agents 1.5.7; package constraint `>=1.5,<1.7` |
+| Pipecat accounting capture | supported through the shared sink adapter | covered by component tests; not part of the native LiveKit acceptance matrix |
+| ClickHouse legacy telemetry | unchanged | existing ClickHouse tests |
+| ClickHouse exact-accounting projection | unsupported/deferred | no supported accounting path depends on it |
+| Exact-ledger file export | unsupported/deferred | tenant report API is the supported read path |
+| MCP per-caller tenant identity | unsupported | shared token is process authority; bind one accounting tenant per process |
+
+## Acceptance evidence
+
+The committed gates are repeatable and use synthetic identities only:
+
+- `test_accounting_postgres_release.py` migrates a disposable PostgreSQL,
+  creates a runtime role without schema-create or ledger-delete privileges,
+  and verifies immutable revisions, independent sides, concurrent activation,
+  Decimal rating, concurrent deduplication, mixed receipts, project/tenant
+  isolation, acquisition privacy, delayed pinned prices, restart, and lost ack.
+- `test_livekit_accounting_integration.py` uses native LiveKit STT, TTS, LLM,
+  and realtime base instances. It covers registration timing, cancellation,
+  cache and realtime quantities, missing measurements, streaming segments,
+  stable duplicate replay, ownership modes, tracing context, outage retention,
+  and failed-delivery health.
+- `test_release_boundary.py` installs a fail-on-use ClickHouse sentinel and
+  proves the supported accounting API/dashboard reads remain SQL-only and do
+  not expose `pending_delivery`. It also freezes the legacy export privacy
+  boundary.
+- `test_accounting_sync_example.py` runs the executable synchronization example
+  against the ASGI API, including readback hash verification and delayed usage
+  pinned to an older active price.
+
+Release rehearsal commands:
+
+```bash
+uv run pytest -q src/voicegateway/tests/accounting
+VOICEGW_DB_URL=postgresql+asyncpg://... \
+  uv run pytest -q \
+  src/voicegateway/tests/integration/test_postgres_collector.py \
+  src/voicegateway/tests/integration/test_accounting_postgres_release.py
+uv run --frozen pytest -q -rsxX
+uv run --with 'mypy<2' --with types-PyYAML mypy
+uv run --with ruff ruff check .
+uv run python docs/_check_docs.py
+npm --prefix src/dashboard/frontend run build
+uv build
+```
+
+The final release record must attach the exact pass counts, skip/xfail
+classification, built artifact name, and SHA-256 digest from the candidate run.
+
+## Deployment and forward recovery
+
+Deployment order:
+
+1. Back up PostgreSQL and upgrade the collector so migration
+   `a6c9e2f4b817` is applied.
+2. Start with the restricted runtime role and verify `/health` plus accounting
+   capability discovery.
+3. Synchronize and read back acquisition and selling revisions independently;
+   activate only after canonical hashes and complete dimension sets match.
+4. Prepare one binding per offering, configure ownership, then roll producers
+   forward. Monitor every producer outbox before using ledger totals for an
+   invoice.
+5. Reconcile selling totals and completeness before retiring any legacy report.
+
+Application rollback is supported; destructive database downgrade is not.
+Stop new accounting producers, preserve or drain their outboxes, deploy the
+previous application, and retain the additive tables. To recover forward,
+restore the candidate application and drain the same outboxes: stable event IDs
+return duplicate receipts without a second row or charge. The migration's
+`downgrade()` raises before changing schema so an automated rollback cannot
+erase the ledger or API-key project allowlists.

--- a/docs/architecture/immutable-accounting.md
+++ b/docs/architecture/immutable-accounting.md
@@ -24,9 +24,10 @@ collector retries. A later price activation affects only later preparations.
 Missing revisions produce an `unrated` event; VoiceGateway never applies the
 current catalog retroactively.
 
-Usage commits transactionally with a per-record receipt and a projection
-outbox row. The SQL ledger (SQLite or PostgreSQL) is authoritative. ClickHouse
-is an asynchronous, rebuildable analytics projection. Duplicate event payloads
+Usage commits transactionally with a per-record receipt. The SQL ledger
+(SQLite or PostgreSQL) is authoritative. The reserved projection table is not
+written and `pending_delivery` is not reported until a real consumer ships;
+ClickHouse accounting projection remains deferred. Duplicate event payloads
 return their original receipt, while conflicting content or a second billable
 producer for the same provider attempt is durably rejected.
 
@@ -44,7 +45,9 @@ used by the version 1 rater.
 | requests | request |
 
 Cache quantities are subsets of text input. The rater subtracts cache read and
-write from ordinary input once, then applies the cache rates. A revision must
+write from ordinary input only when that cache dimension has its own rate. An
+unpriced cache subset stays in ordinary input and marks the side incomplete
+instead of silently discounting tokens. A revision must
 classify every dimension as rated or unsupported. Unknown prices, missing
 measurements, unsupported measurements, and explicit zero prices are distinct.
 
@@ -65,18 +68,27 @@ The usage schema is an allowlist. It has no fields for credentials, prompts,
 transcripts, caller values, arbitrary metadata, or tool arguments. Do not add
 these fields to accounting extensions.
 
+Pricing mutations require both an admin principal and the `admin` scope. A
+tenant-bound admin remains bound to that tenant. Producer-facing preparation
+responses omit acquisition revision IDs; during ingestion, the collector
+resolves acquisition, selling, and ownership from the stored binding.
+
 ## Producer delivery
 
 `AccountingOutbox.submit()` is the durable producer API. It writes the exact
-envelope and stable event ID to a bounded SQLite outbox before returning.
+envelope and stable event ID to a record- and byte-bounded SQLite outbox before
+returning.
 `enqueue_nowait()` is intended for the voice response path: it cannot block the
 call, but a process crash before the background write is a documented capture
 window. A full memory queue, full disk outbox, or persistence failure increments
-an explicit capture-failure signal and logs an error.
+an explicit capture-failure signal, persists that counter across restarts, and
+logs an error.
 
 The outbox never evicts persisted, unacknowledged usage. It deletes a row only
-after an `accepted` or `duplicate` durable receipt, quarantines terminal
-rejections, and retains retryable or missing-receipt rows across restarts.
+after an `accepted` or `duplicate` receipt with a receipt ID, quarantines
+terminal rejections and HTTP 4xx responses, and retains retryable or
+missing-receipt rows across restarts. Backoff is bounded and jittered; rows that
+exhaust the configured attempt limit are quarantined.
 Operators must monitor pending count, oldest pending age, rejected count, and
 capture failures. Bounded storage and an indefinitely unavailable collector
 cannot mathematically guarantee zero loss; this condition is visible rather
@@ -100,27 +112,40 @@ Rollout order:
 1. Back up the SQL database and upgrade collectors.
 2. Create and read back acquisition and selling revisions, verify their hashes,
    then activate each side independently.
-3. Configure ownership, upgrade producers, and monitor unrated and pending
-   counts side-by-side with legacy reporting.
+3. Configure ownership, upgrade producers, and monitor unrated ledger rows plus
+   each producer outbox's pending/rejected health side-by-side with legacy reporting.
 4. Switch invoice exports only after reconciliation passes.
 
 To roll back, stop new version 1 producers, drain or preserve their local
 outboxes, and deploy the earlier application. Do not downgrade the database:
 the additive tables are inert to older code and retain receipts for a later
-resume. A destructive Alembic downgrade removes the ledger and is not a normal
-rollback procedure.
+resume. Migration `a6c9e2f4b817` explicitly refuses destructive downgrade so a
+routine rollback cannot erase ledger data or project allowlists.
 
 ## Minimal SDK example
 
 ```python
+from voicegateway import attach
 from voicegateway.accounting.outbox import AccountingOutbox
 
-# Obtain an immutable preparation binding from the collector before the attempt,
-# build a strict UsageEnvelope from provider measurements, then persist it.
+# Obtain an immutable preparation binding from the collector before the attempt.
 outbox = AccountingOutbox("accounting-outbox.db", "https://collector.example")
-await outbox.submit(envelope)
-await outbox.drain()
+attach(
+    session,
+    accounting_outbox=outbox,
+    accounting_binding=prepared_binding,
+    accounting_producer_id="agent-worker",
+)
 ```
+
+Supplying `accounting_outbox` is the explicit opt-in. Normal telemetry continues
+through its configured sink, while usage-v1 capture persists without blocking
+the voice response. If prepared ownership is `external`, the SDK does not send
+a duplicate billable record.
+
+The read-only MCP accounting tool accepts no tenant argument. Bind it to one
+tenant with `VOICEGW_MCP_ACCOUNTING_TENANT`; without that setting it returns
+`accounting_tenant_not_configured` and no accounting data.
 
 Provider adapters must report unsupported measurements explicitly. They must
 not infer absent cache, realtime-audio, reasoning, or character measurements.

--- a/docs/architecture/immutable-accounting.md
+++ b/docs/architecture/immutable-accounting.md
@@ -1,0 +1,126 @@
+---
+title: Immutable pricing and exact usage accounting
+description: "Version 1 pricing revisions, decimal rating, durable usage receipts, ownership, and migration guidance"
+---
+
+VoiceGateway's version 1 accounting ledger is an opt-in companion to the
+legacy request-cost records. Legacy APIs remain available; new invoice-grade
+integrations should use `/v1/accounting/*`.
+
+## Guarantees
+
+Pricing has independent acquisition and selling revisions. A revision is
+identified by tenant scope, side, revision ID, contract version, and the
+SHA-256 hash of canonical JSON. Repeating identical content is idempotent.
+Reusing an identity with different content returns `409`. Activation is a
+separate operation and can include `expected_current_revision_id` to prevent a
+lost update. Failed creation or activation does not change the previous active
+revision.
+
+`POST /v1/accounting/prepare` captures active revisions and accounting
+ownership for one project, component, and offering. The resulting binding is
+immutable. Provider attempts retain that binding across delayed delivery and
+collector retries. A later price activation affects only later preparations.
+Missing revisions produce an `unrated` event; VoiceGateway never applies the
+current catalog retroactively.
+
+Usage commits transactionally with a per-record receipt and a projection
+outbox row. The SQL ledger (SQLite or PostgreSQL) is authoritative. ClickHouse
+is an asynchronous, rebuildable analytics projection. Duplicate event payloads
+return their original receipt, while conflicting content or a second billable
+producer for the same provider attempt is durably rejected.
+
+## Exact units and rounding
+
+Rates and quantities are JSON decimal strings. Binary floating-point is not
+used by the version 1 rater.
+
+| Dimension | Fixed unit |
+| --- | --- |
+| text input/output and cache read/write | token |
+| realtime audio input/output/cache | token |
+| characters | character |
+| audio | second |
+| requests | request |
+
+Cache quantities are subsets of text input. The rater subtracts cache read and
+write from ordinary input once, then applies the cache rates. A revision must
+classify every dimension as rated or unsupported. Unknown prices, missing
+measurements, unsupported measurements, and explicit zero prices are distinct.
+
+The `usd-v1-half-even-12` profile computes with 60 decimal digits and rounds
+each event-side total to 12 USD fractional digits using half-even rounding.
+Stored event totals are aggregated; display rounding is not accounting.
+Version 1 supports USD only and rejects other currencies.
+
+## Security and data minimization
+
+The authenticated principal supplies the tenant. A submitted tenant identifier
+is never trusted as authority. Project-restricted API keys may ingest and read
+only their allowed projects. Acquisition rates, acquisition totals, and margin
+are operator-only; tenant reports, dashboard responses, and the read-only MCP
+status tool expose selling totals and completeness only.
+
+The usage schema is an allowlist. It has no fields for credentials, prompts,
+transcripts, caller values, arbitrary metadata, or tool arguments. Do not add
+these fields to accounting extensions.
+
+## Producer delivery
+
+`AccountingOutbox.submit()` is the durable producer API. It writes the exact
+envelope and stable event ID to a bounded SQLite outbox before returning.
+`enqueue_nowait()` is intended for the voice response path: it cannot block the
+call, but a process crash before the background write is a documented capture
+window. A full memory queue, full disk outbox, or persistence failure increments
+an explicit capture-failure signal and logs an error.
+
+The outbox never evicts persisted, unacknowledged usage. It deletes a row only
+after an `accepted` or `duplicate` durable receipt, quarantines terminal
+rejections, and retains retryable or missing-receipt rows across restarts.
+Operators must monitor pending count, oldest pending age, rejected count, and
+capture failures. Bounded storage and an indefinitely unavailable collector
+cannot mathematically guarantee zero loss; this condition is visible rather
+than silent.
+
+Delivery retries preserve event and attempt IDs. A new provider retry or
+fallback receives a new attempt and event ID. SDK-owned and externally owned
+accounting are selected in an operator-managed ownership assignment. Diagnostic
+telemetry may still be emitted by the non-owner, but it must not be submitted
+as billable usage.
+
+## Compatibility and migration
+
+Database migration `a6c9e2f4b817` adds the ledger and optional project allowlists
+to API keys. Existing keys remain unrestricted within their tenant. Existing
+request rows keep their stored floating-point totals and are labeled by their
+legacy provenance; they are not re-rated or assigned invented revisions.
+
+Rollout order:
+
+1. Back up the SQL database and upgrade collectors.
+2. Create and read back acquisition and selling revisions, verify their hashes,
+   then activate each side independently.
+3. Configure ownership, upgrade producers, and monitor unrated and pending
+   counts side-by-side with legacy reporting.
+4. Switch invoice exports only after reconciliation passes.
+
+To roll back, stop new version 1 producers, drain or preserve their local
+outboxes, and deploy the earlier application. Do not downgrade the database:
+the additive tables are inert to older code and retain receipts for a later
+resume. A destructive Alembic downgrade removes the ledger and is not a normal
+rollback procedure.
+
+## Minimal SDK example
+
+```python
+from voicegateway.accounting.outbox import AccountingOutbox
+
+# Obtain an immutable preparation binding from the collector before the attempt,
+# build a strict UsageEnvelope from provider measurements, then persist it.
+outbox = AccountingOutbox("accounting-outbox.db", "https://collector.example")
+await outbox.submit(envelope)
+await outbox.drain()
+```
+
+Provider adapters must report unsupported measurements explicitly. They must
+not infer absent cache, realtime-audio, reasoning, or character measurements.

--- a/docs/architecture/immutable-accounting.md
+++ b/docs/architecture/immutable-accounting.md
@@ -78,11 +78,17 @@ resolves acquisition, selling, and ownership from the stored binding.
 `AccountingOutbox.submit()` is the durable producer API. It writes the exact
 envelope and stable event ID to a record- and byte-bounded SQLite outbox before
 returning.
-`enqueue_nowait()` is intended for the voice response path: it cannot block the
-call, but a process crash before the background write is a documented capture
-window. A full memory queue, full disk outbox, or persistence failure increments
-an explicit capture-failure signal, persists that counter across restarts, and
-logs an error.
+`attach()` registers its LiveKit component and session event handlers
+synchronously before it returns. When a native metric arrives, its sink work is
+scheduled outside provider execution and the accounting decorator calls
+`submit()` before writing ordinary telemetry. Collector I/O happens only during
+drain, so a collector outage cannot delay the voice response. A full disk
+outbox or persistence failure increments an explicit capture-failure signal,
+persists that counter when storage is available, and logs an error.
+
+`enqueue_nowait()` remains available for producers that cannot await even a
+local write. It has a documented process-crash window before its background
+worker persists the event. `attach()` does not use that weaker path.
 
 The outbox never evicts persisted, unacknowledged usage. It deletes a row only
 after an `accepted` or `duplicate` receipt with a receipt ID, quarantines
@@ -100,6 +106,21 @@ accounting are selected in an operator-managed ownership assignment. Diagnostic
 telemetry may still be emitted by the non-owner, but it must not be submitted
 as billable usage.
 
+Native LiveKit request IDs and streaming segment IDs are retained as
+non-content correlation metadata. They generate replay-stable accounting event
+IDs, so replaying one metric deduplicates while different TTS segments that
+share a request ID remain distinct. Realtime text, audio, and cached-audio token
+quantities are carried separately. An absent native measurement is emitted as
+`missing`, never as a measured zero.
+
+The remaining observation boundary is explicit: work completed before
+`attach()` returns, a provider that emits neither a metric nor cumulative
+session usage, and an abrupt process termination before the scheduled metric
+task starts cannot be reconstructed. Graceful session close reconciles missing
+per-call metrics from cumulative LiveKit usage. The Wave 0 tracing context does
+not create accounting records; enabling or propagating that context leaves the
+single accounting capture sink as the only billable producer.
+
 ## Compatibility and migration
 
 Database migration `a6c9e2f4b817` adds the ledger and optional project allowlists
@@ -116,6 +137,11 @@ Rollout order:
    each producer outbox's pending/rejected health side-by-side with legacy reporting.
 4. Switch invoice exports only after reconciliation passes.
 
+The existing `voicegw export-costs` command exports legacy request-cost rows.
+It is not an immutable-ledger export and contains no acquisition revision,
+acquisition total, or margin fields. A versioned exact-accounting export is
+deferred; use the tenant-scoped report API for supported ledger reads.
+
 To roll back, stop new version 1 producers, drain or preserve their local
 outboxes, and deploy the earlier application. Do not downgrade the database:
 the additive tables are inert to older code and retain receipts for a later
@@ -128,12 +154,16 @@ routine rollback cannot erase ledger data or project allowlists.
 from voicegateway import attach
 from voicegateway.accounting.outbox import AccountingOutbox
 
-# Obtain an immutable preparation binding from the collector before the attempt.
+# Obtain one immutable preparation binding per offering before execution.
 outbox = AccountingOutbox("accounting-outbox.db", "https://collector.example")
 attach(
     session,
     accounting_outbox=outbox,
-    accounting_binding=prepared_binding,
+    accounting_binding={
+        "provider/stt-model": prepared_stt_binding,
+        "provider/llm-model": prepared_llm_binding,
+        "provider/tts-model": prepared_tts_binding,
+    },
     accounting_producer_id="agent-worker",
 )
 ```
@@ -149,3 +179,9 @@ tenant with `VOICEGW_MCP_ACCOUNTING_TENANT`; without that setting it returns
 
 Provider adapters must report unsupported measurements explicitly. They must
 not infer absent cache, realtime-audio, reasoning, or character measurements.
+
+For a complete synchronization and delayed-delivery example, run
+`python examples/accounting_sync.py`. It discovers capabilities, synchronizes
+acquisition and selling independently, verifies readback hashes and dimension
+sets, prepares a binding, changes the active selling revision, and submits a
+delayed event against the pinned older revision with a per-record receipt.

--- a/docs/architecture/observability-security.md
+++ b/docs/architecture/observability-security.md
@@ -43,13 +43,20 @@ opening one file at one line.
 
 ### VG-THREAT-001: cross-tenant write
 
-**VG-SEC-001** (gap, Wave 1) is live today. `POST /v1/ingest/tool-calls`
-admits `tenant_id` through its field allow-list, and the repository resolves
-the row tenant as the payload value when one is present, falling back to the
-key-derived tenant only when it is absent. A key scoped to one tenant can
-therefore write rows attributed to another. Measured against an unmodified
-checkout, a batch posted with one tenant's key produced one row tagged the
-other tenant and none tagged its own.
+**VG-SEC-001** (closed in 0.26.0) was live through Wave 0.
+`POST /v1/ingest/tool-calls` admitted `tenant_id` through its field
+allow-list, and the repository resolved the row tenant as the payload value
+when one was present, falling back to the key-derived tenant only when it was
+absent. A key scoped to one tenant could therefore write rows attributed to
+another. Measured against an unmodified checkout, a batch posted with one
+tenant's key produced one row tagged the other tenant and none tagged its own.
+
+Closed by making tenancy explicit rather than ambient. All seven writers now
+take `tenant_id` as a required keyword, `create_tool_calls` no longer reads
+the field off the row, and no module under `repository/` can import
+`current_tenant`. The fixture that characterized the defect is kept as a
+guarantee: it is the exact request that used to succeed, so it is the one
+that must keep failing to write.
 
 The sibling writers do not share this shape, which is what makes it a defect
 rather than a design. The turns and dead-air writers apply a single tenant,

--- a/docs/architecture/observability-security.md
+++ b/docs/architecture/observability-security.md
@@ -96,10 +96,16 @@ reads. `tests/server/test_auth.py::test_reads_open_regardless_of_auth` pins
 this as intended for the current slice, so that pin and this gap have to be
 closed in the same change.
 
-**VG-SEC-005** (gap, Wave 2): with no keys configured, the read path resolves
-a full admin principal with no tenant binding. This is the deliberate
-self-hosted default, but it means the difference between a locked deployment
-and an open one is a config block rather than a code path.
+**VG-SEC-005** (closed in 0.26.0) was the soft default: with no keys
+configured, the read path resolved a full admin principal with no tenant
+binding, so the difference between a locked deployment and an open one was
+a config block rather than a code path. It now runs through `decide()`,
+which refuses under `enforce`, serves with a `vg.auth.would_refuse` warning
+under `warn`, and stays silent only under the explicit
+`auth.local_development` flag. That flag is itself refused at startup in
+the company of configured keys, a non-loopback bind, or enforce mode, and
+the check runs in `build_app` as well as the serve CLI so the container
+entry point cannot bypass it.
 
 The read side is not uniformly weak, and the contract records what already
 works. A tenant-scoped key asking for another tenant's rows by query param is

--- a/docs/architecture/observability-security.md
+++ b/docs/architecture/observability-security.md
@@ -147,15 +147,35 @@ Two compatibility grants keep existing keys working and both stop under
   request logs a warning naming the key id;
 - a wildcard (`*`) key still matches, as it always has.
 
-Both are withdrawn in 0.27.0, and until VG-SEC-006 closes there is no way to
-mint a key that would survive that: `POST /v1/api-keys` takes no `scopes`
-field, so every key the product issues is a wildcard. The two gaps therefore
-have to close in that order, and the grants above are what keeps 0.26.0
-shippable in between.
+Both are withdrawn in 0.27.0. Minting a key that survives that is what
+VG-SEC-006 (below) makes possible: `--scopes` is now required at every mint,
+so an operator can issue `ingest`-only agent keys today.
 
-**VG-SEC-006** (gap, Wave 1): every key the product mints defaults to the
-wildcard scope, and the scope check short-circuits on the wildcard. Scope
-enforcement runs and always passes.
+**VG-SEC-006** (closed in 0.26.0): every key the product minted defaulted to
+the wildcard scope, and the scope check short-circuits on the wildcard, so
+enforcement ran on every request and always passed. That is the worst of the
+three possible states: the key list, the matrix and this page all described a
+system of scopes that decided nothing.
+
+`scopes` is now required at all three mints, and each validates through the
+same `core.scopes.normalize_scopes`, so the doors cannot drift:
+
+| Mint | How scopes arrive |
+| --- | --- |
+| `voicegw keys create` | `--scopes` (required) |
+| `POST /v1/api-keys` | `scopes` on the body (required); a refusal is a 422 |
+| `POST /api/api_keys` | `scopes` on the body (required); a refusal is a 400 |
+
+The wildcard is refused, as is any name that is not a scope. Keys minted
+before 0.26.0 keep working and log a warning on every use naming the key id.
+`voicegw keys audit` lists exactly those keys and exits non-zero when it finds
+any, so it can be a deployment gate rather than only something to read.
+
+The refusal deliberately sits at the mint and not in `has_scope`: those are
+different populations. Refusing `*` at the check would lock out every key
+already in the field on upgrade; refusing it at the mint means no new inert
+key can be created while the existing ones keep working, loudly, until 0.27.0
+withdraws them.
 
 **VG-SEC-007** (gap, Wave 2): admin is enforced two ways, through a role
 column and through the scope list, so a key can satisfy one and not the other.

--- a/docs/architecture/observability-security.md
+++ b/docs/architecture/observability-security.md
@@ -192,18 +192,20 @@ To add a route, run the generator and paste what it prints:
 
 ## Content states
 
-Stored call content moves through five states: pending, stored, redacted,
-purged and unavailable. Transitions are one-way, so a purged recording cannot
-be resurrected by a later ingest replaying an older revision.
+Stored call content moves through five states: captured, redacted, truncated,
+expired and unavailable. These are the roadmap's frozen vocabulary, and Waves 3
+and 4 label content with exactly these words. Transitions are one-way, so an
+expired recording cannot be resurrected by a later ingest replaying an older
+revision, and a truncation is recorded rather than silently served as complete.
 
 `unavailable` is the projection an unauthorized caller sees, and it is the
 load-bearing part of the contract. A descriptor in that state may not report a
-byte count or an expiry. Either one would let a caller distinguish "purged"
+byte count or an expiry. Either one would let a caller distinguish "expired"
 from "not yours", which turns the endpoint into an existence oracle for
 session ids. This is the same rule the 404-not-403 fixture enforces at the
 request level, stated once in the type system so both surfaces inherit it.
 
-The rule is deliberately narrow. An authorized caller reading purged content
+The rule is deliberately narrow. An authorized caller reading expired content
 still gets the truth, including a zero byte count.
 
 ## Encryption envelope

--- a/docs/architecture/observability-security.md
+++ b/docs/architecture/observability-security.md
@@ -89,7 +89,7 @@ without a row stating where its tenant comes from.
 
 ### VG-THREAT-002: cross-tenant and unauthenticated read
 
-**VG-SEC-004** (gap, Wave 1): 28 of the 89 routes resolve no auth dependency
+**VG-SEC-004** (gap, Wave 1): 28 of the 98 routes resolve no auth dependency
 at all and answer an unauthenticated caller regardless of configured keys. The
 set includes the audit log, costs, logs, metrics and the billing rate-card
 reads. `tests/server/test_auth.py::test_reads_open_regardless_of_auth` pins
@@ -116,15 +116,11 @@ regress unnoticed.
 
 ### VG-THREAT-003: missing project authorization
 
-**VG-SEC-002** (planned, Wave 1): project-level authorization does not exist
-in any form. There is no tenant column on managed projects, no project column
-on API keys, no project field on the principal, and no check on the project
-query parameter. 22 of the 89 routes accept a project identifier and none of
-them compares it against anything the caller is entitled to.
-
-Because there is no surface to hold the check, this is recorded as an absence
-guard rather than a characterization: the fixture asserts the two attributes a
-project binding would need do not exist yet.
+**VG-SEC-002** (planned, Wave 1): project authorization is now available to the
+exact-accounting surface: API keys and principals carry optional project
+allowlists, and accounting ingest and reports enforce them. Legacy APIs that
+accept project filters do not yet apply the allowlist, so the gap remains open
+and is recorded as a characterization rather than an absence.
 
 ### VG-THREAT-004: coarse and inert scopes
 
@@ -133,9 +129,10 @@ ingest was gated by the same `write` scope that guards provider, model and
 project mutation, across 18 routes in total, so an agent key that only needed
 to post telemetry could rewrite gateway configuration.
 
-The six ingest routes (`POST /v1/ingest`, `/v1/ingest/turns`,
+The eight ingest routes (`POST /v1/ingest`, `/v1/ingest/turns`,
 `/v1/ingest/tool-calls`, `/v1/ingest/dead-air`, `/v1/agents/heartbeat`,
-`/v1/calls/observations`) now sit behind `require_ingest_principal`, which
+`/v1/calls/observations`, `/v1/accounting/prepare`, and
+`/v1/accounting/usage`) now sit behind `require_ingest_principal`, which
 enforces the `ingest` scope and returns the `Principal` whose `tenant_id` the
 handler stamps on every row it writes. `write` is left covering 12 routes, all
 of them config mutation.
@@ -218,8 +215,8 @@ record does not imply absence of the event.
 
 ## Authorization matrix
 
-`authorization_matrix.json` carries one row per live route: 89 rows against 89
-routes, 49 enforced and 40 gaps. Rows are generated mechanically and then
+`authorization_matrix.json` carries one row per live route: 98 rows against 98
+routes, 62 enforced and 36 gaps. Rows are generated mechanically and then
 hand-classified where the classification carries meaning.
 
 Three tests keep it bound to reality:
@@ -306,7 +303,7 @@ that module exists anywhere in the schema package.
 | :--- | :--- |
 | `src/voicegateway/schemas/telemetry/security_schema.py` | All exported contract types |
 | `src/voicegateway/schemas/telemetry/threat_model.json` | The 14 gaps, with evidence |
-| `src/voicegateway/schemas/telemetry/authorization_matrix.json` | 89 route rows plus planned routes |
+| `src/voicegateway/schemas/telemetry/authorization_matrix.json` | 98 route rows plus planned routes |
 | `src/voicegateway/tests/fixtures/security/` | The five cross-tenant fixtures |
 | `src/voicegateway/tests/server/_telemetry_harness.py` | Shared app harness and route introspection |
 | `src/voicegateway/tests/server/test_telemetry_security_contract.py` | Contract shape and absence guards |

--- a/docs/architecture/observability-security.md
+++ b/docs/architecture/observability-security.md
@@ -128,11 +128,30 @@ project binding would need do not exist yet.
 
 ### VG-THREAT-004: coarse and inert scopes
 
-**VG-SEC-003** (planned, Wave 1): there is no ingest scope. Telemetry ingest
-is gated by the same `write` scope that guards provider, model and project
-mutation, across 18 routes in total. An agent key that only needs to post
-telemetry can rewrite gateway configuration. Splitting this is semantic rather
-than a rename, which is why it is recorded before the endpoints multiply.
+**VG-SEC-003** (closed in 0.26.0): there was no ingest scope. Telemetry
+ingest was gated by the same `write` scope that guards provider, model and
+project mutation, across 18 routes in total, so an agent key that only needed
+to post telemetry could rewrite gateway configuration.
+
+The six ingest routes (`POST /v1/ingest`, `/v1/ingest/turns`,
+`/v1/ingest/tool-calls`, `/v1/ingest/dead-air`, `/v1/agents/heartbeat`,
+`/v1/calls/observations`) now sit behind `require_ingest_principal`, which
+enforces the `ingest` scope and returns the `Principal` whose `tenant_id` the
+handler stamps on every row it writes. `write` is left covering 12 routes, all
+of them config mutation.
+
+Two compatibility grants keep existing keys working and both stop under
+`auth.enforcement: enforce`:
+
+- a key holding `write` but not `ingest` is still admitted, and each such
+  request logs a warning naming the key id;
+- a wildcard (`*`) key still matches, as it always has.
+
+Both are withdrawn in 0.27.0, and until VG-SEC-006 closes there is no way to
+mint a key that would survive that: `POST /v1/api-keys` takes no `scopes`
+field, so every key the product issues is a wildcard. The two gaps therefore
+have to close in that order, and the grants above are what keeps 0.26.0
+shippable in between.
 
 **VG-SEC-006** (gap, Wave 1): every key the product mints defaults to the
 wildcard scope, and the scope check short-circuits on the wildcard. Scope

--- a/docs/architecture/observability-security.md
+++ b/docs/architecture/observability-security.md
@@ -116,7 +116,7 @@ regress unnoticed.
 
 ### VG-THREAT-003: missing project authorization
 
-**VG-SEC-002** (planned, Wave 1): project authorization is now available to the
+**VG-SEC-002** (partially closed; remaining gap, Wave 1): project authorization is now available to the
 exact-accounting surface: API keys and principals carry optional project
 allowlists, and accounting ingest and reports enforce them. Legacy APIs that
 accept project filters do not yet apply the allowlist, so the gap remains open

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -209,6 +209,7 @@
               "architecture/middleware",
               "architecture/cost-tracking",
               "architecture/rating",
+              "architecture/immutable-accounting",
               "architecture/config-layers",
               "architecture/storage",
               "architecture/security",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -210,6 +210,7 @@
               "architecture/cost-tracking",
               "architecture/rating",
               "architecture/immutable-accounting",
+              "architecture/accounting-release-candidate",
               "architecture/config-layers",
               "architecture/storage",
               "architecture/security",

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -7,7 +7,7 @@ VoiceGateway ships a built-in [Model Context Protocol](https://modelcontextproto
 
 ## Tool surface
 
-The server exposes 25 tools across five categories. Ten are visible by default; the rest need `VOICEGW_MCP_ADMIN=1` set on the server process.
+The server exposes 26 tools across six categories. Ten are visible by default; the rest need `VOICEGW_MCP_ADMIN=1` set on the server process.
 
 The default set is the framework-agnostic surface: reads (health, costs, latency, logs, models, projects) plus project and rate-card writes. The admin set is the legacy provider-config surface (`add_provider`, `test_provider`, the per-project `vg_*` key tools) plus every destructive delete. It stays admin-gated because VoiceGateway no longer constructs a provider class to route a request: `attach()`/`guard()` meter the native STT/LLM/TTS instance you pass in, by `model_id`, and never touch these classes. What still runs in production is `health_check()` (reached here through `test_provider` / `vg_test_provider_key`, and also by `voicegw doctor` and `POST /v1/providers/{id}/test`).
 
@@ -17,6 +17,7 @@ The default set is the framework-agnostic surface: reads (health, costs, latency
 | Models | `list_models` | `register_model`, `delete_model` |
 | Projects | `list_projects`, `get_project`, `create_project` | `delete_project` |
 | Rate card | `get_rate_card`, `set_rate_card_override` | `delete_rate_card_override` |
+| Exact accounting | none | `get_accounting_status` |
 | Providers | none | `list_providers`, `get_provider`, `test_provider`, `add_provider`, `delete_provider`, `vg_add_provider`, `vg_remove_provider`, `vg_list_providers`, `vg_set_provider_key`, `vg_test_provider_key` |
 
 Every `delete_*` tool uses a two-phase confirmation: call it with `confirm=false` (the default) to get a `CONFIRMATION_REQUIRED` error carrying an impact preview, then call again with `confirm=true`.

--- a/docs/mcp/transports.md
+++ b/docs/mcp/transports.md
@@ -27,6 +27,15 @@ Runs a Starlette/uvicorn server. Agents open a long-lived `GET /sse` connection 
 
 Controlled by `VOICEGW_MCP_TOKEN`. Unset (the default): every request is accepted. Set: every request needs a matching `Authorization: Bearer <token>` header, checked with `hmac.compare_digest` for constant-time comparison. A missing or malformed header gets `401` with body `Missing bearer token`; a wrong token gets `401 Invalid token`. Only the `Bearer` scheme is accepted. stdio ignores this variable entirely: there's no network boundary to protect.
 
+`VOICEGW_MCP_TOKEN` is one process-wide shared secret, not a user identity. All
+callers holding it receive the same MCP tool permissions; the server does not
+derive a tenant or project from each caller. In particular,
+`get_accounting_status` is bound to the single
+`VOICEGW_MCP_ACCOUNTING_TENANT` configured on that MCP process. This does not
+provide per-caller tenant isolation. For isolated accounting access, run a
+separate tenant-bound MCP process behind an authenticated proxy, or use the
+principal-aware HTTP accounting API instead.
+
 ```bash
 export VOICEGW_MCP_TOKEN=$(python -c "import secrets; print(secrets.token_urlsafe(32))")
 voicegw mcp --transport http --host 0.0.0.0 --port 8090

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Executable VoiceGateway integration examples."""

--- a/examples/accounting_sync.py
+++ b/examples/accounting_sync.py
@@ -1,0 +1,241 @@
+"""Executable immutable-pricing synchronization and pinned-usage example.
+
+Set ``VOICEGW_URL``, ``VOICEGW_OPERATOR_KEY``, and ``VOICEGW_TENANT`` and run:
+
+    python examples/accounting_sync.py
+
+The example uses synthetic identifiers and prints no credentials or price
+content.  It requires an operator key because acquisition revisions are
+operator-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    side: str
+    revision_id: str
+    synchronized: bool
+    detail: str
+
+
+def canonical_hash(content: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        content, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def revision_payload(
+    revision_id: str, side: str, tenant: str, request_rate: str
+) -> dict[str, Any]:
+    return {
+        "contract_version": 1,
+        "revision_id": revision_id,
+        "side": side,
+        "scope": {"tenant_id": tenant, "offering": "provider/model"},
+        "currency": "USD",
+        "rounding_profile": "usd-v1-half-even-12",
+        "rates": [{"dimension": "requests", "unit": "request", "rate": request_rate}],
+        "unsupported_dimensions": [
+            "audio_seconds",
+            "cache_read",
+            "cache_write",
+            "characters",
+            "realtime_audio_cache",
+            "realtime_audio_input",
+            "realtime_audio_output",
+            "text_input",
+            "text_output",
+        ],
+    }
+
+
+async def synchronize_revision(
+    client: httpx.AsyncClient,
+    *,
+    tenant: str,
+    payload: dict[str, Any],
+    expected_current_revision_id: str | None = None,
+) -> SyncResult:
+    """Create, read back, verify, then activate one pricing side independently."""
+    side = str(payload["side"])
+    revision_id = str(payload["revision_id"])
+    created = await client.post(
+        "/v1/accounting/revisions", params={"tenant": tenant}, json=payload
+    )
+    if created.status_code not in {200, 201}:
+        return SyncResult(
+            side, revision_id, False, f"create_http_{created.status_code}"
+        )
+
+    readback = await client.get(
+        f"/v1/accounting/revisions/{side}/{revision_id}",
+        params={"tenant": tenant},
+    )
+    if readback.status_code != 200:
+        return SyncResult(
+            side, revision_id, False, f"readback_http_{readback.status_code}"
+        )
+    stored = readback.json()
+    content = stored.get("content")
+    if not isinstance(content, dict) or canonical_hash(content) != stored.get(
+        "content_hash"
+    ):
+        return SyncResult(side, revision_id, False, "readback_hash_mismatch")
+
+    capabilities = (await client.get("/v1/accounting/capabilities")).json()
+    classified = {rate["dimension"] for rate in content["rates"]} | set(
+        content["unsupported_dimensions"]
+    )
+    if classified != set(capabilities["dimensions"]):
+        return SyncResult(side, revision_id, False, "dimension_set_incomplete")
+
+    activation: dict[str, Any] = {"revision_id": revision_id}
+    if expected_current_revision_id is not None:
+        activation["expected_current_revision_id"] = expected_current_revision_id
+    activated = await client.post(
+        f"/v1/accounting/revisions/{side}/activate",
+        params={"tenant": tenant},
+        json=activation,
+    )
+    if activated.status_code != 200:
+        return SyncResult(
+            side, revision_id, False, f"activate_http_{activated.status_code}"
+        )
+    return SyncResult(side, revision_id, True, "verified_and_active")
+
+
+async def prepare_binding(client: httpx.AsyncClient, *, project: str) -> dict[str, Any]:
+    response = await client.post(
+        "/v1/accounting/prepare",
+        json={
+            "project_id": project,
+            "component": "conversation",
+            "offering": "provider/model",
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def ingest_pinned_usage(
+    client: httpx.AsyncClient,
+    *,
+    project: str,
+    binding: dict[str, Any],
+) -> dict[str, Any]:
+    attempt_id = str(uuid.uuid4())
+    response = await client.post(
+        "/v1/accounting/usage",
+        json=[
+            {
+                "contract_version": 1,
+                "event_id": str(uuid.uuid4()),
+                "attempt_id": attempt_id,
+                "project_id": project,
+                "session_id": "example-session",
+                "turn_id": "example-turn",
+                "component": "conversation",
+                "modality": "llm",
+                "offering": "provider/model",
+                "model_id": "provider/model",
+                "producer_id": "example-producer",
+                "ownership_mode": binding["ownership_mode"],
+                "pricing_binding_id": binding["binding_id"],
+                "selling_revision_id": binding["selling_revision_id"],
+                "occurred_at_ns": time.time_ns(),
+                "quantities": [
+                    {
+                        "dimension": "requests",
+                        "value": "1",
+                        "status": "measured",
+                    }
+                ],
+            }
+        ],
+    )
+    response.raise_for_status()
+    receipt = response.json()["receipts"][0]
+    if receipt["outcome"] not in {"accepted", "duplicate"} or not receipt.get(
+        "receipt_id"
+    ):
+        raise RuntimeError(f"usage was not durably acknowledged: {receipt['code']}")
+    return receipt
+
+
+async def run(base_url: str, operator_key: str, tenant: str) -> dict[str, Any]:
+    headers = {"Authorization": f"Bearer {operator_key}"}
+    project = "example-project"
+    async with httpx.AsyncClient(
+        base_url=base_url.rstrip("/"), headers=headers, timeout=10
+    ) as client:
+        first_results = await asyncio.gather(
+            synchronize_revision(
+                client,
+                tenant=tenant,
+                payload=revision_payload(
+                    "example-acquisition-v1", "acquisition", tenant, "0.01"
+                ),
+            ),
+            synchronize_revision(
+                client,
+                tenant=tenant,
+                payload=revision_payload(
+                    "example-selling-v1", "selling", tenant, "0.02"
+                ),
+            ),
+        )
+        binding = await prepare_binding(client, project=project)
+
+        # Activate a new selling revision after preparation. The delayed event
+        # below still uses the immutable v1 binding and therefore the v1 price.
+        second = await synchronize_revision(
+            client,
+            tenant=tenant,
+            payload=revision_payload("example-selling-v2", "selling", tenant, "0.03"),
+            expected_current_revision_id="example-selling-v1",
+        )
+        receipt = await ingest_pinned_usage(client, project=project, binding=binding)
+        return {
+            "synchronization": [*first_results, second],
+            "receipt": receipt,
+            "pinned_selling_revision_id": binding["selling_revision_id"],
+        }
+
+
+async def _main() -> None:
+    base_url = os.environ.get("VOICEGW_URL", "http://127.0.0.1:8080")
+    operator_key = os.environ.get("VOICEGW_OPERATOR_KEY", "")
+    tenant = os.environ.get("VOICEGW_TENANT", "")
+    if not operator_key or not tenant:
+        raise SystemExit("VOICEGW_OPERATOR_KEY and VOICEGW_TENANT are required")
+    result = await run(base_url, operator_key, tenant)
+    print(
+        json.dumps(
+            {
+                "synchronization": [
+                    item.__dict__ for item in result["synchronization"]
+                ],
+                "receipt_outcome": result["receipt"]["outcome"],
+                "pinned_selling_revision_id": result["pinned_selling_revision_id"],
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -41,13 +41,14 @@ export interface CostsResponse {
 
 export interface AccountingStatusResponse {
   selling_total_usd: string;
+  incomplete_selling_total_usd: string;
+  unrated_selling_total_usd: string;
   records: number;
   counts: {
     rated: number;
     unrated: number;
     incomplete: number;
     rejected: number;
-    pending_delivery: number;
   };
 }
 

--- a/src/dashboard/frontend/src/lib/types.ts
+++ b/src/dashboard/frontend/src/lib/types.ts
@@ -39,6 +39,18 @@ export interface CostsResponse {
   pricing_sources?: { llm?: string; stt?: string; tts?: string };
 }
 
+export interface AccountingStatusResponse {
+  selling_total_usd: string;
+  records: number;
+  counts: {
+    rated: number;
+    unrated: number;
+    incomplete: number;
+    rejected: number;
+    pending_delivery: number;
+  };
+}
+
 export interface PercentileBucket {
   // Known percentiles are optional — the API only emits what the config
   // asks for, so callers must treat missing keys as "unknown".

--- a/src/dashboard/frontend/src/pages/Costs.tsx
+++ b/src/dashboard/frontend/src/pages/Costs.tsx
@@ -220,7 +220,7 @@ function CostsContent() {
             <div className="grid grid-cols-3 mb-lg">
               <StatusCard label="Exact selling total" value={`$${accounting.selling_total_usd}`} accent="green" icon="$" />
               <StatusCard label="Unrated / incomplete" value={`${accounting.counts.unrated + accounting.counts.incomplete}`} accent="pink" icon="!" />
-              <StatusCard label="Pending delivery" value={`${accounting.counts.pending_delivery}`} accent="yellow" icon="↻" />
+              <StatusCard label="Rejected" value={`${accounting.counts.rejected}`} accent="yellow" icon="×" />
             </div>
           )}
 

--- a/src/dashboard/frontend/src/pages/Costs.tsx
+++ b/src/dashboard/frontend/src/pages/Costs.tsx
@@ -9,7 +9,7 @@ import LatencyChart from '../components/LatencyChart';
 import { Skeleton, StatCardSkeleton } from '../components/Skeleton';
 import { fetchJson } from '../lib/api';
 import { formatCost, latencyBadgeClass, formatMs } from '../lib/ui';
-import type { CostsResponse, LatencyResponse, LatencyStats } from '../lib/types';
+import type { AccountingStatusResponse, CostsResponse, LatencyResponse, LatencyStats } from '../lib/types';
 
 /** Return the highest model percentile, or null when no model has that key. */
 function worstP(
@@ -156,6 +156,7 @@ function LatencyContent() {
 
 function CostsContent() {
   const [data, setData] = useState<CostsResponse | null>(null);
+  const [accounting, setAccounting] = useState<AccountingStatusResponse | null>(null);
   const [error, setError] = useState(false);
   const [retry, setRetry] = useState(0);
   const tenant = useTenantFilter();
@@ -177,6 +178,15 @@ function CostsContent() {
       })
       .catch(() => {
         if (active) setError(true);
+      });
+    const accountingParams = new URLSearchParams();
+    if (tenant !== null) accountingParams.set('tenant', tenant);
+    fetchJson<AccountingStatusResponse>(`/api/accounting?${accountingParams.toString()}`)
+      .then((value) => {
+        if (active) setAccounting(value);
+      })
+      .catch(() => {
+        if (active) setAccounting(null);
       });
     return () => {
       active = false;
@@ -205,6 +215,14 @@ function CostsContent() {
             <div className="vg-card__label">Total Spend</div>
             <div className="vg-stat" style={{ fontSize: 42, letterSpacing: '-0.025em', marginTop: 6 }}>{formatCost(data.total)}</div>
           </div>
+
+          {accounting && (
+            <div className="grid grid-cols-3 mb-lg">
+              <StatusCard label="Exact selling total" value={`$${accounting.selling_total_usd}`} accent="green" icon="$" />
+              <StatusCard label="Unrated / incomplete" value={`${accounting.counts.unrated + accounting.counts.incomplete}`} accent="pink" icon="!" />
+              <StatusCard label="Pending delivery" value={`${accounting.counts.pending_delivery}`} accent="yellow" icon="↻" />
+            </div>
+          )}
 
       <div className="grid grid-cols-2">
         <CostChart title="By Provider" data={data.by_provider} />

--- a/src/voicegateway/accounting/__init__.py
+++ b/src/voicegateway/accounting/__init__.py
@@ -1,0 +1,21 @@
+"""Exact, immutable accounting contracts and services."""
+
+from voicegateway.accounting.contracts import (
+    AccountingCapabilities,
+    MeasurementStatus,
+    OwnershipMode,
+    PricingDimension,
+    PricingRevisionCreate,
+    PricingSide,
+    UsageEnvelope,
+)
+
+__all__ = [
+    "AccountingCapabilities",
+    "MeasurementStatus",
+    "OwnershipMode",
+    "PricingDimension",
+    "PricingRevisionCreate",
+    "PricingSide",
+    "UsageEnvelope",
+]

--- a/src/voicegateway/accounting/__init__.py
+++ b/src/voicegateway/accounting/__init__.py
@@ -1,5 +1,6 @@
 """Exact, immutable accounting contracts and services."""
 
+from voicegateway.accounting.adapters import envelope_from_request_record
 from voicegateway.accounting.contracts import (
     AccountingCapabilities,
     MeasurementStatus,
@@ -18,4 +19,5 @@ __all__ = [
     "PricingRevisionCreate",
     "PricingSide",
     "UsageEnvelope",
+    "envelope_from_request_record",
 ]

--- a/src/voicegateway/accounting/adapters.py
+++ b/src/voicegateway/accounting/adapters.py
@@ -10,6 +10,7 @@ from voicegateway.accounting.contracts import (
     MeasurementStatus,
     OwnershipMode,
     PricingBinding,
+    PricingBindingResponse,
     PricingDimension,
     Quantity,
     UsageEnvelope,
@@ -25,7 +26,7 @@ def envelope_from_request_record(
     record: RequestRecord,
     *,
     producer_id: str,
-    binding: PricingBinding | None = None,
+    binding: PricingBinding | PricingBindingResponse | None = None,
     event_id: str | None = None,
     attempt_id: str | None = None,
     component: str = "conversation",
@@ -81,7 +82,9 @@ def envelope_from_request_record(
         ownership_mode=ownership,
         pricing_binding_id=binding.binding_id if binding is not None else None,
         acquisition_revision_id=(
-            binding.acquisition_revision_id if binding is not None else None
+            binding.acquisition_revision_id
+            if isinstance(binding, PricingBinding)
+            else None
         ),
         selling_revision_id=(
             binding.selling_revision_id if binding is not None else None

--- a/src/voicegateway/accounting/adapters.py
+++ b/src/voicegateway/accounting/adapters.py
@@ -1,0 +1,93 @@
+"""Compatibility mapping from existing SDK metering into usage v1."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from decimal import Decimal
+
+from voicegateway.accounting.contracts import (
+    MeasurementStatus,
+    OwnershipMode,
+    PricingBinding,
+    PricingDimension,
+    Quantity,
+    UsageEnvelope,
+)
+from voicegateway.models.request_model import RequestRecord
+
+
+def _decimal(value: Decimal | float | int) -> str:
+    return format(Decimal(str(value)), "f")
+
+
+def envelope_from_request_record(
+    record: RequestRecord,
+    *,
+    producer_id: str,
+    binding: PricingBinding | None = None,
+    event_id: str | None = None,
+    attempt_id: str | None = None,
+    component: str = "conversation",
+) -> UsageEnvelope:
+    """Map the measurements the legacy adapters actually expose.
+
+    This creates a new provider-attempt identity unless the capture hook passes
+    one explicitly. Delivery code must persist and retry the returned envelope,
+    not call this function again for a retry.
+    """
+    measured: dict[PricingDimension, str] = {
+        PricingDimension.REQUESTS: "1",
+    }
+    if record.modality == "llm":
+        measured.update(
+            {
+                PricingDimension.TEXT_INPUT: _decimal(record.input_units),
+                PricingDimension.TEXT_OUTPUT: _decimal(record.output_units),
+                PricingDimension.CACHE_READ: _decimal(record.cached_input_units),
+            }
+        )
+    elif record.modality == "stt":
+        measured[PricingDimension.AUDIO_SECONDS] = _decimal(
+            Decimal(str(record.input_units)) * 60
+        )
+    elif record.modality == "tts":
+        measured[PricingDimension.CHARACTERS] = _decimal(record.input_units)
+
+    quantities = tuple(
+        Quantity(
+            dimension=dimension,
+            value=measured.get(dimension),
+            status=(
+                MeasurementStatus.MEASURED
+                if dimension in measured
+                else MeasurementStatus.UNSUPPORTED
+            ),
+        )
+        for dimension in PricingDimension
+    )
+    ownership = binding.ownership_mode if binding is not None else OwnershipMode.SDK
+    return UsageEnvelope(
+        event_id=event_id or str(uuid.uuid4()),
+        attempt_id=attempt_id or record.id,
+        project_id=record.project,
+        session_id=record.session_id or f"request:{record.id}",
+        turn_id=str(record.turn_index) if record.turn_index is not None else None,
+        component=component,
+        modality=record.modality,
+        offering=record.model_id,
+        model_id=record.model_id,
+        producer_id=producer_id,
+        ownership_mode=ownership,
+        pricing_binding_id=binding.binding_id if binding is not None else None,
+        acquisition_revision_id=(
+            binding.acquisition_revision_id if binding is not None else None
+        ),
+        selling_revision_id=(
+            binding.selling_revision_id if binding is not None else None
+        ),
+        occurred_at_ns=int(Decimal(str(record.timestamp)) * 1_000_000_000)
+        if record.timestamp
+        else time.time_ns(),
+        quantities=quantities,
+    )

--- a/src/voicegateway/accounting/adapters.py
+++ b/src/voicegateway/accounting/adapters.py
@@ -40,7 +40,16 @@ def envelope_from_request_record(
     measured: dict[PricingDimension, str] = {
         PricingDimension.REQUESTS: "1",
     }
-    if record.modality == "llm":
+    realtime = record.metadata.get("accounting_realtime_quantities")
+    if record.modality == "llm" and isinstance(realtime, dict):
+        for raw_dimension, value in realtime.items():
+            try:
+                dimension = PricingDimension(raw_dimension)
+            except ValueError:
+                continue
+            if isinstance(value, int | float | Decimal):
+                measured[dimension] = _decimal(value)
+    elif record.modality == "llm":
         measured.update(
             {
                 PricingDimension.TEXT_INPUT: _decimal(record.input_units),
@@ -55,12 +64,22 @@ def envelope_from_request_record(
     elif record.modality == "tts":
         measured[PricingDimension.CHARACTERS] = _decimal(record.input_units)
 
+    missing = {
+        PricingDimension(item)
+        for item in record.metadata.get("accounting_missing_dimensions", [])
+        if item in PricingDimension._value2member_map_
+    }
+    for dimension in missing:
+        measured.pop(dimension, None)
+
     quantities = tuple(
         Quantity(
             dimension=dimension,
             value=measured.get(dimension),
             status=(
-                MeasurementStatus.MEASURED
+                MeasurementStatus.MISSING
+                if dimension in missing
+                else MeasurementStatus.MEASURED
                 if dimension in measured
                 else MeasurementStatus.UNSUPPORTED
             ),

--- a/src/voicegateway/accounting/contracts.py
+++ b/src/voicegateway/accounting/contracts.py
@@ -1,0 +1,264 @@
+"""Versioned accounting wire contracts.
+
+All monetary values are decimal strings.  These types deliberately reject
+arbitrary metadata: accounting rows must never become a second transcript or
+prompt store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+CONTRACT_VERSION = 1
+ROUNDING_PROFILE = "usd-v1-half-even-12"
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class PricingSide(StrEnum):
+    ACQUISITION = "acquisition"
+    SELLING = "selling"
+
+
+class PricingDimension(StrEnum):
+    TEXT_INPUT = "text_input"
+    TEXT_OUTPUT = "text_output"
+    CACHE_READ = "cache_read"
+    CACHE_WRITE = "cache_write"
+    REALTIME_AUDIO_INPUT = "realtime_audio_input"
+    REALTIME_AUDIO_OUTPUT = "realtime_audio_output"
+    REALTIME_AUDIO_CACHE = "realtime_audio_cache"
+    CHARACTERS = "characters"
+    AUDIO_SECONDS = "audio_seconds"
+    REQUESTS = "requests"
+
+
+class Unit(StrEnum):
+    TOKEN = "token"
+    CHARACTER = "character"
+    SECOND = "second"
+    REQUEST = "request"
+
+
+class OwnershipMode(StrEnum):
+    SDK = "sdk"
+    EXTERNAL = "external"
+
+
+class MeasurementStatus(StrEnum):
+    MEASURED = "measured"
+    ESTIMATED = "estimated"
+    MISSING = "missing"
+    UNSUPPORTED = "unsupported"
+
+
+class RevisionScope(StrictModel):
+    tenant_id: str | None = None
+    project_id: str | None = None
+    component: str | None = None
+    offering: str
+
+    @field_validator("tenant_id", "project_id", "component", "offering")
+    @classmethod
+    def valid_id(cls, value: str | None) -> str | None:
+        if value is not None and not _ID_RE.fullmatch(value):
+            raise ValueError("invalid scope identifier")
+        return value
+
+
+_UNIT_BY_DIMENSION = {
+    PricingDimension.TEXT_INPUT: Unit.TOKEN,
+    PricingDimension.TEXT_OUTPUT: Unit.TOKEN,
+    PricingDimension.CACHE_READ: Unit.TOKEN,
+    PricingDimension.CACHE_WRITE: Unit.TOKEN,
+    PricingDimension.REALTIME_AUDIO_INPUT: Unit.TOKEN,
+    PricingDimension.REALTIME_AUDIO_OUTPUT: Unit.TOKEN,
+    PricingDimension.REALTIME_AUDIO_CACHE: Unit.TOKEN,
+    PricingDimension.CHARACTERS: Unit.CHARACTER,
+    PricingDimension.AUDIO_SECONDS: Unit.SECOND,
+    PricingDimension.REQUESTS: Unit.REQUEST,
+}
+
+
+def canonical_decimal(value: str) -> str:
+    try:
+        number = Decimal(value)
+    except InvalidOperation as exc:
+        raise ValueError("invalid decimal string") from exc
+    if not number.is_finite() or number < 0:
+        raise ValueError("decimal value must be finite and non-negative")
+    if abs(number.as_tuple().exponent) > 18:
+        raise ValueError("decimal value has more than 18 fractional digits")
+    normalized = format(number, "f")
+    if "." in normalized:
+        normalized = normalized.rstrip("0").rstrip(".")
+    return normalized or "0"
+
+
+class DimensionRate(StrictModel):
+    dimension: PricingDimension
+    unit: Unit
+    rate: str
+
+    @field_validator("rate")
+    @classmethod
+    def valid_rate(cls, value: str) -> str:
+        return canonical_decimal(value)
+
+    @model_validator(mode="after")
+    def fixed_unit(self) -> DimensionRate:
+        if self.unit != _UNIT_BY_DIMENSION[self.dimension]:
+            raise ValueError(
+                f"{self.dimension} requires unit {_UNIT_BY_DIMENSION[self.dimension]}"
+            )
+        return self
+
+
+class PricingRevisionCreate(StrictModel):
+    contract_version: Literal[1] = CONTRACT_VERSION
+    revision_id: str
+    side: PricingSide
+    scope: RevisionScope
+    currency: Literal["USD"] = "USD"
+    rounding_profile: Literal["usd-v1-half-even-12"] = ROUNDING_PROFILE
+    rates: tuple[DimensionRate, ...]
+    unsupported_dimensions: tuple[PricingDimension, ...] = ()
+
+    @field_validator("revision_id")
+    @classmethod
+    def valid_revision_id(cls, value: str) -> str:
+        if not _ID_RE.fullmatch(value):
+            raise ValueError("invalid revision_id")
+        return value
+
+    @model_validator(mode="after")
+    def complete_dimensions(self) -> PricingRevisionCreate:
+        rated = [item.dimension for item in self.rates]
+        unsupported = list(self.unsupported_dimensions)
+        if len(set(rated)) != len(rated) or len(set(unsupported)) != len(unsupported):
+            raise ValueError("duplicate pricing dimension")
+        if set(rated) & set(unsupported):
+            raise ValueError("a dimension cannot be both rated and unsupported")
+        if set(rated) | set(unsupported) != set(PricingDimension):
+            raise ValueError("revision must classify every supported dimension")
+        return self
+
+    def canonical_content(self) -> str:
+        raw = self.model_dump(mode="json")
+        raw["rates"] = sorted(raw["rates"], key=lambda item: item["dimension"])
+        raw["unsupported_dimensions"] = sorted(raw["unsupported_dimensions"])
+        return json.dumps(raw, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+    def content_hash(self) -> str:
+        return hashlib.sha256(self.canonical_content().encode()).hexdigest()
+
+
+class Quantity(StrictModel):
+    dimension: PricingDimension
+    value: str | None = None
+    status: MeasurementStatus
+
+    @field_validator("value")
+    @classmethod
+    def valid_value(cls, value: str | None) -> str | None:
+        return canonical_decimal(value) if value is not None else None
+
+    @model_validator(mode="after")
+    def status_matches_value(self) -> Quantity:
+        present = self.status in {
+            MeasurementStatus.MEASURED,
+            MeasurementStatus.ESTIMATED,
+        }
+        if present != (self.value is not None):
+            raise ValueError(
+                "measured/estimated quantities require a value; missing/unsupported forbid one"
+            )
+        return self
+
+
+class UsageEnvelope(StrictModel):
+    contract_version: Literal[1] = CONTRACT_VERSION
+    event_id: str
+    attempt_id: str
+    project_id: str
+    session_id: str
+    turn_id: str | None = None
+    component: str
+    modality: str
+    offering: str
+    model_id: str
+    producer_id: str
+    ownership_mode: OwnershipMode
+    acquisition_revision_id: str | None = None
+    selling_revision_id: str | None = None
+    occurred_at_ns: Annotated[int, Field(ge=0)]
+    quantities: tuple[Quantity, ...]
+
+    @field_validator(
+        "event_id",
+        "attempt_id",
+        "project_id",
+        "session_id",
+        "turn_id",
+        "component",
+        "modality",
+        "offering",
+        "model_id",
+        "producer_id",
+        "acquisition_revision_id",
+        "selling_revision_id",
+    )
+    @classmethod
+    def valid_ids(cls, value: str | None) -> str | None:
+        if value is not None and not _ID_RE.fullmatch(value):
+            raise ValueError("invalid identifier")
+        return value
+
+    @model_validator(mode="after")
+    def unique_quantities_and_cache_subsets(self) -> UsageEnvelope:
+        dimensions = [item.dimension for item in self.quantities]
+        if len(set(dimensions)) != len(dimensions):
+            raise ValueError("duplicate quantity dimension")
+        values = {
+            item.dimension: Decimal(item.value)
+            for item in self.quantities
+            if item.value is not None
+        }
+        cached = values.get(PricingDimension.CACHE_READ, Decimal(0)) + values.get(
+            PricingDimension.CACHE_WRITE, Decimal(0)
+        )
+        if cached > values.get(PricingDimension.TEXT_INPUT, Decimal(0)):
+            raise ValueError("cache quantities must be subsets of text_input")
+        return self
+
+
+class AccountingCapabilities(StrictModel):
+    contract_version: Literal[1] = CONTRACT_VERSION
+    dimensions: tuple[PricingDimension, ...] = tuple(PricingDimension)
+    units: tuple[Unit, ...] = tuple(Unit)
+    currencies: tuple[Literal["USD"], ...] = ("USD",)
+    rate_fractional_digits: int = 18
+    total_fractional_digits: int = 12
+    rounding_profile: str = ROUNDING_PROFILE
+    ownership_modes: tuple[OwnershipMode, ...] = tuple(OwnershipMode)
+
+
+class RecordReceipt(StrictModel):
+    event_id: str
+    outcome: Literal["accepted", "duplicate", "rejected", "retryable"]
+    receipt_id: str | None = None
+    code: str
+
+
+class UsageBatchResponse(StrictModel):
+    receipts: tuple[RecordReceipt, ...]

--- a/src/voicegateway/accounting/contracts.py
+++ b/src/voicegateway/accounting/contracts.py
@@ -97,6 +97,8 @@ def canonical_decimal(value: str) -> str:
         raise ValueError("invalid decimal string") from exc
     if not number.is_finite() or number < 0:
         raise ValueError("decimal value must be finite and non-negative")
+    if number > Decimal("1e18"):
+        raise ValueError("decimal value exceeds supported magnitude")
     if abs(number.as_tuple().exponent) > 18:
         raise ValueError("decimal value has more than 18 fractional digits")
     normalized = format(number, "f")
@@ -183,6 +185,13 @@ class Quantity(StrictModel):
             raise ValueError(
                 "measured/estimated quantities require a value; missing/unsupported forbid one"
             )
+        if self.value is not None:
+            number = Decimal(self.value)
+            if self.dimension is PricingDimension.AUDIO_SECONDS:
+                if max(0, -number.as_tuple().exponent) > 9:
+                    raise ValueError("audio seconds allow at most 9 fractional digits")
+            elif number != number.to_integral_value() or number > 2**63 - 1:
+                raise ValueError("count quantities must be signed-64-bit integers")
         return self
 
 
@@ -199,6 +208,7 @@ class UsageEnvelope(StrictModel):
     model_id: str
     producer_id: str
     ownership_mode: OwnershipMode
+    pricing_binding_id: str | None = None
     acquisition_revision_id: str | None = None
     selling_revision_id: str | None = None
     occurred_at_ns: Annotated[int, Field(ge=0)]
@@ -217,6 +227,7 @@ class UsageEnvelope(StrictModel):
         "producer_id",
         "acquisition_revision_id",
         "selling_revision_id",
+        "pricing_binding_id",
     )
     @classmethod
     def valid_ids(cls, value: str | None) -> str | None:
@@ -262,3 +273,26 @@ class RecordReceipt(StrictModel):
 
 class UsageBatchResponse(StrictModel):
     receipts: tuple[RecordReceipt, ...]
+
+
+class PreparationRequest(StrictModel):
+    project_id: str
+    component: str
+    offering: str
+
+
+class PricingBinding(StrictModel):
+    binding_id: str
+    project_id: str
+    component: str
+    offering: str
+    acquisition_revision_id: str | None
+    selling_revision_id: str | None
+    ownership_mode: OwnershipMode
+    prepared_at_ns: int
+
+
+class OwnershipAssignment(StrictModel):
+    project_id: str
+    component: str
+    mode: OwnershipMode

--- a/src/voicegateway/accounting/contracts.py
+++ b/src/voicegateway/accounting/contracts.py
@@ -99,7 +99,10 @@ def canonical_decimal(value: str) -> str:
         raise ValueError("decimal value must be finite and non-negative")
     if number > Decimal("1e18"):
         raise ValueError("decimal value exceeds supported magnitude")
-    if abs(number.as_tuple().exponent) > 18:
+    exponent = number.as_tuple().exponent
+    if not isinstance(exponent, int):
+        raise ValueError("invalid decimal exponent")
+    if abs(exponent) > 18:
         raise ValueError("decimal value has more than 18 fractional digits")
     normalized = format(number, "f")
     if "." in normalized:
@@ -127,12 +130,12 @@ class DimensionRate(StrictModel):
 
 
 class PricingRevisionCreate(StrictModel):
-    contract_version: Literal[1] = CONTRACT_VERSION
+    contract_version: Literal[1] = 1
     revision_id: str
     side: PricingSide
     scope: RevisionScope
     currency: Literal["USD"] = "USD"
-    rounding_profile: Literal["usd-v1-half-even-12"] = ROUNDING_PROFILE
+    rounding_profile: Literal["usd-v1-half-even-12"] = "usd-v1-half-even-12"
     rates: tuple[DimensionRate, ...]
     unsupported_dimensions: tuple[PricingDimension, ...] = ()
 
@@ -188,7 +191,8 @@ class Quantity(StrictModel):
         if self.value is not None:
             number = Decimal(self.value)
             if self.dimension is PricingDimension.AUDIO_SECONDS:
-                if max(0, -number.as_tuple().exponent) > 9:
+                exponent = number.as_tuple().exponent
+                if not isinstance(exponent, int) or max(0, -exponent) > 9:
                     raise ValueError("audio seconds allow at most 9 fractional digits")
             elif number != number.to_integral_value() or number > 2**63 - 1:
                 raise ValueError("count quantities must be signed-64-bit integers")
@@ -196,7 +200,7 @@ class Quantity(StrictModel):
 
 
 class UsageEnvelope(StrictModel):
-    contract_version: Literal[1] = CONTRACT_VERSION
+    contract_version: Literal[1] = 1
     event_id: str
     attempt_id: str
     project_id: str
@@ -254,7 +258,7 @@ class UsageEnvelope(StrictModel):
 
 
 class AccountingCapabilities(StrictModel):
-    contract_version: Literal[1] = CONTRACT_VERSION
+    contract_version: Literal[1] = 1
     dimensions: tuple[PricingDimension, ...] = tuple(PricingDimension)
     units: tuple[Unit, ...] = tuple(Unit)
     currencies: tuple[Literal["USD"], ...] = ("USD",)

--- a/src/voicegateway/accounting/contracts.py
+++ b/src/voicegateway/accounting/contracts.py
@@ -105,6 +105,8 @@ def canonical_decimal(value: str) -> str:
     if abs(exponent) > 18:
         raise ValueError("decimal value has more than 18 fractional digits")
     normalized = format(number, "f")
+    if number.is_zero():
+        return "0"
     if "." in normalized:
         normalized = normalized.rstrip("0").rstrip(".")
     return normalized or "0"
@@ -291,6 +293,18 @@ class PricingBinding(StrictModel):
     component: str
     offering: str
     acquisition_revision_id: str | None
+    selling_revision_id: str | None
+    ownership_mode: OwnershipMode
+    prepared_at_ns: int
+
+
+class PricingBindingResponse(StrictModel):
+    """Producer-visible binding; acquisition pricing is operator-only."""
+
+    binding_id: str
+    project_id: str
+    component: str
+    offering: str
     selling_revision_id: str | None
     ownership_mode: OwnershipMode
     prepared_at_ns: int

--- a/src/voicegateway/accounting/outbox.py
+++ b/src/voicegateway/accounting/outbox.py
@@ -322,6 +322,10 @@ class AccountingOutbox:
         except Exception:
             logger.exception("accounting loss counter could not be persisted")
 
+    async def record_capture_failure(self) -> None:
+        """Record an envelope that could not be made durable by a producer."""
+        await self._increment_failure()
+
     async def _persist_failures(self, db: aiosqlite.Connection) -> None:
         async with self._failure_lock:
             pending = self._capture_failures
@@ -378,7 +382,5 @@ class AccountingOutbox:
                 pass
         if self._db is not None:
             await self._db.close()
-        if self._owns_client and self._client is not None:
-            await self._client.aclose()
         if self._owns_client and self._client is not None:
             await self._client.aclose()

--- a/src/voicegateway/accounting/outbox.py
+++ b/src/voicegateway/accounting/outbox.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import time
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -65,7 +66,9 @@ class AccountingOutbox:
             )
             columns = {
                 row[1]
-                for row in await self._db.execute_fetchall("PRAGMA table_info(pending)")
+                for row in list(
+                    await self._db.execute_fetchall("PRAGMA table_info(pending)")
+                )
             }
             if "enqueued_at_ns" not in columns:
                 await self._db.execute(
@@ -79,14 +82,17 @@ class AccountingOutbox:
         db = await self._open()
         payload = envelope.model_dump_json()
         digest = hashlib.sha256(payload.encode()).hexdigest()
-        existing = await db.execute_fetchall(
-            "SELECT payload_hash FROM pending WHERE event_id = ?", (envelope.event_id,)
+        existing = list(
+            await db.execute_fetchall(
+                "SELECT payload_hash FROM pending WHERE event_id = ?",
+                (envelope.event_id,),
+            )
         )
         if existing:
             if existing[0][0] != digest:
                 raise ValueError("event identity already queued with different content")
             return "duplicate"
-        count = (await db.execute_fetchall("SELECT COUNT(*) FROM pending"))[0][0]
+        count = list(await db.execute_fetchall("SELECT COUNT(*) FROM pending"))[0][0]
         if count >= self._max_records:
             self._capture_failures += 1
             return "full"
@@ -127,8 +133,10 @@ class AccountingOutbox:
 
     async def drain(self, *, limit: int = 100) -> dict[str, int]:
         db = await self._open()
-        rows = await db.execute_fetchall(
-            "SELECT event_id, payload FROM pending ORDER BY rowid LIMIT ?", (limit,)
+        rows = list(
+            await db.execute_fetchall(
+                "SELECT event_id, payload FROM pending ORDER BY rowid LIMIT ?", (limit,)
+            )
         )
         if not rows:
             return {"accepted": 0, "duplicate": 0, "rejected": 0, "retryable": 0}
@@ -208,7 +216,7 @@ class AccountingOutbox:
         return result
 
     async def _mark_retryable(
-        self, db: aiosqlite.Connection, rows: list[tuple[str, str]], code: str
+        self, db: aiosqlite.Connection, rows: Iterable[Any], code: str
     ) -> None:
         await db.executemany(
             "UPDATE pending SET attempts = attempts + 1, last_error_code = ? WHERE event_id = ?",
@@ -218,14 +226,16 @@ class AccountingOutbox:
 
     async def health(self) -> dict[str, int | float | None]:
         db = await self._open()
-        pending = (await db.execute_fetchall("SELECT COUNT(*) FROM pending"))[0][0]
-        rejected = (await db.execute_fetchall("SELECT COUNT(*) FROM rejected"))[0][0]
-        failed_delivery = (
+        pending = list(await db.execute_fetchall("SELECT COUNT(*) FROM pending"))[0][0]
+        rejected = list(await db.execute_fetchall("SELECT COUNT(*) FROM rejected"))[0][
+            0
+        ]
+        failed_delivery = list(
             await db.execute_fetchall("SELECT COUNT(*) FROM pending WHERE attempts > 0")
         )[0][0]
-        oldest = (await db.execute_fetchall("SELECT MIN(enqueued_at_ns) FROM pending"))[
-            0
-        ][0]
+        oldest = list(
+            await db.execute_fetchall("SELECT MIN(enqueued_at_ns) FROM pending")
+        )[0][0]
         return {
             "pending": pending,
             "rejected": rejected,

--- a/src/voicegateway/accounting/outbox.py
+++ b/src/voicegateway/accounting/outbox.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import random
 import time
 from collections.abc import Iterable
 from pathlib import Path
@@ -28,19 +29,25 @@ class AccountingOutbox:
         *,
         api_key: str | None = None,
         max_records: int = 100_000,
+        max_bytes: int = 64 * 1024 * 1024,
         memory_queue_size: int = 1_000,
+        max_delivery_attempts: int = 12,
         client: Any | None = None,
     ) -> None:
         self._path = Path(path).expanduser()
         self._url = collector_url.rstrip("/") + "/v1/accounting/usage"
         self._headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         self._max_records = max_records
+        self._max_bytes = max_bytes
+        self._max_delivery_attempts = max_delivery_attempts
         self._queue: asyncio.Queue[UsageEnvelope] = asyncio.Queue(memory_queue_size)
         self._client = client
         self._owns_client = client is None
         self._db: aiosqlite.Connection | None = None
         self._worker: asyncio.Task[None] | None = None
         self._capture_failures = 0
+        self._submit_lock = asyncio.Lock()
+        self._failure_lock = asyncio.Lock()
 
     async def _open(self) -> aiosqlite.Connection:
         if self._db is None:
@@ -62,6 +69,12 @@ class AccountingOutbox:
                     payload TEXT NOT NULL,
                     code TEXT NOT NULL
                 );
+                CREATE TABLE IF NOT EXISTS health_counters (
+                    name TEXT PRIMARY KEY,
+                    value INTEGER NOT NULL
+                );
+                INSERT OR IGNORE INTO health_counters(name, value)
+                VALUES ('capture_failures', 0);
                 """
             )
             columns = {
@@ -75,6 +88,7 @@ class AccountingOutbox:
                     "ALTER TABLE pending ADD COLUMN enqueued_at_ns INTEGER NOT NULL DEFAULT 0"
                 )
             await self._db.commit()
+            await self._persist_failures(self._db)
         return self._db
 
     async def submit(self, envelope: UsageEnvelope) -> str:
@@ -82,26 +96,43 @@ class AccountingOutbox:
         db = await self._open()
         payload = envelope.model_dump_json()
         digest = hashlib.sha256(payload.encode()).hexdigest()
-        existing = list(
-            await db.execute_fetchall(
-                "SELECT payload_hash FROM pending WHERE event_id = ?",
-                (envelope.event_id,),
-            )
-        )
-        if existing:
-            if existing[0][0] != digest:
-                raise ValueError("event identity already queued with different content")
-            return "duplicate"
-        count = list(await db.execute_fetchall("SELECT COUNT(*) FROM pending"))[0][0]
-        if count >= self._max_records:
-            self._capture_failures += 1
-            return "full"
-        await db.execute(
-            "INSERT INTO pending(event_id, payload_hash, payload, enqueued_at_ns) VALUES (?, ?, ?, ?)",
-            (envelope.event_id, digest, payload, time.time_ns()),
-        )
-        await db.commit()
-        return "stored"
+        async with self._submit_lock:
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                existing = list(
+                    await db.execute_fetchall(
+                        "SELECT payload_hash FROM pending WHERE event_id = ?",
+                        (envelope.event_id,),
+                    )
+                )
+                if existing:
+                    await db.rollback()
+                    if existing[0][0] != digest:
+                        raise ValueError(
+                            "event identity already queued with different content"
+                        )
+                    return "duplicate"
+                count, used_bytes = list(
+                    await db.execute_fetchall(
+                        "SELECT COUNT(*), COALESCE(SUM(LENGTH(payload)), 0) FROM pending"
+                    )
+                )[0]
+                if (
+                    count >= self._max_records
+                    or used_bytes + len(payload.encode()) > self._max_bytes
+                ):
+                    await db.rollback()
+                    await self._increment_failure()
+                    return "full"
+                await db.execute(
+                    "INSERT INTO pending(event_id, payload_hash, payload, enqueued_at_ns) VALUES (?, ?, ?, ?)",
+                    (envelope.event_id, digest, payload, time.time_ns()),
+                )
+                await db.commit()
+                return "stored"
+            except BaseException:
+                await db.rollback()
+                raise
 
     def enqueue_nowait(self, envelope: UsageEnvelope) -> bool:
         """Non-blocking voice-path capture; False is an explicit loss signal."""
@@ -109,7 +140,7 @@ class AccountingOutbox:
         try:
             self._queue.put_nowait(envelope)
         except asyncio.QueueFull:
-            self._capture_failures += 1
+            asyncio.create_task(self._increment_failure())
             logger.error("accounting capture queue full")
             return False
         return True
@@ -126,7 +157,7 @@ class AccountingOutbox:
                 if outcome == "full":
                     logger.error("accounting outbox full; event was not persisted")
             except Exception:
-                self._capture_failures += 1
+                await self._increment_failure()
                 logger.exception("accounting outbox persistence failed")
             finally:
                 self._queue.task_done()
@@ -152,22 +183,32 @@ class AccountingOutbox:
                 json=[json.loads(payload) for _, payload in rows],
             )
             if response.status_code >= 500 or response.status_code == 429:
-                await self._mark_retryable(db, rows, f"http_{response.status_code}")
+                quarantined = await self._mark_retryable(
+                    db, rows, f"http_{response.status_code}"
+                )
                 return {
                     "accepted": 0,
                     "duplicate": 0,
-                    "rejected": 0,
-                    "retryable": len(rows),
+                    "rejected": quarantined,
+                    "retryable": len(rows) - quarantined,
+                }
+            if 400 <= response.status_code < 500:
+                await self._quarantine(db, rows, f"http_{response.status_code}")
+                return {
+                    "accepted": 0,
+                    "duplicate": 0,
+                    "rejected": len(rows),
+                    "retryable": 0,
                 }
             response.raise_for_status()
             receipts = UsageBatchResponse.model_validate(response.json()).receipts
         except Exception:
-            await self._mark_retryable(db, rows, "delivery_error")
+            quarantined = await self._mark_retryable(db, rows, "delivery_error")
             return {
                 "accepted": 0,
                 "duplicate": 0,
-                "rejected": 0,
-                "retryable": len(rows),
+                "rejected": quarantined,
+                "retryable": len(rows) - quarantined,
             }
         by_id = {receipt.event_id: receipt for receipt in receipts}
         counts = {"accepted": 0, "duplicate": 0, "rejected": 0, "retryable": 0}
@@ -179,10 +220,12 @@ class AccountingOutbox:
                     ("missing_receipt" if receipt is None else receipt.code, event_id),
                 )
                 counts["retryable"] += 1
-            elif receipt.outcome in {"accepted", "duplicate"}:
+            elif receipt.outcome in {"accepted", "duplicate"} and bool(
+                receipt.receipt_id
+            ):
                 await db.execute("DELETE FROM pending WHERE event_id = ?", (event_id,))
                 counts[receipt.outcome] += 1
-            else:
+            elif receipt.outcome == "rejected":
                 digest = hashlib.sha256(payload.encode()).hexdigest()
                 await db.execute(
                     "INSERT OR REPLACE INTO rejected VALUES (?, ?, ?, ?)",
@@ -190,6 +233,12 @@ class AccountingOutbox:
                 )
                 await db.execute("DELETE FROM pending WHERE event_id = ?", (event_id,))
                 counts["rejected"] += 1
+            else:
+                await db.execute(
+                    "UPDATE pending SET attempts = attempts + 1, last_error_code = ? WHERE event_id = ?",
+                    ("invalid_receipt", event_id),
+                )
+                counts["retryable"] += 1
         await db.commit()
         return counts
 
@@ -201,6 +250,7 @@ class AccountingOutbox:
         base_delay: float = 0.2,
         max_delay: float = 5.0,
         sleep: Any = asyncio.sleep,
+        jitter: Any = random.uniform,
     ) -> dict[str, int]:
         """Retry a drain with bounded exponential backoff."""
         result = {"accepted": 0, "duplicate": 0, "rejected": 0, "retryable": 0}
@@ -212,17 +262,77 @@ class AccountingOutbox:
             if current["retryable"] == 0:
                 break
             if attempt + 1 < max_attempts:
-                await sleep(min(max_delay, base_delay * (2**attempt)))
+                ceiling = min(max_delay, base_delay * (2**attempt))
+                await sleep(jitter(ceiling / 2, ceiling))
         return result
 
     async def _mark_retryable(
         self, db: aiosqlite.Connection, rows: Iterable[Any], code: str
-    ) -> None:
+    ) -> int:
+        attempts: dict[str, int] = {}
+        for event_id, value in await db.execute_fetchall(
+            "SELECT event_id, attempts FROM pending"
+        ):
+            attempts[str(event_id)] = int(value)
+        quarantine = [
+            row
+            for row in rows
+            if attempts.get(row[0], 0) + 1 >= self._max_delivery_attempts
+        ]
+        retry = [row for row in rows if row not in quarantine]
         await db.executemany(
             "UPDATE pending SET attempts = attempts + 1, last_error_code = ? WHERE event_id = ?",
-            [(code, event_id) for event_id, _ in rows],
+            [(code, event_id) for event_id, _ in retry],
         )
+        if quarantine:
+            await self._quarantine(
+                db, quarantine, f"attempts_exhausted:{code}", commit=False
+            )
         await db.commit()
+        return len(quarantine)
+
+    async def _quarantine(
+        self,
+        db: aiosqlite.Connection,
+        rows: Iterable[Any],
+        code: str,
+        *,
+        commit: bool = True,
+    ) -> None:
+        materialized = list(rows)
+        await db.executemany(
+            "INSERT OR REPLACE INTO rejected VALUES (?, ?, ?, ?)",
+            [
+                (event_id, hashlib.sha256(payload.encode()).hexdigest(), payload, code)
+                for event_id, payload in materialized
+            ],
+        )
+        await db.executemany(
+            "DELETE FROM pending WHERE event_id = ?",
+            [(event_id,) for event_id, _ in materialized],
+        )
+        if commit:
+            await db.commit()
+
+    async def _increment_failure(self) -> None:
+        self._capture_failures += 1
+        try:
+            db = await self._open()
+            await self._persist_failures(db)
+        except Exception:
+            logger.exception("accounting loss counter could not be persisted")
+
+    async def _persist_failures(self, db: aiosqlite.Connection) -> None:
+        async with self._failure_lock:
+            pending = self._capture_failures
+            if pending == 0:
+                return
+            await db.execute(
+                "UPDATE health_counters SET value = value + ? WHERE name = 'capture_failures'",
+                (pending,),
+            )
+            await db.commit()
+            self._capture_failures -= pending
 
     async def health(self) -> dict[str, int | float | None]:
         db = await self._open()
@@ -236,16 +346,26 @@ class AccountingOutbox:
         oldest = list(
             await db.execute_fetchall("SELECT MIN(enqueued_at_ns) FROM pending")
         )[0][0]
+        persisted_failures = list(
+            await db.execute_fetchall(
+                "SELECT value FROM health_counters WHERE name = 'capture_failures'"
+            )
+        )[0][0]
         return {
             "pending": pending,
             "rejected": rejected,
             "memory_pending": self._queue.qsize(),
-            "capture_failures": self._capture_failures,
+            "capture_failures": persisted_failures,
             "failed_delivery": failed_delivery,
             "oldest_pending_seconds": (
                 max(0.0, (time.time_ns() - oldest) / 1_000_000_000) if oldest else None
             ),
         }
+
+    async def flush_memory(self) -> None:
+        """Wait until every non-blocking capture has reached durable storage."""
+        if self._worker is not None:
+            await self._queue.join()
 
     async def aclose(self, *, drain_memory: bool = True) -> None:
         if drain_memory and self._worker is not None:
@@ -258,5 +378,7 @@ class AccountingOutbox:
                 pass
         if self._db is not None:
             await self._db.close()
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
         if self._owns_client and self._client is not None:
             await self._client.aclose()

--- a/src/voicegateway/accounting/outbox.py
+++ b/src/voicegateway/accounting/outbox.py
@@ -1,0 +1,252 @@
+"""Bounded, restart-safe store-and-forward for accounting envelopes."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from voicegateway.accounting.contracts import UsageBatchResponse, UsageEnvelope
+
+logger = logging.getLogger(__name__)
+
+
+class AccountingOutbox:
+    """Persist before delivery and delete only after a durable receipt."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        collector_url: str,
+        *,
+        api_key: str | None = None,
+        max_records: int = 100_000,
+        memory_queue_size: int = 1_000,
+        client: Any | None = None,
+    ) -> None:
+        self._path = Path(path).expanduser()
+        self._url = collector_url.rstrip("/") + "/v1/accounting/usage"
+        self._headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        self._max_records = max_records
+        self._queue: asyncio.Queue[UsageEnvelope] = asyncio.Queue(memory_queue_size)
+        self._client = client
+        self._owns_client = client is None
+        self._db: aiosqlite.Connection | None = None
+        self._worker: asyncio.Task[None] | None = None
+        self._capture_failures = 0
+
+    async def _open(self) -> aiosqlite.Connection:
+        if self._db is None:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._db = await aiosqlite.connect(self._path)
+            await self._db.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS pending (
+                    event_id TEXT PRIMARY KEY,
+                    payload_hash TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    enqueued_at_ns INTEGER NOT NULL,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    last_error_code TEXT
+                );
+                CREATE TABLE IF NOT EXISTS rejected (
+                    event_id TEXT PRIMARY KEY,
+                    payload_hash TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    code TEXT NOT NULL
+                );
+                """
+            )
+            columns = {
+                row[1]
+                for row in await self._db.execute_fetchall("PRAGMA table_info(pending)")
+            }
+            if "enqueued_at_ns" not in columns:
+                await self._db.execute(
+                    "ALTER TABLE pending ADD COLUMN enqueued_at_ns INTEGER NOT NULL DEFAULT 0"
+                )
+            await self._db.commit()
+        return self._db
+
+    async def submit(self, envelope: UsageEnvelope) -> str:
+        """Durably enqueue and return ``stored``, ``duplicate``, or ``full``."""
+        db = await self._open()
+        payload = envelope.model_dump_json()
+        digest = hashlib.sha256(payload.encode()).hexdigest()
+        existing = await db.execute_fetchall(
+            "SELECT payload_hash FROM pending WHERE event_id = ?", (envelope.event_id,)
+        )
+        if existing:
+            if existing[0][0] != digest:
+                raise ValueError("event identity already queued with different content")
+            return "duplicate"
+        count = (await db.execute_fetchall("SELECT COUNT(*) FROM pending"))[0][0]
+        if count >= self._max_records:
+            self._capture_failures += 1
+            return "full"
+        await db.execute(
+            "INSERT INTO pending(event_id, payload_hash, payload, enqueued_at_ns) VALUES (?, ?, ?, ?)",
+            (envelope.event_id, digest, payload, time.time_ns()),
+        )
+        await db.commit()
+        return "stored"
+
+    def enqueue_nowait(self, envelope: UsageEnvelope) -> bool:
+        """Non-blocking voice-path capture; False is an explicit loss signal."""
+        self.start()
+        try:
+            self._queue.put_nowait(envelope)
+        except asyncio.QueueFull:
+            self._capture_failures += 1
+            logger.error("accounting capture queue full")
+            return False
+        return True
+
+    def start(self) -> None:
+        if self._worker is None or self._worker.done():
+            self._worker = asyncio.create_task(self._persist_worker())
+
+    async def _persist_worker(self) -> None:
+        while True:
+            envelope = await self._queue.get()
+            try:
+                outcome = await self.submit(envelope)
+                if outcome == "full":
+                    logger.error("accounting outbox full; event was not persisted")
+            except Exception:
+                self._capture_failures += 1
+                logger.exception("accounting outbox persistence failed")
+            finally:
+                self._queue.task_done()
+
+    async def drain(self, *, limit: int = 100) -> dict[str, int]:
+        db = await self._open()
+        rows = await db.execute_fetchall(
+            "SELECT event_id, payload FROM pending ORDER BY rowid LIMIT ?", (limit,)
+        )
+        if not rows:
+            return {"accepted": 0, "duplicate": 0, "rejected": 0, "retryable": 0}
+        client = self._client
+        if client is None:
+            import httpx
+
+            client = self._client = httpx.AsyncClient(timeout=10.0)
+        try:
+            response = await client.post(
+                self._url,
+                headers=self._headers,
+                json=[json.loads(payload) for _, payload in rows],
+            )
+            if response.status_code >= 500 or response.status_code == 429:
+                await self._mark_retryable(db, rows, f"http_{response.status_code}")
+                return {
+                    "accepted": 0,
+                    "duplicate": 0,
+                    "rejected": 0,
+                    "retryable": len(rows),
+                }
+            response.raise_for_status()
+            receipts = UsageBatchResponse.model_validate(response.json()).receipts
+        except Exception:
+            await self._mark_retryable(db, rows, "delivery_error")
+            return {
+                "accepted": 0,
+                "duplicate": 0,
+                "rejected": 0,
+                "retryable": len(rows),
+            }
+        by_id = {receipt.event_id: receipt for receipt in receipts}
+        counts = {"accepted": 0, "duplicate": 0, "rejected": 0, "retryable": 0}
+        for event_id, payload in rows:
+            receipt = by_id.get(event_id)
+            if receipt is None or receipt.outcome == "retryable":
+                await db.execute(
+                    "UPDATE pending SET attempts = attempts + 1, last_error_code = ? WHERE event_id = ?",
+                    ("missing_receipt" if receipt is None else receipt.code, event_id),
+                )
+                counts["retryable"] += 1
+            elif receipt.outcome in {"accepted", "duplicate"}:
+                await db.execute("DELETE FROM pending WHERE event_id = ?", (event_id,))
+                counts[receipt.outcome] += 1
+            else:
+                digest = hashlib.sha256(payload.encode()).hexdigest()
+                await db.execute(
+                    "INSERT OR REPLACE INTO rejected VALUES (?, ?, ?, ?)",
+                    (event_id, digest, payload, receipt.code),
+                )
+                await db.execute("DELETE FROM pending WHERE event_id = ?", (event_id,))
+                counts["rejected"] += 1
+        await db.commit()
+        return counts
+
+    async def drain_with_backoff(
+        self,
+        *,
+        limit: int = 100,
+        max_attempts: int = 3,
+        base_delay: float = 0.2,
+        max_delay: float = 5.0,
+        sleep: Any = asyncio.sleep,
+    ) -> dict[str, int]:
+        """Retry a drain with bounded exponential backoff."""
+        result = {"accepted": 0, "duplicate": 0, "rejected": 0, "retryable": 0}
+        for attempt in range(max(1, max_attempts)):
+            current = await self.drain(limit=limit)
+            for key in result:
+                result[key] += current[key] if key != "retryable" else 0
+            result["retryable"] = current["retryable"]
+            if current["retryable"] == 0:
+                break
+            if attempt + 1 < max_attempts:
+                await sleep(min(max_delay, base_delay * (2**attempt)))
+        return result
+
+    async def _mark_retryable(
+        self, db: aiosqlite.Connection, rows: list[tuple[str, str]], code: str
+    ) -> None:
+        await db.executemany(
+            "UPDATE pending SET attempts = attempts + 1, last_error_code = ? WHERE event_id = ?",
+            [(code, event_id) for event_id, _ in rows],
+        )
+        await db.commit()
+
+    async def health(self) -> dict[str, int | float | None]:
+        db = await self._open()
+        pending = (await db.execute_fetchall("SELECT COUNT(*) FROM pending"))[0][0]
+        rejected = (await db.execute_fetchall("SELECT COUNT(*) FROM rejected"))[0][0]
+        failed_delivery = (
+            await db.execute_fetchall("SELECT COUNT(*) FROM pending WHERE attempts > 0")
+        )[0][0]
+        oldest = (await db.execute_fetchall("SELECT MIN(enqueued_at_ns) FROM pending"))[
+            0
+        ][0]
+        return {
+            "pending": pending,
+            "rejected": rejected,
+            "memory_pending": self._queue.qsize(),
+            "capture_failures": self._capture_failures,
+            "failed_delivery": failed_delivery,
+            "oldest_pending_seconds": (
+                max(0.0, (time.time_ns() - oldest) / 1_000_000_000) if oldest else None
+            ),
+        }
+
+    async def aclose(self, *, drain_memory: bool = True) -> None:
+        if drain_memory and self._worker is not None:
+            await self._queue.join()
+        if self._worker is not None:
+            self._worker.cancel()
+            try:
+                await self._worker
+            except asyncio.CancelledError:
+                pass
+        if self._db is not None:
+            await self._db.close()
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()

--- a/src/voicegateway/accounting/rating.py
+++ b/src/voicegateway/accounting/rating.py
@@ -1,0 +1,42 @@
+"""Exact rating for immutable usage envelopes."""
+
+from __future__ import annotations
+
+from decimal import Decimal, localcontext
+
+from voicegateway.accounting.contracts import (
+    PricingDimension,
+    PricingRevisionCreate,
+    UsageEnvelope,
+)
+
+_QUANTUM = Decimal("0.000000000001")
+
+
+def rate_usage(
+    envelope: UsageEnvelope, revision: PricingRevisionCreate
+) -> tuple[str | None, bool]:
+    """Return the exact rounded total and whether every quantity was rateable."""
+    rates = {item.dimension: Decimal(item.rate) for item in revision.rates}
+    quantities = {item.dimension: item for item in envelope.quantities}
+    total = Decimal(0)
+    complete = True
+    with localcontext() as ctx:
+        ctx.prec = 60
+        for dimension, quantity in quantities.items():
+            if quantity.value is None:
+                complete = False
+                continue
+            rate = rates.get(dimension)
+            if rate is None:
+                complete = False
+                continue
+            value = Decimal(quantity.value)
+            if dimension is PricingDimension.TEXT_INPUT:
+                value -= sum(
+                    Decimal(quantities[d].value or "0")
+                    for d in (PricingDimension.CACHE_READ, PricingDimension.CACHE_WRITE)
+                    if d in quantities
+                )
+            total += value * rate
+        return format(total.quantize(_QUANTUM), "f"), complete

--- a/src/voicegateway/accounting/rating.py
+++ b/src/voicegateway/accounting/rating.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from decimal import Decimal, localcontext
 
 from voicegateway.accounting.contracts import (
+    MeasurementStatus,
     PricingDimension,
     PricingRevisionCreate,
     UsageEnvelope,
@@ -18,6 +19,7 @@ def rate_usage(
 ) -> tuple[str | None, bool]:
     """Return the exact rounded total and whether every quantity was rateable."""
     rates = {item.dimension: Decimal(item.rate) for item in revision.rates}
+    unsupported = set(revision.unsupported_dimensions)
     quantities = {item.dimension: item for item in envelope.quantities}
     total = Decimal(0)
     complete = True
@@ -25,7 +27,11 @@ def rate_usage(
         ctx.prec = 60
         for dimension, quantity in quantities.items():
             if quantity.value is None:
-                complete = False
+                if not (
+                    quantity.status is MeasurementStatus.UNSUPPORTED
+                    and dimension in unsupported
+                ):
+                    complete = False
                 continue
             rate = rates.get(dimension)
             if rate is None:

--- a/src/voicegateway/accounting/rating.py
+++ b/src/voicegateway/accounting/rating.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from decimal import Decimal, localcontext
+from decimal import ROUND_HALF_EVEN, Decimal, localcontext
 
 from voicegateway.accounting.contracts import (
     MeasurementStatus,
@@ -25,16 +25,18 @@ def rate_usage(
     complete = True
     with localcontext() as ctx:
         ctx.prec = 60
-        for dimension, quantity in quantities.items():
-            if quantity.value is None:
-                if not (
+        ctx.rounding = ROUND_HALF_EVEN
+        for dimension in PricingDimension:
+            quantity = quantities.get(dimension)
+            rate = rates.get(dimension)
+            if rate is None:
+                if quantity is not None and not (
                     quantity.status is MeasurementStatus.UNSUPPORTED
                     and dimension in unsupported
                 ):
                     complete = False
                 continue
-            rate = rates.get(dimension)
-            if rate is None:
+            if quantity is None or quantity.value is None:
                 complete = False
                 continue
             value = Decimal(quantity.value)
@@ -42,7 +44,7 @@ def rate_usage(
                 value -= sum(
                     Decimal(quantities[d].value or "0")
                     for d in (PricingDimension.CACHE_READ, PricingDimension.CACHE_WRITE)
-                    if d in quantities
+                    if d in quantities and d in rates
                 )
             total += value * rate
         return format(total.quantize(_QUANTUM), "f"), complete

--- a/src/voicegateway/cli/__init__.py
+++ b/src/voicegateway/cli/__init__.py
@@ -33,6 +33,7 @@ from voicegateway.cli import dashboard_cli as _dashboard  # noqa: F401, E402
 from voicegateway.cli import doctor_cli as _doctor  # noqa: F401, E402
 from voicegateway.cli import export_costs_cli as _export_costs  # noqa: F401, E402
 from voicegateway.cli import init_cli as _init  # noqa: F401, E402
+from voicegateway.cli import keys_cli as _keys  # noqa: F401, E402
 from voicegateway.cli import lifecycle_cli as _lifecycle  # noqa: F401, E402
 from voicegateway.cli import loadtest_cli as _loadtest  # noqa: F401, E402
 from voicegateway.cli import logs_cli as _logs  # noqa: F401, E402

--- a/src/voicegateway/cli/keys_cli.py
+++ b/src/voicegateway/cli/keys_cli.py
@@ -1,0 +1,151 @@
+"""``voicegw keys`` command group: mint, list, audit and revoke virtual keys.
+
+Until 0.26.0 the only way to mint a key was the HTTP API, which meant the
+first key had to be created by a server that was not yet protected by one.
+More to the point for VG-SEC-006: an operator asked to re-mint their wildcard
+keys with explicit scopes needs a way to see which keys those are and a way
+to make the replacements. ``keys audit`` and ``keys create --scopes`` are
+that pair.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.table import Table
+
+from voicegateway.cli._app import app, console
+from voicegateway.cli.base_cli import BaseCli
+from voicegateway.core import scopes as scopes_mod
+from voicegateway.repository import api_keys_repository as api_keys
+
+_cli = BaseCli()
+
+keys_app = typer.Typer(
+    name="keys",
+    help="Mint, list, audit and revoke virtual API keys.",
+    no_args_is_help=True,
+)
+app.add_typer(keys_app, name="keys")
+
+_SCOPES_HELP = "Comma-separated: " + ", ".join(sorted(scopes_mod.MINTABLE))
+
+
+def _storage(config: str | None):
+    """Load the Gateway and return its storage, failing the CLI way."""
+    return _cli.require_storage(_cli.require_gateway(config))
+
+
+@keys_app.command("create")
+def create_cmd(
+    name: str = typer.Option(..., "--name", "-n", help="Human label for the key."),
+    scopes: str = typer.Option(..., "--scopes", "-s", help=_SCOPES_HELP),
+    tenant: str = typer.Option(
+        None, "--tenant", "-t", help="Bind the key to one tenant."
+    ),
+    role: str = typer.Option("tenant", "--role", help="'tenant' or 'admin'."),
+    config: str = typer.Option(None, "--config", "-c", help="Path to voicegw.yaml"),
+) -> None:
+    """Mint a key. The plaintext is printed once and never stored."""
+    storage = _storage(config)
+
+    async def _run():
+        async with storage.session() as db:
+            return await api_keys.create_api_key(
+                db, name=name, scopes=scopes, tenant_id=tenant, role=role
+            )
+
+    try:
+        created = _cli.async_run(_run())
+    except ValueError as exc:
+        _cli.fail(str(exc))
+    console.print(f"[green]Created key {created.id} ({name!r}).[/green]")
+    console.print(f"[bold]{created.plaintext}[/bold]")
+    _cli.warn("This is the only time the plaintext is shown. Store it now.")
+
+
+@keys_app.command("list")
+def list_cmd(
+    include_revoked: bool = typer.Option(
+        False, "--include-revoked", help="Also show revoked keys."
+    ),
+    config: str = typer.Option(None, "--config", "-c", help="Path to voicegw.yaml"),
+) -> None:
+    """List every key. The plaintext and the hash are never shown."""
+    storage = _storage(config)
+
+    async def _run():
+        async with storage.session() as db:
+            return await api_keys.list_keys(db, include_revoked=include_revoked)
+
+    rows = _cli.async_run(_run())
+    if not rows:
+        console.print("[yellow]No keys.[/yellow]")
+        return
+    table = Table(title="API keys")
+    for column in ("ID", "Name", "Prefix", "Tenant", "Issued", "Revoked"):
+        table.add_column(column)
+    for row in rows:
+        table.add_row(
+            str(row.id),
+            row.name,
+            row.key_prefix,
+            row.tenant_id or "-",
+            row.issued_at,
+            row.revoked_at or "-",
+        )
+    console.print(table)
+
+
+@keys_app.command("audit")
+def audit_cmd(
+    config: str = typer.Option(None, "--config", "-c", help="Path to voicegw.yaml"),
+) -> None:
+    """List keys still carrying the wildcard scope. Re-mint them before 0.27.0.
+
+    Exits non-zero when any are found, so this is usable as a deployment
+    gate rather than only as something to read.
+    """
+    storage = _storage(config)
+
+    async def _run():
+        async with storage.session() as db:
+            return await api_keys.list_wildcard_keys(db)
+
+    rows = _cli.async_run(_run())
+    if not rows:
+        console.print("[green]No wildcard keys.[/green]")
+        return
+    _cli.warn(
+        f"{len(rows)} key(s) still carry the wildcard scope. They authorize "
+        "everything today and will authorize nothing in 0.27.0."
+    )
+    table = Table(title="Wildcard keys")
+    for column in ("ID", "Name", "Tenant", "Role", "Scopes"):
+        table.add_column(column)
+    for row in rows:
+        table.add_row(str(row.id), row.name, row.tenant_id or "-", row.role, row.scopes)
+    console.print(table)
+    console.print(
+        "\nRe-mint each with: "
+        "[bold]voicegw keys create --name <name> --scopes <scopes>[/bold]\n"
+        f"Scopes: {_SCOPES_HELP}"
+    )
+    raise typer.Exit(1)
+
+
+@keys_app.command("revoke")
+def revoke_cmd(
+    key_id: int = typer.Argument(..., help="Id of the key to revoke."),
+    config: str = typer.Option(None, "--config", "-c", help="Path to voicegw.yaml"),
+) -> None:
+    """Soft-revoke a key. The row is kept so the audit trail survives."""
+    storage = _storage(config)
+
+    async def _run():
+        async with storage.session() as db:
+            return await api_keys.revoke(db, key_id)
+
+    if _cli.async_run(_run()):
+        console.print(f"[green]Revoked key {key_id}.[/green]")
+    else:
+        _cli.fail(f"Key {key_id} not found, or already revoked.")

--- a/src/voicegateway/cli/serve_cli.py
+++ b/src/voicegateway/cli/serve_cli.py
@@ -6,7 +6,12 @@ import typer
 
 from voicegateway.cli._app import app
 from voicegateway.cli.base_cli import BaseCli
-from voicegateway.core.auth import describe_auth, load_api_keys
+from voicegateway.core.auth import (
+    AuthConfigError,
+    describe_auth,
+    load_api_keys,
+    validate_auth_startup,
+)
 from voicegateway.utils.cli.serve import _resolve_bind
 
 _cli = BaseCli()
@@ -47,6 +52,16 @@ def serve_cmd(
 
     gw = _cli.require_gateway(config)
     host, port = _resolve_bind(getattr(gw.config, "serve", None), host, port)
+
+    # Before binding anything: refuse a config that asks for unauthenticated
+    # local mode while looking like a deployment. Checked here rather than at
+    # config load because the bind host is only known once --host and
+    # serve.host have been resolved.
+    try:
+        validate_auth_startup(gw.config.auth, bind_host=host)
+    except AuthConfigError as exc:
+        _cli.fail(str(exc))
+        return
 
     api_app = build_app(gw)
     _cli.success(f"VoiceGateway API starting at http://{host}:{port}")

--- a/src/voicegateway/core/auth.py
+++ b/src/voicegateway/core/auth.py
@@ -8,6 +8,8 @@ import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from voicegateway.core import scopes
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -83,8 +85,19 @@ class ApiKey:
     name: str = ""
     scopes: tuple[str, ...] = field(default_factory=lambda: (WILDCARD_SCOPE,))
 
-    def has_scope(self, required: str) -> bool:
-        return WILDCARD_SCOPE in self.scopes or required in self.scopes
+    def has_scope(self, required: str, *, enforce: bool = False) -> bool:
+        """Mirror of :meth:`VerifiedKey.has_scope` for static config keys.
+
+        The same two compatibility grants apply, and stop under ``enforce``:
+        ``write`` covers ``ingest``, and ``*`` covers everything.
+        """
+        if required in self.scopes:
+            return True
+        if enforce:
+            return False
+        if WILDCARD_SCOPE in self.scopes:
+            return True
+        return required == scopes.INGEST and scopes.WRITE in self.scopes
 
 
 def load_api_keys(auth_config: AuthConfig | None) -> list[ApiKey]:
@@ -103,10 +116,13 @@ def load_api_keys(auth_config: AuthConfig | None) -> list[ApiKey]:
 
         if isinstance(raw_scopes, (str, bytes)):
             raw_scopes = [raw_scopes]
-        scopes = tuple(str(s) for s in raw_scopes if str(s))
-        if not scopes:
-            scopes = (WILDCARD_SCOPE,)
-        keys.append(ApiKey(token=token, name=name, scopes=scopes))
+        # Not named ``scopes``: that shadows the module imported above, and a
+        # later reader adding scopes.INGEST here would get a confusing
+        # AttributeError on a tuple.
+        granted = tuple(str(s) for s in raw_scopes if str(s))
+        if not granted:
+            granted = (WILDCARD_SCOPE,)
+        keys.append(ApiKey(token=token, name=name, scopes=granted))
 
     if not keys:
         env_token = os.environ.get(ENV_KEY, "").strip()

--- a/src/voicegateway/core/auth.py
+++ b/src/voicegateway/core/auth.py
@@ -32,6 +32,43 @@ class AuthError(Exception):
         super().__init__(message)
 
 
+class AuthConfigError(ValueError):
+    """Raised at startup when the auth block contradicts itself."""
+
+
+#: Hosts that mean "this machine only". Anything else is reachable.
+_LOOPBACK = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def validate_auth_startup(auth: AuthConfig, bind_host: str) -> None:
+    """Refuse to start when ``local_development`` meets production shape.
+
+    Unauthenticated mode has to be explicit, and explicit is not enough on its
+    own: a flag set on a laptop travels inside a copied config file. So the
+    flag is only honoured in the company of the other things that make a
+    deployment local. Configured keys contradict disabling auth, a
+    non-loopback bind means someone else can reach it, and ``enforce`` asks
+    for the opposite behaviour in the same breath.
+
+    Every conflict is collected before raising, because finding them one
+    restart at a time is a bad afternoon.
+    """
+    if not auth.local_development:
+        return
+    conflicts: list[str] = []
+    if auth.api_keys:
+        conflicts.append(f"auth.api_keys has {len(auth.api_keys)} entries")
+    if bind_host not in _LOOPBACK:
+        conflicts.append(f"bind host {bind_host!r} is not loopback")
+    if auth.enforcement == "enforce":
+        conflicts.append("auth.enforcement is 'enforce'")
+    if conflicts:
+        raise AuthConfigError(
+            "auth.local_development is true but the configuration is "
+            "production-shaped: " + "; ".join(conflicts)
+        )
+
+
 @dataclass(frozen=True)
 class ApiKey:
     """A single configured API key with a scope allowlist."""

--- a/src/voicegateway/core/auth.py
+++ b/src/voicegateway/core/auth.py
@@ -40,7 +40,7 @@ class AuthConfigError(ValueError):
 _LOOPBACK = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
-def validate_auth_startup(auth: AuthConfig, bind_host: str) -> None:
+def validate_auth_startup(auth: AuthConfig, bind_host: str | None = None) -> None:
     """Refuse to start when ``local_development`` meets production shape.
 
     Unauthenticated mode has to be explicit, and explicit is not enough on its
@@ -50,6 +50,12 @@ def validate_auth_startup(auth: AuthConfig, bind_host: str) -> None:
     non-loopback bind means someone else can reach it, and ``enforce`` asks
     for the opposite behaviour in the same breath.
 
+    ``bind_host`` is optional so that callers which have not resolved a host
+    can still run the two config-only checks. ``build_app`` does exactly that:
+    it is reachable from more than one entry point, and a guard that lived
+    only in the serve CLI would refuse an unauthenticated public deployment on
+    a laptop while waving the container through.
+
     Every conflict is collected before raising, because finding them one
     restart at a time is a bad afternoon.
     """
@@ -58,7 +64,7 @@ def validate_auth_startup(auth: AuthConfig, bind_host: str) -> None:
     conflicts: list[str] = []
     if auth.api_keys:
         conflicts.append(f"auth.api_keys has {len(auth.api_keys)} entries")
-    if bind_host not in _LOOPBACK:
+    if bind_host is not None and bind_host not in _LOOPBACK:
         conflicts.append(f"bind host {bind_host!r} is not loopback")
     if auth.enforcement == "enforce":
         conflicts.append("auth.enforcement is 'enforce'")

--- a/src/voicegateway/core/config.py
+++ b/src/voicegateway/core/config.py
@@ -131,10 +131,21 @@ class ProjectConfig:
 
 @dataclass
 class AuthConfig:
-    """HTTP API authentication settings."""
+    """HTTP API authentication settings.
+
+    Mirrors ``schemas.config_schema.AuthConfig``, which validates the YAML;
+    this is the runtime shape the Gateway carries. A field added to one and
+    not the other is invisible until something reads it, so
+    ``tests/core/test_auth_config_parity.py`` asserts the two agree.
+    """
 
     api_keys: list[dict[str, Any]] = field(default_factory=list)
     cors_origins: list[str] = field(default_factory=list)
+    #: Explicit local mode: unauthenticated requests allowed, nothing logged.
+    #: Refused at startup alongside production-shaped config.
+    local_development: bool = False
+    #: ``warn`` serves and logs what it would refuse; ``enforce`` refuses.
+    enforcement: str = "warn"
 
 
 @dataclass
@@ -361,6 +372,8 @@ class GatewayConfig:
                 if isinstance(entry, dict)
             ],
             cors_origins=[str(o) for o in (auth_raw.get("cors_origins") or []) if o],
+            local_development=bool(auth_raw.get("local_development", False)),
+            enforcement=str(auth_raw.get("enforcement", "warn")),
         )
 
         default_project_raw = raw.get("default_project")

--- a/src/voicegateway/core/scopes.py
+++ b/src/voicegateway/core/scopes.py
@@ -1,0 +1,36 @@
+"""Scope name constants. A leaf module: it imports nothing.
+
+``repository`` imports these, so this file must never import from
+``repository``, ``services``, ``server`` or ``schemas``. That is precisely the
+cycle Wave 1 breaks: ``api_keys_repository.has_scope`` needed
+``WILDCARD_SCOPE`` from ``core.auth``, while ``core.auth.verify_api_key``
+needed the repository, so one of them had to import lazily inside a function
+to keep the import graph acyclic. Constants live down here instead, and the
+direction is one way.
+
+The contract enum lives in ``schemas.telemetry.security_schema.ScopeName``;
+``tests/core/test_scopes.py`` asserts the two agree, so a scope cannot exist
+at runtime without also being visible to the authorization matrix.
+"""
+
+from __future__ import annotations
+
+#: Telemetry ingest. Deliberately narrower than WRITE: an agent key that only
+#: posts telemetry must not be able to rewrite gateway configuration.
+INGEST = "ingest"
+#: Reading traces, costs, sessions and replay.
+READ = "read"
+#: Retention, key management, the audit log, and anything that spends money.
+ADMIN = "admin"
+#: The read-only MCP debugging surface. Not yet enforced (VG-SEC-008, wave 3).
+MCP_READ = "mcp:read"
+#: Config mutation: providers, models, projects, rate-card rules. Retained,
+#: but from 0.26.0 it no longer covers telemetry ingest.
+WRITE = "write"
+#: Matches every check. Refused at mint from 0.26.0, and satisfies nothing
+#: once auth.enforcement is "enforce" (VG-SEC-006).
+WILDCARD = "*"
+
+ALL: frozenset[str] = frozenset({INGEST, READ, ADMIN, MCP_READ, WRITE, WILDCARD})
+
+__all__ = ["ADMIN", "ALL", "INGEST", "MCP_READ", "READ", "WILDCARD", "WRITE"]

--- a/src/voicegateway/core/scopes.py
+++ b/src/voicegateway/core/scopes.py
@@ -33,4 +33,49 @@ WILDCARD = "*"
 
 ALL: frozenset[str] = frozenset({INGEST, READ, ADMIN, MCP_READ, WRITE, WILDCARD})
 
-__all__ = ["ADMIN", "ALL", "INGEST", "MCP_READ", "READ", "WILDCARD", "WRITE"]
+#: Everything a key may actually be minted with, which is ALL minus the
+#: wildcard. Named separately because "the scopes that exist" and "the scopes
+#: you may ask for" stopped being the same set in 0.26.0.
+MINTABLE: frozenset[str] = ALL - {WILDCARD}
+
+
+def normalize_scopes(scopes: str) -> str:
+    """Validate a comma-separated scope string and return its canonical form.
+
+    Raises :class:`ValueError` for an empty list, the wildcard, or a name that
+    is not a scope. Returns the requested scopes sorted and de-duplicated, so
+    two keys granting the same authority store the same string.
+
+    This lives in the leaf module because there are two mint paths that must
+    not drift: the function-style repository used by the dashboard and the
+    CLI, and ``ApiKeyService.create_key`` behind ``POST /v1/api-keys``. A rule
+    enforced in one of them is a rule an operator can walk around by picking
+    the other door, which is how VG-SEC-007 (admin checked two ways) happened.
+    """
+    requested = {s.strip() for s in scopes.split(",") if s.strip()}
+    if not requested:
+        raise ValueError("scopes must name at least one scope")
+    if WILDCARD in requested:
+        raise ValueError(
+            "wildcard scope may not be minted; name the scopes explicitly "
+            f"(one or more of: {', '.join(sorted(MINTABLE))})"
+        )
+    unknown = requested - MINTABLE
+    if unknown:
+        raise ValueError(
+            f"unknown scope(s): {sorted(unknown)}; known scopes are {sorted(MINTABLE)}"
+        )
+    return ",".join(sorted(requested))
+
+
+__all__ = [
+    "ADMIN",
+    "ALL",
+    "INGEST",
+    "MCP_READ",
+    "MINTABLE",
+    "READ",
+    "WILDCARD",
+    "WRITE",
+    "normalize_scopes",
+]

--- a/src/voicegateway/inference/pipecat/guard_pipecat.py
+++ b/src/voicegateway/inference/pipecat/guard_pipecat.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from typing import Any
 
 from pipecat.frames.frames import (
@@ -371,8 +371,17 @@ class GuardedTTSService(TTSService, _GuardProcessorMixin):
         self._control = control
         self._wrapped = wrapped
 
-    async def run_tts(self, text: str) -> Any:
-        async for frame in self._wrapped.run_tts(text):
+    async def run_tts(
+        self, text: str, context_id: str = ""
+    ) -> AsyncGenerator[Frame | None, None]:
+        """Delegate across both the Pipecat 1.5 and 1.8 TTS signatures."""
+        parameters = inspect.signature(self._wrapped.run_tts).parameters
+        stream = (
+            self._wrapped.run_tts(text, context_id)
+            if "context_id" in parameters
+            else self._wrapped.run_tts(text)
+        )
+        async for frame in stream:
             yield frame
 
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -16,6 +16,8 @@ from voicegateway.inference.session.context import (
 )
 
 if TYPE_CHECKING:
+    from voicegateway.accounting.contracts import PricingBinding, PricingBindingResponse
+    from voicegateway.accounting.outbox import AccountingOutbox
     from voicegateway.middleware.cost_tracker_middleware import CostTracker
     from voicegateway.middleware.dead_air_detector_middleware import DeadAirDetector
     from voicegateway.middleware.turn_tracker_middleware import TurnTracker
@@ -396,6 +398,22 @@ def _build_default_sink(
     return LocalSqliteSink(StorageService(resolved_path))
 
 
+def _with_accounting(
+    sink: Sink,
+    outbox: AccountingOutbox | None,
+    binding: PricingBinding | PricingBindingResponse | None,
+    producer_id: str | None,
+) -> Sink:
+    """Apply the explicit invoice-accounting capture opt-in."""
+    if outbox is None:
+        return sink
+    if not producer_id:
+        raise ValueError("accounting_producer_id is required with accounting_outbox")
+    from voicegateway.services.sinks import AccountingCaptureSink
+
+    return AccountingCaptureSink(sink, outbox, producer_id=producer_id, binding=binding)
+
+
 # Strong refs to in-flight session-close finalize tasks; the event loop only
 # weak-refs scheduled tasks, so without this a close-time reconcile/flush can be
 # GC'd mid-write (the hazard MetricCapture._schedule guards against for writes).
@@ -429,6 +447,9 @@ def attach(
     snapshots: bool | None = None,
     turns: bool | None = None,
     dead_air: bool | None = None,
+    accounting_outbox: AccountingOutbox | None = None,
+    accounting_binding: PricingBinding | PricingBindingResponse | None = None,
+    accounting_producer_id: str | None = None,
 ) -> str:
     """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
 
@@ -556,6 +577,13 @@ def attach(
             now, so a long utterance cannot trip it. Set ``VOICEGW_DEAD_AIR=0``
             to force it off fleet-wide. LiveKit-only, like ``turns``.
 
+        accounting_outbox: explicit invoice-accounting opt-in. Each captured
+            request is persisted to this bounded outbox before delivery.
+        accounting_binding: immutable pricing and ownership binding returned by
+            ``POST /v1/accounting/prepare``. The collector remains authoritative.
+        accounting_producer_id: stable producer identity. Required whenever an
+            ``accounting_outbox`` is supplied.
+
     Returns:
         The correlation session id stamped on every captured row.
     """
@@ -586,6 +614,9 @@ def attach(
             snapshots=snapshots,
             turns=turns,
             dead_air=dead_air,
+            accounting_outbox=accounting_outbox,
+            accounting_binding=accounting_binding,
+            accounting_producer_id=accounting_producer_id,
         )
     return _attach_livekit(
         session,
@@ -602,6 +633,9 @@ def attach(
         snapshots=snapshots,
         turns=turns,
         dead_air=dead_air,
+        accounting_outbox=accounting_outbox,
+        accounting_binding=accounting_binding,
+        accounting_producer_id=accounting_producer_id,
     )
 
 
@@ -1247,6 +1281,9 @@ def _attach_livekit(
     snapshots: bool = False,
     turns: bool = True,
     dead_air: bool = True,
+    accounting_outbox: AccountingOutbox | None = None,
+    accounting_binding: PricingBinding | PricingBindingResponse | None = None,
+    accounting_producer_id: str | None = None,
 ) -> str:
     """LiveKit ``attach()`` body: bind ``MetricCapture`` to an ``AgentSession``."""
     import asyncio
@@ -1267,6 +1304,9 @@ def _attach_livekit(
         set_tenant(tenant_id)
     if sink is None:
         sink = _build_default_sink(resolved_collector, resolved_key)
+    sink = _with_accounting(
+        sink, accounting_outbox, accounting_binding, accounting_producer_id
+    )
 
     # Built before MetricCapture, which needs the correction hook below.
     turn_tracker = (
@@ -1571,6 +1611,9 @@ def _attach_pipecat(
     snapshots: bool = False,
     turns: bool = True,
     dead_air: bool = True,
+    accounting_outbox: AccountingOutbox | None = None,
+    accounting_binding: PricingBinding | PricingBindingResponse | None = None,
+    accounting_producer_id: str | None = None,
 ) -> str:
     """Register a ``VoiceGatewayObserver`` on a Pipecat ``PipelineTask``.
 
@@ -1606,6 +1649,9 @@ def _attach_pipecat(
         set_tenant(tenant_id)
     if sink is None:
         sink = _build_default_sink(resolved_collector, resolved_key)
+    sink = _with_accounting(
+        sink, accounting_outbox, accounting_binding, accounting_producer_id
+    )
 
     resolved_channel = channel or _detect_pipecat_channel(task)
 

--- a/src/voicegateway/inference/session/attach.py
+++ b/src/voicegateway/inference/session/attach.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from voicegateway.inference.session.context import (
@@ -401,7 +402,12 @@ def _build_default_sink(
 def _with_accounting(
     sink: Sink,
     outbox: AccountingOutbox | None,
-    binding: PricingBinding | PricingBindingResponse | None,
+    binding: (
+        PricingBinding
+        | PricingBindingResponse
+        | Mapping[str, PricingBinding | PricingBindingResponse]
+        | None
+    ),
     producer_id: str | None,
 ) -> Sink:
     """Apply the explicit invoice-accounting capture opt-in."""
@@ -448,7 +454,12 @@ def attach(
     turns: bool | None = None,
     dead_air: bool | None = None,
     accounting_outbox: AccountingOutbox | None = None,
-    accounting_binding: PricingBinding | PricingBindingResponse | None = None,
+    accounting_binding: (
+        PricingBinding
+        | PricingBindingResponse
+        | Mapping[str, PricingBinding | PricingBindingResponse]
+        | None
+    ) = None,
     accounting_producer_id: str | None = None,
 ) -> str:
     """Attach VoiceGateway to a LiveKit ``AgentSession`` or Pipecat ``PipelineTask``.
@@ -580,7 +591,9 @@ def attach(
         accounting_outbox: explicit invoice-accounting opt-in. Each captured
             request is persisted to this bounded outbox before delivery.
         accounting_binding: immutable pricing and ownership binding returned by
-            ``POST /v1/accounting/prepare``. The collector remains authoritative.
+            ``POST /v1/accounting/prepare``. For a multi-model session, pass a
+            mapping keyed by normalized model ID (preferred) or modality. The
+            collector remains authoritative.
         accounting_producer_id: stable producer identity. Required whenever an
             ``accounting_outbox`` is supplied.
 
@@ -1282,7 +1295,12 @@ def _attach_livekit(
     turns: bool = True,
     dead_air: bool = True,
     accounting_outbox: AccountingOutbox | None = None,
-    accounting_binding: PricingBinding | PricingBindingResponse | None = None,
+    accounting_binding: (
+        PricingBinding
+        | PricingBindingResponse
+        | Mapping[str, PricingBinding | PricingBindingResponse]
+        | None
+    ) = None,
     accounting_producer_id: str | None = None,
 ) -> str:
     """LiveKit ``attach()`` body: bind ``MetricCapture`` to an ``AgentSession``."""
@@ -1612,7 +1630,12 @@ def _attach_pipecat(
     turns: bool = True,
     dead_air: bool = True,
     accounting_outbox: AccountingOutbox | None = None,
-    accounting_binding: PricingBinding | PricingBindingResponse | None = None,
+    accounting_binding: (
+        PricingBinding
+        | PricingBindingResponse
+        | Mapping[str, PricingBinding | PricingBindingResponse]
+        | None
+    ) = None,
     accounting_producer_id: str | None = None,
 ) -> str:
     """Register a ``VoiceGatewayObserver`` on a Pipecat ``PipelineTask``.

--- a/src/voicegateway/inference/session/capture.py
+++ b/src/voicegateway/inference/session/capture.py
@@ -110,6 +110,15 @@ def units_from_metric(
     """
     ttfb_ms = _ttfb_ms(metric)
     if modality == "llm":
+        if "realtime" in type(metric).__name__.lower():
+            details = getattr(metric, "input_token_details", None)
+            cached = getattr(details, "cached_tokens", 0) or 0
+            return (
+                float(getattr(metric, "input_tokens", 0) or 0),
+                float(getattr(metric, "output_tokens", 0) or 0),
+                float(cached),
+                ttfb_ms,
+            )
         return (
             float(getattr(metric, "prompt_tokens", 0) or 0),
             float(getattr(metric, "completion_tokens", 0) or 0),
@@ -127,6 +136,82 @@ def units_from_metric(
             ttfb_ms,
         )
     return (0.0, 0.0, 0.0, ttfb_ms)
+
+
+def _accounting_metric_metadata(metric: object, modality: str) -> dict[str, Any]:
+    """Preserve accounting measurement state that legacy float columns cannot.
+
+    RequestRecord predates the exact ledger and uses zero-valued float defaults.
+    This private metadata keeps a genuinely measured zero distinct from an
+    absent measurement, and carries realtime text/audio token splits.  It holds
+    counts and opaque provider correlation IDs only; never content.
+    """
+    result: dict[str, Any] = {}
+    request_id = getattr(metric, "request_id", None)
+    if isinstance(request_id, str) and request_id:
+        result["provider_request_id"] = request_id
+    segment_id = getattr(metric, "segment_id", None)
+    if isinstance(segment_id, str) and segment_id:
+        result["provider_segment_id"] = segment_id
+
+    missing: list[str] = []
+    if modality == "llm" and "realtime" in type(metric).__name__.lower():
+        input_details = getattr(metric, "input_token_details", None)
+        output_details = getattr(metric, "output_token_details", None)
+        cached_details = getattr(input_details, "cached_tokens_details", None)
+        cached_total = getattr(input_details, "cached_tokens", None)
+        cache_text = getattr(cached_details, "text_tokens", None)
+        cache_audio = getattr(cached_details, "audio_tokens", None)
+        if cached_details is None and cached_total == 0:
+            cache_text = cache_audio = 0
+        values = {
+            "text_input": getattr(input_details, "text_tokens", None),
+            "text_output": getattr(output_details, "text_tokens", None),
+            "cache_read": cache_text,
+            "realtime_audio_input": getattr(input_details, "audio_tokens", None),
+            "realtime_audio_output": getattr(output_details, "audio_tokens", None),
+            "realtime_audio_cache": cache_audio,
+        }
+        result["accounting_realtime_quantities"] = {
+            key: int(value) for key, value in values.items() if value is not None
+        }
+        missing.extend(key for key, value in values.items() if value is None)
+    else:
+        fields = {
+            "llm": {
+                "text_input": "prompt_tokens",
+                "text_output": "completion_tokens",
+                "cache_read": "prompt_cached_tokens",
+            },
+            "stt": {"audio_seconds": "audio_duration"},
+            "tts": {"characters": "characters_count"},
+        }.get(modality, {})
+        missing.extend(
+            dimension
+            for dimension, field in fields.items()
+            if getattr(metric, field, None) is None
+        )
+    if missing:
+        result["accounting_missing_dimensions"] = sorted(missing)
+    return result
+
+
+def _stable_metric_record_id(
+    metric: object, *, modality: str, provider: str, model_id: str
+) -> str | None:
+    """Return a replay-stable ID when the native SDK supplies correlation.
+
+    A TTS request can emit several segments with one request ID.  Segment and
+    metric timestamp keep those subrequests distinct; replaying the same metric
+    produces the same ID and therefore one accounting event.
+    """
+    request_id = getattr(metric, "request_id", None)
+    if not isinstance(request_id, str) or not request_id:
+        return None
+    segment = getattr(metric, "segment_id", None) or ""
+    timestamp = getattr(metric, "timestamp", None)
+    material = f"{provider}|{model_id}|{modality}|{request_id}|{segment}|{timestamp}"
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, material))
 
 
 def _provider_name(component: object) -> str:
@@ -418,9 +503,20 @@ class MetricCapture:
             revision=self._revision,
             turn_index=turn_index,
         )
-        network = _network_meta(metric)
-        if network:
-            record.metadata = {**record.metadata, **network}
+        stable_id = _stable_metric_record_id(
+            metric, modality=modality, provider=provider, model_id=model_id
+        )
+        if stable_id is not None:
+            record.id = stable_id
+            metric_timestamp = getattr(metric, "timestamp", None)
+            if isinstance(metric_timestamp, int | float) and metric_timestamp > 0:
+                record.timestamp = float(metric_timestamp)
+        metric_metadata = {
+            **_network_meta(metric),
+            **_accounting_metric_metadata(metric, modality),
+        }
+        if metric_metadata:
+            record.metadata = {**record.metadata, **metric_metadata}
         self._stamp_context(record)
         tally = self._recorded.setdefault(
             (provider, model_id), {"input": 0.0, "output": 0.0, "cached": 0.0}

--- a/src/voicegateway/models/__init__.py
+++ b/src/voicegateway/models/__init__.py
@@ -7,6 +7,11 @@ both see them.
 
 from __future__ import annotations
 
+from voicegateway.models.accounting_model import (
+    AccountingProjection,
+    AccountingUsage,
+    PricingRevision,
+)
 from voicegateway.models.agent_observation_model import AgentObservation
 from voicegateway.models.agent_probe_result_model import AgentProbeResult
 from voicegateway.models.api_key_model import ApiKey
@@ -41,6 +46,8 @@ __all__ = [
     "ToolCall",
     "AgentObservation",
     "AgentProbeResult",
+    "AccountingProjection",
+    "AccountingUsage",
     "BaseModel",
     "BaseUUIDModel",
     "Call",
@@ -60,6 +67,7 @@ __all__ = [
     "ReplaySttEvent",
     "ReplayStateSnapshot",
     "ReplayTtsFrame",
+    "PricingRevision",
     "Request",
     "RequestRecord",
     "Session",

--- a/src/voicegateway/models/__init__.py
+++ b/src/voicegateway/models/__init__.py
@@ -8,8 +8,11 @@ both see them.
 from __future__ import annotations
 
 from voicegateway.models.accounting_model import (
+    AccountingOwnership,
     AccountingProjection,
+    AccountingRejection,
     AccountingUsage,
+    PreparedPricingBinding,
     PricingRevision,
 )
 from voicegateway.models.agent_observation_model import AgentObservation
@@ -47,6 +50,8 @@ __all__ = [
     "AgentObservation",
     "AgentProbeResult",
     "AccountingProjection",
+    "AccountingRejection",
+    "AccountingOwnership",
     "AccountingUsage",
     "BaseModel",
     "BaseUUIDModel",
@@ -68,6 +73,7 @@ __all__ = [
     "ReplayStateSnapshot",
     "ReplayTtsFrame",
     "PricingRevision",
+    "PreparedPricingBinding",
     "Request",
     "RequestRecord",
     "Session",

--- a/src/voicegateway/models/accounting_model.py
+++ b/src/voicegateway/models/accounting_model.py
@@ -1,0 +1,69 @@
+"""Append-only accounting ledger entities."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sqlalchemy import Column, Text, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+class PricingRevision(SQLModel, table=True):
+    __tablename__: ClassVar[str] = "pricing_revisions"
+    __table_args__ = (UniqueConstraint("tenant_id", "side", "revision_id"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: str = Field(index=True)
+    revision_id: str = Field(index=True)
+    side: str
+    scope_json: str = Field(sa_column=Column(Text, nullable=False))
+    content_json: str = Field(sa_column=Column(Text, nullable=False))
+    content_hash: str
+    contract_version: int
+    currency: str
+    active: bool = Field(default=False, index=True)
+    created_at_ns: int
+
+
+class AccountingUsage(SQLModel, table=True):
+    __tablename__: ClassVar[str] = "accounting_usage"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "project_id", "event_id"),
+        UniqueConstraint("tenant_id", "project_id", "component", "attempt_id"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: str = Field(index=True)
+    project_id: str = Field(index=True)
+    event_id: str = Field(index=True)
+    attempt_id: str
+    component: str
+    modality: str
+    offering: str
+    model_id: str
+    session_id: str = Field(index=True)
+    turn_id: str | None = None
+    producer_id: str
+    ownership_mode: str
+    acquisition_revision_id: str | None = None
+    selling_revision_id: str | None = None
+    occurred_at_ns: int
+    payload_hash: str
+    envelope_json: str = Field(sa_column=Column(Text, nullable=False))
+    acquisition_total_usd: str | None = None
+    selling_total_usd: str | None = None
+    acquisition_complete: bool
+    selling_complete: bool
+    status: str = Field(index=True)
+    receipt_id: str
+    created_at_ns: int
+
+
+class AccountingProjection(SQLModel, table=True):
+    __tablename__: ClassVar[str] = "accounting_projection_outbox"
+
+    event_id: str = Field(primary_key=True)
+    payload_json: str = Field(sa_column=Column(Text, nullable=False))
+    attempts: int = 0
+    last_error_code: str | None = None
+    projected_at_ns: int | None = None

--- a/src/voicegateway/models/accounting_model.py
+++ b/src/voicegateway/models/accounting_model.py
@@ -4,13 +4,24 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from sqlalchemy import Column, Text, UniqueConstraint
+from sqlalchemy import BigInteger, Column, Index, String, Text, UniqueConstraint, text
 from sqlmodel import Field, SQLModel
 
 
 class PricingRevision(SQLModel, table=True):
     __tablename__: ClassVar[str] = "pricing_revisions"
-    __table_args__ = (UniqueConstraint("tenant_id", "side", "revision_id"),)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "side", "revision_id"),
+        Index(
+            "uq_pricing_revisions_active_scope",
+            "tenant_id",
+            "side",
+            "scope_key",
+            unique=True,
+            sqlite_where=text("active = 1"),
+            postgresql_where=text("active"),
+        ),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     tenant_id: str = Field(index=True)
@@ -19,18 +30,18 @@ class PricingRevision(SQLModel, table=True):
     scope_json: str = Field(sa_column=Column(Text, nullable=False))
     scope_key: str = Field(index=True)
     content_json: str = Field(sa_column=Column(Text, nullable=False))
-    content_hash: str
+    content_hash: str = Field(sa_column=Column(String(64), nullable=False))
     contract_version: int
-    currency: str
+    currency: str = Field(sa_column=Column(String(3), nullable=False))
     active: bool = Field(default=False, index=True)
-    created_at_ns: int
+    created_at_ns: int = Field(sa_column=Column(BigInteger, nullable=False))
 
 
 class AccountingUsage(SQLModel, table=True):
     __tablename__: ClassVar[str] = "accounting_usage"
     __table_args__ = (
         UniqueConstraint("tenant_id", "project_id", "event_id"),
-        UniqueConstraint("tenant_id", "project_id", "component", "attempt_id"),
+        UniqueConstraint("tenant_id", "project_id", "attempt_id"),
     )
 
     id: int | None = Field(default=None, primary_key=True)
@@ -49,8 +60,8 @@ class AccountingUsage(SQLModel, table=True):
     pricing_binding_id: str | None = None
     acquisition_revision_id: str | None = None
     selling_revision_id: str | None = None
-    occurred_at_ns: int
-    payload_hash: str
+    occurred_at_ns: int = Field(sa_column=Column(BigInteger, nullable=False))
+    payload_hash: str = Field(sa_column=Column(String(64), nullable=False))
     envelope_json: str = Field(sa_column=Column(Text, nullable=False))
     acquisition_total_usd: str | None = None
     selling_total_usd: str | None = None
@@ -58,7 +69,7 @@ class AccountingUsage(SQLModel, table=True):
     selling_complete: bool
     status: str = Field(index=True)
     receipt_id: str
-    created_at_ns: int
+    created_at_ns: int = Field(sa_column=Column(BigInteger, nullable=False))
 
 
 class AccountingProjection(SQLModel, table=True):
@@ -72,7 +83,9 @@ class AccountingProjection(SQLModel, table=True):
     payload_json: str = Field(sa_column=Column(Text, nullable=False))
     attempts: int = 0
     last_error_code: str | None = None
-    projected_at_ns: int | None = None
+    projected_at_ns: int | None = Field(
+        default=None, sa_column=Column(BigInteger, nullable=True)
+    )
 
 
 class AccountingRejection(SQLModel, table=True):
@@ -85,10 +98,10 @@ class AccountingRejection(SQLModel, table=True):
     tenant_id: str = Field(index=True)
     project_id: str = Field(index=True)
     event_id: str
-    payload_hash: str
+    payload_hash: str = Field(sa_column=Column(String(64), nullable=False))
     code: str
     receipt_id: str
-    created_at_ns: int
+    created_at_ns: int = Field(sa_column=Column(BigInteger, nullable=False))
 
 
 class AccountingOwnership(SQLModel, table=True):
@@ -100,7 +113,7 @@ class AccountingOwnership(SQLModel, table=True):
     project_id: str = Field(index=True)
     component: str
     mode: str
-    updated_at_ns: int
+    updated_at_ns: int = Field(sa_column=Column(BigInteger, nullable=False))
 
 
 class PreparedPricingBinding(SQLModel, table=True):
@@ -114,4 +127,4 @@ class PreparedPricingBinding(SQLModel, table=True):
     acquisition_revision_id: str | None = None
     selling_revision_id: str | None = None
     ownership_mode: str
-    prepared_at_ns: int
+    prepared_at_ns: int = Field(sa_column=Column(BigInteger, nullable=False))

--- a/src/voicegateway/models/accounting_model.py
+++ b/src/voicegateway/models/accounting_model.py
@@ -17,6 +17,7 @@ class PricingRevision(SQLModel, table=True):
     revision_id: str = Field(index=True)
     side: str
     scope_json: str = Field(sa_column=Column(Text, nullable=False))
+    scope_key: str = Field(index=True)
     content_json: str = Field(sa_column=Column(Text, nullable=False))
     content_hash: str
     contract_version: int
@@ -45,6 +46,7 @@ class AccountingUsage(SQLModel, table=True):
     turn_id: str | None = None
     producer_id: str
     ownership_mode: str
+    pricing_binding_id: str | None = None
     acquisition_revision_id: str | None = None
     selling_revision_id: str | None = None
     occurred_at_ns: int
@@ -61,9 +63,55 @@ class AccountingUsage(SQLModel, table=True):
 
 class AccountingProjection(SQLModel, table=True):
     __tablename__: ClassVar[str] = "accounting_projection_outbox"
+    __table_args__ = (UniqueConstraint("tenant_id", "project_id", "event_id"),)
 
-    event_id: str = Field(primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: str = Field(index=True)
+    project_id: str = Field(index=True)
+    event_id: str = Field(index=True)
     payload_json: str = Field(sa_column=Column(Text, nullable=False))
     attempts: int = 0
     last_error_code: str | None = None
     projected_at_ns: int | None = None
+
+
+class AccountingRejection(SQLModel, table=True):
+    __tablename__: ClassVar[str] = "accounting_rejections"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "project_id", "event_id", "payload_hash"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: str = Field(index=True)
+    project_id: str = Field(index=True)
+    event_id: str
+    payload_hash: str
+    code: str
+    receipt_id: str
+    created_at_ns: int
+
+
+class AccountingOwnership(SQLModel, table=True):
+    __tablename__: ClassVar[str] = "accounting_ownership"
+    __table_args__ = (UniqueConstraint("tenant_id", "project_id", "component"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    tenant_id: str = Field(index=True)
+    project_id: str = Field(index=True)
+    component: str
+    mode: str
+    updated_at_ns: int
+
+
+class PreparedPricingBinding(SQLModel, table=True):
+    __tablename__: ClassVar[str] = "prepared_pricing_bindings"
+
+    binding_id: str = Field(primary_key=True)
+    tenant_id: str = Field(index=True)
+    project_id: str = Field(index=True)
+    component: str
+    offering: str
+    acquisition_revision_id: str | None = None
+    selling_revision_id: str | None = None
+    ownership_mode: str
+    prepared_at_ns: int

--- a/src/voicegateway/models/api_key_model.py
+++ b/src/voicegateway/models/api_key_model.py
@@ -25,6 +25,7 @@ class ApiKey(SQLModel, table=True):
     tenant_id: str | None = Field(default=None, index=True)
     role: str = Field(default="tenant")
     scopes: str = Field(default="*")
+    project_ids: str | None = None
     issued_by: str | None = None
     issued_at: datetime = Field(  # type: ignore[call-overload]
         default_factory=_utcnow,

--- a/src/voicegateway/models/api_key_model.py
+++ b/src/voicegateway/models/api_key_model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import ClassVar
 
-from sqlalchemy import DateTime
+from sqlalchemy import Column, DateTime, Text
 from sqlmodel import Field, SQLModel
 
 
@@ -25,7 +25,7 @@ class ApiKey(SQLModel, table=True):
     tenant_id: str | None = Field(default=None, index=True)
     role: str = Field(default="tenant")
     scopes: str = Field(default="*")
-    project_ids: str | None = None
+    project_ids: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
     issued_by: str | None = None
     issued_at: datetime = Field(  # type: ignore[call-overload]
         default_factory=_utcnow,

--- a/src/voicegateway/repository/api_key_repository.py
+++ b/src/voicegateway/repository/api_key_repository.py
@@ -22,9 +22,7 @@ class ApiKeyRepository(BaseRepository[ApiKey]):
     ) -> list[ApiKey]:
         """Return every row matching the visible 8-char prefix."""
         async with self._session(session) as s:
-            result = await s.execute(
-                select(ApiKey).where(ApiKey.key_prefix == prefix)
-            )
+            result = await s.execute(select(ApiKey).where(ApiKey.key_prefix == prefix))
             return list(result.scalars().all())
 
     async def list_keys(

--- a/src/voicegateway/repository/api_keys_repository.py
+++ b/src/voicegateway/repository/api_keys_repository.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Final
 import bcrypt
 from sqlalchemy import text
 
+from voicegateway.core import scopes
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -62,13 +64,24 @@ class VerifiedKey:
     role: str = "tenant"
     scopes: str = "*"
 
-    def has_scope(self, required: str) -> bool:
-        """Return True if this key covers ``required``."""
-        # Lazy import to avoid core.auth -> repository -> core.auth cycle.
-        from voicegateway.core.auth import WILDCARD_SCOPE  # noqa: PLC0415
+    def has_scope(self, required: str, *, enforce: bool = False) -> bool:
+        """Return True if this key covers ``required``.
 
-        csv = [s.strip() for s in self.scopes.split(",") if s.strip()]
-        return WILDCARD_SCOPE in csv or required in csv
+        Two compatibility grants exist during the warn release and stop under
+        ``enforce``: ``write`` covers ``ingest``, so existing agent keys keep
+        posting telemetry after the scope split, and ``*`` covers everything,
+        so keys minted before 0.26.0 keep working. Both are exactly what
+        0.27.0 withdraws, which is why they are conditioned on the same flag
+        rather than left as unconditional behaviour with a comment.
+        """
+        granted = {s.strip() for s in self.scopes.split(",") if s.strip()}
+        if required in granted:
+            return True
+        if enforce:
+            return False
+        if scopes.WILDCARD in granted:
+            return True
+        return required == scopes.INGEST and scopes.WRITE in granted
 
 
 def _generate_plaintext_key() -> str:

--- a/src/voicegateway/repository/api_keys_repository.py
+++ b/src/voicegateway/repository/api_keys_repository.py
@@ -43,6 +43,7 @@ class ApiKeyRow:
     issued_at: str
     last_used_at: str | None
     revoked_at: str | None
+    project_ids: str | None = None
 
 
 @dataclass(frozen=True)
@@ -63,6 +64,7 @@ class VerifiedKey:
     name: str
     role: str = "tenant"
     scopes: str = "*"
+    project_ids: str | None = None
 
     def has_scope(self, required: str, *, enforce: bool = False) -> bool:
         """Return True if this key covers ``required``.
@@ -116,12 +118,11 @@ def _row_to_dataclass(row) -> ApiKeyRow:
         issued_at=str(row[5]),
         last_used_at=None if row[6] is None else str(row[6]),
         revoked_at=None if row[7] is None else str(row[7]),
+        project_ids=None if row[8] is None else str(row[8]),
     )
 
 
-_SELECT_ROW_FIELDS = (
-    "id, key_prefix, name, tenant_id, issued_by, issued_at, last_used_at, revoked_at"
-)
+_SELECT_ROW_FIELDS = "id, key_prefix, name, tenant_id, issued_by, issued_at, last_used_at, revoked_at, project_ids"
 
 
 async def create_api_key(
@@ -132,6 +133,7 @@ async def create_api_key(
     tenant_id: str | None = None,
     issued_by: str | None = None,
     role: str = "tenant",
+    project_ids: str | None = None,
 ) -> CreatedApiKey:
     """Create a virtual key and return the plaintext once.
 
@@ -155,9 +157,9 @@ async def create_api_key(
     result = await session.execute(
         text(
             "INSERT INTO api_keys ("
-            "key_prefix, key_hash, name, tenant_id, issued_by, role, scopes, issued_at"
+            "key_prefix, key_hash, name, tenant_id, issued_by, role, scopes, project_ids, issued_at"
             ") VALUES ("
-            ":prefix, :digest, :name, :tenant_id, :issued_by, :role, :scopes,"
+            ":prefix, :digest, :name, :tenant_id, :issued_by, :role, :scopes, :project_ids,"
             " CURRENT_TIMESTAMP"
             ") RETURNING id"
         ),
@@ -169,6 +171,7 @@ async def create_api_key(
             "issued_by": issued_by,
             "role": role,
             "scopes": scopes,
+            "project_ids": project_ids,
         },
     )
     # RETURNING works on both Postgres (asyncpg has no ``lastrowid``) and SQLite
@@ -216,13 +219,13 @@ async def verify(session: AsyncSession, plaintext: str) -> VerifiedKey | None:
     prefix = _visible_prefix(plaintext)
     result = await session.execute(
         text(
-            "SELECT id, key_hash, tenant_id, name, revoked_at, role, scopes "
+            "SELECT id, key_hash, tenant_id, name, revoked_at, role, scopes, project_ids "
             "FROM api_keys WHERE key_prefix = :prefix"
         ),
         {"prefix": prefix},
     )
     for row in result:
-        key_id, stored_hash, tenant_id, name, revoked_at, role, scopes = (
+        key_id, stored_hash, tenant_id, name, revoked_at, role, scopes, project_ids = (
             row[0],
             row[1],
             row[2],
@@ -230,6 +233,7 @@ async def verify(session: AsyncSession, plaintext: str) -> VerifiedKey | None:
             row[4],
             row[5],
             row[6],
+            row[7],
         )
         if revoked_at is not None:
             continue
@@ -240,6 +244,7 @@ async def verify(session: AsyncSession, plaintext: str) -> VerifiedKey | None:
                 name=str(name),
                 role=str(role) if role is not None else "tenant",
                 scopes=str(scopes) if scopes is not None else "*",
+                project_ids=None if project_ids is None else str(project_ids),
             )
     return None
 

--- a/src/voicegateway/repository/api_keys_repository.py
+++ b/src/voicegateway/repository/api_keys_repository.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Final
 import bcrypt
 from sqlalchemy import text
 
-from voicegateway.core import scopes
+from voicegateway.core import scopes as scopes_mod
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -79,9 +79,9 @@ class VerifiedKey:
             return True
         if enforce:
             return False
-        if scopes.WILDCARD in granted:
+        if scopes_mod.WILDCARD in granted:
             return True
-        return required == scopes.INGEST and scopes.WRITE in granted
+        return required == scopes_mod.INGEST and scopes_mod.WRITE in granted
 
 
 def _generate_plaintext_key() -> str:
@@ -128,14 +128,27 @@ async def create_api_key(
     session: AsyncSession,
     *,
     name: str,
+    scopes: str,
     tenant_id: str | None = None,
     issued_by: str | None = None,
     role: str = "tenant",
-    scopes: str = "*",
 ) -> CreatedApiKey:
-    """Create a virtual key and return the plaintext once."""
+    """Create a virtual key and return the plaintext once.
+
+    ``scopes`` is required and explicit, and the wildcard is refused
+    (VG-SEC-006). ``*`` short-circuits every scope check, so a wildcard key
+    made enforcement inert while still reporting a scope list: the most
+    misleading of the three possible states.
+
+    The refusal lives here rather than in :meth:`VerifiedKey.has_scope`
+    because those are different populations. Refusing ``*`` at the check
+    would lock out every key already in the field; refusing it at the mint
+    means no new inert key can be created while the existing ones keep
+    working, warning on each use, until 0.27.0 withdraws them.
+    """
     if not name:
         raise ValueError("name must be non-empty")
+    scopes = scopes_mod.normalize_scopes(scopes)
     plaintext = _generate_plaintext_key()
     prefix = _visible_prefix(plaintext)
     digest = _hash_key(plaintext)
@@ -231,6 +244,39 @@ async def verify(session: AsyncSession, plaintext: str) -> VerifiedKey | None:
     return None
 
 
+async def list_wildcard_keys(session: AsyncSession) -> list[VerifiedKey]:
+    """Live keys still carrying the wildcard scope, for ``voicegw keys audit``.
+
+    These are the keys minted before 0.26.0. They still authorize everything
+    and will stop doing so in 0.27.0, so an operator needs a list of exactly
+    what to re-mint. Revoked keys are excluded: nobody needs to re-mint a key
+    that is already dead.
+
+    The three LIKE patterns catch ``*`` alone and ``*`` in any position of a
+    list. ``create_api_key`` now sorts and de-duplicates what it stores, but
+    these rows predate that and were written by hand or by the old default.
+    """
+    result = await session.execute(
+        text(
+            "SELECT id, tenant_id, name, role, scopes FROM api_keys "
+            "WHERE revoked_at IS NULL AND ("
+            "scopes = '*' OR scopes LIKE '%,*' OR scopes LIKE '*,%' "
+            "OR scopes LIKE '%,*,%') "
+            "ORDER BY id ASC"
+        )
+    )
+    return [
+        VerifiedKey(
+            id=int(row[0]),
+            tenant_id=None if row[1] is None else str(row[1]),
+            name=str(row[2]),
+            role=str(row[3]) if row[3] is not None else "tenant",
+            scopes=str(row[4]) if row[4] is not None else "*",
+        )
+        for row in result.all()
+    ]
+
+
 async def mark_used(session: AsyncSession, key_id: int) -> None:
     """Bump ``last_used_at`` to the current timestamp."""
     await session.execute(
@@ -290,6 +336,7 @@ __all__ = [
     "create_api_key",
     "get_by_id",
     "list_keys",
+    "list_wildcard_keys",
     "list_stale",
     "mark_used",
     "revoke",

--- a/src/voicegateway/repository/dead_air_repository.py
+++ b/src/voicegateway/repository/dead_air_repository.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import text
 
-from voicegateway.inference.session.context import current_tenant
 from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
 
 if TYPE_CHECKING:
@@ -25,10 +24,9 @@ async def create_event(
     session: AsyncSession,
     event: DeadAirEvent,
     *,
-    tenant_id: str | None = None,
+    tenant_id: str | None,
 ) -> None:
     """Insert one ``DeadAirEvent``. Commits the session."""
-    resolved = tenant_id if tenant_id is not None else current_tenant()
     await session.execute(
         _INSERT_EVENT,
         {
@@ -36,7 +34,7 @@ async def create_event(
             "started_at_ms": event.started_at_ms,
             "duration_ms": event.duration_ms,
             "threshold_used_ms": event.threshold_used_ms,
-            "tenant_id": resolved,
+            "tenant_id": tenant_id,
             "revision": event.revision,
         },
     )

--- a/src/voicegateway/repository/protocols.py
+++ b/src/voicegateway/repository/protocols.py
@@ -1,0 +1,77 @@
+"""Repository contracts, as ``typing.Protocol``.
+
+A module or object satisfies a Protocol structurally: it exposes the named
+methods. ``runtime_checkable`` lets a test assert conformance with
+``isinstance``, which checks attribute presence; mypy checks the signatures
+when a value is annotated with the Protocol type.
+
+Every method takes ``*, tenant_id`` as a required keyword. There is no
+fallback to a ContextVar and no fallback to a field on the row. That
+signature is VG-SEC-001 made structural: the defect was a writer preferring
+the payload's tenant over the caller's, which cannot be expressed when the
+caller's tenant is the only tenant the function accepts.
+
+Not here yet: a read-side Protocol over ``clickhouse/read_repository.py``.
+The spec assumed that module duplicated one SQL module's surface. Measured,
+its nine read functions map to five different SQL modules and two have no SQL
+counterpart at all, so no single module satisfies a combined Protocol. Wave 3
+owns putting ClickHouse behind an interface, and the shape of that interface
+is a decision for whoever does it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from voicegateway.telemetry.trace_schema import SpanRecord
+
+
+@runtime_checkable
+class TraceRepository(Protocol):
+    """Spans, events and links, tenant-scoped on every call.
+
+    Task 20's ``spans_repository`` is written against this from its first
+    commit, so the trace tables never exist in a state where a read could
+    forget to filter by tenant.
+    """
+
+    async def upsert_spans(
+        self, session: AsyncSession, records: list[SpanRecord], *, tenant_id: str
+    ) -> int:
+        """Insert or update spans under ``tenant_id``, returning how many landed.
+
+        ``tenant_id`` wins over anything the record carries. A ``SpanRecord``
+        has a ``correlation.tenant_id`` field that an untrusted payload can
+        set, and a receiver that stored it would be VG-SEC-001 again on a new
+        route (VG-SEC-015).
+        """
+        ...
+
+    async def get_trace(
+        self, session: AsyncSession, trace_id: str, *, tenant_id: str
+    ) -> list[dict[str, Any]]:
+        """Return every span of one trace, filtered to ``tenant_id``."""
+        ...
+
+    async def list_spans_by_session(
+        self, session: AsyncSession, session_id: str, *, tenant_id: str
+    ) -> list[dict[str, Any]]:
+        """Return the spans of one voice session, filtered to ``tenant_id``."""
+        ...
+
+    async def list_events(
+        self, session: AsyncSession, span_row_id: int, *, tenant_id: str
+    ) -> list[dict[str, Any]]:
+        """Return one span's events. Tenant-scoped so a row id cannot leak."""
+        ...
+
+    async def list_links(
+        self, session: AsyncSession, span_row_id: int, *, tenant_id: str
+    ) -> list[dict[str, Any]]:
+        """Return one span's links. Tenant-scoped so a row id cannot leak."""
+        ...
+
+
+__all__ = ["TraceRepository"]

--- a/src/voicegateway/repository/replay_repository.py
+++ b/src/voicegateway/repository/replay_repository.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import text
 
-from voicegateway.inference.session.context import current_tenant
 from voicegateway.middleware.replay_capture_middleware import ReplayEvent
 
 if TYPE_CHECKING:
@@ -55,12 +54,11 @@ async def bulk_write_events(
     session: AsyncSession,
     events: list[ReplayEvent],
     *,
-    tenant_id: str | None = None,
+    tenant_id: str | None,
 ) -> int:
     """Bulk-insert events into their per-modality tables."""
     if not events:
         return 0
-    resolved = tenant_id if tenant_id is not None else current_tenant()
 
     by_modality: dict[str, list[dict[str, Any]]] = {
         "stt": [],
@@ -80,7 +78,7 @@ async def bulk_write_events(
                     "session_id": ev.session_id,
                     "t_ms": ev.t_ms,
                     "payload": _payload_to_text(ev.payload),
-                    "tenant_id": resolved,
+                    "tenant_id": tenant_id,
                 }
             )
         else:
@@ -91,7 +89,7 @@ async def bulk_write_events(
                     "payload": _payload_to_text(ev.payload),
                     "provider": ev.provider,
                     "cost_usd": ev.cost_usd,
-                    "tenant_id": resolved,
+                    "tenant_id": tenant_id,
                 }
             )
 

--- a/src/voicegateway/repository/request_log_repository.py
+++ b/src/voicegateway/repository/request_log_repository.py
@@ -24,10 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import text
 
-from voicegateway.inference.session.context import (
-    current_routing_decision,
-    current_tenant,
-)
+from voicegateway.inference.session.context import current_routing_decision
 from voicegateway.repository import session_repository as session_repo
 
 if TYPE_CHECKING:
@@ -160,9 +157,11 @@ def _session_upsert_stmt(session: AsyncSession) -> Any:
     return _UPSERT_SESSION_BY_DIALECT.get(name, _UPSERT_SESSION_BY_DIALECT["sqlite"])
 
 
-async def log_request(session: AsyncSession, record: RequestRecord) -> None:
+async def log_request(
+    session: AsyncSession, record: RequestRecord, *, tenant_id: str | None
+) -> None:
     """Insert one request row + accumulate the session row (UPSERT)."""
-    request_tenant_id = current_tenant()
+    request_tenant_id = tenant_id
     await session.execute(
         _INSERT_REQUEST,
         {

--- a/src/voicegateway/repository/tool_calls_repository.py
+++ b/src/voicegateway/repository/tool_calls_repository.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import text
 
-from voicegateway.inference.session.context import current_tenant
 from voicegateway.models.tool_call_model import ToolCall
 
 if TYPE_CHECKING:
@@ -34,12 +33,11 @@ async def create_tool_calls(
     session: AsyncSession,
     rows: list[ToolCall],
     *,
-    tenant_id: str | None = None,
+    tenant_id: str | None,
 ) -> int:
     """Insert tool-call rows. Commits the session. Returns how many landed."""
     if not rows:
         return 0
-    resolved = tenant_id if tenant_id is not None else current_tenant()
     await session.execute(
         _INSERT,
         [
@@ -51,7 +49,7 @@ async def create_tool_calls(
                 "duration_ms": r.duration_ms,
                 "outcome": r.outcome,
                 "turn_index": r.turn_index,
-                "tenant_id": r.tenant_id if r.tenant_id is not None else resolved,
+                "tenant_id": tenant_id,
                 "revision": r.revision,
             }
             for r in rows

--- a/src/voicegateway/repository/transcript_turns_repository.py
+++ b/src/voicegateway/repository/transcript_turns_repository.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import text
 
-from voicegateway.inference.session.context import current_tenant
-
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -35,7 +33,7 @@ async def create_transcript_bulk(
     session_id: str,
     turns: list[tuple[str, str]],
     *,
-    tenant_id: str | None = None,
+    tenant_id: str | None,
 ) -> int:
     """Replace a session's transcript with ``turns`` (a list of (role, text)).
 
@@ -43,7 +41,6 @@ async def create_transcript_bulk(
     close handler that runs twice) is idempotent rather than doubling the
     transcript. ``seq`` is assigned from list order. Returns the count inserted.
     """
-    resolved = tenant_id if tenant_id is not None else current_tenant()
     await session.execute(
         text("DELETE FROM transcript_turns WHERE session_id = :session_id"),
         {"session_id": session_id},
@@ -57,7 +54,7 @@ async def create_transcript_bulk(
             "seq": i,
             "role": role,
             "text": body,
-            "tenant_id": resolved,
+            "tenant_id": tenant_id,
         }
         for i, (role, body) in enumerate(turns)
     ]

--- a/src/voicegateway/repository/turns_repository.py
+++ b/src/voicegateway/repository/turns_repository.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import text
 
-from voicegateway.inference.session.context import current_tenant
 from voicegateway.middleware.turn_tracker_middleware import TurnRow
 
 if TYPE_CHECKING:
@@ -52,11 +51,10 @@ async def create_turn(
     session: AsyncSession,
     turn: TurnRow,
     *,
-    tenant_id: str | None = None,
+    tenant_id: str | None,
 ) -> None:
     """Insert one ``TurnRow``. Commits the session."""
-    resolved = tenant_id if tenant_id is not None else current_tenant()
-    await session.execute(_INSERT_TURN, _turn_to_params(turn, resolved))
+    await session.execute(_INSERT_TURN, _turn_to_params(turn, tenant_id))
     await session.commit()
 
 
@@ -64,13 +62,12 @@ async def create_turns_bulk(
     session: AsyncSession,
     turns: list[TurnRow],
     *,
-    tenant_id: str | None = None,
+    tenant_id: str | None,
 ) -> int:
     """Bulk-insert turns. Returns the number inserted."""
     if not turns:
         return 0
-    resolved = tenant_id if tenant_id is not None else current_tenant()
-    await session.execute(_INSERT_TURN, [_turn_to_params(t, resolved) for t in turns])
+    await session.execute(_INSERT_TURN, [_turn_to_params(t, tenant_id) for t in turns])
     await session.commit()
     return len(turns)
 

--- a/src/voicegateway/schemas/api/api_key_schema.py
+++ b/src/voicegateway/schemas/api/api_key_schema.py
@@ -17,6 +17,7 @@ class ApiKeyCreate(BaseModel):
     scopes: str = Field(min_length=1)
     tenant_id: str | None = None
     issued_by: str | None = None
+    project_ids: tuple[str, ...] | None = None
 
 
 class ApiKeyResponse(BaseModel):
@@ -32,6 +33,7 @@ class ApiKeyResponse(BaseModel):
     issued_at: datetime
     last_used_at: datetime | None = None
     revoked_at: datetime | None = None
+    project_ids: str | None = None
 
 
 class CreatedApiKey(BaseModel):

--- a/src/voicegateway/schemas/api/api_key_schema.py
+++ b/src/voicegateway/schemas/api/api_key_schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ApiKeyCreate(BaseModel):
@@ -18,6 +18,19 @@ class ApiKeyCreate(BaseModel):
     tenant_id: str | None = None
     issued_by: str | None = None
     project_ids: tuple[str, ...] | None = None
+
+    @field_validator("project_ids")
+    @classmethod
+    def validate_project_ids(
+        cls, value: tuple[str, ...] | None
+    ) -> tuple[str, ...] | None:
+        if value == ():
+            raise ValueError(
+                "project_ids must be omitted or contain at least one project"
+            )
+        if value is not None and any("," in project_id for project_id in value):
+            raise ValueError("project_ids entries cannot contain commas")
+        return value
 
 
 class ApiKeyResponse(BaseModel):
@@ -33,7 +46,14 @@ class ApiKeyResponse(BaseModel):
     issued_at: datetime
     last_used_at: datetime | None = None
     revoked_at: datetime | None = None
-    project_ids: str | None = None
+    project_ids: tuple[str, ...] | None = None
+
+    @field_validator("project_ids", mode="before")
+    @classmethod
+    def decode_project_ids(cls, value: object) -> object:
+        if isinstance(value, str):
+            return tuple(item for item in value.split(",") if item)
+        return value
 
 
 class CreatedApiKey(BaseModel):

--- a/src/voicegateway/schemas/api/api_key_schema.py
+++ b/src/voicegateway/schemas/api/api_key_schema.py
@@ -11,6 +11,10 @@ class ApiKeyCreate(BaseModel):
     """Payload to mint a new api key."""
 
     name: str = Field(min_length=1, max_length=128)
+    #: Comma-separated and required. No default, because the default used to
+    #: be the wildcard and every key the product minted inherited it
+    #: (VG-SEC-006). A caller must now say what the key is for.
+    scopes: str = Field(min_length=1)
     tenant_id: str | None = None
     issued_by: str | None = None
 

--- a/src/voicegateway/schemas/config_schema.py
+++ b/src/voicegateway/schemas/config_schema.py
@@ -251,6 +251,16 @@ class ApiKeyEntry(_StrictBase):
 class AuthConfig(_StrictBase):
     api_keys: list[ApiKeyEntry] = Field(default_factory=list)
     cors_origins: list[str] = Field(default_factory=list)
+    #: Explicit local mode: unauthenticated requests are allowed and nothing
+    #: is logged about them. Refused at startup in the company of anything
+    #: production-shaped, so it cannot travel to a server inside a copied
+    #: config file. See ``core.auth.validate_auth_startup``.
+    local_development: bool = False
+    #: ``warn`` serves every request that would be refused and emits one
+    #: ``vg.auth.would_refuse`` event naming it, so an operator can see the
+    #: blast radius before anything breaks. ``enforce`` refuses. 0.26.0
+    #: defaults to warn; 0.27.0 defaults to enforce.
+    enforcement: Literal["warn", "enforce"] = "warn"
 
 
 class FallbackConfig(BaseModel):

--- a/src/voicegateway/schemas/telemetry/authorization_matrix.json
+++ b/src/voicegateway/schemas/telemetry/authorization_matrix.json
@@ -92,7 +92,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -102,7 +102,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -160,7 +160,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -170,7 +170,7 @@
       "tenant_scoped": false,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -180,7 +180,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -236,7 +236,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "POST",
@@ -246,7 +246,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "POST",
@@ -256,7 +256,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -282,7 +282,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -350,7 +350,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -676,7 +676,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -696,7 +696,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -764,7 +764,7 @@
       "tenant_scoped": true,
       "gap_id": "VG-SEC-002",
       "wave": 1,
-      "note": "Tenant is enforced; the project identifier is not authorized against the caller. No project column exists on api_keys."
+      "note": "Tenant is enforced; this legacy route does not yet apply the principal project allowlist."
     },
     {
       "method": "GET",
@@ -783,6 +783,78 @@
       "gap_id": "VG-SEC-004",
       "wave": 1,
       "note": "Answers an unauthenticated caller regardless of configured keys."
+    },
+    {
+      "method": "GET",
+      "path": "/api/accounting",
+      "auth": "principal",
+      "status": "enforced",
+      "tenant_scoped": true,
+      "note": "Tenant and optional project scope are derived from the authenticated principal; only selling totals are returned."
+    },
+    {
+      "method": "GET",
+      "path": "/v1/accounting/capabilities",
+      "auth": "principal",
+      "status": "enforced",
+      "tenant_scoped": false,
+      "note": "Static capability metadata contains no tenant data."
+    },
+    {
+      "method": "PUT",
+      "path": "/v1/accounting/ownership",
+      "auth": "principal",
+      "status": "enforced",
+      "tenant_scoped": true,
+      "note": "Operator-only ownership mutation; the target tenant is resolved from the authenticated principal or explicit operator filter."
+    },
+    {
+      "method": "POST",
+      "path": "/v1/accounting/prepare",
+      "auth": "scope:ingest",
+      "status": "enforced",
+      "tenant_scoped": true,
+      "note": "Tenant is server-derived and project allowlists are enforced before preparing a binding."
+    },
+    {
+      "method": "GET",
+      "path": "/v1/accounting/report",
+      "auth": "principal",
+      "status": "enforced",
+      "tenant_scoped": true,
+      "note": "Tenant and project filters are authorized; acquisition and margin require an operator principal."
+    },
+    {
+      "method": "POST",
+      "path": "/v1/accounting/revisions",
+      "auth": "principal",
+      "status": "enforced",
+      "tenant_scoped": true,
+      "note": "Operator-only immutable revision creation."
+    },
+    {
+      "method": "POST",
+      "path": "/v1/accounting/revisions/{side}/activate",
+      "auth": "principal",
+      "status": "enforced",
+      "tenant_scoped": true,
+      "note": "Operator-only scoped revision activation."
+    },
+    {
+      "method": "GET",
+      "path": "/v1/accounting/revisions/{side}/{revision_id}",
+      "auth": "principal",
+      "status": "enforced",
+      "tenant_scoped": true,
+      "note": "Acquisition content requires an operator; tenant selling reads remain tenant-scoped."
+    },
+    {
+      "method": "POST",
+      "path": "/v1/accounting/usage",
+      "auth": "scope:ingest",
+      "status": "enforced",
+      "tenant_scoped": true,
+      "note": "Tenant is always server-derived and project allowlists are enforced for every envelope."
     }
   ],
   "planned_routes": [

--- a/src/voicegateway/schemas/telemetry/authorization_matrix.json
+++ b/src/voicegateway/schemas/telemetry/authorization_matrix.json
@@ -403,10 +403,10 @@
     {
       "method": "POST",
       "path": "/v1/agents/heartbeat",
-      "auth": "scope:write",
+      "auth": "scope:ingest",
       "status": "enforced",
       "tenant_scoped": true,
-      "note": "Config mutation behind require_scope(\"write\")."
+      "note": "Telemetry ingest behind the ingest scope, which does not cover config mutation (closed VG-SEC-003)."
     },
     {
       "method": "GET",
@@ -539,10 +539,10 @@
     {
       "method": "POST",
       "path": "/v1/calls/observations",
-      "auth": "scope:write",
+      "auth": "scope:ingest",
       "status": "enforced",
       "tenant_scoped": true,
-      "note": "Config mutation behind require_scope(\"write\")."
+      "note": "Telemetry ingest behind the ingest scope, which does not cover config mutation (closed VG-SEC-003)."
     },
     {
       "method": "GET",
@@ -557,40 +557,34 @@
     {
       "method": "POST",
       "path": "/v1/ingest",
-      "auth": "scope:write",
-      "status": "gap",
+      "auth": "scope:ingest",
+      "status": "enforced",
       "tenant_scoped": true,
-      "gap_id": "VG-SEC-003",
-      "wave": 1,
-      "note": "Telemetry ingest gated by write, the same scope that guards config mutation. Needs a dedicated ingest scope."
+      "note": "Telemetry ingest behind the ingest scope, which does not cover config mutation (closed VG-SEC-003)."
     },
     {
       "method": "POST",
       "path": "/v1/ingest/dead-air",
-      "auth": "scope:write",
-      "status": "gap",
+      "auth": "scope:ingest",
+      "status": "enforced",
       "tenant_scoped": true,
-      "gap_id": "VG-SEC-003",
-      "wave": 1,
-      "note": "Telemetry ingest gated by write, the same scope that guards config mutation. Needs a dedicated ingest scope."
+      "note": "Telemetry ingest behind the ingest scope, which does not cover config mutation (closed VG-SEC-003)."
     },
     {
       "method": "POST",
       "path": "/v1/ingest/tool-calls",
-      "auth": "scope:write",
+      "auth": "scope:ingest",
       "status": "enforced",
       "tenant_scoped": true,
-      "note": "Tenant comes from the verified key, never the payload (closed VG-SEC-001). Still gated by the write scope rather than ingest until VG-SEC-003."
+      "note": "Telemetry ingest behind the ingest scope, which does not cover config mutation (closed VG-SEC-003). Tenant comes from the principal, never the payload (closed VG-SEC-001)."
     },
     {
       "method": "POST",
       "path": "/v1/ingest/turns",
-      "auth": "scope:write",
-      "status": "gap",
+      "auth": "scope:ingest",
+      "status": "enforced",
       "tenant_scoped": true,
-      "gap_id": "VG-SEC-003",
-      "wave": 1,
-      "note": "Telemetry ingest gated by write, the same scope that guards config mutation. Needs a dedicated ingest scope."
+      "note": "Telemetry ingest behind the ingest scope, which does not cover config mutation (closed VG-SEC-003)."
     },
     {
       "method": "GET",

--- a/src/voicegateway/schemas/telemetry/authorization_matrix.json
+++ b/src/voicegateway/schemas/telemetry/authorization_matrix.json
@@ -803,7 +803,7 @@
     {
       "method": "PUT",
       "path": "/v1/accounting/ownership",
-      "auth": "principal",
+      "auth": "principal+scope:admin",
       "status": "enforced",
       "tenant_scoped": true,
       "note": "Operator-only ownership mutation; the target tenant is resolved from the authenticated principal or explicit operator filter."
@@ -827,7 +827,7 @@
     {
       "method": "POST",
       "path": "/v1/accounting/revisions",
-      "auth": "principal",
+      "auth": "principal+scope:admin",
       "status": "enforced",
       "tenant_scoped": true,
       "note": "Operator-only immutable revision creation."
@@ -835,7 +835,7 @@
     {
       "method": "POST",
       "path": "/v1/accounting/revisions/{side}/activate",
-      "auth": "principal",
+      "auth": "principal+scope:admin",
       "status": "enforced",
       "tenant_scoped": true,
       "note": "Operator-only scoped revision activation."

--- a/src/voicegateway/schemas/telemetry/authorization_matrix.json
+++ b/src/voicegateway/schemas/telemetry/authorization_matrix.json
@@ -578,11 +578,9 @@
       "method": "POST",
       "path": "/v1/ingest/tool-calls",
       "auth": "scope:write",
-      "status": "gap",
+      "status": "enforced",
       "tenant_scoped": true,
-      "gap_id": "VG-SEC-001",
-      "wave": 1,
-      "note": "Live cross-tenant write: the payload's tenant_id overrides the tenant resolved from the key. Also gated by write rather than ingest (VG-SEC-003)."
+      "note": "Tenant comes from the verified key, never the payload (closed VG-SEC-001). Still gated by the write scope rather than ingest until VG-SEC-003."
     },
     {
       "method": "POST",

--- a/src/voicegateway/schemas/telemetry/security_schema.py
+++ b/src/voicegateway/schemas/telemetry/security_schema.py
@@ -66,7 +66,7 @@ class ScopeName(StrEnum):
     ADMIN = "admin"
     #: Matches every check. Every minted key defaults to this value.
     WILDCARD = "*"
-    #: Target. Does not exist: ingest is gated by ``write`` today.
+    #: Exists as of 0.26.0. Telemetry ingest only; never config mutation.
     INGEST = "ingest"
     #: Target. Does not exist: MCP auth is one shared static token.
     MCP_READ = "mcp:read"
@@ -74,11 +74,17 @@ class ScopeName(StrEnum):
 
 #: The scopes an unmodified checkout can actually enforce right now.
 EXISTING_SCOPES: frozenset[ScopeName] = frozenset(
-    {ScopeName.WRITE, ScopeName.READ, ScopeName.ADMIN, ScopeName.WILDCARD}
+    {
+        ScopeName.WRITE,
+        ScopeName.READ,
+        ScopeName.ADMIN,
+        ScopeName.WILDCARD,
+        ScopeName.INGEST,
+    }
 )
 
 #: The scopes Wave 1 must introduce. Asserted absent by the absence guards.
-PLANNED_SCOPES: frozenset[ScopeName] = frozenset({ScopeName.INGEST, ScopeName.MCP_READ})
+PLANNED_SCOPES: frozenset[ScopeName] = frozenset({ScopeName.MCP_READ})
 
 
 class PrincipalKind(StrEnum):

--- a/src/voicegateway/schemas/telemetry/security_schema.py
+++ b/src/voicegateway/schemas/telemetry/security_schema.py
@@ -119,6 +119,9 @@ class RouteAuth(StrEnum):
     SCOPE_WRITE = "scope:write"
     #: Guarded by ``require_scope("admin")``.
     SCOPE_ADMIN = "scope:admin"
+    #: Guarded by ``require_ingest_principal``, which enforces the ingest
+    #: scope and yields the Principal the handler writes rows under.
+    SCOPE_INGEST = "scope:ingest"
 
 
 class AuthorizationRule(BaseModel):

--- a/src/voicegateway/schemas/telemetry/security_schema.py
+++ b/src/voicegateway/schemas/telemetry/security_schema.py
@@ -48,6 +48,10 @@ class ContractStatus(StrEnum):
     GAP = "gap"
     #: No production surface exists yet. Carries an absence guard.
     PLANNED = "planned"
+    #: Production now meets the row. Threat-model entries only: the entry
+    #: stays as history and keeps its evidence line, while the matrix row
+    #: for the same route becomes ENFORCED with no gap id.
+    CLOSED = "closed"
 
 
 class ScopeName(StrEnum):
@@ -151,6 +155,12 @@ class AuthorizationRule(BaseModel):
             raise ValueError(
                 f"{self.method} {self.path}: a matrix row describes a route "
                 "that exists; use planned_routes for one that does not"
+            )
+        if self.status is ContractStatus.CLOSED:
+            raise ValueError(
+                f"{self.method} {self.path}: CLOSED belongs to the threat "
+                "model, which keeps a gap as history; the row for a closed "
+                "gap becomes ENFORCED with no gap_id"
             )
         if self.status is ContractStatus.ENFORCED:
             if self.gap_id is not None or self.wave is not None:
@@ -275,14 +285,35 @@ class ThreatEntry(BaseModel):
     #: Fixture file that exercises this gap, relative to the fixture root.
     #: ``None`` where the gap has no request-shaped expression.
     fixture: str | None = None
+    #: Release that closed the gap, e.g. ``0.26.0``. Required iff CLOSED.
+    closed_in: str | None = Field(default=None, pattern=r"^\d+\.\d+\.\d+$")
+    #: Commit that closed it. Required iff CLOSED.
+    closed_by: str | None = Field(default=None, pattern=r"^[0-9a-f]{7,40}$")
 
     @model_validator(mode="after")
-    def _planned_and_gap_only(self) -> ThreatEntry:
-        """The threat model records deviations, never satisfied guarantees."""
+    def _status_and_closure_agree(self) -> ThreatEntry:
+        """Enforced guarantees live in the matrix; closed gaps stay as history.
+
+        A closed entry is never deleted: the docs page cites gap ids verbatim
+        and the keystone test asserts the minted set is contiguous from
+        VG-SEC-001, so removing one would break both. It keeps its evidence
+        line and gains a receipt: which release closed it, and which commit.
+        """
         if self.status is ContractStatus.ENFORCED:
             raise ValueError(
-                f"{self.gap_id}: the threat model holds gap and planned rows "
-                "only; an enforced guarantee belongs in the matrix"
+                f"{self.gap_id}: the threat model holds gap, planned and closed "
+                "rows only; an enforced guarantee belongs in the matrix"
+            )
+        has_closure = self.closed_in is not None or self.closed_by is not None
+        if self.status is ContractStatus.CLOSED:
+            if self.closed_in is None or self.closed_by is None:
+                raise ValueError(
+                    f"{self.gap_id}: a closed entry needs closed_in and closed_by"
+                )
+            return self
+        if has_closure:
+            raise ValueError(
+                f"{self.gap_id}: only a closed entry carries closed_in or closed_by"
             )
         return self
 
@@ -300,8 +331,20 @@ class ThreatModel(RootModel[list[ThreatEntry]]):
         return self
 
     def gap_ids(self) -> set[str]:
-        """Return the full set of minted gap ids."""
+        """Return the full set of minted gap ids, closed ones included.
+
+        Deliberately complete: the contiguity pin and the docs cross-reference
+        both check against every id ever minted, not just the open ones.
+        """
         return {entry.gap_id for entry in self.root}
+
+    def open_gap_ids(self) -> set[str]:
+        """Return the ids still open. This is the remaining work."""
+        return {
+            entry.gap_id
+            for entry in self.root
+            if entry.status is not ContractStatus.CLOSED
+        }
 
     def by_gap_id(self) -> dict[str, ThreatEntry]:
         """Index the entries by gap id."""

--- a/src/voicegateway/schemas/telemetry/security_schema.py
+++ b/src/voicegateway/schemas/telemetry/security_schema.py
@@ -315,45 +315,56 @@ class ThreatModel(RootModel[list[ThreatEntry]]):
 class ContentState(StrEnum):
     """Lifecycle of stored call content (transcripts, replay audio).
 
+    The five states are the roadmap's frozen vocabulary; Waves 3 and 4
+    enumerate them verbatim, so this module does not get to invent its own.
     :attr:`UNAVAILABLE` is the projection an unauthorized caller sees. It is
     deliberately indistinguishable from every other state, which is why
     :class:`ContentDescriptor` forbids byte counts and expiry on it.
     """
 
-    #: Announced by an agent, not yet durable.
-    PENDING = "pending"
     #: Durable and retrievable by an authorized caller.
-    STORED = "stored"
-    #: Content removed, metadata retained deliberately.
+    CAPTURED = "captured"
+    #: Content removed by policy, metadata retained deliberately.
     REDACTED = "redacted"
+    #: Captured but cut at a size limit. The state records the cut, so a
+    #: partial transcript is never served as though it were complete.
+    TRUNCATED = "truncated"
     #: Content removed by retention. Metadata may survive.
-    PURGED = "purged"
+    EXPIRED = "expired"
     #: The caller may not learn whether this content exists.
     UNAVAILABLE = "unavailable"
 
 
-#: One-way lifecycle. Content never moves back toward a richer state, so a
-#: purged recording can never be resurrected by a later ingest replaying an
-#: older revision. Every state may collapse to ``UNAVAILABLE`` because that
-#: is an authorization projection rather than a storage event.
+#: One-way lifecycle. Content never moves back toward a richer state, so an
+#: expired recording can never be resurrected by a later ingest replaying an
+#: older revision, and a truncation is never silently un-cut. Every state may
+#: collapse to ``UNAVAILABLE`` because that is an authorization projection
+#: rather than a storage event.
 CONTENT_STATE_TRANSITIONS: Mapping[ContentState, frozenset[ContentState]] = {
-    ContentState.PENDING: frozenset(
-        {ContentState.STORED, ContentState.PURGED, ContentState.UNAVAILABLE}
+    ContentState.CAPTURED: frozenset(
+        {
+            ContentState.TRUNCATED,
+            ContentState.REDACTED,
+            ContentState.EXPIRED,
+            ContentState.UNAVAILABLE,
+        }
     ),
-    ContentState.STORED: frozenset(
-        {ContentState.REDACTED, ContentState.PURGED, ContentState.UNAVAILABLE}
+    ContentState.TRUNCATED: frozenset(
+        {ContentState.REDACTED, ContentState.EXPIRED, ContentState.UNAVAILABLE}
     ),
-    ContentState.REDACTED: frozenset({ContentState.PURGED, ContentState.UNAVAILABLE}),
-    ContentState.PURGED: frozenset({ContentState.UNAVAILABLE}),
+    ContentState.REDACTED: frozenset({ContentState.EXPIRED, ContentState.UNAVAILABLE}),
+    ContentState.EXPIRED: frozenset({ContentState.UNAVAILABLE}),
     ContentState.UNAVAILABLE: frozenset(),
 }
 
-#: States in which no plaintext may be returned to any caller.
+#: States in which no plaintext may be returned to any caller as though it
+#: were whole. ``TRUNCATED`` is in here deliberately: its partial bytes are
+#: served through the redaction policy, never as plain captured content.
 NON_READABLE_CONTENT_STATES: frozenset[ContentState] = frozenset(
     {
-        ContentState.PENDING,
         ContentState.REDACTED,
-        ContentState.PURGED,
+        ContentState.TRUNCATED,
+        ContentState.EXPIRED,
         ContentState.UNAVAILABLE,
     }
 )

--- a/src/voicegateway/schemas/telemetry/security_schema.py
+++ b/src/voicegateway/schemas/telemetry/security_schema.py
@@ -121,6 +121,8 @@ class RouteAuth(StrEnum):
     OPEN = "open"
     #: Guarded by ``require_principal``.
     PRINCIPAL = "principal"
+    #: Guarded by both ``require_principal`` and ``require_scope("admin")``.
+    PRINCIPAL_SCOPE_ADMIN = "principal+scope:admin"
     #: Guarded by ``require_scope("write")``.
     SCOPE_WRITE = "scope:write"
     #: Guarded by ``require_scope("admin")``.

--- a/src/voicegateway/schemas/telemetry/threat_model.json
+++ b/src/voicegateway/schemas/telemetry/threat_model.json
@@ -59,11 +59,13 @@
     "gap_id": "VG-SEC-006",
     "threat": "VG-THREAT-004",
     "title": "Every minted key defaults to the wildcard scope",
-    "description": "create_api_key defaults scopes to \"*\", and has_scope short-circuits on the wildcard before comparing the required scope. Scope enforcement is therefore inert for every key the product mints through its own API: the checks run and always pass.",
-    "status": "gap",
+    "description": "create_api_key defaults scopes to \"*\", and has_scope short-circuits on the wildcard before comparing the required scope. Scope enforcement is therefore inert for every key the product mints through its own API: the checks run and always pass. CLOSED in 0.26.0: scopes is a required argument at all three mints (voicegw keys create, POST /v1/api-keys, POST /api/api_keys), all three validate through core.scopes.normalize_scopes, and the wildcard is refused there. has_scope still honours an existing wildcard key so an upgrade does not lock anyone out, every such use logs a warning naming the key id, and voicegw keys audit lists them and exits non-zero. The grant stops under auth.enforcement == \"enforce\" and is withdrawn in 0.27.0.",
+    "status": "closed",
     "wave": 1,
-    "evidence": "src/voicegateway/repository/api_keys_repository.py:121",
-    "fixture": null
+    "evidence": "src/voicegateway/core/scopes.py:41",
+    "fixture": null,
+    "closed_in": "0.26.0",
+    "closed_by": "f6d2ec3e"
   },
   {
     "gap_id": "VG-SEC-007",

--- a/src/voicegateway/schemas/telemetry/threat_model.json
+++ b/src/voicegateway/schemas/telemetry/threat_model.json
@@ -3,11 +3,13 @@
     "gap_id": "VG-SEC-001",
     "threat": "VG-THREAT-001",
     "title": "Tool-call ingest lets the payload override the authenticated tenant",
-    "description": "POST /v1/ingest/tool-calls admits tenant_id through the field allow-list, and the repository prefers the payload value over the tenant resolved from the API key. A key scoped to tenant A can therefore write rows tagged tenant B. The sibling writers are safe: turns and dead-air apply one tenant resolved from the function argument to every row, and log_request reads current_tenant() and ignores the payload entirely. The comment above the allow-list already argues that an agent-supplied primary key would let one agent overwrite another's row, which is the same argument that should have excluded tenant_id.",
-    "status": "gap",
+    "description": "POST /v1/ingest/tool-calls admits tenant_id through the field allow-list, and the repository prefers the payload value over the tenant resolved from the API key. A key scoped to tenant A can therefore write rows tagged tenant B. The sibling writers are safe: turns and dead-air apply one tenant resolved from the function argument to every row, and log_request reads current_tenant() and ignores the payload entirely. The comment above the allow-list already argues that an agent-supplied primary key would let one agent overwrite another's row, which is the same argument that should have excluded tenant_id. CLOSED in 0.26.0: create_tool_calls takes tenant_id as a required keyword and no longer reads the field off the row, and the same signature change went to all seven writers so no write decides tenancy from ambient state.",
+    "status": "closed",
     "wave": 1,
     "evidence": "src/voicegateway/repository/tool_calls_repository.py:54",
-    "fixture": "ingest_tool_calls_tenant_override.json"
+    "fixture": "ingest_tool_calls_tenant_override.json",
+    "closed_in": "0.26.0",
+    "closed_by": "f9a86001"
   },
   {
     "gap_id": "VG-SEC-002",

--- a/src/voicegateway/schemas/telemetry/threat_model.json
+++ b/src/voicegateway/schemas/telemetry/threat_model.json
@@ -25,11 +25,13 @@
     "gap_id": "VG-SEC-003",
     "threat": "VG-THREAT-004",
     "title": "No ingest scope: telemetry ingest and config mutation share write",
-    "description": "Ingest routes are gated by require_scope(\"write\"), the same scope that guards provider, model and project mutation across 18 routes in total. An agent key that only needs to post telemetry can therefore rewrite gateway configuration. Splitting the scope is semantic rather than a rename, which is why it is recorded before the endpoints multiply.",
-    "status": "planned",
+    "description": "Ingest routes are gated by require_scope(\"write\"), the same scope that guards provider, model and project mutation across 18 routes in total. An agent key that only needs to post telemetry can therefore rewrite gateway configuration. Splitting the scope is semantic rather than a rename, which is why it is recorded before the endpoints multiply. CLOSED in 0.26.0: the six telemetry ingest routes moved behind require_ingest_principal, which enforces a dedicated ingest scope and hands the handler the Principal it stamps rows with. Write now covers 12 routes, all config mutation. Two compatibility grants remain until 0.27.0 and both stop under auth.enforcement == \"enforce\": write covers ingest (logged per request with the key id), and the wildcard covers everything.",
+    "status": "closed",
     "wave": 1,
-    "evidence": "src/voicegateway/server/api/ingest.py:91",
-    "fixture": null
+    "evidence": "src/voicegateway/server/api/_deps.py:244",
+    "fixture": null,
+    "closed_in": "0.26.0",
+    "closed_by": "6548175a"
   },
   {
     "gap_id": "VG-SEC-004",

--- a/src/voicegateway/schemas/telemetry/threat_model.json
+++ b/src/voicegateway/schemas/telemetry/threat_model.json
@@ -15,8 +15,8 @@
     "gap_id": "VG-SEC-002",
     "threat": "VG-THREAT-003",
     "title": "Project-level authorization does not exist in any form",
-    "description": "There is no tenant_id on managed_projects, no project column on api_keys, no project field on Principal, and no check on the project query parameter. resolve_read_tenant narrows a read to a tenant and stops there, so any caller who clears the tenant gate sees every project within it.",
-    "status": "planned",
+    "description": "PARTIALLY CLOSED by exact accounting: API keys and principals now carry optional project allowlists, and accounting ingest and report routes enforce them. Legacy project-filtered reads still do not apply the allowlist, so a caller who clears the tenant gate may select another project within that tenant.",
+    "status": "gap",
     "wave": 1,
     "evidence": "src/voicegateway/server/api/_deps.py:183",
     "fixture": "project_param_unscoped.json"

--- a/src/voicegateway/schemas/telemetry/threat_model.json
+++ b/src/voicegateway/schemas/telemetry/threat_model.json
@@ -45,11 +45,13 @@
     "gap_id": "VG-SEC-005",
     "threat": "VG-THREAT-002",
     "title": "Absence of a credential resolves to a full admin principal",
-    "description": "When no API keys are configured, require_principal returns _OPERATOR, an admin principal with no tenant binding. This is the deliberate self-hosted default and tests/server/test_auth.py pins it, but it means the difference between a locked deployment and an open one is a config block rather than a code path.",
-    "status": "gap",
-    "wave": 2,
+    "description": "When no API keys are configured, require_principal returns _OPERATOR, an admin principal with no tenant binding. This is the deliberate self-hosted default and tests/server/test_auth.py pins it, but it means the difference between a locked deployment and an open one is a config block rather than a code path. CLOSED in 0.26.0: with no keys configured and no credential, require_principal refuses under enforce and serves with a vg.auth.would_refuse warning under warn. Only auth.local_development, which is refused alongside production-shaped config, makes it silent. Moved to wave 1 to match the roadmap, whose first Wave 1 bullet is 'require authenticated principals outside explicit local-development mode'.",
+    "status": "closed",
+    "wave": 1,
     "evidence": "src/voicegateway/server/api/_deps.py:146",
-    "fixture": null
+    "fixture": null,
+    "closed_in": "0.26.0",
+    "closed_by": "1ec564f7"
   },
   {
     "gap_id": "VG-SEC-006",

--- a/src/voicegateway/server/api/_authz.py
+++ b/src/voicegateway/server/api/_authz.py
@@ -1,0 +1,81 @@
+"""The one place the enforcement mode is consulted.
+
+Every gate computes whether it *would* refuse a request, then asks
+:func:`decide` what to do about that. Under ``warn`` the request proceeds and
+one structured event names it; under ``enforce`` it is refused; under
+``local_development`` it proceeds silently because that is what the operator
+explicitly asked for.
+
+No gate branches on the mode itself. That is what makes flipping 0.27.0 to
+enforce a default change rather than a code change, and what stops one gate
+quietly disagreeing with another about what warn means.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+    from voicegateway.core.config import AuthConfig
+    from voicegateway.schemas.telemetry.security_schema import PrincipalKind
+
+_logger = logging.getLogger("voicegateway.auth")
+
+#: Log event name. Operators grep for this during the warn release, so it is
+#: a stable string and not an f-string that varies per call site.
+WOULD_REFUSE_EVENT = "vg.auth.would_refuse"
+
+
+class Decision(StrEnum):
+    """What a gate should do, once the mode has been taken into account."""
+
+    #: Proceed. Either nothing was wrong, or local development is on.
+    ALLOW = "allow"
+    #: Proceed, but this would be refused under enforce. Logged and counted.
+    WARN = "warn"
+    #: Refuse. The caller raises the appropriate 401 or 403.
+    REFUSE = "refuse"
+
+
+def decide(
+    *,
+    would_refuse: bool,
+    reason: str,
+    auth: AuthConfig,
+    request: Request,
+    principal_kind: PrincipalKind,
+    key_id: int | None,
+) -> Decision:
+    """Turn a would-be refusal into the mode's decision, with side effects.
+
+    ``reason`` is a short machine-ish phrase, never a message built from
+    request content: this line goes to the operator's log, and an auth
+    warning that echoes a payload is a new leak rather than a diagnostic.
+    """
+    if not would_refuse:
+        return Decision.ALLOW
+    if auth.local_development:
+        return Decision.ALLOW
+    if auth.enforcement == "enforce":
+        return Decision.REFUSE
+
+    state = request.app.state
+    state.auth_would_refuse = getattr(state, "auth_would_refuse", 0) + 1
+    _logger.warning(
+        "%s route=%s %s reason=%r principal_kind=%s key_id=%s "
+        "(served under auth.enforcement=warn; refused under enforce)",
+        WOULD_REFUSE_EVENT,
+        request.method,
+        request.url.path,
+        reason,
+        principal_kind.value,
+        key_id,
+    )
+    return Decision.WARN
+
+
+__all__ = ["WOULD_REFUSE_EVENT", "Decision", "decide"]

--- a/src/voicegateway/server/api/_deps.py
+++ b/src/voicegateway/server/api/_deps.py
@@ -14,6 +14,7 @@ Two top-level helpers:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -21,6 +22,7 @@ from typing import TYPE_CHECKING, cast
 from fastapi import Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from voicegateway.core import scopes
 from voicegateway.core.auth import (
     ADMIN_SCOPE,
     AuthError,
@@ -32,6 +34,8 @@ from voicegateway.inference.session.context import set_tenant
 from voicegateway.repository import api_keys_repository as api_keys_repo
 from voicegateway.schemas.telemetry.security_schema import PrincipalKind
 from voicegateway.server.api._authz import Decision, decide
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
@@ -237,6 +241,82 @@ async def require_principal(request: Request) -> Principal:
     return _OPERATOR
 
 
+async def require_ingest_principal(request: Request) -> Principal:
+    """Resolve the principal for a telemetry write, requiring ``ingest``.
+
+    Ingest is deliberately narrower than write (VG-SEC-003): an agent key
+    that only posts telemetry must not also be able to rewrite provider,
+    model and project configuration, which is what sharing one ``write``
+    scope across both meant.
+
+    Yields a :class:`Principal` rather than returning ``None`` like
+    ``require_scope``, because the handler needs ``principal.tenant_id`` to
+    stamp on every row it writes. That is the other half of VG-SEC-001: the
+    tenant has to come from the credential, and the handler has to be handed
+    it rather than going looking.
+    """
+    gateway: Gateway = get_gateway(request)
+    auth_cfg = gateway.config.auth
+    api_keys = getattr(request.app.state, "api_keys", None) or []
+    authorization = request.headers.get("Authorization")
+    enforce = auth_cfg.enforcement == "enforce"
+
+    if is_api_key_token(authorization) and gateway.storage is not None:
+
+        def _authorize(verified: VerifiedKey) -> None:
+            if not verified.has_scope(scopes.INGEST, enforce=enforce):
+                raise AuthError(
+                    f"Token missing required scope: {scopes.INGEST}",
+                    status_code=403,
+                )
+            granted = {s.strip() for s in verified.scopes.split(",") if s.strip()}
+            if scopes.INGEST not in granted and scopes.WRITE in granted:
+                _logger.warning(
+                    "write scope used for ingest by key_id=%s on %s %s; mint an "
+                    "ingest key before 0.27.0, when write stops covering it",
+                    verified.id,
+                    request.method,
+                    request.url.path,
+                )
+
+        verified = await _verify_vk_key(request, gateway, _authorize)
+        return Principal(
+            tenant_id=verified.tenant_id,
+            is_admin=(verified.role == ADMIN_SCOPE),
+            api_key_id=verified.id,
+            kind=(
+                PrincipalKind.ADMIN_KEY
+                if verified.role == ADMIN_SCOPE
+                else PrincipalKind.TENANT_KEY
+            ),
+        )
+
+    try:
+        check_request(authorization, scopes.INGEST, api_keys)
+    except AuthError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from None
+
+    if api_keys:
+        return Principal(
+            tenant_id=None,
+            is_admin=True,
+            api_key_id=None,
+            kind=PrincipalKind.STATIC_KEY,
+        )
+
+    decision = decide(
+        would_refuse=True,
+        reason=f"no credential for scope {scopes.INGEST}",
+        auth=auth_cfg,
+        request=request,
+        principal_kind=PrincipalKind.OPERATOR,
+        key_id=None,
+    )
+    if decision is Decision.REFUSE:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return _OPERATOR
+
+
 def resolve_read_tenant(principal: Principal, requested: str | None) -> str | None:
     """Derive the tenant a read may touch from the authenticated principal.
 
@@ -262,6 +342,7 @@ __all__ = [
     "Principal",
     "get_gateway",
     "get_session",
+    "require_ingest_principal",
     "require_principal",
     "require_scope",
     "resolve_read_tenant",

--- a/src/voicegateway/server/api/_deps.py
+++ b/src/voicegateway/server/api/_deps.py
@@ -14,11 +14,12 @@ Two top-level helpers:
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from fastapi import Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from voicegateway.core.auth import (
     ADMIN_SCOPE,
@@ -44,6 +45,24 @@ def get_gateway(request: Request) -> Gateway:
     return cast("Gateway", gw)
 
 
+async def get_session(
+    gateway: Gateway = Depends(get_gateway),
+) -> AsyncGenerator[AsyncSession, None]:
+    """Yield a database session for the duration of one request.
+
+    Delegates to :meth:`StorageService.session`, which is the only public
+    path to a session and which runs migrations before yielding. Routes
+    declare ``session: AsyncSession = Depends(get_session)`` and never touch
+    storage internals, so there is exactly one place between a handler and
+    the database for a tenant guard to sit.
+    """
+    storage = gateway.storage
+    if storage is None:
+        raise HTTPException(status_code=503, detail="cost tracking storage is disabled")
+    async with storage.session() as session:
+        yield session
+
+
 async def _verify_vk_key(
     request: Request,
     gateway: Gateway,
@@ -63,14 +82,13 @@ async def _verify_vk_key(
     if storage is None:  # pragma: no cover - callers guard storage is not None
         raise HTTPException(status_code=503, detail="cost tracking storage is disabled")
     try:
-        await storage._ensure_initialized()
-        async with storage._conn.session() as session:
+        async with storage.session() as session:
             verified = await verify_api_key(authorization, session)
         if authorize is not None:
             result = authorize(verified)
             if result is not None:
                 await result
-        async with storage._conn.session() as session:
+        async with storage.session() as session:
             await api_keys_repo.mark_used(session, verified.id)
     except AuthError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from None
@@ -217,6 +235,7 @@ __all__ = [
     "Depends",
     "Principal",
     "get_gateway",
+    "get_session",
     "require_principal",
     "require_scope",
     "resolve_read_tenant",

--- a/src/voicegateway/server/api/_deps.py
+++ b/src/voicegateway/server/api/_deps.py
@@ -214,6 +214,11 @@ async def require_principal(request: Request) -> Principal:
             tenant_id=verified.tenant_id,
             is_admin=(verified.role == ADMIN_SCOPE),
             api_key_id=verified.id,
+            project_ids=(
+                frozenset(x for x in (verified.project_ids or "").split(",") if x)
+                if verified.project_ids is not None
+                else None
+            ),
             kind=(
                 PrincipalKind.ADMIN_KEY
                 if verified.role == ADMIN_SCOPE
@@ -296,6 +301,11 @@ async def require_ingest_principal(request: Request) -> Principal:
             tenant_id=verified.tenant_id,
             is_admin=(verified.role == ADMIN_SCOPE),
             api_key_id=verified.id,
+            project_ids=(
+                frozenset(x for x in (verified.project_ids or "").split(",") if x)
+                if verified.project_ids is not None
+                else None
+            ),
             kind=(
                 PrincipalKind.ADMIN_KEY
                 if verified.role == ADMIN_SCOPE

--- a/src/voicegateway/server/api/_deps.py
+++ b/src/voicegateway/server/api/_deps.py
@@ -29,6 +29,7 @@ from voicegateway.core.auth import (
 )
 from voicegateway.inference.session.context import set_tenant
 from voicegateway.repository import api_keys_repository as api_keys_repo
+from voicegateway.schemas.telemetry.security_schema import PrincipalKind
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
@@ -126,18 +127,25 @@ READ_SCOPE = "read"
 
 @dataclass(frozen=True)
 class Principal:
-    """The authenticated identity behind a read request.
+    """The authenticated identity behind a request.
 
     - ``tenant_id``: the tenant this caller is bound to, or ``None`` for an
       operator/admin who sees every tenant.
     - ``is_admin``: True for an admin vk_ key (role == "admin") or the soft
       operator default (no credential / static config key).
     - ``api_key_id``: the vk_ key id when one authenticated, else ``None``.
+    - ``project_ids``: the projects this key may touch, or ``None`` for
+      unrestricted within its tenant. Loaded from ``api_keys.project_ids``
+      in Task 14; ``None`` until then, which is what every existing key gets.
+    - ``kind``: which auth branch produced this principal. Carried so an
+      audit record can say what authenticated, not just who.
     """
 
     tenant_id: str | None
     is_admin: bool
     api_key_id: int | None
+    project_ids: frozenset[str] | None = None
+    kind: PrincipalKind = PrincipalKind.OPERATOR
 
 
 # The soft default for the self-hosted operator: no credential (or a static
@@ -171,6 +179,11 @@ async def require_principal(request: Request) -> Principal:
             tenant_id=verified.tenant_id,
             is_admin=(verified.role == ADMIN_SCOPE),
             api_key_id=verified.id,
+            kind=(
+                PrincipalKind.ADMIN_KEY
+                if verified.role == ADMIN_SCOPE
+                else PrincipalKind.TENANT_KEY
+            ),
         )
 
     try:

--- a/src/voicegateway/server/api/_deps.py
+++ b/src/voicegateway/server/api/_deps.py
@@ -89,6 +89,18 @@ async def _verify_vk_key(
     try:
         async with storage.session() as session:
             verified = await verify_api_key(authorization, session)
+        if scopes.WILDCARD in verified.scopes.split(","):
+            # Every key minted before 0.26.0 lands here (VG-SEC-006). Warning
+            # at verification rather than inside one gate covers all of them:
+            # require_scope, require_principal and require_ingest_principal
+            # share this function, and a wildcard key is equally inert on any.
+            _logger.warning(
+                "wildcard-scoped key_id=%s used on %s %s; re-mint with explicit "
+                "scopes before 0.27.0 (run: voicegw keys audit)",
+                verified.id,
+                request.method,
+                request.url.path,
+            )
         if authorize is not None:
             result = authorize(verified)
             if result is not None:

--- a/src/voicegateway/server/api/_deps.py
+++ b/src/voicegateway/server/api/_deps.py
@@ -31,6 +31,7 @@ from voicegateway.core.auth import (
 from voicegateway.inference.session.context import set_tenant
 from voicegateway.repository import api_keys_repository as api_keys_repo
 from voicegateway.schemas.telemetry.security_schema import PrincipalKind
+from voicegateway.server.api._authz import Decision, decide
 
 if TYPE_CHECKING:
     from voicegateway.core.gateway import Gateway
@@ -208,6 +209,31 @@ async def require_principal(request: Request) -> Principal:
         check_request(authorization, READ_SCOPE, api_keys)
     except AuthError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from None
+
+    if api_keys:
+        # A configured static key matched, or check_request would have raised.
+        # The operator who writes the config is the operator.
+        return Principal(
+            tenant_id=None,
+            is_admin=True,
+            api_key_id=None,
+            kind=PrincipalKind.STATIC_KEY,
+        )
+
+    # No keys configured and no credential presented. This is VG-SEC-005: the
+    # difference between a locked deployment and an open one used to be a
+    # config block rather than a code path, and the code path silently handed
+    # out a full admin.
+    decision = decide(
+        would_refuse=True,
+        reason="no credential and no api_keys configured",
+        auth=gateway.config.auth,
+        request=request,
+        principal_kind=PrincipalKind.OPERATOR,
+        key_id=None,
+    )
+    if decision is Decision.REFUSE:
+        raise HTTPException(status_code=401, detail="Authentication required")
     return _OPERATOR
 
 

--- a/src/voicegateway/server/api/accounting.py
+++ b/src/voicegateway/server/api/accounting.py
@@ -10,11 +10,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from voicegateway.accounting.contracts import (
     AccountingCapabilities,
+    OwnershipAssignment,
+    PreparationRequest,
+    PricingBinding,
     PricingRevisionCreate,
     PricingSide,
     UsageBatchResponse,
     UsageEnvelope,
 )
+from voicegateway.repository.request_log_repository import log_audit_event
 from voicegateway.server.api._deps import (
     Principal,
     get_session,
@@ -29,6 +33,7 @@ router = APIRouter(prefix="/accounting", tags=["accounting"])
 class ActivationRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
     revision_id: str
+    expected_current_revision_id: str | None = None
 
 
 def _tenant(principal: Principal, requested: str | None = None) -> str:
@@ -74,9 +79,10 @@ async def create_revision(
 ) -> dict[str, object]:
     if not principal.is_admin:
         raise HTTPException(status_code=403, detail="operator_required")
-    service = AccountingService(
-        session, tenant_id=_tenant(principal, tenant or payload.scope.tenant_id)
-    )
+    target_tenant = _tenant(principal, tenant or payload.scope.tenant_id)
+    if payload.scope.tenant_id is not None and payload.scope.tenant_id != target_tenant:
+        raise HTTPException(status_code=422, detail="scope_tenant_mismatch")
+    service = AccountingService(session, tenant_id=target_tenant)
     try:
         row, created = await service.create_revision(payload)
     except RevisionConflict as exc:
@@ -85,6 +91,14 @@ async def create_revision(
         ) from exc
     result = _revision_response(row, include_content=True)
     result["created"] = created
+    await log_audit_event(
+        session,
+        "pricing_revision",
+        payload.revision_id,
+        "create" if created else "idempotent_create",
+        {"side": payload.side.value, "content_hash": row.content_hash},
+        "accounting_api",
+    )
     return result
 
 
@@ -102,6 +116,15 @@ async def get_revision(
     row = await service.get_revision(side, revision_id)
     if row is None:
         raise HTTPException(status_code=404, detail="revision_not_found")
+    if side is PricingSide.ACQUISITION:
+        await log_audit_event(
+            session,
+            "pricing_revision",
+            revision_id,
+            "read_acquisition",
+            {"tenant": _tenant(principal, tenant)},
+            "accounting_api",
+        )
     return _revision_response(row, include_content=principal.is_admin)
 
 
@@ -117,12 +140,51 @@ async def activate_revision(
         raise HTTPException(status_code=403, detail="operator_required")
     service = AccountingService(session, tenant_id=_tenant(principal, tenant))
     try:
-        row = await service.activate_revision(side, payload.revision_id)
+        row = await service.activate_revision(
+            side,
+            payload.revision_id,
+            expected_current_revision_id=payload.expected_current_revision_id,
+        )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail="revision_not_found") from exc
     except RevisionConflict as exc:
         raise HTTPException(status_code=409, detail="revision_hash_mismatch") from exc
+    await log_audit_event(
+        session,
+        "pricing_revision",
+        payload.revision_id,
+        "activate",
+        {"side": side.value},
+        "accounting_api",
+    )
     return _revision_response(row, include_content=True)
+
+
+@router.put("/ownership")
+async def set_ownership(
+    payload: OwnershipAssignment,
+    tenant: str | None = Query(None),
+    principal: Principal = Depends(require_principal),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    if not principal.is_admin:
+        raise HTTPException(status_code=403, detail="operator_required")
+    row = await AccountingService(
+        session, tenant_id=_tenant(principal, tenant)
+    ).set_ownership(payload)
+    return {"project_id": row.project_id, "component": row.component, "mode": row.mode}
+
+
+@router.post("/prepare", response_model=PricingBinding)
+async def prepare(
+    payload: PreparationRequest,
+    principal: Principal = Depends(require_ingest_principal),
+    session: AsyncSession = Depends(get_session),
+) -> PricingBinding:
+    _project(principal, payload.project_id)
+    return await AccountingService(session, tenant_id=_tenant(principal)).prepare(
+        payload
+    )
 
 
 @router.post("/usage", response_model=UsageBatchResponse)
@@ -145,11 +207,32 @@ async def ingest_usage(
 async def report(
     project: str | None = Query(None),
     tenant: str | None = Query(None),
+    group_by: list[str] = Query(default=[]),
+    include_acquisition: bool = Query(False),
     principal: Principal = Depends(require_principal),
     session: AsyncSession = Depends(get_session),
 ) -> dict[str, object]:
     if project is not None:
         _project(principal, project)
-    return await AccountingService(
-        session, tenant_id=_tenant(principal, tenant)
-    ).report(project_id=project)
+    if include_acquisition and not principal.is_admin:
+        raise HTTPException(status_code=403, detail="operator_required")
+    if include_acquisition:
+        await log_audit_event(
+            session,
+            "accounting_report",
+            tenant or "all",
+            "read_acquisition",
+            {"project": project},
+            "accounting_api",
+        )
+    try:
+        return await AccountingService(
+            session, tenant_id=_tenant(principal, tenant)
+        ).report(
+            project_id=project,
+            allowed_project_ids=principal.project_ids,
+            group_by=tuple(group_by),
+            include_acquisition=include_acquisition,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="unsupported_group") from exc

--- a/src/voicegateway/server/api/accounting.py
+++ b/src/voicegateway/server/api/accounting.py
@@ -1,0 +1,155 @@
+"""Versioned immutable-pricing and durable usage-accounting API."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from voicegateway.accounting.contracts import (
+    AccountingCapabilities,
+    PricingRevisionCreate,
+    PricingSide,
+    UsageBatchResponse,
+    UsageEnvelope,
+)
+from voicegateway.server.api._deps import (
+    Principal,
+    get_session,
+    require_ingest_principal,
+    require_principal,
+)
+from voicegateway.services.accounting_service import AccountingService, RevisionConflict
+
+router = APIRouter(prefix="/accounting", tags=["accounting"])
+
+
+class ActivationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    revision_id: str
+
+
+def _tenant(principal: Principal, requested: str | None = None) -> str:
+    if principal.is_admin:
+        return requested or ""
+    if requested is not None and requested != principal.tenant_id:
+        raise HTTPException(status_code=403, detail="tenant_not_authorized")
+    return principal.tenant_id or ""
+
+
+def _project(principal: Principal, project_id: str) -> None:
+    if principal.project_ids is not None and project_id not in principal.project_ids:
+        raise HTTPException(status_code=403, detail="project_not_authorized")
+
+
+def _revision_response(row: object, *, include_content: bool) -> dict[str, object]:
+    result: dict[str, object] = {
+        "revision_id": row.revision_id,
+        "side": row.side,
+        "content_hash": row.content_hash,
+        "contract_version": row.contract_version,
+        "currency": row.currency,
+        "active": row.active,
+    }
+    if include_content:
+        result["content"] = json.loads(row.content_json)
+    return result
+
+
+@router.get("/capabilities", response_model=AccountingCapabilities)
+async def capabilities(
+    _principal: Principal = Depends(require_principal),
+) -> AccountingCapabilities:
+    return AccountingCapabilities()
+
+
+@router.post("/revisions", status_code=201)
+async def create_revision(
+    payload: PricingRevisionCreate,
+    tenant: str | None = Query(None),
+    principal: Principal = Depends(require_principal),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, object]:
+    if not principal.is_admin:
+        raise HTTPException(status_code=403, detail="operator_required")
+    service = AccountingService(
+        session, tenant_id=_tenant(principal, tenant or payload.scope.tenant_id)
+    )
+    try:
+        row, created = await service.create_revision(payload)
+    except RevisionConflict as exc:
+        raise HTTPException(
+            status_code=409, detail="revision_content_conflict"
+        ) from exc
+    result = _revision_response(row, include_content=True)
+    result["created"] = created
+    return result
+
+
+@router.get("/revisions/{side}/{revision_id}")
+async def get_revision(
+    side: PricingSide,
+    revision_id: str,
+    tenant: str | None = Query(None),
+    principal: Principal = Depends(require_principal),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, object]:
+    if side is PricingSide.ACQUISITION and not principal.is_admin:
+        raise HTTPException(status_code=403, detail="operator_required")
+    service = AccountingService(session, tenant_id=_tenant(principal, tenant))
+    row = await service.get_revision(side, revision_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="revision_not_found")
+    return _revision_response(row, include_content=principal.is_admin)
+
+
+@router.post("/revisions/{side}/activate")
+async def activate_revision(
+    side: PricingSide,
+    payload: ActivationRequest,
+    tenant: str | None = Query(None),
+    principal: Principal = Depends(require_principal),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, object]:
+    if not principal.is_admin:
+        raise HTTPException(status_code=403, detail="operator_required")
+    service = AccountingService(session, tenant_id=_tenant(principal, tenant))
+    try:
+        row = await service.activate_revision(side, payload.revision_id)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail="revision_not_found") from exc
+    except RevisionConflict as exc:
+        raise HTTPException(status_code=409, detail="revision_hash_mismatch") from exc
+    return _revision_response(row, include_content=True)
+
+
+@router.post("/usage", response_model=UsageBatchResponse)
+async def ingest_usage(
+    payload: tuple[UsageEnvelope, ...],
+    principal: Principal = Depends(require_ingest_principal),
+    session: AsyncSession = Depends(get_session),
+) -> UsageBatchResponse:
+    if len(payload) > 1000:
+        raise HTTPException(status_code=413, detail="batch_too_large")
+    service = AccountingService(session, tenant_id=_tenant(principal))
+    receipts = []
+    for envelope in payload:
+        _project(principal, envelope.project_id)
+        receipts.append(await service.ingest(envelope))
+    return UsageBatchResponse(receipts=tuple(receipts))
+
+
+@router.get("/report")
+async def report(
+    project: str | None = Query(None),
+    tenant: str | None = Query(None),
+    principal: Principal = Depends(require_principal),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, object]:
+    if project is not None:
+        _project(principal, project)
+    return await AccountingService(
+        session, tenant_id=_tenant(principal, tenant)
+    ).report(project_id=project)

--- a/src/voicegateway/server/api/accounting.py
+++ b/src/voicegateway/server/api/accounting.py
@@ -18,6 +18,7 @@ from voicegateway.accounting.contracts import (
     UsageBatchResponse,
     UsageEnvelope,
 )
+from voicegateway.models.accounting_model import PricingRevision
 from voicegateway.repository.request_log_repository import log_audit_event
 from voicegateway.server.api._deps import (
     Principal,
@@ -49,7 +50,9 @@ def _project(principal: Principal, project_id: str) -> None:
         raise HTTPException(status_code=403, detail="project_not_authorized")
 
 
-def _revision_response(row: object, *, include_content: bool) -> dict[str, object]:
+def _revision_response(
+    row: PricingRevision, *, include_content: bool
+) -> dict[str, object]:
     result: dict[str, object] = {
         "revision_id": row.revision_id,
         "side": row.side,

--- a/src/voicegateway/server/api/accounting.py
+++ b/src/voicegateway/server/api/accounting.py
@@ -12,12 +12,13 @@ from voicegateway.accounting.contracts import (
     AccountingCapabilities,
     OwnershipAssignment,
     PreparationRequest,
-    PricingBinding,
+    PricingBindingResponse,
     PricingRevisionCreate,
     PricingSide,
     UsageBatchResponse,
     UsageEnvelope,
 )
+from voicegateway.core.auth import ADMIN_SCOPE
 from voicegateway.models.accounting_model import PricingRevision
 from voicegateway.repository.request_log_repository import log_audit_event
 from voicegateway.server.api._deps import (
@@ -25,6 +26,7 @@ from voicegateway.server.api._deps import (
     get_session,
     require_ingest_principal,
     require_principal,
+    require_scope,
 )
 from voicegateway.services.accounting_service import AccountingService, RevisionConflict
 
@@ -39,6 +41,10 @@ class ActivationRequest(BaseModel):
 
 def _tenant(principal: Principal, requested: str | None = None) -> str:
     if principal.is_admin:
+        if principal.tenant_id is not None:
+            if requested is not None and requested != principal.tenant_id:
+                raise HTTPException(status_code=403, detail="tenant_not_authorized")
+            return principal.tenant_id
         return requested or ""
     if requested is not None and requested != principal.tenant_id:
         raise HTTPException(status_code=403, detail="tenant_not_authorized")
@@ -73,7 +79,11 @@ async def capabilities(
     return AccountingCapabilities()
 
 
-@router.post("/revisions", status_code=201)
+@router.post(
+    "/revisions",
+    status_code=201,
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 async def create_revision(
     payload: PricingRevisionCreate,
     tenant: str | None = Query(None),
@@ -131,7 +141,10 @@ async def get_revision(
     return _revision_response(row, include_content=principal.is_admin)
 
 
-@router.post("/revisions/{side}/activate")
+@router.post(
+    "/revisions/{side}/activate",
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 async def activate_revision(
     side: PricingSide,
     payload: ActivationRequest,
@@ -163,7 +176,10 @@ async def activate_revision(
     return _revision_response(row, include_content=True)
 
 
-@router.put("/ownership")
+@router.put(
+    "/ownership",
+    dependencies=[Depends(require_scope(ADMIN_SCOPE))],
+)
 async def set_ownership(
     payload: OwnershipAssignment,
     tenant: str | None = Query(None),
@@ -178,15 +194,24 @@ async def set_ownership(
     return {"project_id": row.project_id, "component": row.component, "mode": row.mode}
 
 
-@router.post("/prepare", response_model=PricingBinding)
+@router.post("/prepare", response_model=PricingBindingResponse)
 async def prepare(
     payload: PreparationRequest,
     principal: Principal = Depends(require_ingest_principal),
     session: AsyncSession = Depends(get_session),
-) -> PricingBinding:
+) -> PricingBindingResponse:
     _project(principal, payload.project_id)
-    return await AccountingService(session, tenant_id=_tenant(principal)).prepare(
+    binding = await AccountingService(session, tenant_id=_tenant(principal)).prepare(
         payload
+    )
+    return PricingBindingResponse(
+        binding_id=binding.binding_id,
+        project_id=binding.project_id,
+        component=binding.component,
+        offering=binding.offering,
+        selling_revision_id=binding.selling_revision_id,
+        ownership_mode=binding.ownership_mode,
+        prepared_at_ns=binding.prepared_at_ns,
     )
 
 
@@ -201,7 +226,12 @@ async def ingest_usage(
     service = AccountingService(session, tenant_id=_tenant(principal))
     receipts = []
     for envelope in payload:
-        _project(principal, envelope.project_id)
+        if (
+            principal.project_ids is not None
+            and envelope.project_id not in principal.project_ids
+        ):
+            receipts.append(await service.reject(envelope, "project_not_authorized"))
+            continue
         receipts.append(await service.ingest(envelope))
     return UsageBatchResponse(receipts=tuple(receipts))
 
@@ -218,6 +248,8 @@ async def report(
     if project is not None:
         _project(principal, project)
     if include_acquisition and not principal.is_admin:
+        raise HTTPException(status_code=403, detail="operator_required")
+    if "acquisition_revision" in group_by and not principal.is_admin:
         raise HTTPException(status_code=403, detail="operator_required")
     if include_acquisition:
         await log_audit_event(

--- a/src/voicegateway/server/api/agents.py
+++ b/src/voicegateway/server/api/agents.py
@@ -22,8 +22,8 @@ from voicegateway.repository.workers_repository import DEFAULT_TTL_SECONDS
 from voicegateway.server.api._deps import (
     Principal,
     get_gateway,
+    require_ingest_principal,
     require_principal,
-    require_scope,
     resolve_read_tenant,
 )
 
@@ -41,7 +41,7 @@ def _memory_pct(rss: int | None, total: int | None) -> float | None:
 @router.post(
     "/heartbeat",
     status_code=202,
-    dependencies=[Depends(require_scope("write"))],
+    dependencies=[Depends(require_ingest_principal)],
 )
 async def heartbeat(request: Request) -> dict[str, str]:
     """Upsert the caller's worker presence row."""

--- a/src/voicegateway/server/api/api_keys.py
+++ b/src/voicegateway/server/api/api_keys.py
@@ -47,6 +47,11 @@ async def create_api_key(
             scopes=payload.scopes,
             tenant_id=payload.tenant_id,
             issued_by=payload.issued_by,
+            project_ids=(
+                ",".join(sorted(set(payload.project_ids)))
+                if payload.project_ids is not None
+                else None
+            ),
         )
     except ValueError as exc:
         # A refused scope list is a bad request, not a server fault. 422 to

--- a/src/voicegateway/server/api/api_keys.py
+++ b/src/voicegateway/server/api/api_keys.py
@@ -1,8 +1,8 @@
 """FastAPI router for api-key management.
 
 Auth is declared ONCE, here, for every route on this router. A minted key
-carries the wildcard scope (``api_keys_repository`` defaults ``scopes='*'``),
-so an ungated mint hands the caller write access to every ``/v1`` endpoint.
+names its scopes explicitly as of 0.26.0, but a mint is still an admin act:
+it hands out a credential.
 ``require_scope(ADMIN_SCOPE)`` is a no-op while no API keys are configured
 (the self-hosted single-operator default: ``core.auth.check_request``
 returns None on an empty key list), and enforces the admin scope once auth
@@ -13,7 +13,7 @@ route cannot forget to opt in.
 from __future__ import annotations
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from voicegateway.core.auth import ADMIN_SCOPE
 from voicegateway.core.container import Container
@@ -41,11 +41,17 @@ async def create_api_key(
     service: ApiKeyService = Depends(Provide[Container.api_key_service]),
 ) -> CreatedApiKey:
     """Mint a new virtual key. The plaintext is returned exactly once."""
-    created = await service.create_key(
-        name=payload.name,
-        tenant_id=payload.tenant_id,
-        issued_by=payload.issued_by,
-    )
+    try:
+        created = await service.create_key(
+            name=payload.name,
+            scopes=payload.scopes,
+            tenant_id=payload.tenant_id,
+            issued_by=payload.issued_by,
+        )
+    except ValueError as exc:
+        # A refused scope list is a bad request, not a server fault. 422 to
+        # match the shape pydantic already returns for this body.
+        raise HTTPException(status_code=422, detail=str(exc)) from None
     return CreatedApiKey(
         plaintext=created.plaintext,
         key=ApiKeyResponse.model_validate(created.row),

--- a/src/voicegateway/server/api/call_observations.py
+++ b/src/voicegateway/server/api/call_observations.py
@@ -44,7 +44,7 @@ Observing the counters: every response carries ``queue_depth`` and
 ``flusher_running`` for the process, and each drop logs a WARNING (the first,
 then every 100th) so the gap is visible in the log as well as in the response.
 
-Auth: the standard ``require_scope("write")``, declared **once on the router**
+Auth: ``require_ingest_principal`` (the ingest scope), declared **once on the router**
 Unlike the LiveKit webhook -- which LiveKit posts and cannot sign with a
 VoiceGateway key -- this endpoint is called by the operator's own agents and load
 workers, which already carry ``VOICEGW_API_KEY`` for ``/v1/ingest``. So it takes
@@ -135,7 +135,7 @@ from typing import TYPE_CHECKING, Annotated, Literal
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 
-from voicegateway.server.api._deps import get_gateway, require_scope
+from voicegateway.server.api._deps import get_gateway, require_ingest_principal
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from voicegateway.services.storage_service import StorageService
@@ -148,7 +148,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/calls",
     tags=["calls"],
-    dependencies=[Depends(require_scope("write"))],
+    dependencies=[Depends(require_ingest_principal)],
 )
 
 # The kill switch. Any value other than an explicit falsy word disables the

--- a/src/voicegateway/server/api/dashboard/accounting.py
+++ b/src/voicegateway/server/api/dashboard/accounting.py
@@ -1,0 +1,42 @@
+"""Tenant-scoped exact-accounting status for the dashboard."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from voicegateway.server.api._deps import (
+    Principal,
+    get_session,
+    require_principal,
+    resolve_read_tenant,
+)
+from voicegateway.services.accounting_service import AccountingService
+
+router = APIRouter(
+    prefix="/accounting",
+    tags=["dashboard-accounting"],
+    dependencies=[Depends(require_principal)],
+)
+
+
+@router.get("")
+async def accounting_status(
+    project: str | None = Query(None),
+    tenant: str | None = Query(None),
+    principal: Principal = Depends(require_principal),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, object]:
+    resolved = resolve_read_tenant(principal, tenant)
+    if (
+        project is not None
+        and principal.project_ids is not None
+        and project not in principal.project_ids
+    ):
+        raise HTTPException(status_code=403, detail="project_not_authorized")
+    # The service intentionally exposes selling totals and completeness only.
+    # Acquisition and margin require an operator-specific endpoint.
+    return await AccountingService(session, tenant_id=resolved or "").report(
+        project_id=project,
+        allowed_project_ids=principal.project_ids,
+    )

--- a/src/voicegateway/server/api/dashboard/api_keys.py
+++ b/src/voicegateway/server/api/dashboard/api_keys.py
@@ -82,6 +82,16 @@ async def create_api_key_endpoint(
     issued_by_raw = body.get("issued_by")
     issued_by = str(issued_by_raw).strip() if issued_by_raw not in (None, "") else None
     scopes = str(body.get("scopes") or "").strip()
+    raw_projects = body.get("project_ids")
+    if raw_projects is not None and not isinstance(raw_projects, list):
+        raise HTTPException(status_code=400, detail="`project_ids` must be a list")
+    project_ids = (
+        ",".join(
+            sorted({str(item).strip() for item in raw_projects if str(item).strip()})
+        )
+        if raw_projects is not None
+        else None
+    )
     if not scopes:
         raise HTTPException(
             status_code=400,
@@ -99,6 +109,7 @@ async def create_api_key_endpoint(
                 scopes=scopes,
                 tenant_id=tenant_id,
                 issued_by=issued_by,
+                project_ids=project_ids,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from None

--- a/src/voicegateway/server/api/dashboard/api_keys.py
+++ b/src/voicegateway/server/api/dashboard/api_keys.py
@@ -81,13 +81,27 @@ async def create_api_key_endpoint(
     tenant_id = str(tenant_id_raw).strip() if tenant_id_raw not in (None, "") else None
     issued_by_raw = body.get("issued_by")
     issued_by = str(issued_by_raw).strip() if issued_by_raw not in (None, "") else None
+    scopes = str(body.get("scopes") or "").strip()
+    if not scopes:
+        raise HTTPException(
+            status_code=400,
+            detail="`scopes` is required; the wildcard default was removed "
+            "in 0.26.0 (VG-SEC-006)",
+        )
     if gateway.storage is None:
         raise HTTPException(status_code=503, detail="Storage backend not configured")
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(
-            db, name=name, tenant_id=tenant_id, issued_by=issued_by
-        )
+        try:
+            created = await api_keys.create_api_key(
+                db,
+                name=name,
+                scopes=scopes,
+                tenant_id=tenant_id,
+                issued_by=issued_by,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from None
     return {
         "id": created.id,
         "plaintext": created.plaintext,

--- a/src/voicegateway/server/api/dashboard/status.py
+++ b/src/voicegateway/server/api/dashboard/status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 
 from voicegateway._version import __version__
 from voicegateway.inference.pricing import llm as _llm_pricing
@@ -38,7 +38,7 @@ router = APIRouter(tags=["dashboard"])
 
 
 @router.get("/status")
-async def get_status(gateway: Gateway = Depends(get_gateway)) -> dict:
+async def get_status(request: Request, gateway: Gateway = Depends(get_gateway)) -> dict:
     """Status of configured providers and the models the operator can call.
 
     Models are filtered to providers that are usable (a cloud key is set, or
@@ -78,8 +78,19 @@ async def get_status(gateway: Gateway = Depends(get_gateway)) -> dict:
         "tts": {"source": _tts_pricing.PRICING_SOURCE},
     }
 
+    # What an operator watches during the warn release: how many requests
+    # would already have been refused under enforce. Flipping the mode with
+    # this at zero is safe; flipping it at 400 is an outage.
+    auth_cfg = config.auth
+    auth = {
+        "enforcement": auth_cfg.enforcement,
+        "local_development": auth_cfg.local_development,
+        "would_refuse_count": getattr(request.app.state, "auth_would_refuse", 0),
+    }
+
     return {
         "version": _PUBLIC_VERSION,
+        "auth": auth,
         "providers": providers,
         "models": models,
         "fallbacks": config.fallbacks,

--- a/src/voicegateway/server/api/ingest.py
+++ b/src/voicegateway/server/api/ingest.py
@@ -23,23 +23,15 @@ from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
 from voicegateway.middleware.turn_tracker_middleware import TurnRow
 from voicegateway.models.request_model import RequestRecord
 from voicegateway.models.tool_call_model import ToolCall
-from voicegateway.server.api._deps import get_gateway, require_scope
+from voicegateway.server.api._deps import (
+    Principal,
+    get_gateway,
+    require_ingest_principal,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-def _authenticated_tenant(request: Request) -> str | None:
-    """The tenant the verified key stamped on this request, or None.
-
-    Never the payload. VG-SEC-001 was one writer preferring a tenant_id
-    carried on the row over the tenant resolved from the key, so a key scoped
-    to one tenant could write rows tagged another. Task 10 replaces this read
-    with ``principal.tenant_id`` when these routes move onto
-    ``require_ingest_principal``; the value is the same either way.
-    """
-    return getattr(request.state, "api_key_tenant_id", None)
 
 
 _RECORD_FIELDS: frozenset[str] = frozenset(
@@ -101,7 +93,7 @@ def _rate_limit_key(request: Request) -> str:
 async def ingest(
     records: list[dict[str, Any]],
     request: Request,
-    _auth: None = Depends(require_scope("write")),
+    principal: Principal = Depends(require_ingest_principal),
 ) -> dict[str, int]:
     """Persist a batch of request records pushed by a fleet agent."""
     gateway = get_gateway(request)
@@ -185,9 +177,7 @@ async def ingest(
             continue
         gateway.cost_tracker.rate_record(record)
         try:
-            await storage.log_request_as(
-                record, tenant_id=_authenticated_tenant(request)
-            )
+            await storage.log_request_as(record, tenant_id=principal.tenant_id)
             accepted += 1
         except IntegrityError:
             # Duplicate id: a sink retry re-sent an already-stored row.
@@ -220,7 +210,7 @@ def _turn_from_payload(raw: dict[str, Any]) -> TurnRow | None:
 async def ingest_turns(
     rows: list[dict[str, Any]],
     request: Request,
-    _auth: None = Depends(require_scope("write")),
+    principal: Principal = Depends(require_ingest_principal),
 ) -> dict[str, int]:
     """Persist a batch of conversation turns pushed by a fleet agent.
 
@@ -262,9 +252,7 @@ async def ingest_turns(
     accepted = 0
     if turns:
         try:
-            accepted = await storage.log_turns(
-                turns, tenant_id=_authenticated_tenant(request)
-            )
+            accepted = await storage.log_turns(turns, tenant_id=principal.tenant_id)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "ingest/turns: failed to persist %d turn(s)", len(turns), exc_info=True
@@ -307,7 +295,7 @@ def _tool_call_from_payload(raw: dict[str, Any]) -> ToolCall | None:
 async def ingest_tool_calls(
     rows: list[dict[str, Any]],
     request: Request,
-    _auth: None = Depends(require_scope("write")),
+    principal: Principal = Depends(require_ingest_principal),
 ) -> dict[str, int]:
     """Persist per-tool-call rows pushed by a fleet agent.
 
@@ -355,7 +343,7 @@ async def ingest_tool_calls(
     if parsed:
         try:
             accepted = await storage.log_tool_calls(
-                parsed, tenant_id=_authenticated_tenant(request)
+                parsed, tenant_id=principal.tenant_id
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
@@ -377,7 +365,7 @@ async def ingest_tool_calls(
 async def ingest_dead_air(
     events: list[dict[str, Any]],
     request: Request,
-    _auth: None = Depends(require_scope("write")),
+    principal: Principal = Depends(require_ingest_principal),
 ) -> dict[str, int]:
     """Persist observed dead-air events pushed by a fleet agent.
 
@@ -415,9 +403,7 @@ async def ingest_dead_air(
     accepted = 0
     if parsed:
         try:
-            accepted = await storage.log_dead_air(
-                parsed, tenant_id=_authenticated_tenant(request)
-            )
+            accepted = await storage.log_dead_air(parsed, tenant_id=principal.tenant_id)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "ingest/dead-air: failed to persist %d event(s)",

--- a/src/voicegateway/server/api/ingest.py
+++ b/src/voicegateway/server/api/ingest.py
@@ -29,6 +29,19 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
+def _authenticated_tenant(request: Request) -> str | None:
+    """The tenant the verified key stamped on this request, or None.
+
+    Never the payload. VG-SEC-001 was one writer preferring a tenant_id
+    carried on the row over the tenant resolved from the key, so a key scoped
+    to one tenant could write rows tagged another. Task 10 replaces this read
+    with ``principal.tenant_id`` when these routes move onto
+    ``require_ingest_principal``; the value is the same either way.
+    """
+    return getattr(request.state, "api_key_tenant_id", None)
+
+
 _RECORD_FIELDS: frozenset[str] = frozenset(
     f.name for f in dataclasses.fields(RequestRecord)
 )
@@ -172,7 +185,9 @@ async def ingest(
             continue
         gateway.cost_tracker.rate_record(record)
         try:
-            await storage.log_request(record)
+            await storage.log_request_as(
+                record, tenant_id=_authenticated_tenant(request)
+            )
             accepted += 1
         except IntegrityError:
             # Duplicate id: a sink retry re-sent an already-stored row.
@@ -247,7 +262,9 @@ async def ingest_turns(
     accepted = 0
     if turns:
         try:
-            accepted = await storage.log_turns(turns)
+            accepted = await storage.log_turns(
+                turns, tenant_id=_authenticated_tenant(request)
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "ingest/turns: failed to persist %d turn(s)", len(turns), exc_info=True
@@ -337,7 +354,9 @@ async def ingest_tool_calls(
     accepted = 0
     if parsed:
         try:
-            accepted = await storage.log_tool_calls(parsed)
+            accepted = await storage.log_tool_calls(
+                parsed, tenant_id=_authenticated_tenant(request)
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "ingest/tool-calls: failed to persist %d row(s)",
@@ -396,7 +415,9 @@ async def ingest_dead_air(
     accepted = 0
     if parsed:
         try:
-            accepted = await storage.log_dead_air(parsed)
+            accepted = await storage.log_dead_air(
+                parsed, tenant_id=_authenticated_tenant(request)
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "ingest/dead-air: failed to persist %d event(s)",

--- a/src/voicegateway/server/main.py
+++ b/src/voicegateway/server/main.py
@@ -20,7 +20,11 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from voicegateway._version import __version__
 from voicegateway.core.app_wiring import attach_layered_stack
-from voicegateway.core.auth import load_api_keys, resolve_cors_origins
+from voicegateway.core.auth import (
+    load_api_keys,
+    resolve_cors_origins,
+    validate_auth_startup,
+)
 from voicegateway.core.events import lifespan
 from voicegateway.server.mcp.transport import mount_sse
 from voicegateway.server.routes import api_router, dashboard_router, system_router
@@ -84,6 +88,11 @@ class ApplicationBuilder:
         attach_layered_stack(self.app, self.gateway)
 
     def _configure_app_state(self) -> None:
+        # Defense in depth: build_app has more than one caller, so the auth
+        # guard cannot live only in the serve CLI. The bind host is not known
+        # here, so this catches the two config-only conflicts; the callers
+        # that do resolve a host pass it and get the loopback check too.
+        validate_auth_startup(self.gateway.config.auth)
         # ``server.api._deps.get_gateway`` and ``require_scope`` read these
         # off app.state instead of closing over them, so each request can
         # resolve the gateway and api_keys without a per-call lookup.
@@ -175,6 +184,11 @@ def main() -> None:
     # bakes VOICEGW_CONFIG=/data/voicegw.yaml and creates no such file, so
     # requiring it crash-looped every host that mounts nothing there.
     gw = Gateway(config_path=config_path, require_config=False)
+    # This is the container's entry point and it binds 0.0.0.0 by default,
+    # so it is the path where an unauthenticated public deployment would
+    # actually happen. build_app checks the config-only conflicts; passing
+    # the resolved host here adds the loopback check.
+    validate_auth_startup(gw.config.auth, bind_host=host)
     app = build_app(gw)
 
     logger.info("Starting VoiceGateway server on %s:%d", host, port)

--- a/src/voicegateway/server/mcp/tools/__init__.py
+++ b/src/voicegateway/server/mcp/tools/__init__.py
@@ -1,5 +1,6 @@
 """MCP tool aggregation."""
 
+from voicegateway.server.mcp.tools.accounting import ACCOUNTING_TOOLS
 from voicegateway.server.mcp.tools.base import ToolDef
 from voicegateway.server.mcp.tools.models import MODEL_TOOLS
 from voicegateway.server.mcp.tools.observability import OBSERVABILITY_TOOLS
@@ -8,6 +9,7 @@ from voicegateway.server.mcp.tools.providers import PROVIDER_TOOLS
 from voicegateway.server.mcp.tools.rate_card import RATE_CARD_TOOLS
 
 ALL_TOOLS: list[ToolDef] = [
+    *ACCOUNTING_TOOLS,
     *OBSERVABILITY_TOOLS,
     *PROVIDER_TOOLS,
     *MODEL_TOOLS,

--- a/src/voicegateway/server/mcp/tools/accounting.py
+++ b/src/voicegateway/server/mcp/tools/accounting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
@@ -13,7 +14,6 @@ from voicegateway.services.accounting_service import AccountingService
 
 class GetAccountingStatusInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    tenant: str = ""
     project: str | None = None
 
 
@@ -21,22 +21,39 @@ async def _handle_get_accounting_status(
     gateway: Any, arguments: dict[str, Any]
 ) -> dict[str, object]:
     payload = GetAccountingStatusInput.model_validate(arguments)
+    tenant = os.environ.get("VOICEGW_MCP_ACCOUNTING_TENANT", "").strip()
+    if not tenant:
+        return {
+            "error": "accounting_tenant_not_configured",
+            "message": (
+                "Set VOICEGW_MCP_ACCOUNTING_TENANT on the MCP server to bind "
+                "accounting reads to one tenant."
+            ),
+        }
     if gateway.storage is None:
         return {
             "selling_total_usd": "0",
+            "incomplete_selling_total_usd": "0",
+            "unrated_selling_total_usd": "0",
             "records": 0,
-            "counts": {"rated": 0, "unrated": 0, "pending_delivery": 0},
+            "counts": {
+                "rated": 0,
+                "unrated": 0,
+                "incomplete": 0,
+                "rejected": 0,
+            },
         }
     async with gateway.storage.session() as session:
-        return await AccountingService(session, tenant_id=payload.tenant).report(
+        return await AccountingService(session, tenant_id=tenant).report(
             project_id=payload.project
         )
 
 
 GET_ACCOUNTING_STATUS_DOC = """Return exact-accounting selling totals and health.
 
-This read-only operator tool reports rated, unrated, incomplete and pending
-counts. It never returns acquisition rates, acquisition totals, margins, raw
+This read-only operator tool is bound to the tenant configured by
+VOICEGW_MCP_ACCOUNTING_TENANT and reports rated, unrated and incomplete counts.
+It never returns acquisition rates, acquisition totals, margins, raw
 usage envelopes, prompts, transcripts, or tool arguments.
 """
 

--- a/src/voicegateway/server/mcp/tools/accounting.py
+++ b/src/voicegateway/server/mcp/tools/accounting.py
@@ -1,0 +1,51 @@
+"""Read-only exact-accounting status tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from voicegateway.core.auth import ADMIN_SCOPE
+from voicegateway.server.mcp.tools.base import ToolDef, make_tool
+from voicegateway.services.accounting_service import AccountingService
+
+
+class GetAccountingStatusInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    tenant: str = ""
+    project: str | None = None
+
+
+async def _handle_get_accounting_status(
+    gateway: Any, arguments: dict[str, Any]
+) -> dict[str, object]:
+    payload = GetAccountingStatusInput.model_validate(arguments)
+    if gateway.storage is None:
+        return {
+            "selling_total_usd": "0",
+            "records": 0,
+            "counts": {"rated": 0, "unrated": 0, "pending_delivery": 0},
+        }
+    async with gateway.storage.session() as session:
+        return await AccountingService(session, tenant_id=payload.tenant).report(
+            project_id=payload.project
+        )
+
+
+GET_ACCOUNTING_STATUS_DOC = """Return exact-accounting selling totals and health.
+
+This read-only operator tool reports rated, unrated, incomplete and pending
+counts. It never returns acquisition rates, acquisition totals, margins, raw
+usage envelopes, prompts, transcripts, or tool arguments.
+"""
+
+ACCOUNTING_TOOLS: list[ToolDef] = [
+    make_tool(
+        "get_accounting_status",
+        GET_ACCOUNTING_STATUS_DOC,
+        GetAccountingStatusInput,
+        _handle_get_accounting_status,
+        required_scope=ADMIN_SCOPE,
+    )
+]

--- a/src/voicegateway/server/routes.py
+++ b/src/voicegateway/server/routes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from voicegateway.server.api import (
+    accounting,
     agents,
     api_keys,
     audit_log,
@@ -96,6 +97,7 @@ system_router = APIRouter()
 system_router.include_router(system.router)
 
 api_router = APIRouter(prefix="/v1")
+api_router.include_router(accounting.router)
 api_router.include_router(models.router)
 api_router.include_router(costs.router)
 api_router.include_router(billing.router)

--- a/src/voicegateway/server/routes.py
+++ b/src/voicegateway/server/routes.py
@@ -39,6 +39,9 @@ from voicegateway.server.api import (
     system,
 )
 from voicegateway.server.api.dashboard import (
+    accounting as dashboard_accounting,
+)
+from voicegateway.server.api.dashboard import (
     agents as dashboard_agents,
 )
 from voicegateway.server.api.dashboard import (
@@ -126,6 +129,7 @@ api_router.include_router(call_observations.router)
 
 dashboard_router = APIRouter(prefix="/api")
 dashboard_router.include_router(dashboard_health.router)
+dashboard_router.include_router(dashboard_accounting.router)
 dashboard_router.include_router(dashboard_auth_status.router)
 dashboard_router.include_router(dashboard_status.router)
 dashboard_router.include_router(dashboard_costs.router)

--- a/src/voicegateway/services/accounting_service.py
+++ b/src/voicegateway/services/accounting_service.py
@@ -6,12 +6,17 @@ import hashlib
 import json
 import time
 import uuid
+from decimal import Decimal
 
 from sqlalchemy import and_, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from voicegateway.accounting.contracts import (
+    OwnershipAssignment,
+    OwnershipMode,
+    PreparationRequest,
+    PricingBinding,
     PricingRevisionCreate,
     PricingSide,
     RecordReceipt,
@@ -19,8 +24,11 @@ from voicegateway.accounting.contracts import (
 )
 from voicegateway.accounting.rating import rate_usage
 from voicegateway.models.accounting_model import (
+    AccountingOwnership,
     AccountingProjection,
+    AccountingRejection,
     AccountingUsage,
+    PreparedPricingBinding,
     PricingRevision,
 )
 
@@ -58,6 +66,11 @@ class AccountingService:
             scope_json=json.dumps(
                 payload.scope.model_dump(mode="json"), sort_keys=True
             ),
+            scope_key=json.dumps(
+                payload.scope.model_dump(mode="json"),
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
             content_json=content,
             content_hash=digest,
             contract_version=payload.contract_version,
@@ -65,7 +78,16 @@ class AccountingService:
             created_at_ns=time.time_ns(),
         )
         self._session.add(row)
-        await self._session.commit()
+        try:
+            await self._session.commit()
+        except IntegrityError:
+            await self._session.rollback()
+            concurrent = (await self._session.execute(query)).scalar_one()
+            if concurrent.content_hash != digest:
+                raise RevisionConflict(
+                    "revision identity already exists with different content"
+                ) from None
+            return concurrent, False
         await self._session.refresh(row)
         return row, True
 
@@ -80,18 +102,37 @@ class AccountingService:
         return (await self._session.execute(query)).scalar_one_or_none()
 
     async def activate_revision(
-        self, side: PricingSide, revision_id: str
+        self,
+        side: PricingSide,
+        revision_id: str,
+        *,
+        expected_current_revision_id: str | None = None,
     ) -> PricingRevision:
         row = await self.get_revision(side, revision_id)
         if row is None:
             raise LookupError("pricing revision not found")
         if hashlib.sha256(row.content_json.encode()).hexdigest() != row.content_hash:
             raise RevisionConflict("stored pricing revision hash mismatch")
+        current = (
+            await self._session.execute(
+                select(PricingRevision).where(
+                    PricingRevision.tenant_id == self._tenant_id,
+                    PricingRevision.side == side.value,
+                    PricingRevision.scope_key == row.scope_key,
+                    PricingRevision.active.is_(True),
+                )
+            )
+        ).scalar_one_or_none()
+        if expected_current_revision_id is not None and (
+            current is None or current.revision_id != expected_current_revision_id
+        ):
+            raise RevisionConflict("active revision changed")
         await self._session.execute(
             update(PricingRevision)
             .where(
                 PricingRevision.tenant_id == self._tenant_id,
                 PricingRevision.side == side.value,
+                PricingRevision.scope_key == row.scope_key,
             )
             .values(active=False)
         )
@@ -100,6 +141,102 @@ class AccountingService:
         await self._session.commit()
         await self._session.refresh(row)
         return row
+
+    async def set_ownership(
+        self, assignment: OwnershipAssignment
+    ) -> AccountingOwnership:
+        query = select(AccountingOwnership).where(
+            AccountingOwnership.tenant_id == self._tenant_id,
+            AccountingOwnership.project_id == assignment.project_id,
+            AccountingOwnership.component == assignment.component,
+        )
+        row = (await self._session.execute(query)).scalar_one_or_none()
+        if row is None:
+            row = AccountingOwnership(
+                tenant_id=self._tenant_id,
+                project_id=assignment.project_id,
+                component=assignment.component,
+                mode=assignment.mode.value,
+                updated_at_ns=time.time_ns(),
+            )
+        else:
+            row.mode = assignment.mode.value
+            row.updated_at_ns = time.time_ns()
+        self._session.add(row)
+        await self._session.commit()
+        await self._session.refresh(row)
+        return row
+
+    async def prepare(self, request: PreparationRequest) -> PricingBinding:
+        ownership_query = select(AccountingOwnership).where(
+            AccountingOwnership.tenant_id == self._tenant_id,
+            AccountingOwnership.project_id == request.project_id,
+            AccountingOwnership.component == request.component,
+        )
+        ownership = (await self._session.execute(ownership_query)).scalar_one_or_none()
+        mode = (
+            OwnershipMode(ownership.mode)
+            if ownership is not None
+            else OwnershipMode.SDK
+        )
+        revisions: dict[PricingSide, str | None] = {}
+        for side in PricingSide:
+            rows = (
+                (
+                    await self._session.execute(
+                        select(PricingRevision).where(
+                            PricingRevision.tenant_id == self._tenant_id,
+                            PricingRevision.side == side.value,
+                            PricingRevision.active.is_(True),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            matches = []
+            for row in rows:
+                scope = json.loads(row.scope_json)
+                if scope["offering"] != request.offering:
+                    continue
+                if scope.get("project_id") not in (None, request.project_id):
+                    continue
+                if scope.get("component") not in (None, request.component):
+                    continue
+                matches.append(
+                    (
+                        sum(
+                            scope.get(key) is not None
+                            for key in ("project_id", "component")
+                        ),
+                        row,
+                    )
+                )
+            matches.sort(key=lambda item: item[0], reverse=True)
+            revisions[side] = matches[0][1].revision_id if matches else None
+        binding = PreparedPricingBinding(
+            binding_id=str(uuid.uuid4()),
+            tenant_id=self._tenant_id,
+            project_id=request.project_id,
+            component=request.component,
+            offering=request.offering,
+            acquisition_revision_id=revisions[PricingSide.ACQUISITION],
+            selling_revision_id=revisions[PricingSide.SELLING],
+            ownership_mode=mode.value,
+            prepared_at_ns=time.time_ns(),
+        )
+        self._session.add(binding)
+        await self._session.commit()
+        return PricingBinding(
+            binding_id=binding.binding_id,
+            project_id=binding.project_id,
+            component=binding.component,
+            offering=binding.offering,
+            acquisition_revision_id=binding.acquisition_revision_id,
+            selling_revision_id=binding.selling_revision_id,
+            ownership_mode=mode,
+            prepared_at_ns=binding.prepared_at_ns,
+        )
 
     async def ingest(self, envelope: UsageEnvelope) -> RecordReceipt:
         canonical = envelope.model_dump_json()
@@ -112,11 +249,7 @@ class AccountingService:
         existing = (await self._session.execute(query)).scalar_one_or_none()
         if existing is not None:
             if existing.payload_hash != digest:
-                return RecordReceipt(
-                    event_id=envelope.event_id,
-                    outcome="rejected",
-                    code="identity_conflict",
-                )
+                return await self._reject(envelope, digest, "identity_conflict")
             return RecordReceipt(
                 event_id=envelope.event_id,
                 outcome="duplicate",
@@ -124,13 +257,47 @@ class AccountingService:
                 code="already_committed",
             )
 
+        if envelope.pricing_binding_id is not None:
+            binding = await self._session.get(
+                PreparedPricingBinding, envelope.pricing_binding_id
+            )
+            if binding is None or binding.tenant_id != self._tenant_id:
+                return await self._reject(envelope, digest, "binding_not_found")
+            expected = (
+                binding.project_id,
+                binding.component,
+                binding.offering,
+                binding.ownership_mode,
+                binding.acquisition_revision_id,
+                binding.selling_revision_id,
+            )
+            supplied = (
+                envelope.project_id,
+                envelope.component,
+                envelope.offering,
+                envelope.ownership_mode.value,
+                envelope.acquisition_revision_id,
+                envelope.selling_revision_id,
+            )
+            if expected != supplied:
+                return await self._reject(envelope, digest, "binding_mismatch")
+
         acquisition_total, acquisition_complete = await self._rate(
             envelope, PricingSide.ACQUISITION
         )
         selling_total, selling_complete = await self._rate(
             envelope, PricingSide.SELLING
         )
-        status = "rated" if acquisition_complete and selling_complete else "unrated"
+        has_missing_measurement = any(
+            item.value is None for item in envelope.quantities
+        )
+        status = (
+            "rated"
+            if acquisition_complete and selling_complete
+            else "incomplete"
+            if has_missing_measurement
+            else "unrated"
+        )
         receipt_id = str(uuid.uuid4())
         row = AccountingUsage(
             tenant_id=self._tenant_id,
@@ -145,6 +312,7 @@ class AccountingService:
             turn_id=envelope.turn_id,
             producer_id=envelope.producer_id,
             ownership_mode=envelope.ownership_mode.value,
+            pricing_binding_id=envelope.pricing_binding_id,
             acquisition_revision_id=envelope.acquisition_revision_id,
             selling_revision_id=envelope.selling_revision_id,
             occurred_at_ns=envelope.occurred_at_ns,
@@ -160,22 +328,70 @@ class AccountingService:
         )
         self._session.add(row)
         self._session.add(
-            AccountingProjection(event_id=envelope.event_id, payload_json=canonical)
+            AccountingProjection(
+                tenant_id=self._tenant_id,
+                project_id=envelope.project_id,
+                event_id=envelope.event_id,
+                payload_json=canonical,
+            )
         )
         try:
             await self._session.commit()
         except IntegrityError:
             await self._session.rollback()
-            return RecordReceipt(
-                event_id=envelope.event_id,
-                outcome="rejected",
-                code="attempt_or_ownership_conflict",
-            )
+            concurrent = (await self._session.execute(query)).scalar_one_or_none()
+            if concurrent is not None:
+                if concurrent.payload_hash == digest:
+                    return RecordReceipt(
+                        event_id=envelope.event_id,
+                        outcome="duplicate",
+                        receipt_id=concurrent.receipt_id,
+                        code="already_committed",
+                    )
+                return await self._reject(envelope, digest, "identity_conflict")
+            return await self._reject(envelope, digest, "attempt_or_ownership_conflict")
         return RecordReceipt(
             event_id=envelope.event_id,
             outcome="accepted",
             receipt_id=receipt_id,
             code="committed",
+        )
+
+    async def _reject(
+        self, envelope: UsageEnvelope, payload_hash: str, code: str
+    ) -> RecordReceipt:
+        query = select(AccountingRejection).where(
+            AccountingRejection.tenant_id == self._tenant_id,
+            AccountingRejection.project_id == envelope.project_id,
+            AccountingRejection.event_id == envelope.event_id,
+            AccountingRejection.payload_hash == payload_hash,
+        )
+        existing = (await self._session.execute(query)).scalar_one_or_none()
+        if existing is not None:
+            return RecordReceipt(
+                event_id=envelope.event_id,
+                outcome="rejected",
+                receipt_id=existing.receipt_id,
+                code=existing.code,
+            )
+        receipt_id = str(uuid.uuid4())
+        self._session.add(
+            AccountingRejection(
+                tenant_id=self._tenant_id,
+                project_id=envelope.project_id,
+                event_id=envelope.event_id,
+                payload_hash=payload_hash,
+                code=code,
+                receipt_id=receipt_id,
+                created_at_ns=time.time_ns(),
+            )
+        )
+        await self._session.commit()
+        return RecordReceipt(
+            event_id=envelope.event_id,
+            outcome="rejected",
+            receipt_id=receipt_id,
+            code=code,
         )
 
     async def _rate(
@@ -197,10 +413,19 @@ class AccountingService:
         revision = PricingRevisionCreate.model_validate_json(row.content_json)
         return rate_usage(envelope, revision)
 
-    async def report(self, *, project_id: str | None = None) -> dict[str, object]:
+    async def report(
+        self,
+        *,
+        project_id: str | None = None,
+        allowed_project_ids: frozenset[str] | None = None,
+        group_by: tuple[str, ...] = (),
+        include_acquisition: bool = False,
+    ) -> dict[str, object]:
         conditions = [AccountingUsage.tenant_id == self._tenant_id]
         if project_id is not None:
             conditions.append(AccountingUsage.project_id == project_id)
+        elif allowed_project_ids is not None:
+            conditions.append(AccountingUsage.project_id.in_(allowed_project_ids))
         rows = (
             (
                 await self._session.execute(
@@ -212,25 +437,93 @@ class AccountingService:
         )
         selling = sum(
             (
-                __import__("decimal").Decimal(row.selling_total_usd)
+                Decimal(row.selling_total_usd)
                 for row in rows
                 if row.selling_total_usd is not None
             ),
-            start=__import__("decimal").Decimal(0),
+            start=Decimal(0),
+        )
+        acquisition = sum(
+            (
+                Decimal(row.acquisition_total_usd)
+                for row in rows
+                if row.acquisition_total_usd is not None
+            ),
+            start=Decimal(0),
         )
         counts = {
             name: sum(row.status == name for row in rows)
             for name in ("rated", "unrated", "incomplete", "rejected")
         }
+        projection_conditions = [AccountingProjection.tenant_id == self._tenant_id]
+        rejection_conditions = [AccountingRejection.tenant_id == self._tenant_id]
+        if project_id is not None:
+            projection_conditions.append(AccountingProjection.project_id == project_id)
+            rejection_conditions.append(AccountingRejection.project_id == project_id)
+        elif allowed_project_ids is not None:
+            projection_conditions.append(
+                AccountingProjection.project_id.in_(allowed_project_ids)
+            )
+            rejection_conditions.append(
+                AccountingRejection.project_id.in_(allowed_project_ids)
+            )
         pending = (
             await self._session.execute(
                 select(func.count())
                 .select_from(AccountingProjection)
-                .where(AccountingProjection.projected_at_ns.is_(None))
+                .where(
+                    and_(
+                        *projection_conditions,
+                        AccountingProjection.projected_at_ns.is_(None),
+                    )
+                )
             )
         ).scalar_one()
-        return {
+        counts["rejected"] = (
+            await self._session.execute(
+                select(func.count())
+                .select_from(AccountingRejection)
+                .where(and_(*rejection_conditions))
+            )
+        ).scalar_one()
+        result: dict[str, object] = {
             "selling_total_usd": format(selling, "f"),
             "counts": {**counts, "pending_delivery": pending},
             "records": len(rows),
         }
+        if include_acquisition:
+            result["acquisition_total_usd"] = format(acquisition, "f")
+            result["margin_usd"] = format(selling - acquisition, "f")
+        allowed_groups = {
+            "session": "session_id",
+            "component": "component",
+            "modality": "modality",
+            "model": "model_id",
+            "acquisition_revision": "acquisition_revision_id",
+            "selling_revision": "selling_revision_id",
+        }
+        if any(item not in allowed_groups for item in group_by):
+            raise ValueError("unsupported reconciliation group")
+        groups: dict[tuple[str | None, ...], list[AccountingUsage]] = {}
+        for row in rows:
+            key = tuple(getattr(row, allowed_groups[item]) for item in group_by)
+            groups.setdefault(key, []).append(row)
+        result["groups"] = [
+            {
+                "keys": dict(zip(group_by, key, strict=True)),
+                "records": len(group_rows),
+                "selling_total_usd": format(
+                    sum(
+                        (
+                            Decimal(row.selling_total_usd)
+                            for row in group_rows
+                            if row.selling_total_usd is not None
+                        ),
+                        start=Decimal(0),
+                    ),
+                    "f",
+                ),
+            }
+            for key, group_rows in groups.items()
+        ]
+        return result

--- a/src/voicegateway/services/accounting_service.py
+++ b/src/voicegateway/services/accounting_service.py
@@ -1,5 +1,7 @@
 """Transactional immutable-pricing and usage-ledger operations."""
 
+# mypy: disable-error-code="arg-type,attr-defined,union-attr"
+
 from __future__ import annotations
 
 import hashlib

--- a/src/voicegateway/services/accounting_service.py
+++ b/src/voicegateway/services/accounting_service.py
@@ -1,18 +1,18 @@
 """Transactional immutable-pricing and usage-ledger operations."""
 
-# mypy: disable-error-code="arg-type,attr-defined,union-attr"
-
 from __future__ import annotations
 
 import hashlib
 import json
 import time
 import uuid
+from collections.abc import Sequence
 from decimal import Decimal
 
 from sqlalchemy import and_, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from voicegateway.accounting.contracts import (
     OwnershipAssignment,
@@ -27,7 +27,6 @@ from voicegateway.accounting.contracts import (
 from voicegateway.accounting.rating import rate_usage
 from voicegateway.models.accounting_model import (
     AccountingOwnership,
-    AccountingProjection,
     AccountingRejection,
     AccountingUsage,
     PreparedPricingBinding,
@@ -50,9 +49,9 @@ class AccountingService:
         content = payload.canonical_content()
         digest = payload.content_hash()
         query = select(PricingRevision).where(
-            PricingRevision.tenant_id == self._tenant_id,
-            PricingRevision.side == payload.side.value,
-            PricingRevision.revision_id == payload.revision_id,
+            col(PricingRevision.tenant_id) == self._tenant_id,
+            col(PricingRevision.side) == payload.side.value,
+            col(PricingRevision.revision_id) == payload.revision_id,
         )
         existing = (await self._session.execute(query)).scalar_one_or_none()
         if existing is not None:
@@ -97,9 +96,9 @@ class AccountingService:
         self, side: PricingSide, revision_id: str
     ) -> PricingRevision | None:
         query = select(PricingRevision).where(
-            PricingRevision.tenant_id == self._tenant_id,
-            PricingRevision.side == side.value,
-            PricingRevision.revision_id == revision_id,
+            col(PricingRevision.tenant_id) == self._tenant_id,
+            col(PricingRevision.side) == side.value,
+            col(PricingRevision.revision_id) == revision_id,
         )
         return (await self._session.execute(query)).scalar_one_or_none()
 
@@ -117,12 +116,14 @@ class AccountingService:
             raise RevisionConflict("stored pricing revision hash mismatch")
         current = (
             await self._session.execute(
-                select(PricingRevision).where(
-                    PricingRevision.tenant_id == self._tenant_id,
-                    PricingRevision.side == side.value,
-                    PricingRevision.scope_key == row.scope_key,
-                    PricingRevision.active.is_(True),
+                select(PricingRevision)
+                .where(
+                    col(PricingRevision.tenant_id) == self._tenant_id,
+                    col(PricingRevision.side) == side.value,
+                    col(PricingRevision.scope_key) == row.scope_key,
+                    col(PricingRevision.active).is_(True),
                 )
+                .with_for_update()
             )
         ).scalar_one_or_none()
         if expected_current_revision_id is not None and (
@@ -132,15 +133,19 @@ class AccountingService:
         await self._session.execute(
             update(PricingRevision)
             .where(
-                PricingRevision.tenant_id == self._tenant_id,
-                PricingRevision.side == side.value,
-                PricingRevision.scope_key == row.scope_key,
+                col(PricingRevision.tenant_id) == self._tenant_id,
+                col(PricingRevision.side) == side.value,
+                col(PricingRevision.scope_key) == row.scope_key,
             )
             .values(active=False)
         )
         row.active = True
         self._session.add(row)
-        await self._session.commit()
+        try:
+            await self._session.commit()
+        except IntegrityError:
+            await self._session.rollback()
+            raise RevisionConflict("active revision changed") from None
         await self._session.refresh(row)
         return row
 
@@ -148,9 +153,9 @@ class AccountingService:
         self, assignment: OwnershipAssignment
     ) -> AccountingOwnership:
         query = select(AccountingOwnership).where(
-            AccountingOwnership.tenant_id == self._tenant_id,
-            AccountingOwnership.project_id == assignment.project_id,
-            AccountingOwnership.component == assignment.component,
+            col(AccountingOwnership.tenant_id) == self._tenant_id,
+            col(AccountingOwnership.project_id) == assignment.project_id,
+            col(AccountingOwnership.component) == assignment.component,
         )
         row = (await self._session.execute(query)).scalar_one_or_none()
         if row is None:
@@ -171,9 +176,9 @@ class AccountingService:
 
     async def prepare(self, request: PreparationRequest) -> PricingBinding:
         ownership_query = select(AccountingOwnership).where(
-            AccountingOwnership.tenant_id == self._tenant_id,
-            AccountingOwnership.project_id == request.project_id,
-            AccountingOwnership.component == request.component,
+            col(AccountingOwnership.tenant_id) == self._tenant_id,
+            col(AccountingOwnership.project_id) == request.project_id,
+            col(AccountingOwnership.component) == request.component,
         )
         ownership = (await self._session.execute(ownership_query)).scalar_one_or_none()
         mode = (
@@ -187,9 +192,9 @@ class AccountingService:
                 (
                     await self._session.execute(
                         select(PricingRevision).where(
-                            PricingRevision.tenant_id == self._tenant_id,
-                            PricingRevision.side == side.value,
-                            PricingRevision.active.is_(True),
+                            col(PricingRevision.tenant_id) == self._tenant_id,
+                            col(PricingRevision.side) == side.value,
+                            col(PricingRevision.active).is_(True),
                         )
                     )
                 )
@@ -244,9 +249,9 @@ class AccountingService:
         canonical = envelope.model_dump_json()
         digest = hashlib.sha256(canonical.encode()).hexdigest()
         query = select(AccountingUsage).where(
-            AccountingUsage.tenant_id == self._tenant_id,
-            AccountingUsage.project_id == envelope.project_id,
-            AccountingUsage.event_id == envelope.event_id,
+            col(AccountingUsage.tenant_id) == self._tenant_id,
+            col(AccountingUsage.project_id) == envelope.project_id,
+            col(AccountingUsage.event_id) == envelope.event_id,
         )
         existing = (await self._session.execute(query)).scalar_one_or_none()
         if existing is not None:
@@ -259,45 +264,79 @@ class AccountingService:
                 code="already_committed",
             )
 
+        effective = envelope
         if envelope.pricing_binding_id is not None:
             binding = await self._session.get(
                 PreparedPricingBinding, envelope.pricing_binding_id
             )
             if binding is None or binding.tenant_id != self._tenant_id:
                 return await self._reject(envelope, digest, "binding_not_found")
-            expected = (
+            expected_identity = (
                 binding.project_id,
                 binding.component,
                 binding.offering,
-                binding.ownership_mode,
-                binding.acquisition_revision_id,
-                binding.selling_revision_id,
             )
-            supplied = (
+            supplied_identity = (
                 envelope.project_id,
                 envelope.component,
                 envelope.offering,
-                envelope.ownership_mode.value,
-                envelope.acquisition_revision_id,
-                envelope.selling_revision_id,
             )
-            if expected != supplied:
+            if expected_identity != supplied_identity:
                 return await self._reject(envelope, digest, "binding_mismatch")
+            effective = envelope.model_copy(
+                update={
+                    "ownership_mode": OwnershipMode(binding.ownership_mode),
+                    "acquisition_revision_id": binding.acquisition_revision_id,
+                    "selling_revision_id": binding.selling_revision_id,
+                }
+            )
+        else:
+            ownership = (
+                await self._session.execute(
+                    select(AccountingOwnership).where(
+                        col(AccountingOwnership.tenant_id) == self._tenant_id,
+                        col(AccountingOwnership.project_id) == envelope.project_id,
+                        col(AccountingOwnership.component) == envelope.component,
+                    )
+                )
+            ).scalar_one_or_none()
+            expected_mode = (
+                OwnershipMode(ownership.mode)
+                if ownership is not None
+                else OwnershipMode.SDK
+            )
+            if envelope.ownership_mode is not expected_mode:
+                return await self._reject(envelope, digest, "ownership_mismatch")
 
         acquisition_total, acquisition_complete = await self._rate(
-            envelope, PricingSide.ACQUISITION
+            effective, PricingSide.ACQUISITION
         )
         selling_total, selling_complete = await self._rate(
-            envelope, PricingSide.SELLING
+            effective, PricingSide.SELLING
         )
         has_missing_measurement = any(
-            item.value is None for item in envelope.quantities
+            item.value is None for item in effective.quantities
         )
+        has_partial_total = any(
+            total is not None and not complete
+            for total, complete in (
+                (acquisition_total, acquisition_complete),
+                (selling_total, selling_complete),
+            )
+        )
+        provided_sides = [
+            complete
+            for revision_id, complete in (
+                (effective.acquisition_revision_id, acquisition_complete),
+                (effective.selling_revision_id, selling_complete),
+            )
+            if revision_id is not None
+        ]
         status = (
             "rated"
-            if acquisition_complete and selling_complete
+            if provided_sides and all(provided_sides)
             else "incomplete"
-            if has_missing_measurement
+            if has_missing_measurement or has_partial_total
             else "unrated"
         )
         receipt_id = str(uuid.uuid4())
@@ -313,10 +352,10 @@ class AccountingService:
             session_id=envelope.session_id,
             turn_id=envelope.turn_id,
             producer_id=envelope.producer_id,
-            ownership_mode=envelope.ownership_mode.value,
+            ownership_mode=effective.ownership_mode.value,
             pricing_binding_id=envelope.pricing_binding_id,
-            acquisition_revision_id=envelope.acquisition_revision_id,
-            selling_revision_id=envelope.selling_revision_id,
+            acquisition_revision_id=effective.acquisition_revision_id,
+            selling_revision_id=effective.selling_revision_id,
             occurred_at_ns=envelope.occurred_at_ns,
             payload_hash=digest,
             envelope_json=canonical,
@@ -329,14 +368,6 @@ class AccountingService:
             created_at_ns=time.time_ns(),
         )
         self._session.add(row)
-        self._session.add(
-            AccountingProjection(
-                tenant_id=self._tenant_id,
-                project_id=envelope.project_id,
-                event_id=envelope.event_id,
-                payload_json=canonical,
-            )
-        )
         try:
             await self._session.commit()
         except IntegrityError:
@@ -359,14 +390,20 @@ class AccountingService:
             code="committed",
         )
 
+    async def reject(self, envelope: UsageEnvelope, code: str) -> RecordReceipt:
+        """Persist a stable per-record rejection without attempting ingestion."""
+        canonical = envelope.model_dump_json()
+        digest = hashlib.sha256(canonical.encode()).hexdigest()
+        return await self._reject(envelope, digest, code)
+
     async def _reject(
         self, envelope: UsageEnvelope, payload_hash: str, code: str
     ) -> RecordReceipt:
         query = select(AccountingRejection).where(
-            AccountingRejection.tenant_id == self._tenant_id,
-            AccountingRejection.project_id == envelope.project_id,
-            AccountingRejection.event_id == envelope.event_id,
-            AccountingRejection.payload_hash == payload_hash,
+            col(AccountingRejection.tenant_id) == self._tenant_id,
+            col(AccountingRejection.project_id) == envelope.project_id,
+            col(AccountingRejection.event_id) == envelope.event_id,
+            col(AccountingRejection.payload_hash) == payload_hash,
         )
         existing = (await self._session.execute(query)).scalar_one_or_none()
         if existing is not None:
@@ -388,7 +425,17 @@ class AccountingService:
                 created_at_ns=time.time_ns(),
             )
         )
-        await self._session.commit()
+        try:
+            await self._session.commit()
+        except IntegrityError:
+            await self._session.rollback()
+            concurrent = (await self._session.execute(query)).scalar_one()
+            return RecordReceipt(
+                event_id=envelope.event_id,
+                outcome="rejected",
+                receipt_id=concurrent.receipt_id,
+                code=concurrent.code,
+            )
         return RecordReceipt(
             event_id=envelope.event_id,
             outcome="rejected",
@@ -423,11 +470,11 @@ class AccountingService:
         group_by: tuple[str, ...] = (),
         include_acquisition: bool = False,
     ) -> dict[str, object]:
-        conditions = [AccountingUsage.tenant_id == self._tenant_id]
+        conditions = [col(AccountingUsage.tenant_id) == self._tenant_id]
         if project_id is not None:
-            conditions.append(AccountingUsage.project_id == project_id)
+            conditions.append(col(AccountingUsage.project_id) == project_id)
         elif allowed_project_ids is not None:
-            conditions.append(AccountingUsage.project_id.in_(allowed_project_ids))
+            conditions.append(col(AccountingUsage.project_id).in_(allowed_project_ids))
         rows = (
             (
                 await self._session.execute(
@@ -437,10 +484,11 @@ class AccountingService:
             .scalars()
             .all()
         )
+        rated_rows = [row for row in rows if row.status == "rated"]
         selling = sum(
             (
                 Decimal(row.selling_total_usd)
-                for row in rows
+                for row in rated_rows
                 if row.selling_total_usd is not None
             ),
             start=Decimal(0),
@@ -448,7 +496,7 @@ class AccountingService:
         acquisition = sum(
             (
                 Decimal(row.acquisition_total_usd)
-                for row in rows
+                for row in rated_rows
                 if row.acquisition_total_usd is not None
             ),
             start=Decimal(0),
@@ -457,30 +505,15 @@ class AccountingService:
             name: sum(row.status == name for row in rows)
             for name in ("rated", "unrated", "incomplete", "rejected")
         }
-        projection_conditions = [AccountingProjection.tenant_id == self._tenant_id]
-        rejection_conditions = [AccountingRejection.tenant_id == self._tenant_id]
+        rejection_conditions = [col(AccountingRejection.tenant_id) == self._tenant_id]
         if project_id is not None:
-            projection_conditions.append(AccountingProjection.project_id == project_id)
-            rejection_conditions.append(AccountingRejection.project_id == project_id)
-        elif allowed_project_ids is not None:
-            projection_conditions.append(
-                AccountingProjection.project_id.in_(allowed_project_ids)
-            )
             rejection_conditions.append(
-                AccountingRejection.project_id.in_(allowed_project_ids)
+                col(AccountingRejection.project_id) == project_id
             )
-        pending = (
-            await self._session.execute(
-                select(func.count())
-                .select_from(AccountingProjection)
-                .where(
-                    and_(
-                        *projection_conditions,
-                        AccountingProjection.projected_at_ns.is_(None),
-                    )
-                )
+        elif allowed_project_ids is not None:
+            rejection_conditions.append(
+                col(AccountingRejection.project_id).in_(allowed_project_ids)
             )
-        ).scalar_one()
         counts["rejected"] = (
             await self._session.execute(
                 select(func.count())
@@ -490,12 +523,26 @@ class AccountingService:
         ).scalar_one()
         result: dict[str, object] = {
             "selling_total_usd": format(selling, "f"),
-            "counts": {**counts, "pending_delivery": pending},
+            "incomplete_selling_total_usd": format(
+                self._sum_side(rows, "selling_total_usd", status="incomplete"), "f"
+            ),
+            "unrated_selling_total_usd": format(
+                self._sum_side(rows, "selling_total_usd", status="unrated"), "f"
+            ),
+            "counts": counts,
             "records": len(rows),
         }
         if include_acquisition:
             result["acquisition_total_usd"] = format(acquisition, "f")
             result["margin_usd"] = format(selling - acquisition, "f")
+            result["incomplete_acquisition_total_usd"] = format(
+                self._sum_side(rows, "acquisition_total_usd", status="incomplete"),
+                "f",
+            )
+            result["unrated_acquisition_total_usd"] = format(
+                self._sum_side(rows, "acquisition_total_usd", status="unrated"),
+                "f",
+            )
         allowed_groups = {
             "session": "session_id",
             "component": "component",
@@ -519,6 +566,7 @@ class AccountingService:
                         (
                             Decimal(row.selling_total_usd)
                             for row in group_rows
+                            if row.status == "rated"
                             if row.selling_total_usd is not None
                         ),
                         start=Decimal(0),
@@ -529,3 +577,17 @@ class AccountingService:
             for key, group_rows in groups.items()
         ]
         return result
+
+    @staticmethod
+    def _sum_side(
+        rows: Sequence[AccountingUsage], field: str, *, status: str
+    ) -> Decimal:
+        return sum(
+            (
+                Decimal(value)
+                for row in rows
+                if row.status == status
+                if (value := getattr(row, field)) is not None
+            ),
+            start=Decimal(0),
+        )

--- a/src/voicegateway/services/accounting_service.py
+++ b/src/voicegateway/services/accounting_service.py
@@ -1,0 +1,236 @@
+"""Transactional immutable-pricing and usage-ledger operations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+
+from sqlalchemy import and_, func, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from voicegateway.accounting.contracts import (
+    PricingRevisionCreate,
+    PricingSide,
+    RecordReceipt,
+    UsageEnvelope,
+)
+from voicegateway.accounting.rating import rate_usage
+from voicegateway.models.accounting_model import (
+    AccountingProjection,
+    AccountingUsage,
+    PricingRevision,
+)
+
+
+class RevisionConflict(ValueError):
+    pass
+
+
+class AccountingService:
+    def __init__(self, session: AsyncSession, *, tenant_id: str) -> None:
+        self._session = session
+        self._tenant_id = tenant_id
+
+    async def create_revision(
+        self, payload: PricingRevisionCreate
+    ) -> tuple[PricingRevision, bool]:
+        content = payload.canonical_content()
+        digest = payload.content_hash()
+        query = select(PricingRevision).where(
+            PricingRevision.tenant_id == self._tenant_id,
+            PricingRevision.side == payload.side.value,
+            PricingRevision.revision_id == payload.revision_id,
+        )
+        existing = (await self._session.execute(query)).scalar_one_or_none()
+        if existing is not None:
+            if existing.content_hash != digest:
+                raise RevisionConflict(
+                    "revision identity already exists with different content"
+                )
+            return existing, False
+        row = PricingRevision(
+            tenant_id=self._tenant_id,
+            revision_id=payload.revision_id,
+            side=payload.side.value,
+            scope_json=json.dumps(
+                payload.scope.model_dump(mode="json"), sort_keys=True
+            ),
+            content_json=content,
+            content_hash=digest,
+            contract_version=payload.contract_version,
+            currency=payload.currency,
+            created_at_ns=time.time_ns(),
+        )
+        self._session.add(row)
+        await self._session.commit()
+        await self._session.refresh(row)
+        return row, True
+
+    async def get_revision(
+        self, side: PricingSide, revision_id: str
+    ) -> PricingRevision | None:
+        query = select(PricingRevision).where(
+            PricingRevision.tenant_id == self._tenant_id,
+            PricingRevision.side == side.value,
+            PricingRevision.revision_id == revision_id,
+        )
+        return (await self._session.execute(query)).scalar_one_or_none()
+
+    async def activate_revision(
+        self, side: PricingSide, revision_id: str
+    ) -> PricingRevision:
+        row = await self.get_revision(side, revision_id)
+        if row is None:
+            raise LookupError("pricing revision not found")
+        if hashlib.sha256(row.content_json.encode()).hexdigest() != row.content_hash:
+            raise RevisionConflict("stored pricing revision hash mismatch")
+        await self._session.execute(
+            update(PricingRevision)
+            .where(
+                PricingRevision.tenant_id == self._tenant_id,
+                PricingRevision.side == side.value,
+            )
+            .values(active=False)
+        )
+        row.active = True
+        self._session.add(row)
+        await self._session.commit()
+        await self._session.refresh(row)
+        return row
+
+    async def ingest(self, envelope: UsageEnvelope) -> RecordReceipt:
+        canonical = envelope.model_dump_json()
+        digest = hashlib.sha256(canonical.encode()).hexdigest()
+        query = select(AccountingUsage).where(
+            AccountingUsage.tenant_id == self._tenant_id,
+            AccountingUsage.project_id == envelope.project_id,
+            AccountingUsage.event_id == envelope.event_id,
+        )
+        existing = (await self._session.execute(query)).scalar_one_or_none()
+        if existing is not None:
+            if existing.payload_hash != digest:
+                return RecordReceipt(
+                    event_id=envelope.event_id,
+                    outcome="rejected",
+                    code="identity_conflict",
+                )
+            return RecordReceipt(
+                event_id=envelope.event_id,
+                outcome="duplicate",
+                receipt_id=existing.receipt_id,
+                code="already_committed",
+            )
+
+        acquisition_total, acquisition_complete = await self._rate(
+            envelope, PricingSide.ACQUISITION
+        )
+        selling_total, selling_complete = await self._rate(
+            envelope, PricingSide.SELLING
+        )
+        status = "rated" if acquisition_complete and selling_complete else "unrated"
+        receipt_id = str(uuid.uuid4())
+        row = AccountingUsage(
+            tenant_id=self._tenant_id,
+            project_id=envelope.project_id,
+            event_id=envelope.event_id,
+            attempt_id=envelope.attempt_id,
+            component=envelope.component,
+            modality=envelope.modality,
+            offering=envelope.offering,
+            model_id=envelope.model_id,
+            session_id=envelope.session_id,
+            turn_id=envelope.turn_id,
+            producer_id=envelope.producer_id,
+            ownership_mode=envelope.ownership_mode.value,
+            acquisition_revision_id=envelope.acquisition_revision_id,
+            selling_revision_id=envelope.selling_revision_id,
+            occurred_at_ns=envelope.occurred_at_ns,
+            payload_hash=digest,
+            envelope_json=canonical,
+            acquisition_total_usd=acquisition_total,
+            selling_total_usd=selling_total,
+            acquisition_complete=acquisition_complete,
+            selling_complete=selling_complete,
+            status=status,
+            receipt_id=receipt_id,
+            created_at_ns=time.time_ns(),
+        )
+        self._session.add(row)
+        self._session.add(
+            AccountingProjection(event_id=envelope.event_id, payload_json=canonical)
+        )
+        try:
+            await self._session.commit()
+        except IntegrityError:
+            await self._session.rollback()
+            return RecordReceipt(
+                event_id=envelope.event_id,
+                outcome="rejected",
+                code="attempt_or_ownership_conflict",
+            )
+        return RecordReceipt(
+            event_id=envelope.event_id,
+            outcome="accepted",
+            receipt_id=receipt_id,
+            code="committed",
+        )
+
+    async def _rate(
+        self, envelope: UsageEnvelope, side: PricingSide
+    ) -> tuple[str | None, bool]:
+        revision_id = (
+            envelope.acquisition_revision_id
+            if side is PricingSide.ACQUISITION
+            else envelope.selling_revision_id
+        )
+        if revision_id is None:
+            return None, False
+        row = await self.get_revision(side, revision_id)
+        if (
+            row is None
+            or hashlib.sha256(row.content_json.encode()).hexdigest() != row.content_hash
+        ):
+            return None, False
+        revision = PricingRevisionCreate.model_validate_json(row.content_json)
+        return rate_usage(envelope, revision)
+
+    async def report(self, *, project_id: str | None = None) -> dict[str, object]:
+        conditions = [AccountingUsage.tenant_id == self._tenant_id]
+        if project_id is not None:
+            conditions.append(AccountingUsage.project_id == project_id)
+        rows = (
+            (
+                await self._session.execute(
+                    select(AccountingUsage).where(and_(*conditions))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        selling = sum(
+            (
+                __import__("decimal").Decimal(row.selling_total_usd)
+                for row in rows
+                if row.selling_total_usd is not None
+            ),
+            start=__import__("decimal").Decimal(0),
+        )
+        counts = {
+            name: sum(row.status == name for row in rows)
+            for name in ("rated", "unrated", "incomplete", "rejected")
+        }
+        pending = (
+            await self._session.execute(
+                select(func.count())
+                .select_from(AccountingProjection)
+                .where(AccountingProjection.projected_at_ns.is_(None))
+            )
+        ).scalar_one()
+        return {
+            "selling_total_usd": format(selling, "f"),
+            "counts": {**counts, "pending_delivery": pending},
+            "records": len(rows),
+        }

--- a/src/voicegateway/services/api_key_service.py
+++ b/src/voicegateway/services/api_key_service.py
@@ -8,6 +8,7 @@ from typing import Final
 
 import bcrypt
 
+from voicegateway.core.scopes import normalize_scopes
 from voicegateway.models.api_key_model import ApiKey
 from voicegateway.repository.api_key_repository import ApiKeyRepository
 from voicegateway.services.base_service import BaseService
@@ -74,17 +75,27 @@ class ApiKeyService(BaseService[ApiKey]):
         self,
         *,
         name: str,
+        scopes: str,
         tenant_id: str | None = None,
         issued_by: str | None = None,
     ) -> CreatedKey:
-        """Mint a new virtual key. The plaintext is returned exactly once."""
+        """Mint a new virtual key. The plaintext is returned exactly once.
+
+        ``scopes`` is required and goes through the same
+        :func:`~voicegateway.core.scopes.normalize_scopes` as the
+        function-style repository, so this door and that one refuse exactly
+        the same requests. Before 0.26.0 this path set no scopes at all and
+        the model default (``"*"``) applied, which is VG-SEC-006.
+        """
         if not name:
             raise ValueError("name must be non-empty")
+        granted = normalize_scopes(scopes)
         plaintext = _generate_plaintext_key()
         row = ApiKey(
             key_prefix=_visible_prefix(plaintext),
             key_hash=_hash(plaintext),
             name=name,
+            scopes=granted,
             tenant_id=tenant_id,
             issued_by=issued_by,
         )

--- a/src/voicegateway/services/api_key_service.py
+++ b/src/voicegateway/services/api_key_service.py
@@ -35,6 +35,7 @@ class VerifiedKey:
     id: int
     tenant_id: str | None
     name: str
+    project_ids: str | None = None
 
 
 def _generate_plaintext_key() -> str:
@@ -78,6 +79,7 @@ class ApiKeyService(BaseService[ApiKey]):
         scopes: str,
         tenant_id: str | None = None,
         issued_by: str | None = None,
+        project_ids: str | None = None,
     ) -> CreatedKey:
         """Mint a new virtual key. The plaintext is returned exactly once.
 
@@ -98,6 +100,7 @@ class ApiKeyService(BaseService[ApiKey]):
             scopes=granted,
             tenant_id=tenant_id,
             issued_by=issued_by,
+            project_ids=project_ids,
         )
         persisted = await self._repository.create(row)
         return CreatedKey(plaintext=plaintext, row=persisted)
@@ -116,7 +119,12 @@ class ApiKeyService(BaseService[ApiKey]):
                 continue
             if _check(plaintext, row.key_hash):
                 assert row.id is not None
-                return VerifiedKey(id=row.id, tenant_id=row.tenant_id, name=row.name)
+                return VerifiedKey(
+                    id=row.id,
+                    tenant_id=row.tenant_id,
+                    name=row.name,
+                    project_ids=row.project_ids,
+                )
         return None
 
     async def mark_used(self, key_id: int) -> None:

--- a/src/voicegateway/services/request_log_service.py
+++ b/src/voicegateway/services/request_log_service.py
@@ -17,10 +17,12 @@ class RequestLogService:
     def __init__(self, database: Database) -> None:
         self._db = database
 
-    async def log_request(self, record: RequestRecord) -> None:
-        """Persist one request row + accumulate the session row."""
+    async def log_request(
+        self, record: RequestRecord, *, tenant_id: str | None
+    ) -> None:
+        """Persist one request row + accumulate the session row under ``tenant_id``."""
         async with self._db.session() as s:
-            await repo.log_request(s, record)
+            await repo.log_request(s, record, tenant_id=tenant_id)
 
     async def log_audit_event(
         self,

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -17,7 +17,7 @@ import asyncio
 import hashlib
 import json
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import asdict
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -133,31 +133,51 @@ class AccountingCaptureSink:
         outbox: AccountingOutbox,
         *,
         producer_id: str,
-        binding: PricingBinding | PricingBindingResponse | None = None,
+        binding: (
+            PricingBinding
+            | PricingBindingResponse
+            | Mapping[str, PricingBinding | PricingBindingResponse]
+            | None
+        ) = None,
     ) -> None:
         self._sink = sink
         self._outbox = outbox
         self._producer_id = producer_id
         self._binding = binding
 
+    def _binding_for(
+        self, record: RequestRecord
+    ) -> PricingBinding | PricingBindingResponse | None:
+        if isinstance(self._binding, Mapping):
+            return self._binding.get(record.model_id) or self._binding.get(
+                record.modality
+            )
+        return self._binding
+
     async def log_request(self, record: RequestRecord) -> None:
-        await self._sink.log_request(record)
         from voicegateway.accounting.adapters import envelope_from_request_record
         from voicegateway.accounting.contracts import OwnershipMode
 
-        if (
-            self._binding is not None
-            and self._binding.ownership_mode is OwnershipMode.EXTERNAL
-        ):
-            return
-        envelope = envelope_from_request_record(
-            record,
-            producer_id=self._producer_id,
-            binding=self._binding,
-            event_id=f"usage:{record.id}",
-            attempt_id=record.id,
-        )
-        self._outbox.enqueue_nowait(envelope)
+        binding = self._binding_for(record)
+        if binding is None or binding.ownership_mode is not OwnershipMode.EXTERNAL:
+            envelope = envelope_from_request_record(
+                record,
+                producer_id=self._producer_id,
+                binding=binding,
+                event_id=f"usage:{record.id}",
+                attempt_id=record.id,
+            )
+            try:
+                outcome = await self._outbox.submit(envelope)
+                if outcome == "full":
+                    logger.error("accounting outbox full; event was not persisted")
+            except Exception:
+                await self._outbox.record_capture_failure()
+                logger.exception("accounting outbox persistence failed")
+        # Legacy observability remains independent: accounting failure cannot
+        # suppress the normal telemetry row, and collector delivery never runs
+        # on this path.
+        await self._sink.log_request(record)
 
     async def log_turns(self, rows: list[TurnRow]) -> None:
         await self._sink.log_turns(rows)

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -67,6 +67,24 @@ class Sink(Protocol):
     async def aclose(self) -> None: ...
 
 
+def _enqueue_tenant() -> str | None:
+    """The tenant to stamp on an agent-side write, read at enqueue time.
+
+    This is the one place the ContextVar stays legitimate. A sink runs in the
+    same task as the session that set the tenant, so reading it here is
+    reading the caller's own identity. ``flush`` may run later in a background
+    task whose context no longer carries it, which is why every write captures
+    the tenant when it is buffered rather than when it lands.
+
+    Server routes never come through here: they pass the authenticated
+    principal's tenant explicitly, because a request handler's context holds
+    whatever the previous request happened to leave behind.
+    """
+    from voicegateway.inference.session.context import current_tenant
+
+    return current_tenant()
+
+
 class LocalSqliteSink:
     """Default single-node sink: writes through the embedded StorageService.
 
@@ -83,13 +101,13 @@ class LocalSqliteSink:
         await self._storage.log_request(record)
 
     async def log_turns(self, rows: list[TurnRow]) -> None:
-        await self._storage.log_turns(rows)
+        await self._storage.log_turns(rows, tenant_id=_enqueue_tenant())
 
     async def log_dead_air(self, events: list[DeadAirEvent]) -> None:
-        await self._storage.log_dead_air(events)
+        await self._storage.log_dead_air(events, tenant_id=_enqueue_tenant())
 
     async def log_tool_calls(self, rows: list[ToolCall]) -> None:
-        await self._storage.log_tool_calls(rows)
+        await self._storage.log_tool_calls(rows, tenant_id=_enqueue_tenant())
 
     async def flush(self) -> None:
         return None

--- a/src/voicegateway/services/sinks.py
+++ b/src/voicegateway/services/sinks.py
@@ -23,6 +23,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from voicegateway.accounting.contracts import PricingBinding, PricingBindingResponse
+    from voicegateway.accounting.outbox import AccountingOutbox
     from voicegateway.middleware.dead_air_detector_middleware import DeadAirEvent
     from voicegateway.middleware.turn_tracker_middleware import TurnRow
     from voicegateway.models.request_model import RequestRecord
@@ -120,6 +122,63 @@ class LocalSqliteSink:
 
     async def finalize_session_replay(self, session_id: str) -> None:
         await self._storage.finalize_session_replay(session_id)
+
+
+class AccountingCaptureSink:
+    """Opt-in decorator that mirrors request measurements to usage v1."""
+
+    def __init__(
+        self,
+        sink: Sink,
+        outbox: AccountingOutbox,
+        *,
+        producer_id: str,
+        binding: PricingBinding | PricingBindingResponse | None = None,
+    ) -> None:
+        self._sink = sink
+        self._outbox = outbox
+        self._producer_id = producer_id
+        self._binding = binding
+
+    async def log_request(self, record: RequestRecord) -> None:
+        await self._sink.log_request(record)
+        from voicegateway.accounting.adapters import envelope_from_request_record
+        from voicegateway.accounting.contracts import OwnershipMode
+
+        if (
+            self._binding is not None
+            and self._binding.ownership_mode is OwnershipMode.EXTERNAL
+        ):
+            return
+        envelope = envelope_from_request_record(
+            record,
+            producer_id=self._producer_id,
+            binding=self._binding,
+            event_id=f"usage:{record.id}",
+            attempt_id=record.id,
+        )
+        self._outbox.enqueue_nowait(envelope)
+
+    async def log_turns(self, rows: list[TurnRow]) -> None:
+        await self._sink.log_turns(rows)
+
+    async def log_dead_air(self, events: list[DeadAirEvent]) -> None:
+        await self._sink.log_dead_air(events)
+
+    async def log_tool_calls(self, rows: list[ToolCall]) -> None:
+        await self._sink.log_tool_calls(rows)
+
+    async def flush(self) -> None:
+        await self._sink.flush()
+        await self._outbox.flush_memory()
+        await self._outbox.drain_with_backoff()
+
+    async def aclose(self) -> None:
+        await self._sink.aclose()
+        await self._outbox.aclose()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._sink, name)
 
 
 def _normalize_ingest_url(url: str) -> str:

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from voicegateway.core.config import GatewayConfig
 from voicegateway.core.database import Database, DatabaseAheadOfCode
@@ -73,6 +77,24 @@ class StorageService:
                 # of the process. Warn once, here, instead of per write.
                 _logger.warning("%s Writing anyway; the schema is a superset.", exc)
             self._initialized = True
+
+    @asynccontextmanager
+    async def session(self) -> AsyncGenerator[AsyncSession, None]:
+        """The one public way to a database session.
+
+        Runs migrations once, then yields a session with rollback-on-error
+        and always-close from :meth:`Database.session`. Routes reach this
+        through the ``get_session`` dependency and never touch ``_conn`` or
+        ``_ensure_initialized``; a structural test enforces that.
+
+        The pairing matters. Every caller that reached in previously had to
+        remember to call ``_ensure_initialized()`` first, and forgetting it
+        was a latent "no such table" on a fresh database. Here it cannot be
+        forgotten, because there is no way to get a session without it.
+        """
+        await self._ensure_initialized()
+        async with self._conn.session() as session:
+            yield session
 
     async def aclose(self) -> None:
         """Dispose the underlying engine."""

--- a/src/voicegateway/services/storage_service.py
+++ b/src/voicegateway/services/storage_service.py
@@ -136,9 +136,26 @@ class StorageService:
     # ------------------------------------------------------------------
 
     async def log_request(self, record: RequestRecord) -> None:
-        """Delegate to RequestLogService.log_request."""
+        """Agent-side entry point: the tenant is the process's ContextVar.
+
+        In-process sinks call this from the task that set the tenant, so
+        reading the ContextVar here, at the service layer, is correct and is
+        the one place it stays legitimate. Server routes must call
+        :meth:`log_request_as` with the authenticated principal's tenant
+        instead: a request handler runs under whatever tenant the *previous*
+        request happened to leave in the context, which is not a tenant
+        boundary at all.
+        """
+        from voicegateway.inference.session.context import current_tenant
+
+        await self.log_request_as(record, tenant_id=current_tenant())
+
+    async def log_request_as(
+        self, record: RequestRecord, *, tenant_id: str | None
+    ) -> None:
+        """Server-side entry point: the tenant is explicit and comes from the key."""
         await self._ensure_initialized()
-        await self._request_log_service.log_request(record)
+        await self._request_log_service.log_request(record, tenant_id=tenant_id)
 
     # ------------------------------------------------------------------
     # Reads
@@ -411,7 +428,7 @@ class StorageService:
     # Turns
     # ------------------------------------------------------------------
 
-    async def log_turns(self, rows: list[Any]) -> int:
+    async def log_turns(self, rows: list[Any], *, tenant_id: str | None) -> int:
         """Bulk-write captured turns. Returns the number inserted.
 
         A passthrough for the same reason as the load-run writes above: the
@@ -424,9 +441,9 @@ class StorageService:
             return 0
         await self._ensure_initialized()
         async with self._conn.session() as db:
-            return await turns.create_turns_bulk(db, rows)
+            return await turns.create_turns_bulk(db, rows, tenant_id=tenant_id)
 
-    async def log_tool_calls(self, rows: list[Any]) -> int:
+    async def log_tool_calls(self, rows: list[Any], *, tenant_id: str | None) -> int:
         """Write per-tool-call rows. Returns the number inserted.
 
         Bulk, unlike dead air: a single turn can dispatch several tools and the
@@ -438,7 +455,7 @@ class StorageService:
             return 0
         await self._ensure_initialized()
         async with self._conn.session() as db:
-            return await tool_calls.create_tool_calls(db, rows)
+            return await tool_calls.create_tool_calls(db, rows, tenant_id=tenant_id)
 
     async def aggregate_tool_calls(self, session_id: str | None = None) -> dict:
         """Per-tool call count, total and average duration, failures."""
@@ -448,7 +465,7 @@ class StorageService:
         async with self._conn.session() as db:
             return await tool_calls.aggregate_by_tool(db, session_id=session_id)
 
-    async def log_dead_air(self, events: list[Any]) -> int:
+    async def log_dead_air(self, events: list[Any], *, tenant_id: str | None) -> int:
         """Write observed dead-air events. Returns the number inserted.
 
         Looped rather than bulk-inserted: the repository exposes one insert per
@@ -463,7 +480,7 @@ class StorageService:
         await self._ensure_initialized()
         async with self._conn.session() as db:
             for event in events:
-                await dead_air.create_event(db, event)
+                await dead_air.create_event(db, event, tenant_id=tenant_id)
         return len(events)
 
     # ------------------------------------------------------------------
@@ -556,7 +573,7 @@ class StorageService:
         self,
         events: list[Any],
         *,
-        tenant_id: str | None = None,
+        tenant_id: str | None,
     ) -> int:
         """Persist captured replay events into their per-modality tables.
 
@@ -583,7 +600,7 @@ class StorageService:
         session_id: str,
         turns: list[tuple[str, str]],
         *,
-        tenant_id: str | None = None,
+        tenant_id: str | None,
     ) -> int:
         """Replace a session's transcript with ``turns`` ((role, text) list)."""
         from voicegateway.repository import transcript_turns_repository

--- a/src/voicegateway/tests/accounting/test_accounting_sync_example.py
+++ b/src/voicegateway/tests/accounting/test_accounting_sync_example.py
@@ -1,0 +1,101 @@
+"""The published accounting synchronization example stays executable."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.repository.api_keys_repository import create_api_key
+from voicegateway.server import build_app
+
+_EXAMPLE_PATH = Path(__file__).parents[4] / "examples" / "accounting_sync.py"
+_SPEC = importlib.util.spec_from_file_location("accounting_sync_example", _EXAMPLE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_EXAMPLE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _EXAMPLE
+_SPEC.loader.exec_module(_EXAMPLE)
+ingest_pinned_usage = _EXAMPLE.ingest_pinned_usage
+prepare_binding = _EXAMPLE.prepare_binding
+revision_payload = _EXAMPLE.revision_payload
+synchronize_revision = _EXAMPLE.synchronize_revision
+
+
+async def test_sync_readback_and_delayed_pinned_usage_example(
+    tmp_path, monkeypatch
+) -> None:
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "cost_tracking": {"enabled": True},
+                "auth": {"enforcement": "enforce"},
+            }
+        )
+    )
+    monkeypatch.delenv("VOICEGW_DB_URL", raising=False)
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "example.db"))
+    gateway = Gateway(config_path=str(config))
+    async with gateway.storage.session() as session:
+        key = await create_api_key(
+            session,
+            name="example-operator",
+            role="admin",
+            scopes="read,ingest,admin",
+            tenant_id="example-tenant",
+        )
+    client = AsyncClient(
+        transport=ASGITransport(app=build_app(gateway)),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {key.plaintext}"},
+    )
+    async with client:
+        acquisition = await synchronize_revision(
+            client,
+            tenant="example-tenant",
+            payload=revision_payload(
+                "example-acquisition-v1",
+                "acquisition",
+                "example-tenant",
+                "0.01",
+            ),
+        )
+        selling = await synchronize_revision(
+            client,
+            tenant="example-tenant",
+            payload=revision_payload(
+                "example-selling-v1", "selling", "example-tenant", "0.02"
+            ),
+        )
+        assert acquisition.synchronized and selling.synchronized
+
+        binding = await prepare_binding(client, project="example-project")
+        switched = await synchronize_revision(
+            client,
+            tenant="example-tenant",
+            payload=revision_payload(
+                "example-selling-v2", "selling", "example-tenant", "0.03"
+            ),
+            expected_current_revision_id="example-selling-v1",
+        )
+        assert switched.synchronized
+        receipt = await ingest_pinned_usage(
+            client, project="example-project", binding=binding
+        )
+        assert receipt["outcome"] == "accepted"
+        report = await client.get(
+            "/v1/accounting/report?include_acquisition=true",
+        )
+        assert report.status_code == 200
+        assert report.json()["selling_total_usd"] == "0.020000000000"
+        assert report.json()["acquisition_total_usd"] == "0.010000000000"
+
+    await gateway.storage.aclose()

--- a/src/voicegateway/tests/accounting/test_adapters.py
+++ b/src/voicegateway/tests/accounting/test_adapters.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from voicegateway.accounting.adapters import envelope_from_request_record
+from voicegateway.accounting.contracts import MeasurementStatus, PricingDimension
+from voicegateway.models.request_model import RequestRecord
+
+
+def _record(
+    modality: str, *, input_units: float, output_units: float = 0
+) -> RequestRecord:
+    return RequestRecord(
+        id=f"request-{modality}",
+        timestamp=1.5,
+        modality=modality,
+        model_id="provider/model",
+        provider="provider",
+        input_units=input_units,
+        output_units=output_units,
+        cached_input_units=2,
+        session_id="session-1",
+    )
+
+
+def test_llm_adapter_preserves_cache_subset_and_stable_attempt() -> None:
+    envelope = envelope_from_request_record(
+        _record("llm", input_units=10, output_units=3),
+        producer_id="sdk-1",
+        event_id="event-1",
+    )
+    values = {item.dimension: item.value for item in envelope.quantities}
+    assert envelope.attempt_id == "request-llm"
+    assert values[PricingDimension.TEXT_INPUT] == "10"
+    assert values[PricingDimension.CACHE_READ] == "2"
+    assert values[PricingDimension.TEXT_OUTPUT] == "3"
+
+
+def test_stt_minutes_are_normalized_to_seconds() -> None:
+    envelope = envelope_from_request_record(
+        _record("stt", input_units=1.25), producer_id="sdk-1"
+    )
+    audio = next(
+        item
+        for item in envelope.quantities
+        if item.dimension is PricingDimension.AUDIO_SECONDS
+    )
+    assert audio.value == "75"
+    cache = next(
+        item
+        for item in envelope.quantities
+        if item.dimension is PricingDimension.CACHE_READ
+    )
+    assert cache.status is MeasurementStatus.UNSUPPORTED

--- a/src/voicegateway/tests/accounting/test_capture_sink.py
+++ b/src/voicegateway/tests/accounting/test_capture_sink.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from voicegateway.accounting.contracts import OwnershipMode, PricingBindingResponse
+from voicegateway.accounting.outbox import AccountingOutbox
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.services.sinks import AccountingCaptureSink
+from voicegateway.tests.accounting.test_outbox import Client
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.records: list[RequestRecord] = []
+
+    async def log_request(self, record: RequestRecord) -> None:
+        self.records.append(record)
+
+    async def log_turns(self, _rows) -> None:
+        return None
+
+    async def log_dead_air(self, _events) -> None:
+        return None
+
+    async def log_tool_calls(self, _rows) -> None:
+        return None
+
+    async def flush(self) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _record() -> RequestRecord:
+    return RequestRecord(
+        id="provider-attempt-1",
+        timestamp=1,
+        modality="llm",
+        model_id="provider/model",
+        provider="provider",
+        input_units=10,
+        output_units=2,
+        session_id="session-1",
+    )
+
+
+def _binding(mode: OwnershipMode) -> PricingBindingResponse:
+    return PricingBindingResponse(
+        binding_id="binding-1",
+        project_id="default",
+        component="conversation",
+        offering="provider/model",
+        selling_revision_id="sell-1",
+        ownership_mode=mode,
+        prepared_at_ns=1,
+    )
+
+
+async def test_capture_sink_wires_stable_usage_to_outbox(tmp_path) -> None:
+    client = Client()
+    outbox = AccountingOutbox(
+        tmp_path / "capture.db", "https://collector.invalid", client=client
+    )
+    primary = RecordingSink()
+    sink = AccountingCaptureSink(
+        primary, outbox, producer_id="worker-1", binding=_binding(OwnershipMode.SDK)
+    )
+    await sink.log_request(_record())
+    await sink.flush()
+    assert [record.id for record in primary.records] == ["provider-attempt-1"]
+    assert client.calls == 1
+    assert (await outbox.health())["pending"] == 0
+    await outbox.aclose()
+
+
+async def test_capture_sink_does_not_bill_externally_owned_component(tmp_path) -> None:
+    client = Client()
+    outbox = AccountingOutbox(
+        tmp_path / "external.db", "https://collector.invalid", client=client
+    )
+    sink = AccountingCaptureSink(
+        RecordingSink(),
+        outbox,
+        producer_id="worker-1",
+        binding=_binding(OwnershipMode.EXTERNAL),
+    )
+    await sink.log_request(_record())
+    await sink.flush()
+    assert client.calls == 0
+    assert (await outbox.health())["pending"] == 0
+    await outbox.aclose()

--- a/src/voicegateway/tests/accounting/test_capture_sink.py
+++ b/src/voicegateway/tests/accounting/test_capture_sink.py
@@ -88,3 +88,24 @@ async def test_capture_sink_does_not_bill_externally_owned_component(tmp_path) -
     assert client.calls == 0
     assert (await outbox.health())["pending"] == 0
     await outbox.aclose()
+
+
+async def test_capture_persistence_failure_is_visible_and_does_not_hide_telemetry(
+    tmp_path, monkeypatch
+) -> None:
+    outbox = AccountingOutbox(
+        tmp_path / "failed.db", "https://collector.invalid", client=Client()
+    )
+    primary = RecordingSink()
+    sink = AccountingCaptureSink(
+        primary, outbox, producer_id="worker-1", binding=_binding(OwnershipMode.SDK)
+    )
+
+    async def fail_submit(_envelope) -> str:
+        raise OSError("synthetic local persistence failure")
+
+    monkeypatch.setattr(outbox, "submit", fail_submit)
+    await sink.log_request(_record())
+    assert [record.id for record in primary.records] == ["provider-attempt-1"]
+    assert (await outbox.health())["capture_failures"] == 1
+    await outbox.aclose()

--- a/src/voicegateway/tests/accounting/test_contracts.py
+++ b/src/voicegateway/tests/accounting/test_contracts.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from voicegateway.accounting.contracts import (
+    DimensionRate,
+    MeasurementStatus,
+    OwnershipMode,
+    PricingDimension,
+    PricingRevisionCreate,
+    PricingSide,
+    Quantity,
+    RevisionScope,
+    Unit,
+    UsageEnvelope,
+)
+from voicegateway.accounting.rating import rate_usage
+
+
+def revision(side: PricingSide = PricingSide.SELLING) -> PricingRevisionCreate:
+    rated = {
+        PricingDimension.TEXT_INPUT: "0.000001",
+        PricingDimension.TEXT_OUTPUT: "0.000002",
+        PricingDimension.CACHE_READ: "0.0000001",
+        PricingDimension.CACHE_WRITE: "0.0000002",
+    }
+    return PricingRevisionCreate(
+        revision_id=f"{side}-v1",
+        side=side,
+        scope=RevisionScope(offering="provider/model"),
+        rates=tuple(
+            DimensionRate(dimension=d, unit=Unit.TOKEN, rate=value)
+            for d, value in rated.items()
+        ),
+        unsupported_dimensions=tuple(set(PricingDimension) - set(rated)),
+    )
+
+
+def usage(**overrides: object) -> UsageEnvelope:
+    values = {
+        "event_id": "evt-1",
+        "attempt_id": "attempt-1",
+        "project_id": "default",
+        "session_id": "session-1",
+        "component": "conversation",
+        "modality": "llm",
+        "offering": "provider/model",
+        "model_id": "provider/model",
+        "producer_id": "sdk-1",
+        "ownership_mode": OwnershipMode.SDK,
+        "selling_revision_id": "selling-v1",
+        "occurred_at_ns": 1,
+        "quantities": (
+            Quantity(
+                dimension=PricingDimension.TEXT_INPUT,
+                value="100",
+                status=MeasurementStatus.MEASURED,
+            ),
+            Quantity(
+                dimension=PricingDimension.CACHE_READ,
+                value="20",
+                status=MeasurementStatus.MEASURED,
+            ),
+            Quantity(
+                dimension=PricingDimension.TEXT_OUTPUT,
+                value="10",
+                status=MeasurementStatus.MEASURED,
+            ),
+        ),
+    }
+    values.update(overrides)
+    return UsageEnvelope.model_validate(values)
+
+
+def test_revision_hash_is_canonical_and_models_are_frozen() -> None:
+    first = revision()
+    second = PricingRevisionCreate.model_validate(first.model_dump())
+    assert first.content_hash() == second.content_hash()
+    with pytest.raises(ValidationError):
+        first.currency = "EUR"  # type: ignore[misc]
+
+
+def test_revision_requires_complete_dimension_manifest() -> None:
+    with pytest.raises(ValidationError, match="classify every"):
+        PricingRevisionCreate(
+            revision_id="bad",
+            side="selling",
+            scope={"offering": "provider/model"},
+            rates=(),
+        )
+
+
+def test_decimal_rating_subtracts_cache_once() -> None:
+    total, complete = rate_usage(usage(), revision())
+    expected = (
+        Decimal(80) * Decimal(".000001")
+        + Decimal(20) * Decimal(".0000001")
+        + Decimal(10) * Decimal(".000002")
+    )
+    assert Decimal(total or "0") == expected
+    assert complete
+
+
+def test_cache_cannot_exceed_input() -> None:
+    with pytest.raises(ValidationError, match="subsets"):
+        usage(
+            quantities=(
+                Quantity(dimension="text_input", value="1", status="measured"),
+                Quantity(dimension="cache_read", value="2", status="measured"),
+            )
+        )
+
+
+def test_missing_is_distinct_from_zero() -> None:
+    with pytest.raises(ValidationError):
+        Quantity(dimension="requests", value="0", status="missing")
+    assert Quantity(dimension="requests", value="0", status="measured").value == "0"

--- a/src/voicegateway/tests/accounting/test_contracts.py
+++ b/src/voicegateway/tests/accounting/test_contracts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from decimal import Decimal
+from decimal import ROUND_UP, Decimal, getcontext
 
 import pytest
 from pydantic import ValidationError
@@ -65,6 +65,11 @@ def usage(**overrides: object) -> UsageEnvelope:
                 status=MeasurementStatus.MEASURED,
             ),
             Quantity(
+                dimension=PricingDimension.CACHE_WRITE,
+                value="0",
+                status=MeasurementStatus.MEASURED,
+            ),
+            Quantity(
                 dimension=PricingDimension.TEXT_OUTPUT,
                 value="10",
                 status=MeasurementStatus.MEASURED,
@@ -81,6 +86,16 @@ def test_revision_hash_is_canonical_and_models_are_frozen() -> None:
     assert first.content_hash() == second.content_hash()
     with pytest.raises(ValidationError):
         first.currency = "EUR"  # type: ignore[misc]
+
+
+def test_revision_hash_normalizes_negative_zero() -> None:
+    first = revision()
+    raw = first.model_dump()
+    raw["rates"][0]["rate"] = "-0"
+    negative = PricingRevisionCreate.model_validate(raw)
+    raw["rates"][0]["rate"] = "0"
+    zero = PricingRevisionCreate.model_validate(raw)
+    assert negative.content_hash() == zero.content_hash()
 
 
 def test_revision_requires_complete_dimension_manifest() -> None:
@@ -161,8 +176,69 @@ def test_all_dimensions_have_exact_fixed_units(dimension, unit, quantity) -> Non
         ),
     )
     total, complete = rate_usage(envelope, price)
-    assert Decimal(total or "0") >= 0
+    assert Decimal(total or "0") == Decimal("0.000000000001")
     assert complete
+
+
+def test_missing_rated_dimension_marks_side_incomplete() -> None:
+    total, complete = rate_usage(
+        usage(
+            quantities=(Quantity(dimension="text_input", value="1", status="measured"),)
+        ),
+        revision(),
+    )
+    assert total == "0.000001000000"
+    assert complete is False
+
+
+def test_unpriced_cache_subset_stays_in_ordinary_input() -> None:
+    price = PricingRevisionCreate(
+        revision_id="input-only",
+        side="selling",
+        scope={"offering": "provider/model"},
+        rates=(DimensionRate(dimension="text_input", unit="token", rate="1"),),
+        unsupported_dimensions=tuple(
+            item for item in PricingDimension if item is not PricingDimension.TEXT_INPUT
+        ),
+    )
+    envelope = usage(
+        quantities=(
+            Quantity(dimension="text_input", value="100", status="measured"),
+            Quantity(dimension="cache_read", value="20", status="measured"),
+        )
+    )
+    total, complete = rate_usage(envelope, price)
+    assert total == "100.000000000000"
+    assert complete is False
+
+
+def test_rating_uses_profile_rounding_not_global_decimal_context() -> None:
+    original = getcontext().rounding
+    getcontext().rounding = ROUND_UP
+    try:
+        price = PricingRevisionCreate(
+            revision_id="rounding",
+            side="selling",
+            scope={"offering": "provider/model"},
+            rates=(
+                DimensionRate(
+                    dimension="audio_seconds", unit="second", rate="0.0000000000025"
+                ),
+            ),
+            unsupported_dimensions=tuple(
+                item
+                for item in PricingDimension
+                if item is not PricingDimension.AUDIO_SECONDS
+            ),
+        )
+        envelope = usage(
+            quantities=(
+                Quantity(dimension="audio_seconds", value="1", status="measured"),
+            )
+        )
+        assert rate_usage(envelope, price) == ("0.000000000002", True)
+    finally:
+        getcontext().rounding = original
 
 
 def test_non_audio_quantities_must_be_integer() -> None:

--- a/src/voicegateway/tests/accounting/test_contracts.py
+++ b/src/voicegateway/tests/accounting/test_contracts.py
@@ -118,3 +118,53 @@ def test_missing_is_distinct_from_zero() -> None:
     with pytest.raises(ValidationError):
         Quantity(dimension="requests", value="0", status="missing")
     assert Quantity(dimension="requests", value="0", status="measured").value == "0"
+
+
+@pytest.mark.parametrize(
+    ("dimension", "unit", "quantity"),
+    [
+        (PricingDimension.TEXT_INPUT, Unit.TOKEN, "1"),
+        (PricingDimension.TEXT_OUTPUT, Unit.TOKEN, "1"),
+        (PricingDimension.CACHE_READ, Unit.TOKEN, "1"),
+        (PricingDimension.CACHE_WRITE, Unit.TOKEN, "1"),
+        (PricingDimension.REALTIME_AUDIO_INPUT, Unit.TOKEN, "1"),
+        (PricingDimension.REALTIME_AUDIO_OUTPUT, Unit.TOKEN, "1"),
+        (PricingDimension.REALTIME_AUDIO_CACHE, Unit.TOKEN, "1"),
+        (PricingDimension.CHARACTERS, Unit.CHARACTER, "1"),
+        (PricingDimension.AUDIO_SECONDS, Unit.SECOND, "1.000000001"),
+        (PricingDimension.REQUESTS, Unit.REQUEST, "1"),
+    ],
+)
+def test_all_dimensions_have_exact_fixed_units(dimension, unit, quantity) -> None:
+    rate = DimensionRate(dimension=dimension, unit=unit, rate="0.000000000001")
+    rates = [rate]
+    quantities = [Quantity(dimension=dimension, value=quantity, status="measured")]
+    if dimension in {PricingDimension.CACHE_READ, PricingDimension.CACHE_WRITE}:
+        rates.append(
+            DimensionRate(
+                dimension=PricingDimension.TEXT_INPUT, unit=Unit.TOKEN, rate="0"
+            )
+        )
+        quantities.append(
+            Quantity(
+                dimension=PricingDimension.TEXT_INPUT, value=quantity, status="measured"
+            )
+        )
+    envelope = usage(quantities=tuple(quantities))
+    price = PricingRevisionCreate(
+        revision_id="dimension-v1",
+        side="selling",
+        scope={"offering": "provider/model"},
+        rates=tuple(rates),
+        unsupported_dimensions=tuple(
+            set(PricingDimension) - {item.dimension for item in rates}
+        ),
+    )
+    total, complete = rate_usage(envelope, price)
+    assert Decimal(total or "0") >= 0
+    assert complete
+
+
+def test_non_audio_quantities_must_be_integer() -> None:
+    with pytest.raises(ValidationError, match="integers"):
+        Quantity(dimension="requests", value="0.5", status="measured")

--- a/src/voicegateway/tests/accounting/test_livekit_accounting_integration.py
+++ b/src/voicegateway/tests/accounting/test_livekit_accounting_integration.py
@@ -1,0 +1,485 @@
+"""Representative native LiveKit-to-accounting integration checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from livekit.agents import llm, stt, tts
+from livekit.agents.metrics import (
+    LLMMetrics,
+    RealtimeModelMetrics,
+    STTMetrics,
+    TTSMetrics,
+)
+
+from voicegateway import attach
+from voicegateway.accounting.contracts import OwnershipMode, PricingBindingResponse
+from voicegateway.accounting.outbox import AccountingOutbox
+from voicegateway.models.request_model import RequestRecord
+from voicegateway.telemetry import SpanContext, reset_trace_context, set_trace_context
+
+
+class _NativeSTT(stt.STT):
+    __module__ = "livekit.plugins.synthetic.stt"
+
+    def __init__(self) -> None:
+        super().__init__(
+            capabilities=stt.STTCapabilities(streaming=True, interim_results=True)
+        )
+        self._model = "stt-model"
+
+    @property
+    def model(self) -> str:
+        return "stt-model"
+
+    async def _recognize_impl(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _NativeTTS(tts.TTS):
+    __module__ = "livekit.plugins.synthetic.tts"
+
+    def __init__(self) -> None:
+        super().__init__(
+            capabilities=tts.TTSCapabilities(streaming=True),
+            sample_rate=24_000,
+            num_channels=1,
+        )
+        self._model = "tts-model"
+
+    @property
+    def model(self) -> str:
+        return "tts-model"
+
+    def synthesize(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _NativeLLM(llm.LLM):
+    __module__ = "livekit.plugins.synthetic.llm"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._model = "llm-model"
+
+    @property
+    def model(self) -> str:
+        return "llm-model"
+
+    def chat(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _NativeRealtime(llm.RealtimeModel):
+    __module__ = "livekit.plugins.synthetic.realtime"
+
+    def __init__(self) -> None:
+        super().__init__(
+            capabilities=llm.RealtimeCapabilities(
+                message_truncation=True,
+                turn_detection=True,
+                user_transcription=True,
+                auto_tool_reply_generation=True,
+                audio_output=True,
+                manual_function_calls=True,
+            )
+        )
+
+    @property
+    def model(self) -> str:
+        return "realtime-model"
+
+    @property
+    def provider(self) -> str:
+        return "synthetic"
+
+    def session(self):  # pragma: no cover
+        raise NotImplementedError
+
+    async def aclose(self) -> None:  # pragma: no cover
+        return None
+
+
+class _Session:
+    def __init__(
+        self,
+        *,
+        stt_instance: Any = None,
+        llm_instance: Any = None,
+        tts_instance: Any = None,
+        agent_llm: Any = None,
+    ) -> None:
+        self.stt = stt_instance
+        self.llm = llm_instance
+        self.tts = tts_instance
+        self.current_agent = type("Agent", (), {"llm": agent_llm})()
+        self._handlers: dict[str, list[Any]] = {}
+
+    def on(self, event: str, handler: Any) -> None:
+        self._handlers.setdefault(event, []).append(handler)
+
+    def emit(self, event: str, value: Any) -> None:
+        for handler in self._handlers.get(event, []):
+            handler(value)
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.records: list[RequestRecord] = []
+
+    async def log_request(self, record: RequestRecord) -> None:
+        self.records.append(record)
+
+    async def log_turns(self, _rows) -> None:
+        return None
+
+    async def log_dead_air(self, _events) -> None:
+        return None
+
+    async def log_tool_calls(self, _rows) -> None:
+        return None
+
+    async def flush(self) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _Response:
+    status_code = 200
+
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _Collector:
+    def __init__(self, *, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self.envelopes: list[dict[str, object]] = []
+
+    async def post(self, _url: str, **kwargs: Any) -> _Response:
+        batch = kwargs["json"]
+        self.envelopes.extend(batch)
+        response = _Response(
+            {
+                "receipts": [
+                    {
+                        "event_id": row["event_id"],
+                        "outcome": "accepted",
+                        "receipt_id": f"receipt:{row['event_id']}",
+                        "code": "committed",
+                    }
+                    for row in batch
+                ]
+            }
+        )
+        response.status_code = self.status_code
+        return response
+
+
+class _CancelledIncompleteMetric:
+    request_id = "llm-retry-2"
+    timestamp = 1_800_000_004.0
+    duration = 0.1
+    ttft = None
+    cancelled = True
+
+
+def _binding(
+    offering: str, mode: OwnershipMode = OwnershipMode.SDK
+) -> PricingBindingResponse:
+    return PricingBindingResponse(
+        binding_id=f"binding:{offering}",
+        project_id="default",
+        component="conversation",
+        offering=offering,
+        selling_revision_id="selling-v1",
+        ownership_mode=mode,
+        prepared_at_ns=1,
+    )
+
+
+def _quantities(envelope: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {
+        str(item["dimension"]): item
+        for item in envelope["quantities"]  # type: ignore[union-attr]
+    }
+
+
+async def test_attach_captures_native_stt_tts_llm_and_realtime_without_duplicates(
+    tmp_path,
+) -> None:
+    collector = _Collector()
+    outbox = AccountingOutbox(
+        tmp_path / "native.db", "http://collector.invalid", client=collector
+    )
+    sink = _RecordingSink()
+    native_stt = _NativeSTT()
+    native_tts = _NativeTTS()
+    native_llm = _NativeLLM()
+    session = _Session(
+        stt_instance=native_stt,
+        llm_instance=native_llm,
+        tts_instance=native_tts,
+    )
+
+    attach(
+        session,
+        sink=sink,
+        transcript=False,
+        turns=False,
+        dead_air=False,
+        accounting_outbox=outbox,
+        accounting_binding={
+            model_id: _binding(model_id)
+            for model_id in (
+                "synthetic/stt-model",
+                "synthetic/llm-model",
+                "synthetic/tts-model",
+                "synthetic/realtime-model",
+            )
+        },
+        accounting_producer_id="native-worker",
+    )
+    # Registration happens synchronously in attach(), before any provider call.
+    assert len(native_stt._events["metrics_collected"]) == 1
+    assert len(native_tts._events["metrics_collected"]) == 1
+    assert len(native_llm._events["metrics_collected"]) == 1
+
+    native_stt.emit(
+        "metrics_collected",
+        STTMetrics(
+            label="stt",
+            request_id="stt-1",
+            timestamp=1_800_000_000.0,
+            duration=0.4,
+            audio_duration=2.25,
+            streamed=True,
+        ),
+    )
+    trace_token = set_trace_context(
+        SpanContext(trace_id="1" * 32, span_id="2" * 16, trace_flags=1)
+    )
+    try:
+        native_llm.emit(
+            "metrics_collected",
+            LLMMetrics(
+                label="llm",
+                request_id="llm-1",
+                timestamp=1_800_000_001.0,
+                duration=0.8,
+                ttft=0.1,
+                cancelled=False,
+                completion_tokens=7,
+                prompt_tokens=20,
+                prompt_cached_tokens=3,
+                total_tokens=27,
+                tokens_per_second=10,
+            ),
+        )
+    finally:
+        reset_trace_context(trace_token)
+    for segment, timestamp in (
+        ("segment-a", 1_800_000_002.0),
+        ("segment-b", 1_800_000_003.0),
+    ):
+        metric = TTSMetrics(
+            label="tts",
+            request_id="tts-stream-1",
+            segment_id=segment,
+            timestamp=timestamp,
+            ttfb=0.05,
+            duration=0.2,
+            audio_duration=0.1,
+            cancelled=False,
+            characters_count=11,
+            streamed=True,
+        )
+        native_tts.emit("metrics_collected", metric)
+        if segment == "segment-a":
+            native_tts.emit("metrics_collected", metric)  # duplicate SDK event
+    native_llm.emit("metrics_collected", _CancelledIncompleteMetric())
+    await session._vg_capture.drain()
+
+    realtime = _NativeRealtime()
+    realtime_session = _Session(agent_llm=realtime)
+    attach(
+        realtime_session,
+        sink=sink,
+        transcript=False,
+        turns=False,
+        dead_air=False,
+        accounting_outbox=outbox,
+        accounting_binding={
+            "synthetic/realtime-model": _binding("synthetic/realtime-model")
+        },
+        accounting_producer_id="native-worker",
+    )
+    cached_details = RealtimeModelMetrics.CachedTokenDetails(
+        text_tokens=2, audio_tokens=3
+    )
+    realtime_session.emit(
+        "metrics_collected",
+        RealtimeModelMetrics(
+            request_id="realtime-1",
+            timestamp=1_800_000_005.0,
+            duration=1.0,
+            input_tokens=35,
+            output_tokens=17,
+            total_tokens=52,
+            input_token_details=RealtimeModelMetrics.InputTokenDetails(
+                text_tokens=20,
+                audio_tokens=15,
+                cached_tokens=5,
+                cached_tokens_details=cached_details,
+            ),
+            output_token_details=RealtimeModelMetrics.OutputTokenDetails(
+                text_tokens=7, audio_tokens=10
+            ),
+        ),
+    )
+    await realtime_session._vg_capture.drain()
+    await outbox.flush_memory()
+    result = await outbox.drain()
+    assert result == {"accepted": 6, "duplicate": 0, "rejected": 0, "retryable": 0}
+
+    # Duplicate TTS delivery had the same deterministic event ID; the two real
+    # stream segments share provider correlation but remain distinct charges.
+    assert len(collector.envelopes) == 6
+    tts_rows = [row for row in collector.envelopes if row["modality"] == "tts"]
+    assert len(tts_rows) == 2
+    assert len({row["event_id"] for row in tts_rows}) == 2
+    assert {
+        row["model_id"]: row["pricing_binding_id"] for row in collector.envelopes
+    } == {
+        model_id: f"binding:{model_id}"
+        for model_id in {
+            "synthetic/stt-model",
+            "synthetic/llm-model",
+            "synthetic/tts-model",
+            "synthetic/realtime-model",
+        }
+    }
+    observed_tts = [record for record in sink.records if record.modality == "tts"]
+    assert {record.metadata["provider_request_id"] for record in observed_tts} == {
+        "tts-stream-1"
+    }
+    assert {record.metadata["provider_segment_id"] for record in observed_tts} == {
+        "segment-a",
+        "segment-b",
+    }
+
+    cancelled = next(
+        row
+        for row in collector.envelopes
+        if _quantities(row)["text_input"]["status"] == "missing"
+    )
+    assert _quantities(cancelled)["text_output"] == {
+        "dimension": "text_output",
+        "value": None,
+        "status": "missing",
+    }
+    realtime_row = next(
+        row
+        for row in collector.envelopes
+        if row["model_id"] == "synthetic/realtime-model"
+    )
+    realtime_quantities = _quantities(realtime_row)
+    assert realtime_quantities["realtime_audio_input"]["value"] == "15"
+    assert realtime_quantities["realtime_audio_output"]["value"] == "10"
+    assert realtime_quantities["realtime_audio_cache"]["value"] == "3"
+    assert realtime_quantities["cache_read"]["value"] == "2"
+    await outbox.aclose()
+
+
+async def test_attach_external_ownership_and_collector_outage_are_explicit(
+    tmp_path,
+) -> None:
+    native_llm = _NativeLLM()
+    external_collector = _Collector()
+    external_outbox = AccountingOutbox(
+        tmp_path / "external.db",
+        "http://collector.invalid",
+        client=external_collector,
+    )
+    external_session = _Session(llm_instance=native_llm)
+    attach(
+        external_session,
+        sink=_RecordingSink(),
+        transcript=False,
+        turns=False,
+        dead_air=False,
+        accounting_outbox=external_outbox,
+        accounting_binding=_binding("synthetic/llm-model", OwnershipMode.EXTERNAL),
+        accounting_producer_id="native-worker",
+    )
+    native_llm.emit(
+        "metrics_collected",
+        LLMMetrics(
+            label="llm",
+            request_id="external-1",
+            timestamp=1_800_000_010.0,
+            duration=0.2,
+            ttft=0.1,
+            cancelled=False,
+            completion_tokens=1,
+            prompt_tokens=1,
+            prompt_cached_tokens=0,
+            total_tokens=2,
+            tokens_per_second=5,
+        ),
+    )
+    await external_session._vg_capture.drain()
+    await external_outbox.flush_memory()
+    assert (await external_outbox.health())["pending"] == 0
+    assert external_collector.envelopes == []
+    await external_outbox.aclose()
+
+    outage_collector = _Collector(status_code=503)
+    outage_outbox = AccountingOutbox(
+        tmp_path / "outage.db",
+        "http://collector.invalid",
+        client=outage_collector,
+    )
+    outage_llm = _NativeLLM()
+    outage_session = _Session(llm_instance=outage_llm)
+    attach(
+        outage_session,
+        sink=_RecordingSink(),
+        transcript=False,
+        turns=False,
+        dead_air=False,
+        accounting_outbox=outage_outbox,
+        accounting_binding=_binding("synthetic/llm-model"),
+        accounting_producer_id="native-worker",
+    )
+    outage_llm.emit(
+        "metrics_collected",
+        LLMMetrics(
+            label="llm",
+            request_id="outage-1",
+            timestamp=1_800_000_011.0,
+            duration=0.2,
+            ttft=0.1,
+            cancelled=False,
+            completion_tokens=1,
+            prompt_tokens=1,
+            prompt_cached_tokens=0,
+            total_tokens=2,
+            tokens_per_second=5,
+        ),
+    )
+    await outage_session._vg_capture.drain()
+    await outage_outbox.flush_memory()
+    assert (await outage_outbox.drain())["retryable"] == 1
+    health = await outage_outbox.health()
+    assert health["pending"] == 1
+    assert health["failed_delivery"] == 1
+    await outage_outbox.aclose()

--- a/src/voicegateway/tests/accounting/test_outbox.py
+++ b/src/voicegateway/tests/accounting/test_outbox.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from voicegateway.accounting.outbox import AccountingOutbox
+from voicegateway.tests.accounting.test_contracts import usage
+
+
+class Response:
+    status_code = 200
+
+    def __init__(self, body: dict) -> None:
+        self._body = body
+
+    def json(self) -> dict:
+        return self._body
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class Client:
+    def __init__(self, outcome: str = "accepted") -> None:
+        self.outcome = outcome
+        self.calls = 0
+
+    async def post(self, _url: str, **kwargs) -> Response:
+        self.calls += 1
+        return Response(
+            {
+                "receipts": [
+                    {
+                        "event_id": item["event_id"],
+                        "outcome": self.outcome,
+                        "receipt_id": "receipt-1"
+                        if self.outcome != "rejected"
+                        else None,
+                        "code": "committed"
+                        if self.outcome == "accepted"
+                        else "invalid",
+                    }
+                    for item in kwargs["json"]
+                ]
+            }
+        )
+
+
+async def test_outbox_survives_restart_and_deletes_only_after_receipt(tmp_path) -> None:
+    path = tmp_path / "accounting-outbox.db"
+    first = AccountingOutbox(path, "https://collector.invalid", client=Client())
+    assert await first.submit(usage()) == "stored"
+    await first.aclose()
+
+    client = Client()
+    restarted = AccountingOutbox(path, "https://collector.invalid", client=client)
+    assert (await restarted.health())["pending"] == 1
+    assert await restarted.drain() == {
+        "accepted": 1,
+        "duplicate": 0,
+        "rejected": 0,
+        "retryable": 0,
+    }
+    assert (await restarted.health())["pending"] == 0
+    await restarted.aclose()
+
+
+async def test_outbox_conflict_bound_and_rejected_quarantine(tmp_path) -> None:
+    path = tmp_path / "bounded.db"
+    outbox = AccountingOutbox(
+        path, "https://collector.invalid", max_records=1, client=Client("rejected")
+    )
+    assert await outbox.submit(usage()) == "stored"
+    assert await outbox.submit(usage()) == "duplicate"
+    assert (
+        await outbox.submit(usage(event_id="event-2", attempt_id="attempt-2")) == "full"
+    )
+    result = await outbox.drain()
+    assert result["rejected"] == 1
+    health = await outbox.health()
+    assert health["pending"] == 0
+    assert health["rejected"] == 1
+    assert health["memory_pending"] == 0
+    assert health["capture_failures"] == 1
+    assert health["failed_delivery"] == 0
+    assert health["oldest_pending_seconds"] is None
+    await outbox.aclose()

--- a/src/voicegateway/tests/accounting/test_outbox.py
+++ b/src/voicegateway/tests/accounting/test_outbox.py
@@ -1,25 +1,30 @@
 from __future__ import annotations
 
+import asyncio
+
+import aiosqlite
+
 from voicegateway.accounting.outbox import AccountingOutbox
 from voicegateway.tests.accounting.test_contracts import usage
 
 
 class Response:
-    status_code = 200
-
-    def __init__(self, body: dict) -> None:
+    def __init__(self, body: dict, status_code: int = 200) -> None:
         self._body = body
+        self.status_code = status_code
 
     def json(self) -> dict:
         return self._body
 
     def raise_for_status(self) -> None:
-        return None
+        if self.status_code >= 400:
+            raise RuntimeError(f"http {self.status_code}")
 
 
 class Client:
-    def __init__(self, outcome: str = "accepted") -> None:
+    def __init__(self, outcome: str = "accepted", status_code: int = 200) -> None:
         self.outcome = outcome
+        self.status_code = status_code
         self.calls = 0
 
     async def post(self, _url: str, **kwargs) -> Response:
@@ -39,7 +44,8 @@ class Client:
                     }
                     for item in kwargs["json"]
                 ]
-            }
+            },
+            self.status_code,
         )
 
 
@@ -81,4 +87,142 @@ async def test_outbox_conflict_bound_and_rejected_quarantine(tmp_path) -> None:
     assert health["capture_failures"] == 1
     assert health["failed_delivery"] == 0
     assert health["oldest_pending_seconds"] is None
+    await outbox.aclose()
+
+
+async def test_outbox_terminal_422_is_quarantined(tmp_path) -> None:
+    outbox = AccountingOutbox(
+        tmp_path / "terminal.db",
+        "https://collector.invalid",
+        client=Client(status_code=422),
+    )
+    await outbox.submit(usage())
+    assert await outbox.drain() == {
+        "accepted": 0,
+        "duplicate": 0,
+        "rejected": 1,
+        "retryable": 0,
+    }
+    assert (await outbox.health())["pending"] == 0
+    await outbox.aclose()
+
+
+async def test_outbox_does_not_delete_on_outcome_without_receipt_id(tmp_path) -> None:
+    class MissingReceiptClient(Client):
+        async def post(self, url: str, **kwargs) -> Response:
+            response = await super().post(url, **kwargs)
+            response._body["receipts"][0]["receipt_id"] = None
+            return response
+
+    outbox = AccountingOutbox(
+        tmp_path / "missing-receipt.db",
+        "https://collector.invalid",
+        client=MissingReceiptClient(),
+    )
+    await outbox.submit(usage())
+    assert (await outbox.drain())["retryable"] == 1
+    assert (await outbox.health())["pending"] == 1
+    await outbox.aclose()
+
+
+async def test_outbox_enforces_byte_bound_and_persists_loss_counter(tmp_path) -> None:
+    path = tmp_path / "bytes.db"
+    outbox = AccountingOutbox(
+        path, "https://collector.invalid", max_bytes=1, client=Client()
+    )
+    assert await outbox.submit(usage()) == "full"
+    assert (await outbox.health())["capture_failures"] == 1
+    await outbox.aclose()
+    restarted = AccountingOutbox(path, "https://collector.invalid", client=Client())
+    assert (await restarted.health())["capture_failures"] == 1
+    await restarted.aclose()
+
+
+async def test_concurrent_submit_is_idempotent(tmp_path) -> None:
+    outbox = AccountingOutbox(
+        tmp_path / "concurrent.db", "https://collector.invalid", client=Client()
+    )
+    outcomes = await asyncio.gather(*(outbox.submit(usage()) for _ in range(8)))
+    assert outcomes.count("stored") == 1
+    assert outcomes.count("duplicate") == 7
+    await outbox.aclose()
+
+
+async def test_memory_queue_saturation_is_visible(tmp_path) -> None:
+    outbox = AccountingOutbox(
+        tmp_path / "memory.db",
+        "https://collector.invalid",
+        memory_queue_size=1,
+        client=Client(),
+    )
+    outbox.start = lambda: None  # type: ignore[method-assign]
+    assert outbox.enqueue_nowait(usage()) is True
+    assert (
+        outbox.enqueue_nowait(usage(event_id="event-2", attempt_id="attempt-2"))
+        is False
+    )
+    await asyncio.sleep(0)
+    assert (await outbox.health())["capture_failures"] == 1
+    await outbox.aclose(drain_memory=False)
+
+
+async def test_lost_ack_survives_restart_and_duplicate_receipt_drains(tmp_path) -> None:
+    class LostAckClient:
+        async def post(self, *_args, **_kwargs):
+            raise ConnectionError("response lost after collector commit")
+
+    path = tmp_path / "lost-ack.db"
+    first = AccountingOutbox(path, "https://collector.invalid", client=LostAckClient())
+    await first.submit(usage())
+    assert (await first.drain())["retryable"] == 1
+    await first.aclose()
+    restarted = AccountingOutbox(
+        path, "https://collector.invalid", client=Client("duplicate")
+    )
+    assert (await restarted.drain())["duplicate"] == 1
+    assert (await restarted.health())["pending"] == 0
+    await restarted.aclose()
+
+
+async def test_backoff_is_jittered_and_poison_rows_exhaust(tmp_path) -> None:
+    delays: list[float] = []
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    outbox = AccountingOutbox(
+        tmp_path / "retry.db",
+        "https://collector.invalid",
+        client=Client(status_code=503),
+        max_delivery_attempts=2,
+    )
+    await outbox.submit(usage())
+    result = await outbox.drain_with_backoff(
+        max_attempts=2,
+        base_delay=1,
+        sleep=record_sleep,
+        jitter=lambda low, high: (low + high) / 2,
+    )
+    assert delays == [0.75]
+    assert result["rejected"] == 1
+    assert result["retryable"] == 0
+    assert (await outbox.health())["rejected"] == 1
+    await outbox.aclose()
+
+
+async def test_disk_failure_counter_is_flushed_after_storage_recovers(
+    tmp_path, monkeypatch
+) -> None:
+    outbox = AccountingOutbox(
+        tmp_path / "recovery.db", "https://collector.invalid", client=Client()
+    )
+    connect = aiosqlite.connect
+
+    def fail_connect(*_args, **_kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(aiosqlite, "connect", fail_connect)
+    await outbox._increment_failure()
+    monkeypatch.setattr(aiosqlite, "connect", connect)
+    assert (await outbox.health())["capture_failures"] == 1
     await outbox.aclose()

--- a/src/voicegateway/tests/accounting/test_release_boundary.py
+++ b/src/voicegateway/tests/accounting/test_release_boundary.py
@@ -1,0 +1,60 @@
+"""Executable boundaries for the supported accounting release."""
+
+from __future__ import annotations
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+from voicegateway.utils.cli.export_costs import _EXPORT_COLUMNS
+
+
+class _ForbiddenClickHouse:
+    def __getattr__(self, name: str):
+        raise AssertionError(f"exact accounting unexpectedly used ClickHouse: {name}")
+
+
+async def test_supported_accounting_reads_are_sql_only_and_expose_no_pending_metric(
+    tmp_path, monkeypatch
+) -> None:
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "cost_tracking": {"enabled": True},
+            }
+        )
+    )
+    monkeypatch.delenv("VOICEGW_DB_URL", raising=False)
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "accounting.db"))
+    gateway = Gateway(config_path=str(config))
+    app = build_app(gateway)
+    app.state.ch_client = _ForbiddenClickHouse()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        for path in (
+            "/v1/accounting/capabilities",
+            "/v1/accounting/report",
+            "/api/accounting",
+        ):
+            response = await client.get(path)
+            assert response.status_code == 200, response.text
+            assert "pending_delivery" not in response.text
+
+    await gateway.storage.aclose()
+
+
+def test_legacy_cost_export_cannot_expose_exact_accounting_cost_basis() -> None:
+    """The only current export is legacy request-cost export, not ledger export."""
+    assert not {
+        "acquisition_revision_id",
+        "acquisition_total_usd",
+        "margin_usd",
+    }.intersection(_EXPORT_COLUMNS)

--- a/src/voicegateway/tests/architecture/__init__.py
+++ b/src/voicegateway/tests/architecture/__init__.py
@@ -1,0 +1,5 @@
+"""Structural tests: invariants about the shape of the codebase itself.
+
+These assert things no unit test can, because they are properties of the
+import graph and the module boundaries rather than of any one function.
+"""

--- a/src/voicegateway/tests/architecture/test_arch_repository_tenancy.py
+++ b/src/voicegateway/tests/architecture/test_arch_repository_tenancy.py
@@ -1,0 +1,61 @@
+"""No repository reads tenant identity from the ambient ContextVar.
+
+Six writers carried ``tenant_id if tenant_id is not None else current_tenant()``
+and ``log_request`` read the ContextVar directly, so tenancy was decided in
+seven places by whatever happened to be in scope. One of them,
+``create_tool_calls``, also preferred a ``tenant_id`` on the row itself over
+the caller's, which is VG-SEC-001: a key scoped to one tenant could write rows
+tagged another.
+
+Tenancy is now an explicit required keyword on every write. The ContextVar
+stays legitimate on the agent side, where the process is the tenant and the
+sink reads it at enqueue time, but it is not readable from ``repository/``.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2] / "repository"
+
+#: Every write that stamps a tenant onto a row.
+_WRITERS = [
+    ("tool_calls_repository", "create_tool_calls"),
+    ("turns_repository", "create_turn"),
+    ("turns_repository", "create_turns_bulk"),
+    ("dead_air_repository", "create_event"),
+    ("transcript_turns_repository", "create_transcript_bulk"),
+    ("replay_repository", "bulk_write_events"),
+    ("request_log_repository", "log_request"),
+]
+
+
+def test_repository_never_imports_current_tenant():
+    offenders = []
+    for path in sorted(_REPO.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.names:
+                if any(alias.name == "current_tenant" for alias in node.names):
+                    offenders.append(f"{path.name}:{node.lineno}")
+    assert not offenders, offenders
+
+
+@pytest.mark.parametrize(("module", "function"), _WRITERS, ids=[f for _, f in _WRITERS])
+def test_every_writer_requires_an_explicit_tenant(module, function):
+    """Required keyword, no default. Forgetting it is a type error, not a silent row."""
+    import importlib
+
+    fn = getattr(importlib.import_module(f"voicegateway.repository.{module}"), function)
+    parameter = inspect.signature(fn).parameters.get("tenant_id")
+    assert parameter is not None, f"{function} takes no tenant_id"
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY, (
+        f"{function} tenant_id must be keyword-only so it is never passed by position"
+    )
+    assert parameter.default is inspect.Parameter.empty, (
+        f"{function} tenant_id has a default, so a caller can still omit it"
+    )

--- a/src/voicegateway/tests/architecture/test_arch_storage_boundary.py
+++ b/src/voicegateway/tests/architecture/test_arch_storage_boundary.py
@@ -1,0 +1,52 @@
+"""Storage internals are private in fact, not just in name.
+
+Before this wave, 63 call sites across 12 production modules reached through
+``storage._conn`` and ``storage._ensure_initialized()``, and 24 route handlers
+opened their own database session. Nothing could sit between a route and the
+database, which is exactly where a tenant guard has to live: VG-SEC-001 was
+one writer preferring a payload tenant because no single place decided
+tenancy for every write.
+
+The first test is red until Task 13 retires the last reach-through, so it
+carries a strict xfail until then. That marker is the acceptance test for the
+whole seam: when it XPASSes, the boundary exists.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).resolve().parents[2]
+#: The one module allowed to touch the connection it owns.
+_ALLOWED = {_SRC / "services" / "storage_service.py"}
+_PATTERN = re.compile(r"\._conn\b|_ensure_initialized\(\)")
+
+
+def _production_files() -> list[Path]:
+    """Every shipped module. Tests may reach in; production may not."""
+    return [p for p in sorted(_SRC.rglob("*.py")) if "tests" not in p.parts]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="closes in Task 13, when the last reach-through is retired",
+)
+def test_no_module_outside_storage_service_touches_internals():
+    offenders = []
+    for path in _production_files():
+        if path in _ALLOWED:
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if _PATTERN.search(line):
+                offenders.append(f"{path.relative_to(_SRC)}:{lineno}: {line.strip()}")
+    assert not offenders, "\n".join(offenders)
+
+
+def test_storage_service_exposes_a_public_session():
+    """The one public path to a session. Routes get it via get_session."""
+    from voicegateway.services.storage_service import StorageService
+
+    assert callable(getattr(StorageService, "session", None))

--- a/src/voicegateway/tests/clickhouse/test_ch_sink.py
+++ b/src/voicegateway/tests/clickhouse/test_ch_sink.py
@@ -675,7 +675,7 @@ class TestIngestCHRouting:
                 await gw.storage._ensure_initialized()
                 async with gw.storage._conn.session() as db:
                     created = await api_keys.create_api_key(
-                        db, name="bot", tenant_id="t1"
+                        db, name="bot", tenant_id="t1", scopes="read,write,ingest,admin"
                     )
 
                 async with AsyncClient(
@@ -766,7 +766,9 @@ class TestIngestCHRouting:
             async def _run():
                 await gw.storage._ensure_initialized()
                 async with gw.storage._conn.session() as db:
-                    created = await api_keys.create_api_key(db, name="bot503")
+                    created = await api_keys.create_api_key(
+                        db, name="bot503", scopes="read,write,ingest,admin"
+                    )
 
                 async with AsyncClient(
                     transport=ASGITransport(app=app), base_url="http://test"
@@ -839,7 +841,9 @@ class TestIngestCHRouting:
             async def _run():
                 await gw.storage._ensure_initialized()
                 async with gw.storage._conn.session() as db:
-                    created = await api_keys.create_api_key(db, name="bot2")
+                    created = await api_keys.create_api_key(
+                        db, name="bot2", scopes="read,write,ingest,admin"
+                    )
 
                 async with AsyncClient(
                     transport=ASGITransport(app=app), base_url="http://test"

--- a/src/voicegateway/tests/core/test_auth_config_parity.py
+++ b/src/voicegateway/tests/core/test_auth_config_parity.py
@@ -1,0 +1,78 @@
+"""The two AuthConfig definitions must not drift apart.
+
+``schemas.config_schema.AuthConfig`` is pydantic and validates the YAML.
+``core.config.AuthConfig`` is a dataclass and is what the Gateway carries at
+runtime. They are parallel declarations of one thing, bridged by a
+field-by-field construction in ``core.config``.
+
+Adding a field to one and not the other is silent: the YAML validates, the
+attribute simply is not there, and the first reader gets an AttributeError at
+runtime on whatever code path happens to touch it. That is exactly what
+happened while wiring auth.local_development, and it was caught by a CLI test
+rather than by either config module.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from voicegateway.core.config import AuthConfig as RuntimeAuthConfig
+from voicegateway.core.config import GatewayConfig
+from voicegateway.schemas.config_schema import AuthConfig as SchemaAuthConfig
+
+
+def test_both_auth_configs_declare_the_same_fields():
+    schema_fields = set(SchemaAuthConfig.model_fields)
+    runtime_fields = {f.name for f in dataclasses.fields(RuntimeAuthConfig)}
+    assert schema_fields == runtime_fields, (
+        f"only in schema: {sorted(schema_fields - runtime_fields)}; "
+        f"only in runtime: {sorted(runtime_fields - schema_fields)}"
+    )
+
+
+def test_both_agree_on_defaults_for_the_auth_mode_fields():
+    """A field present in both but defaulting differently is worse than absent."""
+    schema = SchemaAuthConfig()
+    runtime = RuntimeAuthConfig()
+    assert schema.local_development == runtime.local_development is False
+    assert schema.enforcement == runtime.enforcement == "warn"
+
+
+def test_the_yaml_bridge_carries_the_new_fields(tmp_path):
+    """Declaring a field is not enough; core.config builds this one by hand."""
+    import yaml
+
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(
+        yaml.dump(
+            {
+                "providers": {"openai": {"api_key": "k"}},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "auth": {"local_development": True, "enforcement": "enforce"},
+            }
+        )
+    )
+    config = GatewayConfig.load(str(path))
+    assert config.auth.local_development is True
+    assert config.auth.enforcement == "enforce"
+
+
+def test_the_bridge_defaults_when_the_auth_block_is_absent(tmp_path):
+    import yaml
+
+    path = tmp_path / "voicegw.yaml"
+    path.write_text(
+        yaml.dump(
+            {
+                "providers": {"openai": {"api_key": "k"}},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+            }
+        )
+    )
+    config = GatewayConfig.load(str(path))
+    assert config.auth.local_development is False
+    assert config.auth.enforcement == "warn"

--- a/src/voicegateway/tests/core/test_auth_startup_validation.py
+++ b/src/voicegateway/tests/core/test_auth_startup_validation.py
@@ -129,3 +129,88 @@ def test_serve_refuses_to_start_on_a_contradictory_config(tmp_path, monkeypatch)
     assert "local_development" in plain
     assert "api_keys" in plain
     assert "not loopback" in plain
+
+
+# --------------------------------------------------------------------------
+# Defense in depth: serve is not the only door
+# --------------------------------------------------------------------------
+
+
+def test_bind_host_is_optional_so_hostless_callers_can_still_validate():
+    """build_app has no bind host, but can still catch the config conflicts."""
+    from voicegateway.schemas.config_schema import ApiKeyEntry as Entry
+
+    # Loopback check is skipped, the other two still apply.
+    validate_auth_startup(AuthConfig(local_development=True), bind_host=None)
+    with pytest.raises(AuthConfigError, match="api_keys"):
+        validate_auth_startup(
+            AuthConfig(
+                local_development=True,
+                api_keys=[Entry(token="t", name="n", scopes=["read"])],
+            ),
+            bind_host=None,
+        )
+    with pytest.raises(AuthConfigError, match="enforcement"):
+        validate_auth_startup(
+            AuthConfig(local_development=True, enforcement="enforce"), bind_host=None
+        )
+
+
+def test_build_app_refuses_a_contradictory_config(tmp_path, monkeypatch):
+    """serve is not the only door.
+
+    ``python -m voicegateway.server.main`` is what the container runs, and it
+    binds 0.0.0.0 by default. A guard that only lives in the serve CLI would
+    refuse an unauthenticated public deployment on a laptop and wave it
+    through in production, which is the wrong way round.
+    """
+    import yaml
+
+    from voicegateway.core.gateway import Gateway
+    from voicegateway.server import build_app
+
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.dump(
+            {
+                "providers": {"openai": {"api_key": "k"}},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "auth": {
+                    "local_development": True,
+                    "api_keys": [{"token": "t", "name": "n", "scopes": ["read"]}],
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "build.db"))
+
+    gateway = Gateway(config_path=str(config))
+    with pytest.raises(AuthConfigError, match="api_keys"):
+        build_app(gateway, enable_mcp_sse=False, enable_dashboard=False)
+
+
+def test_build_app_accepts_a_coherent_local_config(tmp_path, monkeypatch):
+    """A genuinely local config must still build, or dev is broken."""
+    import yaml
+
+    from voicegateway.core.gateway import Gateway
+    from voicegateway.server import build_app
+
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.dump(
+            {
+                "providers": {"openai": {"api_key": "k"}},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "auth": {"local_development": True},
+            }
+        )
+    )
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "build_ok.db"))
+
+    gateway = Gateway(config_path=str(config))
+    assert build_app(gateway, enable_mcp_sse=False, enable_dashboard=False) is not None

--- a/src/voicegateway/tests/core/test_auth_startup_validation.py
+++ b/src/voicegateway/tests/core/test_auth_startup_validation.py
@@ -1,0 +1,131 @@
+"""Local development means local. The server refuses contradictory config.
+
+The roadmap requires unauthenticated mode to be explicit and unavailable in
+production configuration. A flag alone is not enough: an operator who sets it
+on a laptop and later copies the file to a server would carry an open
+deployment with it. So the flag is refused at startup in the company of
+anything production-shaped, and the message names which line to fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.core.auth import AuthConfigError, validate_auth_startup
+from voicegateway.schemas.config_schema import ApiKeyEntry, AuthConfig
+
+
+def test_defaults_are_warn_mode_and_not_local():
+    """0.26.0 ships warn: existing deployments keep working and get told."""
+    cfg = AuthConfig()
+    assert cfg.local_development is False
+    assert cfg.enforcement == "warn"
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
+def test_local_development_on_loopback_is_fine(host):
+    validate_auth_startup(AuthConfig(local_development=True), bind_host=host)
+
+
+def test_local_development_refuses_a_public_bind():
+    with pytest.raises(AuthConfigError, match="bind host"):
+        validate_auth_startup(AuthConfig(local_development=True), bind_host="0.0.0.0")
+
+
+def test_local_development_refuses_configured_keys():
+    """Minting keys and then disabling auth is a contradiction, not a config."""
+    cfg = AuthConfig(
+        local_development=True,
+        api_keys=[ApiKeyEntry(token="t", name="n", scopes=["read"])],
+    )
+    with pytest.raises(AuthConfigError, match="api_keys"):
+        validate_auth_startup(cfg, bind_host="127.0.0.1")
+
+
+def test_local_development_refuses_enforce_mode():
+    with pytest.raises(AuthConfigError, match="enforcement"):
+        validate_auth_startup(
+            AuthConfig(local_development=True, enforcement="enforce"),
+            bind_host="127.0.0.1",
+        )
+
+
+def test_every_conflict_is_named_at_once():
+    """One restart per problem is a bad afternoon. List them all."""
+    cfg = AuthConfig(
+        local_development=True,
+        enforcement="enforce",
+        api_keys=[ApiKeyEntry(token="t", name="n", scopes=["read"])],
+    )
+    with pytest.raises(AuthConfigError) as exc:
+        validate_auth_startup(cfg, bind_host="0.0.0.0")
+    message = str(exc.value)
+    assert "api_keys" in message
+    assert "bind host" in message
+    assert "enforcement" in message
+
+
+def test_production_shaped_config_passes():
+    """Not local: a public bind under enforce is exactly what production is."""
+    validate_auth_startup(AuthConfig(enforcement="enforce"), bind_host="0.0.0.0")
+
+
+def test_validation_is_a_no_op_when_not_local():
+    """Nothing else is second-guessed. This guard has one job."""
+    cfg = AuthConfig(api_keys=[ApiKeyEntry(token="t", name="n", scopes=["read"])])
+    validate_auth_startup(cfg, bind_host="0.0.0.0")
+
+
+def test_enforcement_rejects_an_unknown_mode():
+    """A typo must fail loudly at load, not silently mean warn."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AuthConfig(enforcement="enforced")
+
+
+def test_serve_refuses_to_start_on_a_contradictory_config(tmp_path, monkeypatch):
+    """The validator is wired into serve, not merely importable.
+
+    A guard nothing calls is the same as no guard, and this one only fires on
+    a path that binds a socket, so it is easy to leave unwired without any
+    test noticing.
+    """
+    import re
+
+    import yaml
+    from typer.testing import CliRunner
+
+    from voicegateway.cli._app import app
+
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.dump(
+            {
+                "providers": {"openai": {"api_key": "k"}},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "auth": {
+                    "local_development": True,
+                    "api_keys": [{"token": "t", "name": "n", "scopes": ["read"]}],
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "serve.db"))
+    # serve_cmd does os.environ.setdefault("VOICEGW_CONFIG", config), a
+    # process-global that outlives this test and would point later CLI tests
+    # at a deleted tmp directory. Claim it through monkeypatch first so the
+    # setdefault is a no-op and the original value is restored on teardown.
+    monkeypatch.setenv("VOICEGW_CONFIG", str(config))
+
+    result = CliRunner().invoke(
+        app, ["serve", "--config", str(config), "--host", "0.0.0.0", "--port", "8099"]
+    )
+
+    assert result.exit_code != 0
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "local_development" in plain
+    assert "api_keys" in plain
+    assert "not loopback" in plain

--- a/src/voicegateway/tests/core/test_metrics_config_is_read.py
+++ b/src/voicegateway/tests/core/test_metrics_config_is_read.py
@@ -63,7 +63,9 @@ def test_the_flush_size_default_matches_the_schema_default() -> None:
 
 
 def test_turn_buffer_flush_size_is_read_from_the_project(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7))
+    monkeypatch.setenv(
+        "VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7)
+    )
     attach_mod = importlib.import_module("voicegateway.inference.session.attach")
     attach_mod._turn_flush_size_cache.clear()
 
@@ -75,7 +77,9 @@ def test_turn_buffer_flush_size_is_read_from_the_project(tmp_path, monkeypatch) 
 
 def test_the_flush_size_reaches_the_tracker(tmp_path, monkeypatch) -> None:
     """Reading the number is not the same as using it."""
-    monkeypatch.setenv("VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=3))
+    monkeypatch.setenv(
+        "VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=3)
+    )
     attach_mod = importlib.import_module("voicegateway.inference.session.attach")
     attach_mod._turn_flush_size_cache.clear()
 
@@ -128,7 +132,7 @@ async def test_talk_over_threshold_changes_the_overlap_count(tmp_path) -> None:
         ),
     ]
     async with storage._conn.session() as db:
-        await turns.create_turns_bulk(db, rows)
+        await turns.create_turns_bulk(db, rows, tenant_id=None)
 
     async with storage._conn.session() as db:
         assert await turns.count_overlap_turns(db, "s", min_overlap_ms=25) == 1
@@ -146,7 +150,9 @@ def test_the_dead_air_default_matches_the_schema_default() -> None:
 
 
 def test_dead_air_threshold_is_read_from_the_project(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7))
+    monkeypatch.setenv(
+        "VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7)
+    )
     attach_mod = importlib.import_module("voicegateway.inference.session.attach")
     attach_mod._dead_air_threshold_cache.clear()
 
@@ -160,7 +166,9 @@ def test_dead_air_threshold_is_read_from_the_project(tmp_path, monkeypatch) -> N
 
 def test_the_dead_air_threshold_reaches_the_detector(tmp_path, monkeypatch) -> None:
     """Reading the number is not the same as using it."""
-    monkeypatch.setenv("VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7))
+    monkeypatch.setenv(
+        "VOICEGW_CONFIG", _config(tmp_path, overlap_ms=250, flush_size=7)
+    )
     attach_mod = importlib.import_module("voicegateway.inference.session.attach")
     attach_mod._dead_air_threshold_cache.clear()
 

--- a/src/voicegateway/tests/core/test_scopes.py
+++ b/src/voicegateway/tests/core/test_scopes.py
@@ -1,0 +1,36 @@
+"""core.scopes is the runtime vocabulary; ScopeName is the contract. They agree.
+
+Two modules name the same six scopes for different reasons. ``ScopeName`` is
+the Wave 0 contract, consumed by the authorization matrix and the threat
+model. ``core.scopes`` is what production imports at runtime, and it has to be
+a leaf: ``repository`` imports it, so if it imported back into ``repository``
+or ``core.auth`` the cycle Wave 1 exists to break would simply move.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from voicegateway.core import scopes
+from voicegateway.schemas.telemetry.security_schema import RouteAuth, ScopeName
+
+
+def test_runtime_scopes_match_the_contract_enum():
+    """A scope that exists at runtime but not in the contract is invisible."""
+    assert scopes.ALL == {s.value for s in ScopeName}
+
+
+def test_scopes_module_imports_nothing():
+    """A leaf module: repository imports it, so it may import no package."""
+    source = Path(scopes.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imports = [n for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))]
+    assert imports == [] or all(
+        isinstance(n, ast.ImportFrom) and n.module == "__future__" for n in imports
+    )
+
+
+def test_route_auth_has_an_ingest_member():
+    """Task 10 gates six routes on ingest; the matrix needs a name for it."""
+    assert RouteAuth.SCOPE_INGEST.value == "scope:ingest"

--- a/src/voicegateway/tests/fixtures/security/README.md
+++ b/src/voicegateway/tests/fixtures/security/README.md
@@ -27,7 +27,7 @@ prove:
 | `read_tenant_param_override` | guarantee | none | The read path already refuses a foreign `tenant` param with 403. |
 | `session_detail_foreign_id` | guarantee | none | A foreign session id returns 404, not 403, so it is not an existence oracle. |
 | `audit_log_open_read` | characterization | VG-SEC-004 | The audit log answers a caller with no credential. |
-| `project_param_unscoped` | absence | VG-SEC-002 | No surface exists to authorize a project, so there is nothing to characterize. |
+| `project_param_unscoped` | characterization | VG-SEC-002 | Accounting enforces project allowlists; legacy project-filtered reads do not yet. |
 
 Two of the five record guarantees rather than defects. That is deliberate. A
 format that can only express what is broken cannot tell you when something

--- a/src/voicegateway/tests/fixtures/security/README.md
+++ b/src/voicegateway/tests/fixtures/security/README.md
@@ -1,6 +1,6 @@
 # Cross-tenant security fixtures (Wave 0)
 
-Five cases, each one request by one actor against one victim tenant, plus what
+Six cases, each one request by one actor against one victim tenant, plus what
 the contract says must happen. They are data, not tests: the runner lives in
 `tests/server/test_telemetry_tenant_isolation_contract.py`.
 
@@ -28,6 +28,7 @@ prove:
 | `session_detail_foreign_id` | guarantee | none | A foreign session id returns 404, not 403, so it is not an existence oracle. |
 | `audit_log_open_read` | characterization | VG-SEC-004 | The audit log answers a caller with no credential. |
 | `project_param_unscoped` | characterization | VG-SEC-002 | Accounting enforces project allowlists; legacy project-filtered reads do not yet. |
+| `mcp_principal_absent` | absence | VG-SEC-008 | MCP still has no per-caller principal or project allowlist. |
 
 Two of the five record guarantees rather than defects. That is deliberate. A
 format that can only express what is broken cannot tell you when something

--- a/src/voicegateway/tests/fixtures/security/ingest_tool_calls_tenant_override.json
+++ b/src/voicegateway/tests/fixtures/security/ingest_tool_calls_tenant_override.json
@@ -1,9 +1,8 @@
 {
   "case_id": "ingest_tool_calls_tenant_override",
-  "title": "A tenant-scoped key writes a row attributed to another tenant",
-  "kind": "characterization",
-  "gap_id": "VG-SEC-001",
-  "rationale": "The live defect. tool_calls_repository resolves the row tenant as `r.tenant_id if r.tenant_id is not None else resolved`, so a tenant_id present in the payload wins over the tenant resolved from the API key. Measured on an unmodified checkout: the acme key's batch produced one row tagged beta and zero rows tagged acme. The sibling writers do not share this shape, which is what makes it a defect rather than a design: turns and dead-air apply one tenant resolved from the function argument to every row, and log_request reads current_tenant() and ignores the payload entirely.",
+  "title": "A tenant-scoped key cannot write a row attributed to another tenant",
+  "kind": "guarantee",
+  "rationale": "Closed in 0.26.0 by f9a86001. This was the live defect: tool_calls_repository resolved the row tenant as `r.tenant_id if r.tenant_id is not None else resolved`, so a tenant_id present in the payload won over the tenant resolved from the API key, and an acme key's batch produced one row tagged beta and none tagged acme. create_tool_calls now takes tenant_id as a required keyword and never reads the field off the row. Kept as a guarantee rather than deleted: this is the exact request that used to succeed, so it is the one that must keep failing to write.",
   "victim_tenant_id": "beta",
   "actor": {
     "tenant_id": "acme",
@@ -32,13 +31,6 @@
       403
     ],
     "victim_rows": 0,
-    "note": "The status is deliberately not pinned: Wave 1 may reject the batch or silently re-attribute it. What the contract fixes is the attribution. A key bound to acme must never cause a row tagged beta, so victim_rows must be 0 under every acceptable choice."
-  },
-  "observed": {
-    "status_code": [
-      200
-    ],
-    "victim_rows": 1,
-    "note": "Answered 200 {\"accepted\":1}, and the tool_calls table held exactly one row, tagged beta."
+    "note": "The batch may be accepted or refused; what is fixed is the attribution. A key bound to acme must never cause a row tagged beta, so victim_rows is 0 under every acceptable choice."
   }
 }

--- a/src/voicegateway/tests/fixtures/security/mcp_principal_absent.json
+++ b/src/voicegateway/tests/fixtures/security/mcp_principal_absent.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "mcp_principal_absent",
+  "title": "MCP has no per-caller principal or project allowlist",
+  "kind": "absence",
+  "gap_id": "VG-SEC-008",
+  "rationale": "The shared MCP bearer token still carries no caller identity, tenant binding, or project allowlist. This absence guard keeps that limitation explicit until the planned scoped MCP principal is implemented and the fixture can be rewritten as a live authorization guarantee.",
+  "actor": {
+    "tenant_id": null,
+    "role": "admin"
+  },
+  "absent_surfaces": [
+    {
+      "module": "voicegateway.server.mcp.auth",
+      "attribute": "AuthError",
+      "field": "principal"
+    }
+  ]
+}

--- a/src/voicegateway/tests/fixtures/security/project_param_unscoped.json
+++ b/src/voicegateway/tests/fixtures/security/project_param_unscoped.json
@@ -1,9 +1,9 @@
 {
   "case_id": "project_param_unscoped",
   "title": "The project identifier is never authorized against the caller",
-  "kind": "absence",
+  "kind": "characterization",
   "gap_id": "VG-SEC-002",
-  "rationale": "Project-level authorization is greenfield, so this case is an absence guard rather than a characterization: there is nothing to characterize because no surface exists to hold the check. 22 of the 89 routes accept a project identifier, by path parameter or query param, and none of them compares it to anything the caller is entitled to. The absent_surfaces below are the two places a project binding would have to live for such a check to be writable at all. Asserting they are missing is what makes the plan falsifiable: the day either appears, this case fails and must be rewritten as a characterization or a guarantee.",
+  "rationale": "API keys and principals can now carry project allowlists, and the exact-accounting routes enforce them. This characterization remains for legacy read routes that accept a project filter without checking that allowlist.",
   "actor": {
     "tenant_id": "acme",
     "role": "tenant"
@@ -26,17 +26,5 @@
       200
     ],
     "note": "Answered 200 and echoed the requested project back in the response body."
-  },
-  "absent_surfaces": [
-    {
-      "module": "voicegateway.server.api._deps",
-      "attribute": "Principal",
-      "field": "project"
-    },
-    {
-      "module": "voicegateway.repository.api_keys_repository",
-      "attribute": "VerifiedKey",
-      "field": "project"
-    }
-  ]
+  }
 }

--- a/src/voicegateway/tests/fixtures/security/test_security_fixture_schema.py
+++ b/src/voicegateway/tests/fixtures/security/test_security_fixture_schema.py
@@ -43,7 +43,7 @@ def test_every_gap_id_is_minted():
 def test_both_guarantees_and_defects_are_represented():
     """The format must express a satisfied rule, not only a broken one."""
     kinds = {f.kind for f in load_all()}
-    assert {"guarantee", "characterization", "absence"} <= kinds
+    assert {"guarantee", "characterization"} <= kinds
 
 
 def test_characterizations_actually_differ_from_their_contract():

--- a/src/voicegateway/tests/fixtures/security/test_security_fixture_schema.py
+++ b/src/voicegateway/tests/fixtures/security/test_security_fixture_schema.py
@@ -43,7 +43,7 @@ def test_every_gap_id_is_minted():
 def test_both_guarantees_and_defects_are_represented():
     """The format must express a satisfied rule, not only a broken one."""
     kinds = {f.kind for f in load_all()}
-    assert {"guarantee", "characterization"} <= kinds
+    assert {"guarantee", "characterization", "absence"} <= kinds
 
 
 def test_characterizations_actually_differ_from_their_contract():

--- a/src/voicegateway/tests/inference/test_guard_pipecat.py
+++ b/src/voicegateway/tests/inference/test_guard_pipecat.py
@@ -95,6 +95,7 @@ class _StubLLM(LLMService):
         self._settings.model = model
         self._fail = fail
         self.request_calls = 0
+        self.last_context_id: str | None = None
 
     async def run_request(self) -> list[Frame]:
         """Produce the response frames for one guarded LLM request.
@@ -140,8 +141,12 @@ class _StubTTS(TTSService):
         self._settings.model = model
         self._fail = fail
         self.request_calls = 0
+        self.last_context_id: str | None = None
 
-    async def run_tts(self, text: str) -> Any:  # pragma: no cover - not driven
+    async def run_tts(
+        self, text: str, context_id: str = ""
+    ) -> Any:  # pragma: no cover - not driven
+        self.last_context_id = context_id
         yield None
 
     async def run_request(self) -> list[Frame]:
@@ -204,6 +209,13 @@ def test_guard_tts_returns_pipecat_tts_service():
     primary = _StubTTS(provider="cartesia", model="sonic")
     guarded = voicegateway.guard(primary)
     assert isinstance(guarded, TTSService)
+
+
+async def test_guard_tts_forwards_required_context_id():
+    primary = _StubTTS(provider="cartesia", model="sonic")
+    guarded = voicegateway.guard(primary)
+    assert [frame async for frame in guarded.run_tts("hello", "context-1")] == [None]
+    assert primary.last_context_id == "context-1"
 
 
 def test_guard_llm_wrapper_is_a_frame_processor():

--- a/src/voicegateway/tests/inference/test_tool_call_rows.py
+++ b/src/voicegateway/tests/inference/test_tool_call_rows.py
@@ -137,7 +137,8 @@ async def _seeded(tmp_path):
                 outcome=None,
                 turn_index=2,
             ),
-        ]
+        ],
+        tenant_id=None,
     )
     return storage
 

--- a/src/voicegateway/tests/integration/test_accounting_postgres_release.py
+++ b/src/voicegateway/tests/integration/test_accounting_postgres_release.py
@@ -1,0 +1,441 @@
+"""Release acceptance for exact accounting on a disposable PostgreSQL.
+
+CI supplies a fresh PostgreSQL service through ``VOICEGW_DB_URL``.  The tests
+create a non-owner application role after migrations and exercise production
+operations through that role.  They never target a persistent or shared DB.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from decimal import Decimal
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select, text
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from voicegateway.accounting.contracts import (
+    DimensionRate,
+    PreparationRequest,
+    PricingDimension,
+    PricingRevisionCreate,
+    PricingSide,
+    Quantity,
+    RevisionScope,
+    Unit,
+    UsageEnvelope,
+)
+from voicegateway.accounting.outbox import AccountingOutbox
+from voicegateway.core.gateway import Gateway
+from voicegateway.models.accounting_model import AccountingUsage, PricingRevision
+from voicegateway.repository.api_keys_repository import create_api_key
+from voicegateway.server import build_app
+from voicegateway.services.accounting_service import AccountingService, RevisionConflict
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("VOICEGW_DB_URL", "").startswith("postgresql"),
+    reason="requires a disposable PostgreSQL in VOICEGW_DB_URL",
+)
+
+_APP_ROLE = "voicegw_accounting_test_app"
+_APP_PASSWORD = "voicegw_accounting_test_only"
+
+
+def _revision(
+    revision_id: str,
+    side: PricingSide,
+    *,
+    tenant: str,
+    rate: str,
+) -> PricingRevisionCreate:
+    return PricingRevisionCreate(
+        revision_id=revision_id,
+        side=side,
+        scope=RevisionScope(tenant_id=tenant, offering="provider/model"),
+        rates=(
+            DimensionRate(
+                dimension=PricingDimension.TEXT_INPUT,
+                unit=Unit.TOKEN,
+                rate=rate,
+            ),
+            DimensionRate(
+                dimension=PricingDimension.TEXT_OUTPUT,
+                unit=Unit.TOKEN,
+                rate="0.000000000003",
+            ),
+            DimensionRate(
+                dimension=PricingDimension.CACHE_READ,
+                unit=Unit.TOKEN,
+                rate="0.0000000000005",
+            ),
+        ),
+        unsupported_dimensions=tuple(
+            dimension
+            for dimension in PricingDimension
+            if dimension
+            not in {
+                PricingDimension.TEXT_INPUT,
+                PricingDimension.TEXT_OUTPUT,
+                PricingDimension.CACHE_READ,
+            }
+        ),
+    )
+
+
+def _usage(
+    *,
+    event_id: str,
+    attempt_id: str,
+    project: str,
+    selling_revision_id: str,
+    binding_id: str | None = None,
+) -> UsageEnvelope:
+    return UsageEnvelope(
+        event_id=event_id,
+        attempt_id=attempt_id,
+        project_id=project,
+        session_id="session-release-test",
+        turn_id="turn-1",
+        component="conversation",
+        modality="llm",
+        offering="provider/model",
+        model_id="provider/model",
+        producer_id="sdk-release-test",
+        ownership_mode="sdk",
+        pricing_binding_id=binding_id,
+        selling_revision_id=selling_revision_id,
+        occurred_at_ns=1_800_000_000_000_000_000,
+        quantities=(
+            Quantity(dimension="text_input", value="1000003", status="measured"),
+            Quantity(dimension="text_output", value="7", status="measured"),
+            Quantity(dimension="cache_read", value="3", status="measured"),
+        ),
+    )
+
+
+async def _provision_restricted_role(owner_url: str) -> str:
+    engine = create_async_engine(owner_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    f"""
+                    DO $$ BEGIN
+                      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{_APP_ROLE}') THEN
+                        CREATE ROLE {_APP_ROLE} LOGIN PASSWORD '{_APP_PASSWORD}';
+                      END IF;
+                    END $$;
+                    """
+                )
+            )
+            await connection.execute(
+                text(f"ALTER ROLE {_APP_ROLE} PASSWORD '{_APP_PASSWORD}'")
+            )
+            await connection.execute(
+                text(f"GRANT USAGE ON SCHEMA public TO {_APP_ROLE}")
+            )
+            await connection.execute(
+                text(
+                    f"GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA public TO {_APP_ROLE}"
+                )
+            )
+            await connection.execute(
+                text(
+                    f"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {_APP_ROLE}"
+                )
+            )
+    finally:
+        await engine.dispose()
+    parsed = make_url(owner_url).set(username=_APP_ROLE, password=_APP_PASSWORD)
+    return parsed.render_as_string(hide_password=False)
+
+
+def _config(tmp_path) -> str:
+    path = tmp_path / "accounting-release.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "cost_tracking": {"enabled": True},
+                "auth": {"enforcement": "enforce"},
+            }
+        )
+    )
+    return str(path)
+
+
+async def _activate(
+    gateway: Gateway,
+    tenant: str,
+    side: PricingSide,
+    revision_id: str,
+    expected: str,
+) -> str:
+    try:
+        async with gateway.storage.session() as session:
+            await AccountingService(session, tenant_id=tenant).activate_revision(
+                side, revision_id, expected_current_revision_id=expected
+            )
+    except RevisionConflict:
+        return "conflict"
+    return "activated"
+
+
+class _ASGICollector:
+    def __init__(self, client: AsyncClient, *, lose_first_ack: bool = False) -> None:
+        self._client = client
+        self._lose_first_ack = lose_first_ack
+        self._calls = 0
+
+    async def post(self, url: str, **kwargs):
+        self._calls += 1
+        response = await self._client.post(
+            "/v1/accounting/usage",
+            headers=kwargs.get("headers"),
+            json=kwargs["json"],
+        )
+        if self._lose_first_ack and self._calls == 1:
+            assert response.status_code == 200
+            assert response.json()["receipts"][0]["outcome"] == "accepted"
+            raise ConnectionError("synthetic acknowledgement loss after commit")
+        return response
+
+
+async def test_accounting_release_matrix_on_restricted_postgres(
+    tmp_path, monkeypatch
+) -> None:
+    owner_url = os.environ["VOICEGW_DB_URL"]
+
+    # The owner performs the additive migration.  Runtime operations below use
+    # a role with no schema-create, delete, or drop privileges.
+    monkeypatch.setenv("VOICEGW_DB_URL", owner_url)
+    owner_gateway = Gateway(config_path=_config(tmp_path))
+    async with owner_gateway.storage.session() as session:
+        version = (
+            await session.execute(
+                text("SELECT version_num FROM alembic_version_voicegateway")
+            )
+        ).scalar_one()
+        assert version == "a6c9e2f4b817"
+
+    app_url = await _provision_restricted_role(owner_url)
+    monkeypatch.setenv("VOICEGW_DB_URL", app_url)
+    gateway = Gateway(config_path=_config(tmp_path))
+    tenant = f"tenant-{uuid.uuid4().hex}"
+    project = f"project-{uuid.uuid4().hex}"
+
+    async with gateway.storage.session() as session:
+        privileges = (
+            await session.execute(
+                text(
+                    "SELECT current_user, "
+                    "has_schema_privilege(current_user, 'public', 'CREATE'), "
+                    "has_table_privilege(current_user, 'accounting_usage', 'DELETE')"
+                )
+            )
+        ).one()
+        assert privileges == (_APP_ROLE, False, False)
+
+        service = AccountingService(session, tenant_id=tenant)
+        acquisition_v1 = _revision(
+            "acquisition-v1", PricingSide.ACQUISITION, tenant=tenant, rate="0.000001"
+        )
+        selling_v1 = _revision(
+            "selling-v1", PricingSide.SELLING, tenant=tenant, rate="0.000002"
+        )
+        _, created = await service.create_revision(acquisition_v1)
+        assert created
+        _, created = await service.create_revision(selling_v1)
+        assert created
+        _, created = await service.create_revision(selling_v1)
+        assert not created
+        with pytest.raises(RevisionConflict):
+            await service.create_revision(
+                _revision("selling-v1", PricingSide.SELLING, tenant=tenant, rate="0.9")
+            )
+        await service.activate_revision(PricingSide.ACQUISITION, "acquisition-v1")
+        await service.activate_revision(PricingSide.SELLING, "selling-v1")
+        prepared = await service.prepare(
+            PreparationRequest(
+                project_id=project,
+                component="conversation",
+                offering="provider/model",
+            )
+        )
+
+        for revision_id, side, rate in (
+            ("selling-v2", PricingSide.SELLING, "0.000004"),
+            ("selling-v3", PricingSide.SELLING, "0.000005"),
+            ("acquisition-v2", PricingSide.ACQUISITION, "0.000009"),
+        ):
+            await service.create_revision(
+                _revision(revision_id, side, tenant=tenant, rate=rate)
+            )
+
+    # Compare-and-swap activation is serialized by PostgreSQL. Exactly one
+    # writer wins and an independent acquisition revision remains unchanged.
+    outcomes = await asyncio.gather(
+        _activate(gateway, tenant, PricingSide.SELLING, "selling-v2", "selling-v1"),
+        _activate(gateway, tenant, PricingSide.SELLING, "selling-v3", "selling-v1"),
+    )
+    assert sorted(outcomes) == ["activated", "conflict"]
+    async with gateway.storage.session() as session:
+        active = (
+            (
+                await session.execute(
+                    select(PricingRevision).where(
+                        PricingRevision.tenant_id == tenant,
+                        PricingRevision.active.is_(True),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert sum(row.side == "selling" for row in active) == 1
+        assert [row.revision_id for row in active if row.side == "acquisition"] == [
+            "acquisition-v1"
+        ]
+
+    delayed = _usage(
+        event_id=f"event-{uuid.uuid4().hex}",
+        attempt_id=f"attempt-{uuid.uuid4().hex}",
+        project=project,
+        selling_revision_id="selling-v3",  # ignored in favor of the old binding
+        binding_id=prepared.binding_id,
+    )
+
+    async def ingest_once() -> str:
+        async with gateway.storage.session() as session:
+            receipt = await AccountingService(session, tenant_id=tenant).ingest(delayed)
+            return receipt.outcome
+
+    duplicate_outcomes = await asyncio.gather(*(ingest_once() for _ in range(6)))
+    assert duplicate_outcomes.count("accepted") == 1
+    assert duplicate_outcomes.count("duplicate") == 5
+    async with gateway.storage.session() as session:
+        rows = (
+            await session.execute(
+                select(func.count())
+                .select_from(AccountingUsage)
+                .where(
+                    AccountingUsage.tenant_id == tenant,
+                    AccountingUsage.event_id == delayed.event_id,
+                )
+            )
+        ).scalar_one()
+        assert rows == 1
+        report = await AccountingService(session, tenant_id=tenant).report(
+            project_id=project, include_acquisition=True
+        )
+        # Old pinned rates: (1,000,000 uncached * 0.000002) + cache + output.
+        assert Decimal(str(report["selling_total_usd"])) == Decimal("2.000000000022")
+        assert Decimal(str(report["acquisition_total_usd"])) == Decimal(
+            "1.000000000022"
+        )
+
+    # HTTP mixed batches return durable per-record receipts. Authentication,
+    # not submitted tenant data, supplies the ledger tenant.
+    async with gateway.storage.session() as session:
+        key = await create_api_key(
+            session,
+            name="release-producer",
+            scopes="read,ingest",
+            tenant_id=tenant,
+            project_ids=project,
+        )
+    app = build_app(gateway)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        headers = {"Authorization": f"Bearer {key.plaintext}"}
+        allowed = _usage(
+            event_id=f"event-{uuid.uuid4().hex}",
+            attempt_id=f"attempt-{uuid.uuid4().hex}",
+            project=project,
+            selling_revision_id="selling-v1",
+            binding_id=prepared.binding_id,
+        ).model_dump(mode="json")
+        denied = {
+            **allowed,
+            "event_id": f"event-{uuid.uuid4().hex}",
+            "attempt_id": f"attempt-{uuid.uuid4().hex}",
+            "project_id": "not-authorized",
+        }
+        mixed = await client.post(
+            "/v1/accounting/usage", headers=headers, json=[allowed, denied]
+        )
+        assert mixed.status_code == 200
+        assert [item["outcome"] for item in mixed.json()["receipts"]] == [
+            "accepted",
+            "rejected",
+        ]
+        assert mixed.json()["receipts"][1]["code"] == "project_not_authorized"
+
+        tenant_report = await client.get("/v1/accounting/report", headers=headers)
+        dashboard = await client.get("/api/accounting", headers=headers)
+        denied_cost = await client.get(
+            "/v1/accounting/report?include_acquisition=true", headers=headers
+        )
+        denied_revision = await client.get(
+            "/v1/accounting/revisions/acquisition/acquisition-v1", headers=headers
+        )
+        assert tenant_report.status_code == dashboard.status_code == 200
+        assert denied_cost.status_code == denied_revision.status_code == 403
+        for response in (tenant_report, dashboard, denied_cost, denied_revision):
+            assert "acquisition_total" not in response.text
+            assert "margin_usd" not in response.text
+            assert "0.000001" not in response.text
+
+        # The collector commits, the acknowledgement is lost, and a restarted
+        # sender retries the same event. PostgreSQL keeps one row and one charge.
+        ack_event = _usage(
+            event_id=f"event-{uuid.uuid4().hex}",
+            attempt_id=f"attempt-{uuid.uuid4().hex}",
+            project=project,
+            selling_revision_id="selling-v1",
+            binding_id=prepared.binding_id,
+        )
+        outbox_path = tmp_path / "postgres-lost-ack.db"
+        first = AccountingOutbox(
+            outbox_path,
+            "http://test",
+            api_key=key.plaintext,
+            client=_ASGICollector(client, lose_first_ack=True),
+        )
+        assert await first.submit(ack_event) == "stored"
+        assert (await first.drain())["retryable"] == 1
+        await first.aclose()
+        restarted = AccountingOutbox(
+            outbox_path,
+            "http://test",
+            api_key=key.plaintext,
+            client=_ASGICollector(client),
+        )
+        assert (await restarted.drain())["duplicate"] == 1
+        assert (await restarted.health())["pending"] == 0
+        await restarted.aclose()
+
+    async with gateway.storage.session() as session:
+        durable = (
+            await session.execute(
+                select(func.count())
+                .select_from(AccountingUsage)
+                .where(
+                    AccountingUsage.tenant_id == tenant,
+                    AccountingUsage.event_id == ack_event.event_id,
+                )
+            )
+        ).scalar_one()
+        assert durable == 1
+
+    await gateway.storage.aclose()
+    await owner_gateway.storage.aclose()

--- a/src/voicegateway/tests/mcp/test_accounting_status.py
+++ b/src/voicegateway/tests/mcp/test_accounting_status.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from voicegateway.core.auth import ADMIN_SCOPE
+from voicegateway.core.gateway import Gateway
+from voicegateway.server.mcp.tools import ALL_TOOLS
+
+
+def _tool():
+    return next(tool for tool in ALL_TOOLS if tool.name == "get_accounting_status")
+
+
+@pytest.fixture
+def gateway(temp_config, tmp_path, monkeypatch):
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "accounting-mcp.db"))
+    return Gateway(config_path=temp_config)
+
+
+def test_accounting_tool_is_read_only_operator_scoped() -> None:
+    tool = _tool()
+    assert tool.required_scope == ADMIN_SCOPE
+    assert "never returns acquisition" in tool.description.lower()
+    assert "prompt" in tool.description.lower()
+
+
+async def test_accounting_tool_returns_selling_status_only(gateway) -> None:
+    result = await _tool().handler(gateway, {})
+    assert result["selling_total_usd"] == "0"
+    assert "acquisition_total_usd" not in result
+    assert "margin_usd" not in result

--- a/src/voicegateway/tests/mcp/test_accounting_status.py
+++ b/src/voicegateway/tests/mcp/test_accounting_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from voicegateway.core.auth import ADMIN_SCOPE
 from voicegateway.core.gateway import Gateway
@@ -24,8 +25,27 @@ def test_accounting_tool_is_read_only_operator_scoped() -> None:
     assert "prompt" in tool.description.lower()
 
 
-async def test_accounting_tool_returns_selling_status_only(gateway) -> None:
+async def test_accounting_tool_requires_server_bound_tenant(
+    gateway, monkeypatch
+) -> None:
+    monkeypatch.delenv("VOICEGW_MCP_ACCOUNTING_TENANT", raising=False)
+    result = await _tool().handler(gateway, {})
+    assert result["error"] == "accounting_tenant_not_configured"
+
+
+async def test_accounting_tool_returns_selling_status_only(
+    gateway, monkeypatch
+) -> None:
+    monkeypatch.setenv("VOICEGW_MCP_ACCOUNTING_TENANT", "tenant-a")
     result = await _tool().handler(gateway, {})
     assert result["selling_total_usd"] == "0"
     assert "acquisition_total_usd" not in result
     assert "margin_usd" not in result
+
+
+async def test_accounting_tool_caller_cannot_select_tenant(
+    gateway, monkeypatch
+) -> None:
+    monkeypatch.setenv("VOICEGW_MCP_ACCOUNTING_TENANT", "tenant-a")
+    with pytest.raises(ValidationError, match="tenant"):
+        await _tool().handler(gateway, {"tenant": "tenant-b"})

--- a/src/voicegateway/tests/mcp/test_transport.py
+++ b/src/voicegateway/tests/mcp/test_transport.py
@@ -18,12 +18,12 @@ def gateway(temp_config, tmp_path, monkeypatch):
 
 
 async def test_list_tools_protocol(gateway):
-    """In admin mode the client sees all 25 tools (including v0.0.5 vg_* tools)."""
+    """In admin mode the client sees all 26 tools (including exact accounting)."""
     server = create_server(gateway, is_admin=True)
     async with create_connected_server_and_client_session(server) as client:
         await client.initialize()
         result = await client.list_tools()
-        assert len(result.tools) == 25
+        assert len(result.tools) == 26
         names = {t.name for t in result.tools}
         assert "get_health" in names
         assert "add_provider" in names
@@ -33,6 +33,7 @@ async def test_list_tools_protocol(gateway):
         assert "vg_set_provider_key" in names
         assert "vg_test_provider_key" in names
         assert "delete_project" in names
+        assert "get_accounting_status" in names
 
 
 async def test_list_tools_default_hides_admin(gateway):

--- a/src/voicegateway/tests/repository/test_api_keys_scopes.py
+++ b/src/voicegateway/tests/repository/test_api_keys_scopes.py
@@ -1,0 +1,109 @@
+"""Keys are minted with explicit scopes. The wildcard is not mintable.
+
+VG-SEC-006: every key the product minted defaulted to ``*``, and the scope
+check short-circuits on ``*``. Scope enforcement ran on every request and
+always passed, which is worse than not running: the matrix, the docs and the
+key list all described a system of scopes that decided nothing.
+
+The gap closes at the mint, not at the check. Refusing ``*`` in
+``has_scope`` would have locked out every key already issued; refusing it at
+``create_api_key`` means no NEW inert key can be made while the existing ones
+keep working, loudly, until 0.27.0 withdraws them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from voicegateway.repository import api_keys_repository as api_keys
+from voicegateway.tests.server._telemetry_harness import _Harness
+
+
+@pytest.fixture
+async def session():
+    harness = _Harness()
+    try:
+        async with harness.gateway.storage.session() as db:
+            yield db
+    finally:
+        harness.cleanup()
+
+
+async def test_scopes_is_required():
+    """No default. A caller that forgets scopes gets a TypeError, not a ``*``."""
+    with pytest.raises(TypeError):
+        await api_keys.create_api_key(None, name="k")  # type: ignore[call-arg]
+
+
+async def test_wildcard_is_refused_at_mint(session):
+    """Both spellings: the bare wildcard and one hidden in a list."""
+    with pytest.raises(ValueError, match="wildcard"):
+        await api_keys.create_api_key(session, name="k", scopes="*")
+    with pytest.raises(ValueError, match="wildcard"):
+        await api_keys.create_api_key(session, name="k", scopes="read,*")
+
+
+async def test_unknown_scope_is_refused(session):
+    """A typo must not mint a key that silently authorizes nothing."""
+    with pytest.raises(ValueError, match="unknown scope"):
+        await api_keys.create_api_key(session, name="k", scopes="root")
+
+
+async def test_empty_scopes_is_refused(session):
+    """An empty string is a caller bug, not a request for zero scopes."""
+    with pytest.raises(ValueError, match="at least one"):
+        await api_keys.create_api_key(session, name="k", scopes="  ,  ")
+
+
+async def test_scopes_are_normalized(session):
+    """Whitespace and order are not part of a key's identity."""
+    created = await api_keys.create_api_key(
+        session, name="k", scopes=" write , ingest ,ingest"
+    )
+    verified = await api_keys.verify(session, created.plaintext)
+    assert verified is not None
+    assert verified.scopes == "ingest,write"
+
+
+async def test_explicit_scopes_round_trip(session):
+    """The happy path: an ingest key verifies and covers only ingest."""
+    created = await api_keys.create_api_key(session, name="agent", scopes="ingest")
+    verified = await api_keys.verify(session, created.plaintext)
+    assert verified is not None
+    assert verified.has_scope("ingest", enforce=True)
+    assert not verified.has_scope("admin", enforce=True)
+
+
+async def test_audit_lists_legacy_wildcard_keys(session):
+    """A key minted before 0.26.0, written directly the way the old mint did."""
+    await session.execute(
+        text(
+            "INSERT INTO api_keys (key_prefix, key_hash, name, role, scopes, "
+            "issued_at) VALUES ('vk_old', 'h', 'legacy', 'tenant', '*', "
+            "CURRENT_TIMESTAMP)"
+        )
+    )
+    await session.execute(
+        text(
+            "INSERT INTO api_keys (key_prefix, key_hash, name, role, scopes, "
+            "issued_at) VALUES ('vk_mix', 'h', 'mixed', 'tenant', 'read,*', "
+            "CURRENT_TIMESTAMP)"
+        )
+    )
+    await api_keys.create_api_key(session, name="modern", scopes="read")
+    found = await api_keys.list_wildcard_keys(session)
+    assert sorted(k.name for k in found) == ["legacy", "mixed"]
+
+
+async def test_audit_skips_revoked_wildcard_keys(session):
+    """A revoked key needs no re-minting, so it is not a finding."""
+    await session.execute(
+        text(
+            "INSERT INTO api_keys (key_prefix, key_hash, name, role, scopes, "
+            "issued_at, revoked_at) VALUES ('vk_rev', 'h', 'gone', 'tenant', "
+            "'*', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+    )
+    await session.commit()
+    assert await api_keys.list_wildcard_keys(session) == []

--- a/src/voicegateway/tests/repository/test_repository_protocols.py
+++ b/src/voicegateway/tests/repository/test_repository_protocols.py
@@ -1,0 +1,109 @@
+"""The repository Protocols name contracts a storage backend must satisfy.
+
+``TraceRepository`` is the one Wave 1 needs: Task 20's spans repository is
+written against it from its first commit, so the trace tables are born behind
+an interface rather than having one retrofitted in Wave 3.
+
+``RequestReadRepository`` is deliberately absent. The spec assumed
+``clickhouse/read_repository.py`` duplicated one SQL module's read surface, so
+one Protocol could name what both satisfy. Measured, that is false: of its
+nine read functions, seven have same-named SQL counterparts spread across five
+modules (cost, latency, request_log, session, billing) and two
+(``get_session_requests``, ``get_cost_by_tenant_admin``) have none. No single
+SQL module implements the surface, so there is nothing honest for a
+``runtime_checkable`` assertion to bind to. See the Wave 1 report for the
+options; Wave 3 owns putting ClickHouse behind an interface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from voicegateway.repository import protocols
+from voicegateway.schemas.telemetry.security_schema import PrincipalKind
+from voicegateway.server.api._deps import Principal
+from voicegateway.telemetry.trace_schema import SpanRecord
+
+
+def test_principal_defaults_are_unrestricted_operator():
+    """Every existing key keeps working: no allowlist means no restriction."""
+    principal = Principal(tenant_id=None, is_admin=True, api_key_id=None)
+    assert principal.project_ids is None
+    assert principal.kind is PrincipalKind.OPERATOR
+
+
+def test_principal_carries_a_project_allowlist_and_a_kind():
+    principal = Principal(
+        tenant_id="acme",
+        is_admin=False,
+        api_key_id=7,
+        project_ids=frozenset({"p1"}),
+        kind=PrincipalKind.TENANT_KEY,
+    )
+    assert principal.project_ids == frozenset({"p1"})
+    assert principal.kind is PrincipalKind.TENANT_KEY
+
+
+def test_principal_is_still_frozen():
+    """The principal is decided once per request and never edited after."""
+    import dataclasses
+
+    principal = Principal(tenant_id="acme", is_admin=False, api_key_id=1)
+    with __import__("pytest").raises(dataclasses.FrozenInstanceError):
+        principal.tenant_id = "beta"  # type: ignore[misc]
+
+
+class _StubTraceRepository:
+    """Shape check only. Task 20 ships the real one."""
+
+    async def upsert_spans(
+        self, session: AsyncSession, records: list[SpanRecord], *, tenant_id: str
+    ) -> int:
+        return len(records)
+
+    async def get_trace(
+        self, session: AsyncSession, trace_id: str, *, tenant_id: str
+    ) -> list[dict[str, Any]]:
+        return []
+
+    async def list_spans_by_session(
+        self, session: AsyncSession, session_id: str, *, tenant_id: str
+    ) -> list[dict[str, Any]]:
+        return []
+
+    async def list_events(
+        self, session: AsyncSession, span_row_id: int, *, tenant_id: str
+    ) -> list[dict[str, Any]]:
+        return []
+
+    async def list_links(
+        self, session: AsyncSession, span_row_id: int, *, tenant_id: str
+    ) -> list[dict[str, Any]]:
+        return []
+
+
+def test_trace_repository_protocol_is_satisfiable():
+    """A conforming implementation exists, so the Protocol is not aspirational."""
+    assert isinstance(_StubTraceRepository(), protocols.TraceRepository)
+
+
+def test_trace_repository_requires_every_read_to_be_tenant_scoped():
+    """Every method takes tenant_id as a required keyword. That is the point."""
+    import inspect
+
+    for name in (
+        "upsert_spans",
+        "get_trace",
+        "list_spans_by_session",
+        "list_events",
+        "list_links",
+    ):
+        signature = inspect.signature(getattr(protocols.TraceRepository, name))
+        tenant = signature.parameters.get("tenant_id")
+        assert tenant is not None, f"{name} takes no tenant_id"
+        assert tenant.kind is inspect.Parameter.KEYWORD_ONLY, name
+        assert tenant.default is inspect.Parameter.empty, (
+            f"{name} tenant_id is optional"
+        )

--- a/src/voicegateway/tests/repository/test_transcript_turns_repository.py
+++ b/src/voicegateway/tests/repository/test_transcript_turns_repository.py
@@ -27,7 +27,7 @@ async def db():
 
 async def test_create_and_list_preserves_order(db):
     n = await tr.create_transcript_bulk(
-        db, "s1", [("user", "hi"), ("agent", "hello"), ("user", "bye")]
+        db, "s1", [("user", "hi"), ("agent", "hello"), ("user", "bye")], tenant_id=None
     )
     assert n == 3
     rows = await tr.list_transcript_by_session(db, "s1")
@@ -39,21 +39,23 @@ async def test_create_and_list_preserves_order(db):
 
 
 async def test_rewrite_replaces_not_appends(db):
-    await tr.create_transcript_bulk(db, "s1", [("user", "first")])
-    await tr.create_transcript_bulk(db, "s1", [("user", "again"), ("agent", "ok")])
+    await tr.create_transcript_bulk(db, "s1", [("user", "first")], tenant_id=None)
+    await tr.create_transcript_bulk(
+        db, "s1", [("user", "again"), ("agent", "ok")], tenant_id=None
+    )
     rows = await tr.list_transcript_by_session(db, "s1")
     assert [(r.role, r.text) for r in rows] == [("user", "again"), ("agent", "ok")]
 
 
 async def test_empty_turns_clears(db):
-    await tr.create_transcript_bulk(db, "s1", [("user", "hi")])
-    n = await tr.create_transcript_bulk(db, "s1", [])
+    await tr.create_transcript_bulk(db, "s1", [("user", "hi")], tenant_id=None)
+    n = await tr.create_transcript_bulk(db, "s1", [], tenant_id=None)
     assert n == 0
     assert await tr.list_transcript_by_session(db, "s1") == []
 
 
 async def test_scoped_to_session(db):
-    await tr.create_transcript_bulk(db, "s1", [("user", "a")])
-    await tr.create_transcript_bulk(db, "s2", [("user", "b")])
+    await tr.create_transcript_bulk(db, "s1", [("user", "a")], tenant_id=None)
+    await tr.create_transcript_bulk(db, "s2", [("user", "b")], tenant_id=None)
     assert len(await tr.list_transcript_by_session(db, "s1")) == 1
     assert len(await tr.list_transcript_by_session(db, "s2")) == 1

--- a/src/voicegateway/tests/server/_telemetry_harness.py
+++ b/src/voicegateway/tests/server/_telemetry_harness.py
@@ -87,8 +87,11 @@ class _Harness:
 async def _make_key(gateway, *, tenant_id=None, role="tenant", scopes="read"):
     """Mint a vk_ key and return its plaintext token.
 
-    ``scopes`` is explicit because Wave 1 stops minting wildcard keys: a test
-    that wants to write must say so, exactly as an operator now must.
+    ``scopes`` is explicit because 0.26.0 stops minting wildcard keys: a test
+    that wants to write must say so, exactly as an operator now must. The
+    default is ``read`` rather than the old ``*`` so that a test which needs
+    write authority fails loudly instead of passing on a scope that matched
+    everything.
     """
     async with gateway.storage.session() as db:
         created = await api_keys.create_api_key(

--- a/src/voicegateway/tests/server/_telemetry_harness.py
+++ b/src/voicegateway/tests/server/_telemetry_harness.py
@@ -34,7 +34,12 @@ from voicegateway.server import build_app
 class _Harness:
     """Builds an app + Gateway over a fresh SQLite db, yields a client maker."""
 
-    def __init__(self) -> None:
+    def __init__(self, config_overrides: dict | None = None) -> None:
+        """Build the app. ``config_overrides`` merges into the yaml top level.
+
+        Used to vary the ``auth`` block per test (enforcement mode, local
+        development, configured keys) without a second harness.
+        """
         self._tmp = tempfile.TemporaryDirectory()
         tmp = self._tmp.name
         # See the module docstring: restoring this is what keeps the harness
@@ -48,6 +53,8 @@ class _Harness:
             "fallbacks": {"stt": [], "llm": [], "tts": []},
             "cost_tracking": {"enabled": True},
         }
+        if config_overrides:
+            cfg.update(config_overrides)
         cfg_path = os.path.join(tmp, "voicegw.yaml")
         with open(cfg_path, "w") as handle:
             yaml.dump(cfg, handle)

--- a/src/voicegateway/tests/server/_telemetry_harness.py
+++ b/src/voicegateway/tests/server/_telemetry_harness.py
@@ -84,11 +84,19 @@ class _Harness:
         self._tmp.cleanup()
 
 
-async def _make_key(gateway, *, tenant_id=None, role="tenant"):
-    """Mint a vk_ key and return its plaintext token."""
-    async with gateway.storage._conn.session() as db:
+async def _make_key(gateway, *, tenant_id=None, role="tenant", scopes="read"):
+    """Mint a vk_ key and return its plaintext token.
+
+    ``scopes`` is explicit because Wave 1 stops minting wildcard keys: a test
+    that wants to write must say so, exactly as an operator now must.
+    """
+    async with gateway.storage.session() as db:
         created = await api_keys.create_api_key(
-            db, name=f"k-{tenant_id}-{role}", tenant_id=tenant_id, role=role
+            db,
+            name=f"k-{tenant_id}-{role}-{scopes}",
+            tenant_id=tenant_id,
+            role=role,
+            scopes=scopes,
         )
     return created.plaintext
 
@@ -130,6 +138,8 @@ def classify_dependency(fn) -> str | None:
         )
         cell = fn.__closure__[code.co_freevars.index("scope")]
         return f"scope:{cell.cell_contents}"
+    if qualname == "require_ingest_principal":
+        return "scope:ingest"
     if qualname == "require_principal":
         return "principal"
     return None

--- a/src/voicegateway/tests/server/test_accounting_api.py
+++ b/src/voicegateway/tests/server/test_accounting_api.py
@@ -518,6 +518,26 @@ async def test_concurrent_duplicate_delivery_has_one_billable_row(
     assert report["records"] == 1
 
 
+async def test_rebatching_preserves_original_receipts(tmp_path, monkeypatch) -> None:
+    async with await _client(tmp_path, monkeypatch) as client:
+        await client.post("/v1/accounting/revisions", json=_revision())
+        first = await client.post(
+            "/v1/accounting/usage",
+            json=[_usage("event-1", "attempt-1"), _usage("event-2", "attempt-2")],
+        )
+        receipts = {
+            item["event_id"]: item["receipt_id"] for item in first.json()["receipts"]
+        }
+        rebatched = await client.post(
+            "/v1/accounting/usage",
+            json=[_usage("event-2", "attempt-2"), _usage("event-1", "attempt-1")],
+        )
+    assert all(item["outcome"] == "duplicate" for item in rebatched.json()["receipts"])
+    assert {
+        item["event_id"]: item["receipt_id"] for item in rebatched.json()["receipts"]
+    } == receipts
+
+
 async def test_non_admin_report_is_tenant_isolated(tmp_path, monkeypatch) -> None:
     gateway, client = await _gateway_client(tmp_path, monkeypatch)
     from voicegateway.accounting.contracts import UsageEnvelope
@@ -547,3 +567,32 @@ async def test_non_admin_report_is_tenant_isolated(tmp_path, monkeypatch) -> Non
         )
     assert response.json()["records"] == 1
     assert foreign.status_code == 403
+
+
+async def test_dashboard_never_exposes_acquisition_fields(
+    tmp_path, monkeypatch
+) -> None:
+    gateway, client = await _gateway_client(tmp_path, monkeypatch)
+    from voicegateway.accounting.contracts import PricingRevisionCreate, UsageEnvelope
+    from voicegateway.services.accounting_service import AccountingService
+
+    acquisition = _revision("cost-1", "0.1")
+    acquisition["side"] = "acquisition"
+    async with gateway.storage.session() as session:
+        service = AccountingService(session, tenant_id="tenant-a")
+        await service.create_revision(PricingRevisionCreate.model_validate(acquisition))
+        await service.create_revision(PricingRevisionCreate.model_validate(_revision()))
+        event = _usage()
+        event["acquisition_revision_id"] = "cost-1"
+        await service.ingest(UsageEnvelope.model_validate(event))
+        key = await create_api_key(
+            session, name="dashboard-reader", scopes="read", tenant_id="tenant-a"
+        )
+    async with client:
+        response = await client.get(
+            "/api/accounting",
+            headers={"Authorization": f"Bearer {key.plaintext}"},
+        )
+    assert response.status_code == 200
+    assert "acquisition" not in response.text.lower()
+    assert "margin" not in response.text.lower()

--- a/src/voicegateway/tests/server/test_accounting_api.py
+++ b/src/voicegateway/tests/server/test_accounting_api.py
@@ -1,0 +1,111 @@
+"""Immutable accounting API integration tests."""
+
+from __future__ import annotations
+
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from voicegateway.accounting.contracts import PricingDimension
+from voicegateway.core.gateway import Gateway
+from voicegateway.server import build_app
+
+
+def _revision(revision_id: str = "sell-1", rate: str = "0.25") -> dict:
+    return {
+        "revision_id": revision_id,
+        "side": "selling",
+        "scope": {"offering": "provider/model"},
+        "rates": [{"dimension": "requests", "unit": "request", "rate": rate}],
+        "unsupported_dimensions": [
+            item.value
+            for item in PricingDimension
+            if item is not PricingDimension.REQUESTS
+        ],
+    }
+
+
+def _usage(event_id: str = "event-1", attempt_id: str = "attempt-1") -> dict:
+    return {
+        "event_id": event_id,
+        "attempt_id": attempt_id,
+        "project_id": "default",
+        "session_id": "session-1",
+        "component": "conversation",
+        "modality": "llm",
+        "offering": "provider/model",
+        "model_id": "provider/model",
+        "producer_id": "sdk-1",
+        "ownership_mode": "sdk",
+        "selling_revision_id": "sell-1",
+        "occurred_at_ns": 10,
+        "quantities": [{"dimension": "requests", "value": "1", "status": "measured"}],
+    }
+
+
+async def _client(tmp_path, monkeypatch) -> AsyncClient:
+    config = tmp_path / "voicegw.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "cost_tracking": {"enabled": True},
+            }
+        )
+    )
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "accounting.db"))
+    monkeypatch.delenv("VOICEGW_API_KEY", raising=False)
+    return AsyncClient(
+        transport=ASGITransport(app=build_app(Gateway(config_path=str(config)))),
+        base_url="http://test",
+    )
+
+
+async def test_revision_idempotency_conflict_and_usage_receipts(
+    tmp_path, monkeypatch
+) -> None:
+    async with await _client(tmp_path, monkeypatch) as client:
+        created = await client.post("/v1/accounting/revisions", json=_revision())
+        assert created.status_code == 201, created.text
+        assert created.json()["created"] is True
+        retried = await client.post("/v1/accounting/revisions", json=_revision())
+        assert retried.status_code == 201
+        assert retried.json()["created"] is False
+        conflict = await client.post(
+            "/v1/accounting/revisions", json=_revision(rate="0.3")
+        )
+        assert conflict.status_code == 409
+
+        first = await client.post("/v1/accounting/usage", json=[_usage()])
+        assert first.status_code == 200, first.text
+        assert first.json()["receipts"][0]["outcome"] == "accepted"
+        duplicate = await client.post("/v1/accounting/usage", json=[_usage()])
+        assert duplicate.json()["receipts"][0]["outcome"] == "duplicate"
+
+        report = await client.get("/v1/accounting/report")
+        assert report.status_code == 200
+        assert report.json()["selling_total_usd"] == "0.250000000000"
+        assert "acquisition_total_usd" not in report.text
+
+
+async def test_conflicting_event_and_attempt_are_rejected(
+    tmp_path, monkeypatch
+) -> None:
+    async with await _client(tmp_path, monkeypatch) as client:
+        await client.post("/v1/accounting/revisions", json=_revision())
+        assert (
+            await client.post("/v1/accounting/usage", json=[_usage()])
+        ).status_code == 200
+        changed = _usage()
+        changed["producer_id"] = "sdk-2"
+        response = await client.post("/v1/accounting/usage", json=[changed])
+        assert response.json()["receipts"][0]["code"] == "identity_conflict"
+        second_event = await client.post(
+            "/v1/accounting/usage", json=[_usage("event-2", "attempt-1")]
+        )
+        assert (
+            second_event.json()["receipts"][0]["code"]
+            == "attempt_or_ownership_conflict"
+        )

--- a/src/voicegateway/tests/server/test_accounting_api.py
+++ b/src/voicegateway/tests/server/test_accounting_api.py
@@ -7,6 +7,7 @@ from httpx import ASGITransport, AsyncClient
 
 from voicegateway.accounting.contracts import PricingDimension
 from voicegateway.core.gateway import Gateway
+from voicegateway.repository.api_keys_repository import create_api_key
 from voicegateway.server import build_app
 
 
@@ -63,6 +64,27 @@ async def _client(tmp_path, monkeypatch) -> AsyncClient:
     )
 
 
+async def _gateway_client(tmp_path, monkeypatch) -> tuple[Gateway, AsyncClient]:
+    config = tmp_path / "scoped.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "providers": {},
+                "models": {"stt": {}, "llm": {}, "tts": {}},
+                "projects": {},
+                "fallbacks": {"stt": [], "llm": [], "tts": []},
+                "cost_tracking": {"enabled": True},
+                "auth": {"enforcement": "enforce"},
+            }
+        )
+    )
+    monkeypatch.setenv("VOICEGW_DB_PATH", str(tmp_path / "scoped.db"))
+    gateway = Gateway(config_path=str(config))
+    return gateway, AsyncClient(
+        transport=ASGITransport(app=build_app(gateway)), base_url="http://test"
+    )
+
+
 async def test_revision_idempotency_conflict_and_usage_receipts(
     tmp_path, monkeypatch
 ) -> None:
@@ -109,3 +131,70 @@ async def test_conflicting_event_and_attempt_are_rejected(
             second_event.json()["receipts"][0]["code"]
             == "attempt_or_ownership_conflict"
         )
+
+
+async def test_prepared_revision_remains_pinned_after_activation_changes(
+    tmp_path, monkeypatch
+) -> None:
+    async with await _client(tmp_path, monkeypatch) as client:
+        await client.post("/v1/accounting/revisions", json=_revision("sell-1", "0.25"))
+        activated = await client.post(
+            "/v1/accounting/revisions/selling/activate", json={"revision_id": "sell-1"}
+        )
+        assert activated.status_code == 200, activated.text
+        prepared = await client.post(
+            "/v1/accounting/prepare",
+            json={
+                "project_id": "default",
+                "component": "conversation",
+                "offering": "provider/model",
+            },
+        )
+        assert prepared.status_code == 200, prepared.text
+        binding = prepared.json()
+        assert binding["selling_revision_id"] == "sell-1"
+
+        await client.post("/v1/accounting/revisions", json=_revision("sell-2", "0.50"))
+        switched = await client.post(
+            "/v1/accounting/revisions/selling/activate",
+            json={
+                "revision_id": "sell-2",
+                "expected_current_revision_id": "sell-1",
+            },
+        )
+        assert switched.status_code == 200
+        event = _usage()
+        event["pricing_binding_id"] = binding["binding_id"]
+        response = await client.post("/v1/accounting/usage", json=[event])
+        assert response.json()["receipts"][0]["outcome"] == "accepted"
+        report = await client.get("/v1/accounting/report")
+        assert report.json()["selling_total_usd"] == "0.250000000000"
+
+
+async def test_ingest_principal_enforces_project_allowlist(
+    tmp_path, monkeypatch
+) -> None:
+    gateway, client = await _gateway_client(tmp_path, monkeypatch)
+    async with gateway.storage.session() as session:
+        key = await create_api_key(
+            session,
+            name="scoped-agent",
+            scopes="read,ingest",
+            tenant_id="tenant-a",
+            project_ids="allowed",
+        )
+    headers = {"Authorization": f"Bearer {key.plaintext}"}
+    async with client:
+        allowed = _usage()
+        allowed["project_id"] = "allowed"
+        accepted = await client.post(
+            "/v1/accounting/usage", json=[allowed], headers=headers
+        )
+        assert accepted.status_code == 200
+        forbidden = _usage("event-2", "attempt-2")
+        forbidden["project_id"] = "forbidden"
+        rejected = await client.post(
+            "/v1/accounting/usage", json=[forbidden], headers=headers
+        )
+        assert rejected.status_code == 403
+        assert "tenant" not in rejected.text.lower()

--- a/src/voicegateway/tests/server/test_accounting_api.py
+++ b/src/voicegateway/tests/server/test_accounting_api.py
@@ -198,3 +198,32 @@ async def test_ingest_principal_enforces_project_allowlist(
         )
         assert rejected.status_code == 403
         assert "tenant" not in rejected.text.lower()
+
+
+async def test_tenant_key_cannot_read_acquisition_revision(
+    tmp_path, monkeypatch
+) -> None:
+    gateway, client = await _gateway_client(tmp_path, monkeypatch)
+    from voicegateway.accounting.contracts import PricingRevisionCreate
+    from voicegateway.services.accounting_service import AccountingService
+
+    acquisition = _revision("cost-1", "0.1")
+    acquisition["side"] = "acquisition"
+    acquisition["scope"]["tenant_id"] = "tenant-a"
+    async with gateway.storage.session() as session:
+        await AccountingService(session, tenant_id="tenant-a").create_revision(
+            PricingRevisionCreate.model_validate(acquisition)
+        )
+        key = await create_api_key(
+            session,
+            name="tenant-reader",
+            scopes="read,ingest",
+            tenant_id="tenant-a",
+        )
+    async with client:
+        response = await client.get(
+            "/v1/accounting/revisions/acquisition/cost-1",
+            headers={"Authorization": f"Bearer {key.plaintext}"},
+        )
+        assert response.status_code == 403
+        assert "0.1" not in response.text

--- a/src/voicegateway/tests/server/test_accounting_api.py
+++ b/src/voicegateway/tests/server/test_accounting_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import yaml
 from httpx import ASGITransport, AsyncClient
 
@@ -109,6 +111,7 @@ async def test_revision_idempotency_conflict_and_usage_receipts(
         report = await client.get("/v1/accounting/report")
         assert report.status_code == 200
         assert report.json()["selling_total_usd"] == "0.250000000000"
+        assert report.json()["counts"]["rated"] == 1
         assert "acquisition_total_usd" not in report.text
 
 
@@ -125,7 +128,8 @@ async def test_conflicting_event_and_attempt_are_rejected(
         response = await client.post("/v1/accounting/usage", json=[changed])
         assert response.json()["receipts"][0]["code"] == "identity_conflict"
         second_event = await client.post(
-            "/v1/accounting/usage", json=[_usage("event-2", "attempt-1")]
+            "/v1/accounting/usage",
+            json=[{**_usage("event-2", "attempt-1"), "component": "research"}],
         )
         assert (
             second_event.json()["receipts"][0]["code"]
@@ -171,6 +175,28 @@ async def test_prepared_revision_remains_pinned_after_activation_changes(
         assert report.json()["selling_total_usd"] == "0.250000000000"
 
 
+async def test_delayed_unbound_usage_keeps_submitted_revision(
+    tmp_path, monkeypatch
+) -> None:
+    async with await _client(tmp_path, monkeypatch) as client:
+        await client.post("/v1/accounting/revisions", json=_revision("sell-1", "0.25"))
+        await client.post(
+            "/v1/accounting/revisions/selling/activate", json={"revision_id": "sell-1"}
+        )
+        await client.post("/v1/accounting/revisions", json=_revision("sell-2", "0.50"))
+        await client.post(
+            "/v1/accounting/revisions/selling/activate",
+            json={
+                "revision_id": "sell-2",
+                "expected_current_revision_id": "sell-1",
+            },
+        )
+        delayed = await client.post("/v1/accounting/usage", json=[_usage()])
+        assert delayed.json()["receipts"][0]["outcome"] == "accepted"
+        report = (await client.get("/v1/accounting/report")).json()
+    assert report["selling_total_usd"] == "0.250000000000"
+
+
 async def test_ingest_principal_enforces_project_allowlist(
     tmp_path, monkeypatch
 ) -> None:
@@ -196,7 +222,8 @@ async def test_ingest_principal_enforces_project_allowlist(
         rejected = await client.post(
             "/v1/accounting/usage", json=[forbidden], headers=headers
         )
-        assert rejected.status_code == 403
+        assert rejected.status_code == 200
+        assert rejected.json()["receipts"][0]["code"] == "project_not_authorized"
         assert "tenant" not in rejected.text.lower()
 
 
@@ -227,3 +254,296 @@ async def test_tenant_key_cannot_read_acquisition_revision(
         )
         assert response.status_code == 403
         assert "0.1" not in response.text
+
+
+async def test_pricing_mutations_require_admin_scope(tmp_path, monkeypatch) -> None:
+    gateway, client = await _gateway_client(tmp_path, monkeypatch)
+    async with gateway.storage.session() as session:
+        read_only = await create_api_key(
+            session,
+            name="read-only-operator",
+            role="admin",
+            scopes="read",
+        )
+        operator = await create_api_key(
+            session,
+            name="pricing-operator",
+            role="admin",
+            scopes="read,admin",
+        )
+    denied = {"Authorization": f"Bearer {read_only.plaintext}"}
+    allowed = {"Authorization": f"Bearer {operator.plaintext}"}
+    async with client:
+        assert (
+            await client.post(
+                "/v1/accounting/revisions", json=_revision(), headers=denied
+            )
+        ).status_code == 403
+        assert (
+            await client.post(
+                "/v1/accounting/revisions/selling/activate",
+                json={"revision_id": "missing"},
+                headers=denied,
+            )
+        ).status_code == 403
+        assert (
+            await client.put(
+                "/v1/accounting/ownership",
+                json={
+                    "project_id": "default",
+                    "component": "conversation",
+                    "mode": "sdk",
+                },
+                headers=denied,
+            )
+        ).status_code == 403
+        assert (
+            await client.post(
+                "/v1/accounting/revisions", json=_revision(), headers=allowed
+            )
+        ).status_code == 201
+
+
+async def test_tenant_bound_admin_cannot_select_another_tenant(
+    tmp_path, monkeypatch
+) -> None:
+    gateway, client = await _gateway_client(tmp_path, monkeypatch)
+    async with gateway.storage.session() as session:
+        bound = await create_api_key(
+            session,
+            name="bound-operator",
+            role="admin",
+            scopes="read,admin",
+            tenant_id="tenant-a",
+        )
+        global_operator = await create_api_key(
+            session,
+            name="global-operator",
+            role="admin",
+            scopes="read,admin",
+        )
+    async with client:
+        denied = await client.post(
+            "/v1/accounting/revisions?tenant=tenant-b",
+            json=_revision(),
+            headers={"Authorization": f"Bearer {bound.plaintext}"},
+        )
+        assert denied.status_code == 403
+        allowed = await client.post(
+            "/v1/accounting/revisions?tenant=tenant-b",
+            json=_revision(),
+            headers={"Authorization": f"Bearer {global_operator.plaintext}"},
+        )
+        assert allowed.status_code == 201
+
+
+async def test_ownership_is_authoritative_with_and_without_binding(
+    tmp_path, monkeypatch
+) -> None:
+    async with await _client(tmp_path, monkeypatch) as client:
+        assigned = await client.put(
+            "/v1/accounting/ownership",
+            json={
+                "project_id": "default",
+                "component": "conversation",
+                "mode": "external",
+            },
+        )
+        assert assigned.status_code == 200
+        rejected = await client.post("/v1/accounting/usage", json=[_usage()])
+        assert rejected.json()["receipts"][0]["code"] == "ownership_mismatch"
+
+        prepared = await client.post(
+            "/v1/accounting/prepare",
+            json={
+                "project_id": "default",
+                "component": "conversation",
+                "offering": "provider/model",
+            },
+        )
+        binding = prepared.json()
+        assert binding["ownership_mode"] == "external"
+        assert "acquisition_revision_id" not in binding
+        event = _usage("event-2", "attempt-2")
+        event["pricing_binding_id"] = binding["binding_id"]
+        event["ownership_mode"] = "sdk"
+        event["selling_revision_id"] = "producer-spoof"
+        accepted = await client.post("/v1/accounting/usage", json=[event])
+        assert accepted.json()["receipts"][0]["outcome"] == "accepted"
+
+        switched = await client.put(
+            "/v1/accounting/ownership",
+            json={
+                "project_id": "default",
+                "component": "conversation",
+                "mode": "sdk",
+            },
+        )
+        assert switched.status_code == 200
+        sdk_event = _usage("event-3", "attempt-3")
+        sdk_event["selling_revision_id"] = None
+        resumed = await client.post("/v1/accounting/usage", json=[sdk_event])
+        assert resumed.json()["receipts"][0]["outcome"] == "accepted"
+
+
+async def test_mixed_batch_returns_per_record_authorization_outcomes(
+    tmp_path, monkeypatch
+) -> None:
+    gateway, client = await _gateway_client(tmp_path, monkeypatch)
+    async with gateway.storage.session() as session:
+        key = await create_api_key(
+            session,
+            name="one-project",
+            scopes="read,ingest",
+            tenant_id="tenant-a",
+            project_ids="allowed",
+        )
+    allowed = _usage()
+    allowed["project_id"] = "allowed"
+    forbidden = _usage("event-2", "attempt-2")
+    forbidden["project_id"] = "forbidden"
+    async with client:
+        response = await client.post(
+            "/v1/accounting/usage",
+            json=[allowed, forbidden],
+            headers={"Authorization": f"Bearer {key.plaintext}"},
+        )
+    assert response.status_code == 200
+    assert [item["outcome"] for item in response.json()["receipts"]] == [
+        "accepted",
+        "rejected",
+    ]
+    assert response.json()["receipts"][1]["code"] == "project_not_authorized"
+
+
+async def test_incomplete_amount_is_not_a_headline_total(tmp_path, monkeypatch) -> None:
+    incomplete_revision = _revision()
+    incomplete_revision["rates"].append(
+        {"dimension": "text_output", "unit": "token", "rate": "1"}
+    )
+    incomplete_revision["unsupported_dimensions"].remove("text_output")
+    async with await _client(tmp_path, monkeypatch) as client:
+        assert (
+            await client.post("/v1/accounting/revisions", json=incomplete_revision)
+        ).status_code == 201
+        response = await client.post("/v1/accounting/usage", json=[_usage()])
+        assert response.json()["receipts"][0]["outcome"] == "accepted"
+        report = (await client.get("/v1/accounting/report")).json()
+    assert report["selling_total_usd"] == "0"
+    assert report["incomplete_selling_total_usd"] == "0.250000000000"
+    assert report["counts"]["incomplete"] == 1
+
+
+async def test_missing_measurement_and_unknown_price_have_distinct_statuses(
+    tmp_path, monkeypatch
+) -> None:
+    missing = _usage("missing-event", "missing-attempt")
+    missing["quantities"] = [
+        {"dimension": "requests", "value": None, "status": "missing"}
+    ]
+    unknown = _usage("unknown-event", "unknown-attempt")
+    unknown["selling_revision_id"] = "unknown-revision"
+    async with await _client(tmp_path, monkeypatch) as client:
+        await client.post("/v1/accounting/revisions", json=_revision())
+        assert (await client.post("/v1/accounting/usage", json=[missing])).json()[
+            "receipts"
+        ][0]["outcome"] == "accepted"
+        assert (await client.post("/v1/accounting/usage", json=[unknown])).json()[
+            "receipts"
+        ][0]["outcome"] == "accepted"
+        report = (await client.get("/v1/accounting/report")).json()
+    assert report["counts"]["incomplete"] == 1
+    assert report["counts"]["unrated"] == 1
+
+
+async def test_acquisition_grouping_requires_operator(tmp_path, monkeypatch) -> None:
+    gateway, client = await _gateway_client(tmp_path, monkeypatch)
+    async with gateway.storage.session() as session:
+        key = await create_api_key(
+            session,
+            name="tenant-reader",
+            scopes="read",
+            tenant_id="tenant-a",
+        )
+    async with client:
+        response = await client.get(
+            "/v1/accounting/report?group_by=acquisition_revision",
+            headers={"Authorization": f"Bearer {key.plaintext}"},
+        )
+    assert response.status_code == 403
+    assert "revision" not in response.text.lower()
+
+
+async def test_failed_activation_preserves_both_independent_sides(
+    tmp_path, monkeypatch
+) -> None:
+    acquisition = _revision("cost-1", "0.1")
+    acquisition["side"] = "acquisition"
+    async with await _client(tmp_path, monkeypatch) as client:
+        await client.post("/v1/accounting/revisions", json=acquisition)
+        await client.post("/v1/accounting/revisions", json=_revision())
+        await client.post(
+            "/v1/accounting/revisions/acquisition/activate",
+            json={"revision_id": "cost-1"},
+        )
+        await client.post(
+            "/v1/accounting/revisions/selling/activate",
+            json={"revision_id": "sell-1"},
+        )
+        failed = await client.post(
+            "/v1/accounting/revisions/selling/activate",
+            json={"revision_id": "sell-1", "expected_current_revision_id": "stale"},
+        )
+        assert failed.status_code == 409
+        acquisition_read = await client.get(
+            "/v1/accounting/revisions/acquisition/cost-1"
+        )
+        selling_read = await client.get("/v1/accounting/revisions/selling/sell-1")
+    assert acquisition_read.json()["active"] is True
+    assert selling_read.json()["active"] is True
+
+
+async def test_concurrent_duplicate_delivery_has_one_billable_row(
+    tmp_path, monkeypatch
+) -> None:
+    async with await _client(tmp_path, monkeypatch) as client:
+        await client.post("/v1/accounting/revisions", json=_revision())
+        responses = await asyncio.gather(
+            *(client.post("/v1/accounting/usage", json=[_usage()]) for _ in range(8))
+        )
+        outcomes = [response.json()["receipts"][0]["outcome"] for response in responses]
+        report = (await client.get("/v1/accounting/report")).json()
+    assert outcomes.count("accepted") == 1
+    assert outcomes.count("duplicate") == 7
+    assert report["records"] == 1
+
+
+async def test_non_admin_report_is_tenant_isolated(tmp_path, monkeypatch) -> None:
+    gateway, client = await _gateway_client(tmp_path, monkeypatch)
+    from voicegateway.accounting.contracts import UsageEnvelope
+    from voicegateway.services.accounting_service import AccountingService
+
+    async with gateway.storage.session() as session:
+        await AccountingService(session, tenant_id="tenant-a").ingest(
+            UsageEnvelope.model_validate(_usage("a-event", "a-attempt"))
+        )
+    async with gateway.storage.session() as session:
+        event = _usage("b-event", "b-attempt")
+        event["project_id"] = "project-b"
+        await AccountingService(session, tenant_id="tenant-b").ingest(
+            UsageEnvelope.model_validate(event)
+        )
+        key = await create_api_key(
+            session, name="tenant-b", scopes="read", tenant_id="tenant-b"
+        )
+    async with client:
+        response = await client.get(
+            "/v1/accounting/report",
+            headers={"Authorization": f"Bearer {key.plaintext}"},
+        )
+        foreign = await client.get(
+            "/v1/accounting/report?tenant=tenant-a",
+            headers={"Authorization": f"Bearer {key.plaintext}"},
+        )
+    assert response.json()["records"] == 1
+    assert foreign.status_code == 403

--- a/src/voicegateway/tests/server/test_api_key_auth.py
+++ b/src/voicegateway/tests/server/test_api_key_auth.py
@@ -83,7 +83,9 @@ def test_check_tenant_body_conflict_rejects_mismatch():
 async def test_verify_api_key_returns_verified_key(gateway):
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="bot", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
         verified = await verify_api_key(f"Bearer {created.plaintext}", db)
     assert verified.id == created.id
     assert verified.tenant_id == "acme"
@@ -92,7 +94,9 @@ async def test_verify_api_key_returns_verified_key(gateway):
 async def test_verify_api_key_rejects_revoked(gateway):
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot")
+        created = await api_keys.create_api_key(
+            db, name="bot", scopes="read,write,ingest,admin"
+        )
         await api_keys.revoke(db, created.id)
         with pytest.raises(AuthError) as ei:
             await verify_api_key(f"Bearer {created.plaintext}", db)
@@ -129,7 +133,9 @@ async def test_api_key_authenticates_write_request(gateway):
     """A valid scoped virtual key satisfies the write dep."""
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="bot", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     client = await _client(gateway)
     async with client as c:
@@ -146,7 +152,9 @@ async def test_api_key_authenticates_write_request(gateway):
 async def test_api_key_revoked_returns_401(gateway):
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot")
+        created = await api_keys.create_api_key(
+            db, name="bot", scopes="read,write,ingest,admin"
+        )
         await api_keys.revoke(db, created.id)
 
     client = await _client(gateway)
@@ -166,7 +174,9 @@ async def test_api_key_marks_last_used(gateway):
     """Successful verify bumps last_used_at via mark_used."""
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot")
+        created = await api_keys.create_api_key(
+            db, name="bot", scopes="read,write,ingest,admin"
+        )
     assert created.row.last_used_at is None
 
     client = await _client(gateway)
@@ -188,7 +198,9 @@ async def test_unscoped_api_key_does_not_force_tenant(gateway):
     """check_tenant_body_conflict with key_tenant=None lets body pick."""
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        await api_keys.create_api_key(db, name="unscoped")
+        await api_keys.create_api_key(
+            db, name="unscoped", scopes="read,write,ingest,admin"
+        )
 
     # Helper-level check; no app exercise needed because the unscoped
     # behavior is enforced inside check_tenant_body_conflict.
@@ -199,7 +211,9 @@ async def test_api_key_authenticates_write_request_default_scope(gateway):
     """A default (wildcard-scoped) virtual key satisfies the write dep."""
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="bot", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     client = await _client(gateway)
     async with client as c:
@@ -227,7 +241,7 @@ async def test_require_scope_admin_denies_tenant_key(gateway):
         await gateway.storage._ensure_initialized()
         async with gateway.storage._conn.session() as db:
             created = await api_keys.create_api_key(
-                db, name="tenant-bot", role="tenant", scopes="*"
+                db, name="tenant-bot", role="tenant", scopes="read,write,ingest,admin"
             )
         resp = await c.get(
             "/admin-only",

--- a/src/voicegateway/tests/server/test_api_keys_route.py
+++ b/src/voicegateway/tests/server/test_api_keys_route.py
@@ -115,6 +115,31 @@ async def test_create_requires_scopes(client: AsyncClient) -> None:
     assert response.json()["type"] == "RequestValidationError"
 
 
+async def test_project_allowlist_is_validated_and_returned_as_a_list(
+    client: AsyncClient,
+) -> None:
+    comma = await client.post(
+        "/v1/api-keys",
+        json={"name": "comma", "scopes": "read", "project_ids": ["a,b"]},
+    )
+    assert comma.status_code == 422
+    empty = await client.post(
+        "/v1/api-keys",
+        json={"name": "empty", "scopes": "read", "project_ids": []},
+    )
+    assert empty.status_code == 422
+    created = await client.post(
+        "/v1/api-keys",
+        json={
+            "name": "scoped",
+            "scopes": "read",
+            "project_ids": ["project-b", "project-a", "project-a"],
+        },
+    )
+    assert created.status_code == 201
+    assert created.json()["key"]["project_ids"] == ["project-a", "project-b"]
+
+
 async def test_create_refuses_the_wildcard(client: AsyncClient) -> None:
     """The mint refuses ``*`` rather than minting an inert key."""
     response = await client.post("/v1/api-keys", json={"name": "wild", "scopes": "*"})

--- a/src/voicegateway/tests/server/test_api_keys_route.py
+++ b/src/voicegateway/tests/server/test_api_keys_route.py
@@ -50,7 +50,7 @@ async def client(gateway):
 async def test_create_returns_plaintext_and_201(client: AsyncClient) -> None:
     response = await client.post(
         "/v1/api-keys",
-        json={"name": "prod-bot", "tenant_id": "acme"},
+        json={"name": "prod-bot", "scopes": "read", "tenant_id": "acme"},
     )
     assert response.status_code == 201
     body = response.json()
@@ -63,7 +63,9 @@ async def test_create_returns_plaintext_and_201(client: AsyncClient) -> None:
 
 
 async def test_list_includes_created_key(client: AsyncClient) -> None:
-    create_resp = await client.post("/v1/api-keys", json={"name": "list-target"})
+    create_resp = await client.post(
+        "/v1/api-keys", json={"name": "list-target", "scopes": "read"}
+    )
     created_id = create_resp.json()["key"]["id"]
 
     list_resp = await client.get("/v1/api-keys")
@@ -83,7 +85,9 @@ async def test_get_by_id_returns_404_when_missing(client: AsyncClient) -> None:
 async def test_delete_revokes_and_filters_from_active_list(
     client: AsyncClient,
 ) -> None:
-    created = (await client.post("/v1/api-keys", json={"name": "to-revoke"})).json()
+    created = (
+        await client.post("/v1/api-keys", json={"name": "to-revoke", "scopes": "read"})
+    ).json()
     key_id = created["key"]["id"]
 
     delete_resp = await client.delete(f"/v1/api-keys/{key_id}")
@@ -104,6 +108,29 @@ async def test_create_validation_rejects_empty_name(client: AsyncClient) -> None
     assert body["type"] == "RequestValidationError"
 
 
+async def test_create_requires_scopes(client: AsyncClient) -> None:
+    """VG-SEC-006: the field has no default, so pydantic refuses the body."""
+    response = await client.post("/v1/api-keys", json={"name": "no-scopes"})
+    assert response.status_code == 422
+    assert response.json()["type"] == "RequestValidationError"
+
+
+async def test_create_refuses_the_wildcard(client: AsyncClient) -> None:
+    """The mint refuses ``*`` rather than minting an inert key."""
+    response = await client.post("/v1/api-keys", json={"name": "wild", "scopes": "*"})
+    assert response.status_code == 422
+    assert "wildcard" in response.json()["detail"]
+
+
+async def test_create_refuses_an_unknown_scope(client: AsyncClient) -> None:
+    """A typo must not mint a key that authorizes nothing in silence."""
+    response = await client.post(
+        "/v1/api-keys", json={"name": "typo", "scopes": "raed"}
+    )
+    assert response.status_code == 422
+    assert "unknown scope" in response.json()["detail"]
+
+
 # ---------------------------------------------------------------------------
 # Auth: the router is admin-gated once auth is enabled
 # ---------------------------------------------------------------------------
@@ -121,7 +148,9 @@ async def test_mint_stays_open_when_no_keys_are_configured(gateway) -> None:
     assert app.state.api_keys == []
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
-        created = await c.post("/v1/api-keys", json={"name": "local-operator"})
+        created = await c.post(
+            "/v1/api-keys", json={"name": "local-operator", "scopes": "read"}
+        )
         assert created.status_code == 201
         assert created.json()["plaintext"].startswith("vk_")
         assert (await c.get("/v1/api-keys")).status_code == 200
@@ -144,7 +173,9 @@ async def test_router_requires_admin_when_auth_enabled(gateway) -> None:
     ]
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
-        blocked = await c.post("/v1/api-keys", json={"name": "stolen"})
+        blocked = await c.post(
+            "/v1/api-keys", json={"name": "stolen", "scopes": "read"}
+        )
         assert blocked.status_code == 401
         assert (await c.get("/v1/api-keys")).status_code == 401
         assert (await c.get("/v1/api-keys/1")).status_code == 401
@@ -154,14 +185,14 @@ async def test_router_requires_admin_when_auth_enabled(gateway) -> None:
         assert (
             await c.post(
                 "/v1/api-keys",
-                json={"name": "stolen"},
+                json={"name": "stolen", "scopes": "read"},
                 headers={"Authorization": "Bearer wrong-token"},
             )
         ).status_code == 401
 
         ok = await c.post(
             "/v1/api-keys",
-            json={"name": "minted-by-admin"},
+            json={"name": "minted-by-admin", "scopes": "read"},
             headers={"Authorization": "Bearer admin-secret-token"},
         )
         assert ok.status_code == 201
@@ -180,7 +211,7 @@ async def test_router_rejects_key_without_admin_scope(gateway) -> None:
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         denied = await c.post(
             "/v1/api-keys",
-            json={"name": "escalation"},
+            json={"name": "escalation", "scopes": "read"},
             headers={"Authorization": "Bearer read-only-token"},
         )
         assert denied.status_code == 403
@@ -201,7 +232,9 @@ async def test_minted_tenant_key_cannot_mint_another_key(gateway) -> None:
     app = build_app(gateway)
     open_transport = ASGITransport(app=app)
     async with AsyncClient(transport=open_transport, base_url="http://test") as c:
-        minted = (await c.post("/v1/api-keys", json={"name": "agent"})).json()
+        minted = (
+            await c.post("/v1/api-keys", json={"name": "agent", "scopes": "read"})
+        ).json()
     plaintext = minted["plaintext"]
 
     app.state.api_keys = [
@@ -211,7 +244,7 @@ async def test_minted_tenant_key_cannot_mint_another_key(gateway) -> None:
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         denied = await c.post(
             "/v1/api-keys",
-            json={"name": "self-replication"},
+            json={"name": "self-replication", "scopes": "read"},
             headers={"Authorization": f"Bearer {plaintext}"},
         )
         assert denied.status_code == 403

--- a/src/voicegateway/tests/server/test_auth_enforcement_modes.py
+++ b/src/voicegateway/tests/server/test_auth_enforcement_modes.py
@@ -1,0 +1,100 @@
+"""The same request under local_development, warn, and enforce.
+
+Exercised against ``/api/costs``, which already resolves ``require_principal``.
+The plan proposed ``/v1/costs``, but that route is still open until Task 12
+gates it, so the assertions would have been deferred behind strict xfails and
+proved nothing today. A route that is genuinely gated tests the real thing
+now, and Task 12 widens the surface rather than switching the test on.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from voicegateway.server.api._authz import WOULD_REFUSE_EVENT
+from voicegateway.tests.server._telemetry_harness import _Harness
+
+_GATED = "/api/costs"
+
+
+@pytest.fixture
+def make_harness():
+    made: list[_Harness] = []
+
+    def _make(auth: dict) -> _Harness:
+        harness = _Harness(config_overrides={"auth": auth})
+        made.append(harness)
+        return harness
+
+    yield _make
+    for harness in made:
+        harness.cleanup()
+
+
+async def test_no_credential_in_local_development_is_served_silently(
+    make_harness, caplog
+):
+    harness = make_harness({"local_development": True})
+    with caplog.at_level(logging.WARNING):
+        async with harness.client() as client:
+            response = await client.get(_GATED)
+    assert response.status_code == 200
+    assert WOULD_REFUSE_EVENT not in caplog.text
+
+
+async def test_no_credential_under_warn_is_served_and_named(make_harness, caplog):
+    """0.26.0's default: nothing breaks, but the log says what would."""
+    harness = make_harness({"enforcement": "warn"})
+    with caplog.at_level(logging.WARNING):
+        async with harness.client() as client:
+            response = await client.get(_GATED)
+    assert response.status_code == 200
+    assert WOULD_REFUSE_EVENT in caplog.text
+    assert _GATED in caplog.text
+    assert harness.app.state.auth_would_refuse >= 1
+
+
+async def test_no_credential_under_enforce_is_refused(make_harness):
+    """VG-SEC-005: absence of a credential no longer means full admin."""
+    harness = make_harness({"enforcement": "enforce"})
+    async with harness.client() as client:
+        response = await client.get(_GATED)
+    assert response.status_code == 401
+    assert "Authentication required" in response.json()["detail"]
+
+
+async def test_status_reports_the_mode_and_the_counter(make_harness):
+    """The counter is the number an operator checks before flipping to enforce."""
+    harness = make_harness({"enforcement": "warn"})
+    async with harness.client() as client:
+        await client.get(_GATED)
+        await client.get(_GATED)
+        status = await client.get("/api/status")
+
+    auth = status.json()["auth"]
+    assert auth["enforcement"] == "warn"
+    assert auth["local_development"] is False
+    assert auth["would_refuse_count"] >= 2
+
+
+async def test_enforce_does_not_refuse_a_valid_key(make_harness):
+    """The gate must let the authorised through, or it is just an outage."""
+    from voicegateway.tests.server._telemetry_harness import _make_key
+
+    harness = make_harness({"enforcement": "enforce"})
+    token = await _make_key(harness.gateway, tenant_id="acme", role="tenant")
+    async with harness.client() as client:
+        response = await client.get(
+            _GATED, headers={"Authorization": f"Bearer {token}"}
+        )
+    assert response.status_code == 200
+
+
+async def test_enforce_leaves_open_by_design_routes_open(make_harness):
+    """Liveness must answer an unauthenticated caller even under enforce."""
+    harness = make_harness({"enforcement": "enforce"})
+    async with harness.client() as client:
+        assert (await client.get("/health")).status_code == 200
+        assert (await client.get("/api/auth-status")).status_code == 200

--- a/src/voicegateway/tests/server/test_authz_decide.py
+++ b/src/voicegateway/tests/server/test_authz_decide.py
@@ -1,0 +1,133 @@
+"""decide() is the only place the enforcement mode is consulted.
+
+Every gate computes whether it *would* refuse, then asks decide() what to do
+about that. No gate branches on the mode itself, which is what makes flipping
+0.27.0 to enforce a default change rather than a code change, and what stops
+one gate quietly disagreeing with another about what warn means.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import FastAPI, Request
+
+from voicegateway.core.config import AuthConfig
+from voicegateway.schemas.telemetry.security_schema import PrincipalKind
+from voicegateway.server.api._authz import WOULD_REFUSE_EVENT, Decision, decide
+
+
+def _request(path: str = "/v1/costs", method: str = "GET") -> Request:
+    """A minimal ASGI request bound to a throwaway app for its state."""
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": method,
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [],
+            "scheme": "http",
+            "server": ("test", 80),
+            "app": FastAPI(),
+        }
+    )
+
+
+@pytest.mark.parametrize("mode", ["warn", "enforce"])
+def test_no_refusal_is_allow_in_every_mode(mode):
+    decision = decide(
+        would_refuse=False,
+        reason="",
+        auth=AuthConfig(enforcement=mode),
+        request=_request(),
+        principal_kind=PrincipalKind.OPERATOR,
+        key_id=None,
+    )
+    assert decision is Decision.ALLOW
+
+
+def test_local_development_allows_silently(caplog):
+    """Local mode is a deliberate choice, so it is not nagged about."""
+    request = _request()
+    with caplog.at_level(logging.WARNING):
+        decision = decide(
+            would_refuse=True,
+            reason="no credential",
+            auth=AuthConfig(local_development=True),
+            request=request,
+            principal_kind=PrincipalKind.OPERATOR,
+            key_id=None,
+        )
+    assert decision is Decision.ALLOW
+    assert WOULD_REFUSE_EVENT not in caplog.text
+    assert getattr(request.app.state, "auth_would_refuse", 0) == 0
+
+
+def test_warn_mode_allows_logs_and_counts(caplog):
+    """The point of warn: serve it, but say exactly what would have broken."""
+    request = _request()
+    with caplog.at_level(logging.WARNING):
+        decision = decide(
+            would_refuse=True,
+            reason="no credential and no api_keys configured",
+            auth=AuthConfig(enforcement="warn"),
+            request=request,
+            principal_kind=PrincipalKind.OPERATOR,
+            key_id=None,
+        )
+    assert decision is Decision.WARN
+    assert WOULD_REFUSE_EVENT in caplog.text
+    assert "/v1/costs" in caplog.text
+    assert "no credential and no api_keys configured" in caplog.text
+    assert request.app.state.auth_would_refuse == 1
+
+
+def test_warn_counter_accumulates_across_requests():
+    """The counter is what an operator watches before flipping the mode."""
+    request = _request()
+    for _ in range(3):
+        decide(
+            would_refuse=True,
+            reason="no credential",
+            auth=AuthConfig(enforcement="warn"),
+            request=request,
+            principal_kind=PrincipalKind.OPERATOR,
+            key_id=None,
+        )
+    assert request.app.state.auth_would_refuse == 3
+
+
+def test_warn_names_the_key_when_one_authenticated(caplog):
+    """ "Something is unauthorized" is useless; the key id is actionable."""
+    with caplog.at_level(logging.WARNING):
+        decide(
+            would_refuse=True,
+            reason="missing scope ingest",
+            auth=AuthConfig(enforcement="warn"),
+            request=_request("/v1/ingest", "POST"),
+            principal_kind=PrincipalKind.TENANT_KEY,
+            key_id=42,
+        )
+    assert "key_id=42" in caplog.text
+    assert "tenant_key" in caplog.text
+    assert "POST" in caplog.text
+
+
+def test_enforce_mode_refuses_without_logging_a_warning(caplog):
+    """Under enforce the refusal is the signal; a warning would be noise."""
+    request = _request()
+    with caplog.at_level(logging.WARNING):
+        decision = decide(
+            would_refuse=True,
+            reason="no credential",
+            auth=AuthConfig(enforcement="enforce"),
+            request=request,
+            principal_kind=PrincipalKind.OPERATOR,
+            key_id=None,
+        )
+    assert decision is Decision.REFUSE
+    assert WOULD_REFUSE_EVENT not in caplog.text
+    assert getattr(request.app.state, "auth_would_refuse", 0) == 0

--- a/src/voicegateway/tests/server/test_billing_api.py
+++ b/src/voicegateway/tests/server/test_billing_api.py
@@ -166,6 +166,7 @@ async def test_rate_card_models_lists_price_and_override(gateway) -> None:
                 project="default",
                 agent_id="a",
             ),
+            tenant_id=None,
         )
     client = await _client(gateway)
     async with client as c:

--- a/src/voicegateway/tests/server/test_call_observations_endpoint.py
+++ b/src/voicegateway/tests/server/test_call_observations_endpoint.py
@@ -353,7 +353,9 @@ async def test_tenant_is_stamped_from_the_key_not_the_payload(gateway):
     """The tenant travels on the queued item, resolved from the verified key."""
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="agent", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="agent", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     resp = await _post(
         gateway, _observation(), {"Authorization": f"Bearer {created.plaintext}"}

--- a/src/voicegateway/tests/server/test_calls_endpoint.py
+++ b/src/voicegateway/tests/server/test_calls_endpoint.py
@@ -387,7 +387,9 @@ async def test_a_tenant_key_never_reads_another_tenants_calls(client, gateway):
     await _answered_call(gateway.storage, room_sid="RM_acme", tenant_id="acme")
     await _answered_call(gateway.storage, room_sid="RM_beta", tenant_id="beta")
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="acme-ui", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="acme-ui", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     resp = await client.get(
         _URL, headers={"Authorization": f"Bearer {created.plaintext}"}
@@ -430,7 +432,9 @@ async def test_a_tenant_key_gets_a_full_page_not_a_short_one(client, gateway):
             started_at_ms=1_750_000_100_000 + i * 1000,
         )
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="acme-page", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="acme-page", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     resp = await client.get(
         f"{_URL}?limit=6", headers={"Authorization": f"Bearer {created.plaintext}"}
@@ -450,7 +454,9 @@ async def test_a_key_with_no_tenant_reads_the_unattributed_bucket(client, gatewa
     await _answered_call(gateway.storage, room_sid="RM_unattributed")
     await _answered_call(gateway.storage, room_sid="RM_owned", tenant_id="acme")
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="no-tenant-ui")
+        created = await api_keys.create_api_key(
+            db, name="no-tenant-ui", scopes="read,write,ingest,admin"
+        )
 
     resp = await client.get(
         _URL, headers={"Authorization": f"Bearer {created.plaintext}"}

--- a/src/voicegateway/tests/server/test_correlation_endpoint.py
+++ b/src/voicegateway/tests/server/test_correlation_endpoint.py
@@ -286,7 +286,9 @@ async def test_a_tenant_key_is_refused_rather_than_shown_the_whole_deployment(
     otherwise be handed every other tenant's session volume."""
     await _session_in_room(gateway.storage, session_id="vg-t", room="room-t")
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="acme-ui", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="acme-ui", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     resp = await client.get(
         _URL, headers={"Authorization": f"Bearer {created.plaintext}"}

--- a/src/voicegateway/tests/server/test_dashboard_api_keys.py
+++ b/src/voicegateway/tests/server/test_dashboard_api_keys.py
@@ -31,7 +31,12 @@ def test_list_api_keys_starts_empty(client) -> None:
 def test_create_api_key_returns_plaintext_once(client) -> None:
     resp = client.post(
         "/api/api_keys",
-        json={"name": "demo-key", "tenant_id": "acme", "issued_by": "ops"},
+        json={
+            "name": "demo-key",
+            "scopes": "read",
+            "tenant_id": "acme",
+            "issued_by": "ops",
+        },
     )
     assert resp.status_code == 201 or resp.status_code == 200
     body = resp.json()
@@ -52,10 +57,28 @@ def test_create_api_key_rejects_whitespace_name(client) -> None:
     assert resp.status_code == 400
 
 
+def test_create_api_key_requires_scopes(client):
+    """VG-SEC-006: the dashboard door refuses the same requests as the others."""
+    resp = client.post("/api/api_keys", json={"name": "no-scopes"})
+    assert resp.status_code == 400
+    assert "scopes" in resp.json()["detail"]
+
+
+def test_create_api_key_refuses_the_wildcard(client):
+    resp = client.post("/api/api_keys", json={"name": "wild", "scopes": "*"})
+    assert resp.status_code == 400
+    assert "wildcard" in resp.json()["detail"]
+
+
 def test_create_api_key_strips_empty_optional_fields(client) -> None:
     resp = client.post(
         "/api/api_keys",
-        json={"name": "minimal", "tenant_id": "", "issued_by": None},
+        json={
+            "name": "minimal",
+            "scopes": "read",
+            "tenant_id": "",
+            "issued_by": None,
+        },
     )
     assert resp.status_code in (200, 201)
     row = resp.json()["row"]
@@ -64,7 +87,7 @@ def test_create_api_key_strips_empty_optional_fields(client) -> None:
 
 
 def test_list_api_keys_surfaces_created_key(client) -> None:
-    create = client.post("/api/api_keys", json={"name": "to-list"})
+    create = client.post("/api/api_keys", json={"name": "to-list", "scopes": "read"})
     assert create.status_code in (200, 201)
     created_id = create.json()["id"]
 
@@ -75,7 +98,7 @@ def test_list_api_keys_surfaces_created_key(client) -> None:
 
 
 def test_revoke_api_key_returns_revoked_payload(client) -> None:
-    create = client.post("/api/api_keys", json={"name": "to-revoke"})
+    create = client.post("/api/api_keys", json={"name": "to-revoke", "scopes": "read"})
     created_id = create.json()["id"]
 
     resp = client.post(f"/api/api_keys/{created_id}/revoke")
@@ -92,7 +115,9 @@ def test_revoke_unknown_api_key_returns_404(client) -> None:
 
 
 def test_revoke_already_revoked_key_returns_404(client) -> None:
-    create = client.post("/api/api_keys", json={"name": "double-revoke"})
+    create = client.post(
+        "/api/api_keys", json={"name": "double-revoke", "scopes": "read"}
+    )
     created_id = create.json()["id"]
     client.post(f"/api/api_keys/{created_id}/revoke")
 
@@ -102,7 +127,7 @@ def test_revoke_already_revoked_key_returns_404(client) -> None:
 
 
 def test_list_api_keys_filters_revoked_when_include_revoked_false(client) -> None:
-    create = client.post("/api/api_keys", json={"name": "hide-me"})
+    create = client.post("/api/api_keys", json={"name": "hide-me", "scopes": "read"})
     created_id = create.json()["id"]
     client.post(f"/api/api_keys/{created_id}/revoke")
 
@@ -136,7 +161,9 @@ def test_mint_stays_open_when_no_keys_are_configured(app_under_test) -> None:
     """
     assert app_under_test.state.api_keys == []
     client = TestClient(app_under_test)
-    created = client.post("/api/api_keys", json={"name": "local-operator"})
+    created = client.post(
+        "/api/api_keys", json={"name": "local-operator", "scopes": "read"}
+    )
     assert created.status_code in (200, 201)
     assert created.json()["plaintext"].startswith("vk_")
     assert client.get("/api/api_keys").status_code == 200
@@ -158,13 +185,18 @@ def test_router_requires_admin_when_auth_enabled(app_under_test) -> None:
     ]
     client = TestClient(app_under_test)
 
-    assert client.post("/api/api_keys", json={"name": "stolen"}).status_code == 401
+    assert (
+        client.post(
+            "/api/api_keys", json={"name": "stolen", "scopes": "read"}
+        ).status_code
+        == 401
+    )
     assert client.get("/api/api_keys").status_code == 401
     assert client.post("/api/api_keys/1/revoke").status_code == 401
     assert (
         client.post(
             "/api/api_keys",
-            json={"name": "stolen"},
+            json={"name": "stolen", "scopes": "read"},
             headers={"Authorization": "Bearer wrong-token"},
         ).status_code
         == 401
@@ -172,7 +204,7 @@ def test_router_requires_admin_when_auth_enabled(app_under_test) -> None:
 
     ok = client.post(
         "/api/api_keys",
-        json={"name": "minted-by-admin"},
+        json={"name": "minted-by-admin", "scopes": "read"},
         headers={"Authorization": "Bearer admin-secret-token"},
     )
     assert ok.status_code in (200, 201)
@@ -190,7 +222,7 @@ def test_router_rejects_key_without_admin_scope(app_under_test) -> None:
 
     denied = client.post(
         "/api/api_keys",
-        json={"name": "escalation"},
+        json={"name": "escalation", "scopes": "read"},
         headers={"Authorization": "Bearer read-only-token"},
     )
     assert denied.status_code == 403
@@ -210,14 +242,16 @@ def test_minted_tenant_key_cannot_mint_another_key(app_under_test) -> None:
     from voicegateway.core.auth import ADMIN_SCOPE, ApiKey
 
     client = TestClient(app_under_test)
-    plaintext = client.post("/api/api_keys", json={"name": "agent"}).json()["plaintext"]
+    plaintext = client.post(
+        "/api/api_keys", json={"name": "agent", "scopes": "read"}
+    ).json()["plaintext"]
 
     app_under_test.state.api_keys = [
         ApiKey(token="admin-secret-token", name="ops", scopes=(ADMIN_SCOPE,))
     ]
     denied = client.post(
         "/api/api_keys",
-        json={"name": "self-replication"},
+        json={"name": "self-replication", "scopes": "read"},
         headers={"Authorization": f"Bearer {plaintext}"},
     )
     assert denied.status_code == 403

--- a/src/voicegateway/tests/server/test_dashboard_storage_none.py
+++ b/src/voicegateway/tests/server/test_dashboard_storage_none.py
@@ -127,7 +127,9 @@ def test_api_keys_list_returns_empty_when_storage_disabled(storage_disabled_clie
 
 
 def test_api_keys_create_returns_503_when_storage_disabled(storage_disabled_client):
-    resp = storage_disabled_client.post("/api/api_keys", json={"name": "test"})
+    resp = storage_disabled_client.post(
+        "/api/api_keys", json={"name": "test", "scopes": "read"}
+    )
     assert resp.status_code == 503
 
 

--- a/src/voicegateway/tests/server/test_deps_get_session.py
+++ b/src/voicegateway/tests/server/test_deps_get_session.py
@@ -1,0 +1,111 @@
+"""get_session is how a route gets a database session. Nothing else is.
+
+Twenty-four handlers currently open their own via ``storage._conn.session()``,
+each re-solving "how do I reach the database" and each a place where a tenant
+guard could have gone and did not. This dependency is the single seam those
+migrate onto.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from voicegateway.server.api._deps import get_gateway, get_session
+from voicegateway.tests.server._telemetry_harness import _Harness
+
+
+@pytest.fixture
+async def harness():
+    h = _Harness()
+    try:
+        yield h
+    finally:
+        h.cleanup()
+
+
+async def test_route_receives_a_working_session(harness):
+    app: FastAPI = harness.app
+
+    @app.get("/_probe")
+    async def probe(session: AsyncSession = Depends(get_session)) -> dict:
+        one = (await session.execute(text("SELECT 1"))).scalar_one()
+        return {"one": one}
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/_probe")
+
+    assert response.status_code == 200
+    assert response.json() == {"one": 1}
+
+
+async def test_session_has_migrations_already_run(harness):
+    """A route must never be handed a session over an unmigrated database."""
+    app: FastAPI = harness.app
+
+    @app.get("/_probe_migrated")
+    async def probe(session: AsyncSession = Depends(get_session)) -> dict:
+        count = (
+            await session.execute(text("SELECT count(*) FROM api_keys"))
+        ).scalar_one()
+        return {"api_keys": count}
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/_probe_migrated")
+
+    assert response.status_code == 200
+    assert response.json() == {"api_keys": 0}
+
+
+async def test_get_session_503_when_storage_disabled(harness):
+    """Storage off is a 503, not an AttributeError halfway through a handler.
+
+    ``Gateway.storage`` is a read-only property returning ``None`` when cost
+    tracking is disabled, so the dependency is overridden rather than the
+    Gateway mutated. That also keeps the test on ``get_session``'s own
+    contract instead of on how a Gateway decides it has no storage.
+    """
+    app: FastAPI = harness.app
+
+    class _NoStorageGateway:
+        storage = None
+
+    app.dependency_overrides[get_gateway] = lambda: _NoStorageGateway()
+
+    @app.get("/_probe_disabled")
+    async def probe(session: AsyncSession = Depends(get_session)) -> dict:
+        return {}
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/_probe_disabled")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 503
+    assert "storage is disabled" in response.json()["detail"]
+
+
+def test_deps_module_no_longer_reaches_into_storage():
+    """The module that defines the boundary must not be violating it."""
+    import re
+    from pathlib import Path
+
+    import voicegateway.server.api._deps as deps
+
+    source = Path(deps.__file__).read_text(encoding="utf-8")
+    offenders = [
+        f"{lineno}: {line.strip()}"
+        for lineno, line in enumerate(source.splitlines(), 1)
+        if re.search(r"\._conn\b|_ensure_initialized\(\)", line)
+    ]
+    assert not offenders, offenders

--- a/src/voicegateway/tests/server/test_ingest_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_endpoint.py
@@ -57,7 +57,9 @@ def _payload(rid: str, agent_id: str = "agent-1") -> dict:
 async def test_ingest_accepts_batch_and_stamps_tenant(gateway):
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="bot", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     client = await _client(gateway)
     async with client as c:
@@ -80,7 +82,9 @@ async def test_ingest_accepts_batch_and_stamps_tenant(gateway):
 async def test_ingest_is_idempotent_on_id(gateway):
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot")
+        created = await api_keys.create_api_key(
+            db, name="bot", scopes="read,write,ingest,admin"
+        )
 
     client = await _client(gateway)
     async with client as c:
@@ -105,7 +109,9 @@ async def test_ingest_is_idempotent_on_id(gateway):
 async def test_ingest_rejects_revoked_key(gateway):
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot")
+        created = await api_keys.create_api_key(
+            db, name="bot", scopes="read,write,ingest,admin"
+        )
         await api_keys.revoke(db, created.id)
 
     client = await _client(gateway)
@@ -127,7 +133,9 @@ async def test_two_agents_aggregate_in_one_collector(gateway):
 
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="fleet")
+        created = await api_keys.create_api_key(
+            db, name="fleet", scopes="read,write,ingest,admin"
+        )
 
     now = time.time()
 
@@ -171,7 +179,9 @@ async def test_ingest_one_failing_record_does_not_fail_batch(gateway, monkeypatc
     is skipped, not allowed to 500 the whole batch."""
     await gateway.storage._ensure_initialized()
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot")
+        created = await api_keys.create_api_key(
+            db, name="bot", scopes="read,write,ingest,admin"
+        )
 
     real_log = gateway.storage.log_request_as
 

--- a/src/voicegateway/tests/server/test_ingest_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_endpoint.py
@@ -173,14 +173,14 @@ async def test_ingest_one_failing_record_does_not_fail_batch(gateway, monkeypatc
     async with gateway.storage._conn.session() as db:
         created = await api_keys.create_api_key(db, name="bot")
 
-    real_log = gateway.storage.log_request
+    real_log = gateway.storage.log_request_as
 
-    async def flaky_log(record):
+    async def flaky_log(record, *, tenant_id):
         if record.id == "bad-1":
             raise RuntimeError("simulated persistence failure")
-        return await real_log(record)
+        return await real_log(record, tenant_id=tenant_id)
 
-    monkeypatch.setattr(gateway.storage, "log_request", flaky_log)
+    monkeypatch.setattr(gateway.storage, "log_request_as", flaky_log)
 
     client = await _client(gateway)
     async with client as c:

--- a/src/voicegateway/tests/server/test_ingest_rate_limit_endpoint.py
+++ b/src/voicegateway/tests/server/test_ingest_rate_limit_endpoint.py
@@ -46,7 +46,9 @@ def _payload(rid: str) -> dict:
 async def _vk(gw: Gateway) -> str:
     await gw.storage._ensure_initialized()
     async with gw.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot")
+        created = await api_keys.create_api_key(
+            db, name="bot", scopes="read,write,ingest,admin"
+        )
     return created.plaintext
 
 

--- a/src/voicegateway/tests/server/test_ingest_rating.py
+++ b/src/voicegateway/tests/server/test_ingest_rating.py
@@ -48,7 +48,9 @@ async def _client(gw: Gateway) -> AsyncClient:
 async def _key(gw: Gateway, tenant_id: str | None = None) -> str:
     await gw.storage._ensure_initialized()
     async with gw.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="bot", tenant_id=tenant_id)
+        created = await api_keys.create_api_key(
+            db, name="bot", tenant_id=tenant_id, scopes="read,write,ingest,admin"
+        )
     return created.plaintext
 
 

--- a/src/voicegateway/tests/server/test_ingest_scope.py
+++ b/src/voicegateway/tests/server/test_ingest_scope.py
@@ -1,0 +1,121 @@
+"""ingest is its own scope. write implies it only during the warn release.
+
+An agent key exists to post telemetry. Before this split it had to carry
+`write`, which is also what guards provider, model and project mutation, so
+every collector credential in the field could rewrite gateway configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from voicegateway.core import scopes
+from voicegateway.repository.api_keys_repository import VerifiedKey
+from voicegateway.tests.server._telemetry_harness import _Harness, _make_key
+
+_TOOL_CALL = [
+    {
+        "session_id": "s-1",
+        "call_id": "c-1",
+        "tool_name": "lookup",
+        "started_at_ms": 1,
+        "duration_ms": 2,
+        "outcome": "completed",
+    }
+]
+_PROVIDER = {"provider_id": "ollama-x", "provider_type": "ollama", "api_key": ""}
+
+
+def _key(scope: str) -> VerifiedKey:
+    return VerifiedKey(id=1, tenant_id="acme", name="k", scopes=scope)
+
+
+def test_write_implies_ingest_only_while_not_enforcing():
+    """Existing agent keys keep working through 0.26.0, and stop in 0.27.0."""
+    key = _key(scopes.WRITE)
+    assert key.has_scope(scopes.INGEST) is True
+    assert key.has_scope(scopes.INGEST, enforce=True) is False
+
+
+def test_ingest_never_implies_write():
+    """The whole point: a telemetry key must not reach configuration."""
+    key = _key(scopes.INGEST)
+    assert key.has_scope(scopes.WRITE) is False
+    assert key.has_scope(scopes.WRITE, enforce=True) is False
+
+
+def test_wildcard_satisfies_nothing_under_enforce():
+    key = _key(scopes.WILDCARD)
+    assert key.has_scope(scopes.INGEST) is True
+    assert key.has_scope(scopes.INGEST, enforce=True) is False
+
+
+def test_an_exact_scope_holds_under_enforce():
+    assert _key(scopes.INGEST).has_scope(scopes.INGEST, enforce=True) is True
+
+
+@pytest.fixture
+def harness():
+    h = _Harness()
+    try:
+        yield h
+    finally:
+        h.cleanup()
+
+
+async def test_an_ingest_key_may_post_telemetry_but_not_config(harness):
+    token = await _make_key(harness.gateway, tenant_id="acme", scopes="ingest")
+    headers = {"Authorization": f"Bearer {token}"}
+    async with harness.client() as client:
+        telemetry = await client.post(
+            "/v1/ingest/tool-calls", json=_TOOL_CALL, headers=headers
+        )
+        config = await client.post("/v1/providers", json=_PROVIDER, headers=headers)
+
+    assert telemetry.status_code == 200
+    assert config.status_code == 403, "an ingest key reached gateway configuration"
+
+
+async def test_a_write_key_still_ingests_but_is_warned(harness, caplog):
+    """Compatibility for 0.26.0, with a per-use nudge naming the key."""
+    token = await _make_key(harness.gateway, tenant_id="acme", scopes="write")
+    headers = {"Authorization": f"Bearer {token}"}
+    with caplog.at_level(logging.WARNING):
+        async with harness.client() as client:
+            response = await client.post(
+                "/v1/ingest/tool-calls", json=_TOOL_CALL, headers=headers
+            )
+
+    assert response.status_code == 200
+    assert "write scope used for ingest" in caplog.text
+
+
+async def test_a_read_key_cannot_ingest(harness):
+    token = await _make_key(harness.gateway, tenant_id="acme", scopes="read")
+    async with harness.client() as client:
+        response = await client.post(
+            "/v1/ingest/tool-calls",
+            json=_TOOL_CALL,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 403
+
+
+async def test_the_ingest_principal_carries_the_tenant(harness):
+    """The handler writes rows under this, so it must be the key's tenant."""
+    from sqlalchemy import text
+
+    token = await _make_key(harness.gateway, tenant_id="acme", scopes="ingest")
+    async with harness.client() as client:
+        await client.post(
+            "/v1/ingest/tool-calls",
+            json=_TOOL_CALL,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    async with harness.gateway.storage.session() as db:
+        rows = (
+            (await db.execute(text("SELECT tenant_id FROM tool_calls"))).scalars().all()
+        )
+    assert rows == ["acme"]

--- a/src/voicegateway/tests/server/test_metrics_endpoint.py
+++ b/src/voicegateway/tests/server/test_metrics_endpoint.py
@@ -52,7 +52,7 @@ async def _seed_turns(gateway, session_id: str, count: int = 3) -> None:
                     response_speed_ms=100 + i,
                 )
             )
-        await turns.create_turns_bulk(db, rows)
+        await turns.create_turns_bulk(db, rows, tenant_id=None)
 
 
 async def _seed_dead_air(gateway, session_id: str, count: int = 2) -> None:
@@ -67,6 +67,7 @@ async def _seed_dead_air(gateway, session_id: str, count: int = 2) -> None:
                     duration_ms=3500,
                     threshold_used_ms=3000,
                 ),
+                tenant_id=None,
             )
 
 

--- a/src/voicegateway/tests/server/test_nodes_endpoint.py
+++ b/src/voicegateway/tests/server/test_nodes_endpoint.py
@@ -600,7 +600,9 @@ async def test_a_tenant_key_is_refused_rather_than_shown_the_whole_fleet(
         gateway.storage, attempt_id="t", started_at_ms=_T0, ended_at_ms=_T0 + _MINUTE
     )
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="acme-ui", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="acme-ui", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     resp = await client.get(
         _URL, headers={"Authorization": f"Bearer {created.plaintext}"}

--- a/src/voicegateway/tests/server/test_nodes_live_endpoint.py
+++ b/src/voicegateway/tests/server/test_nodes_live_endpoint.py
@@ -100,9 +100,7 @@ async def _insert(
 
 
 def _entry(body: dict, node: str, source: str) -> dict:
-    matches = [
-        e for e in body["nodes"] if e["node"] == node and e["source"] == source
-    ]
+    matches = [e for e in body["nodes"] if e["node"] == node and e["source"] == source]
     assert len(matches) == 1, (
         f"expected exactly one entry for ({node}, {source}), got {len(matches)}"
     )
@@ -368,7 +366,9 @@ async def test_a_tenant_key_is_refused_rather_than_shown_the_fleet(client, gatew
         rooms=1,
     )
     async with gateway.storage._conn.session() as db:
-        created = await api_keys.create_api_key(db, name="acme-ui", tenant_id="acme")
+        created = await api_keys.create_api_key(
+            db, name="acme-ui", tenant_id="acme", scopes="read,write,ingest,admin"
+        )
 
     resp = await client.get(
         _URL, headers={"Authorization": f"Bearer {created.plaintext}"}
@@ -391,8 +391,7 @@ def test_the_default_window_matches_the_scrape_interval() -> None:
     from voicegateway.server.api.dashboard import nodes_live
 
     assert (
-        nodes_live.DEFAULT_STALE_AFTER_SECONDS
-        == worker._DEFAULT_POLL_INTERVAL_SECONDS
+        nodes_live.DEFAULT_STALE_AFTER_SECONDS == worker._DEFAULT_POLL_INTERVAL_SECONDS
     )
 
 

--- a/src/voicegateway/tests/server/test_read_tenant_isolation.py
+++ b/src/voicegateway/tests/server/test_read_tenant_isolation.py
@@ -130,7 +130,11 @@ async def harness():
 async def _make_key(gateway, *, tenant_id=None, role="tenant"):
     async with gateway.storage._conn.session() as db:
         created = await api_keys.create_api_key(
-            db, name=f"k-{tenant_id}-{role}", tenant_id=tenant_id, role=role
+            db,
+            name=f"k-{tenant_id}-{role}",
+            tenant_id=tenant_id,
+            role=role,
+            scopes="read,write,ingest,admin",
         )
     return created.plaintext
 

--- a/src/voicegateway/tests/server/test_replay_endpoint.py
+++ b/src/voicegateway/tests/server/test_replay_endpoint.py
@@ -44,7 +44,7 @@ async def _seed_replay(gateway, session_id: str, n: int = 3) -> None:
             )
             for i in range(n)
         ]
-        await replay.bulk_write_events(db, events)
+        await replay.bulk_write_events(db, events, tenant_id=None)
 
 
 async def test_get_session_replay_returns_ordered_events(client, gateway) -> None:

--- a/src/voicegateway/tests/server/test_room_latency_endpoint.py
+++ b/src/voicegateway/tests/server/test_room_latency_endpoint.py
@@ -143,7 +143,7 @@ async def _seed_turns(storage, session: str, speeds: list[int | None]) -> None:
         for i, s in enumerate(speeds)
     ]
     async with storage._conn.session() as db:
-        await turns.create_turns_bulk(db, rows)
+        await turns.create_turns_bulk(db, rows, tenant_id=None)
 
 
 @pytest.fixture
@@ -439,6 +439,7 @@ async def test_two_sessions_in_one_room_neither_omit_nor_repeat_a_turn(harness):
                 )
                 for i, s in enumerate([1100, 1150])
             ],
+            tenant_id=None,
         )
 
     whole = (await _get(harness, f"/v1/rooms/{ROOM}/latency")).json()

--- a/src/voicegateway/tests/server/test_room_latency_endpoint.py
+++ b/src/voicegateway/tests/server/test_room_latency_endpoint.py
@@ -161,7 +161,11 @@ async def harness():
 async def _make_key(gateway, *, tenant_id=None, role="tenant"):
     async with gateway.storage._conn.session() as db:
         created = await api_keys.create_api_key(
-            db, name=f"k-{tenant_id}-{role}", tenant_id=tenant_id, role=role
+            db,
+            name=f"k-{tenant_id}-{role}",
+            tenant_id=tenant_id,
+            role=role,
+            scopes="read,write,ingest,admin",
         )
     return created.plaintext
 

--- a/src/voicegateway/tests/server/test_sessions_transcript_endpoint.py
+++ b/src/voicegateway/tests/server/test_sessions_transcript_endpoint.py
@@ -26,7 +26,7 @@ def _client(gw: Gateway) -> AsyncClient:
 async def test_transcript_endpoint_returns_ordered_turns(tmp_path, monkeypatch):
     gw = _gateway(tmp_path, monkeypatch)
     await gw.storage.write_transcript(
-        "call-1", [("user", "hi"), ("agent", "hello there")]
+        "call-1", [("user", "hi"), ("agent", "hello there")], tenant_id=None
     )
     async with _client(gw) as c:
         data = (await c.get("/api/sessions/call-1/transcript")).json()
@@ -54,7 +54,7 @@ async def test_transcript_stays_open_when_no_keys_are_configured(tmp_path, monke
     gw = _gateway(tmp_path, monkeypatch)
     app = build_app(gw)
     assert app.state.api_keys == []
-    await gw.storage.write_transcript("call-open", [("user", "hi")])
+    await gw.storage.write_transcript("call-open", [("user", "hi")], tenant_id=None)
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -75,7 +75,9 @@ async def test_transcript_requires_auth_when_enabled(tmp_path, monkeypatch):
     gw = _gateway(tmp_path, monkeypatch)
     app = build_app(gw)
     app.state.api_keys = [ApiKey(token="read-token", name="viewer", scopes=("read",))]
-    await gw.storage.write_transcript("call-secret", [("user", "my card number is")])
+    await gw.storage.write_transcript(
+        "call-secret", [("user", "my card number is")], tenant_id=None
+    )
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"

--- a/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
+++ b/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
@@ -247,6 +247,8 @@ def test_ingest_scope_covers_every_telemetry_write(matrix):
         "/v1/ingest/dead-air",
         "/v1/agents/heartbeat",
         "/v1/calls/observations",
+        "/v1/accounting/prepare",
+        "/v1/accounting/usage",
     }
     assert all(r.status is ContractStatus.ENFORCED for r in ingest_rows)
 

--- a/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
+++ b/src/voicegateway/tests/server/test_telemetry_authorization_matrix.py
@@ -204,29 +204,51 @@ def test_open_routes_are_gap_unless_explicitly_open_by_design(matrix):
             assert rule.gap_id == "VG-SEC-004"
 
 
-def test_write_scope_spans_ingest_and_config(matrix):
-    """Evidence for VG-SEC-003: splitting write is semantic, not a rename.
+def test_write_scope_no_longer_spans_ingest(matrix):
+    """VG-SEC-003 closed: write covers config mutation and nothing else.
 
-    The count is pinned rather than merely non-empty because 18 is quoted as a
-    fact in the VG-SEC-003 threat entry and on the docs page. A looser
-    assertion lets the code drift away from a number the prose still claims.
+    This test is the inverse of the one it replaces. Before 0.26.0 it asserted
+    that ``write`` covered BOTH telemetry ingest and config mutation, which is
+    what made the scope too coarse to hand an agent. The same assertion now
+    reads the other way: no ingest route may be left on ``write``, or the
+    split has regressed and an agent key is back to being able to rewrite
+    provider configuration.
+
+    The count stays pinned because 12 is quoted on the docs page, and because
+    a route silently sliding between the two buckets is exactly the drift
+    worth failing on.
     """
     write_rows = [r for r in matrix.routes if r.auth is RouteAuth.SCOPE_WRITE]
-    assert len(write_rows) == 18, (
+    assert len(write_rows) == 12, (
         f"{len(write_rows)} routes are gated by the write scope, but "
-        "VG-SEC-003 and docs/architecture/observability-security.md both say "
-        "18. Update the count in all three places together."
+        "docs/architecture/observability-security.md says 12. Update both "
+        "together."
     )
     ingest = {r.path for r in write_rows if r.path.startswith("/v1/ingest")}
+    assert not ingest, (
+        f"{sorted(ingest)} are telemetry ingest but still gated by write; "
+        "they belong behind require_ingest_principal (VG-SEC-003)"
+    )
     config = {
         r.path
         for r in write_rows
         if r.path.startswith(("/v1/providers", "/v1/models", "/v1/projects"))
     }
-    assert ingest and config, (
-        "the write scope must be shown to cover both telemetry ingest and "
-        f"config mutation; got ingest={ingest} config={config}"
-    )
+    assert config, "write must still cover config mutation; got none"
+
+
+def test_ingest_scope_covers_every_telemetry_write(matrix):
+    """The other half: every ingest route actually sits behind the new gate."""
+    ingest_rows = [r for r in matrix.routes if r.auth is RouteAuth.SCOPE_INGEST]
+    assert {r.path for r in ingest_rows} == {
+        "/v1/ingest",
+        "/v1/ingest/turns",
+        "/v1/ingest/tool-calls",
+        "/v1/ingest/dead-air",
+        "/v1/agents/heartbeat",
+        "/v1/calls/observations",
+    }
+    assert all(r.status is ContractStatus.ENFORCED for r in ingest_rows)
 
 
 def test_health_routes_are_not_tenant_scoped(matrix):

--- a/src/voicegateway/tests/server/test_telemetry_gap_ids.py
+++ b/src/voicegateway/tests/server/test_telemetry_gap_ids.py
@@ -30,6 +30,7 @@ import pytest
 
 from voicegateway.schemas.telemetry.security_schema import (
     GAP_ID_PATTERN,
+    ContractStatus,
     ThreatId,
     load_authorization_matrix,
     load_threat_model,
@@ -187,7 +188,15 @@ def test_fixture_paths_named_by_the_threat_model_exist():
 
 
 def test_every_gap_with_a_fixture_agrees_with_that_fixture():
-    """The threat entry and the fixture must cite each other, not just exist."""
+    """The threat entry and the fixture must cite each other, not just exist.
+
+    An open gap and its fixture name each other by gap id. A closed gap keeps
+    naming its fixture, but that fixture is now a guarantee and carries no gap
+    id: it is the case that used to fail and must keep passing, which is what
+    stops the gap reopening. Requiring it to still be a characterization would
+    mean deleting the regression test at the moment it starts protecting
+    something.
+    """
     by_case = {f.case_id: f for f in load_all()}
     mismatched = []
     for entry in load_threat_model().root:
@@ -197,6 +206,17 @@ def test_every_gap_with_a_fixture_agrees_with_that_fixture():
         fixture = by_case.get(case_id)
         if fixture is None:
             mismatched.append(f"{entry.gap_id}: no fixture case {case_id}")
+            continue
+        if entry.status is ContractStatus.CLOSED:
+            if fixture.kind != "guarantee":
+                mismatched.append(
+                    f"{entry.gap_id} is closed, so {case_id} must be a guarantee, "
+                    f"not a {fixture.kind}"
+                )
+            if fixture.gap_id is not None:
+                mismatched.append(
+                    f"{entry.gap_id} is closed, so {case_id} must carry no gap_id"
+                )
         elif fixture.gap_id != entry.gap_id:
             mismatched.append(
                 f"{entry.gap_id} names {case_id}, which cites {fixture.gap_id}"

--- a/src/voicegateway/tests/server/test_telemetry_security_contract.py
+++ b/src/voicegateway/tests/server/test_telemetry_security_contract.py
@@ -401,10 +401,18 @@ def test_planned_scopes_are_absent_from_production():
 
 
 def test_existing_scopes_really_are_used():
-    """The other half of the claim: write and admin are live scope literals."""
+    """The other half of the claim: these scopes are live, not aspirational.
+
+    ``ingest`` joined the list in 0.26.0 and is spelled differently: it is
+    enforced by a named dependency rather than a ``require_scope`` literal,
+    because the route needs the resulting Principal and not just a pass/fail.
+    Asserting the dependency's own name keeps the claim honest without
+    pretending the two gates have the same shape.
+    """
     source = "\n".join(p.read_text(encoding="utf-8") for p in _server_sources())
     assert 'require_scope("write")' in source
     assert "require_scope(ADMIN_SCOPE)" in source
+    assert "require_ingest_principal" in source
 
 
 def test_require_scope_closure_shape_is_stable():

--- a/src/voicegateway/tests/server/test_telemetry_security_contract.py
+++ b/src/voicegateway/tests/server/test_telemetry_security_contract.py
@@ -24,6 +24,7 @@ from voicegateway.schemas.telemetry.security_schema import (
     CONTENT_STATE_TRANSITIONS,
     EXISTING_SCOPES,
     FORBIDDEN_IMPORT_ROOT,
+    NON_READABLE_CONTENT_STATES,
     PLANNED_SCOPES,
     TELEMETRY_FIELD_BINDINGS,
     AuthorizationRule,
@@ -133,18 +134,36 @@ def test_rows_are_frozen_and_reject_unknown_fields():
 # --------------------------------------------------------------------------
 
 
+def test_content_state_vocabulary_matches_the_roadmap():
+    """Waves 3 and 4 enumerate these five verbatim."""
+    assert [s.value for s in ContentState] == [
+        "captured",
+        "redacted",
+        "truncated",
+        "expired",
+        "unavailable",
+    ]
+
+
 def test_content_transitions_are_one_way():
     """No state may reach a state that precedes it in the lifecycle."""
     order = [
-        ContentState.PENDING,
-        ContentState.STORED,
+        ContentState.CAPTURED,
+        ContentState.TRUNCATED,
         ContentState.REDACTED,
-        ContentState.PURGED,
+        ContentState.EXPIRED,
         ContentState.UNAVAILABLE,
     ]
     for index, source in enumerate(order):
         for target in CONTENT_STATE_TRANSITIONS[source]:
             assert order.index(target) > index, f"{source} -> {target} moves backward"
+
+
+def test_only_captured_is_readable():
+    """Every state but CAPTURED withholds plaintext from every caller."""
+    assert NON_READABLE_CONTENT_STATES == frozenset(ContentState) - {
+        ContentState.CAPTURED
+    }
 
 
 def test_every_state_is_in_the_transition_map():
@@ -155,13 +174,14 @@ def test_every_state_is_in_the_transition_map():
 def test_unavailable_is_terminal():
     """The unauthorized projection cannot become anything else."""
     assert CONTENT_STATE_TRANSITIONS[ContentState.UNAVAILABLE] == frozenset()
-    assert not may_transition(ContentState.UNAVAILABLE, ContentState.STORED)
+    assert not may_transition(ContentState.UNAVAILABLE, ContentState.CAPTURED)
 
 
-def test_purged_content_never_returns():
+def test_expired_content_never_returns():
     """A late ingest replaying an older revision must not resurrect content."""
-    assert not may_transition(ContentState.PURGED, ContentState.STORED)
-    assert not may_transition(ContentState.REDACTED, ContentState.STORED)
+    assert not may_transition(ContentState.EXPIRED, ContentState.CAPTURED)
+    assert not may_transition(ContentState.REDACTED, ContentState.CAPTURED)
+    assert not may_transition(ContentState.TRUNCATED, ContentState.CAPTURED)
 
 
 @pytest.mark.parametrize("field", ["byte_count", "expires_at"])
@@ -178,10 +198,10 @@ def test_unavailable_content_with_no_metadata_is_valid():
     assert descriptor.expires_at is None
 
 
-def test_purged_may_report_zero_bytes():
+def test_expired_may_report_zero_bytes():
     """The oracle rule is narrow: an authorized caller still gets the truth."""
     descriptor = ContentDescriptor.model_validate(
-        {"state": ContentState.PURGED, "byte_count": 0}
+        {"state": ContentState.EXPIRED, "byte_count": 0}
     )
     assert descriptor.byte_count == 0
 

--- a/src/voicegateway/tests/server/test_telemetry_security_contract.py
+++ b/src/voicegateway/tests/server/test_telemetry_security_contract.py
@@ -38,6 +38,7 @@ from voicegateway.schemas.telemetry.security_schema import (
     ScopeName,
     SealedValue,
     SensitiveAccessEvent,
+    ThreatEntry,
     ThreatModel,
     load_threat_model,
     may_transition,
@@ -112,6 +113,17 @@ def test_matrix_row_cannot_be_planned():
         AuthorizationRule.model_validate(_rule(status=ContractStatus.PLANNED))
 
 
+def test_matrix_row_cannot_be_closed():
+    """CLOSED is threat-model history. A closed route's row is ENFORCED.
+
+    Without this, a CLOSED row would fall through to the gap branch, be
+    required to carry a gap_id, and then be counted as open work by
+    everything that reads the matrix.
+    """
+    with pytest.raises(ValidationError, match="belongs to the threat"):
+        AuthorizationRule.model_validate(_rule(status=ContractStatus.CLOSED))
+
+
 def test_gap_id_format_is_enforced():
     """Free-form ids would break the verbatim join across the four places."""
     with pytest.raises(ValidationError):
@@ -127,6 +139,52 @@ def test_rows_are_frozen_and_reject_unknown_fields():
     rule = AuthorizationRule.model_validate(_rule())
     with pytest.raises(ValidationError):
         rule.status = ContractStatus.ENFORCED
+
+
+# --------------------------------------------------------------------------
+# Closing a gap: the entry stays as history
+# --------------------------------------------------------------------------
+
+
+def _entry(**overrides) -> dict:
+    base = {
+        "gap_id": "VG-SEC-001",
+        "threat": "VG-THREAT-001",
+        "title": "t",
+        "description": "d",
+        "status": ContractStatus.GAP,
+        "wave": 1,
+        "evidence": "src/voicegateway/repository/tool_calls_repository.py:54",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_closed_entry_requires_release_and_commit():
+    """A closure with no release or commit is a claim with no receipt."""
+    with pytest.raises(ValidationError, match="closed_in and closed_by"):
+        ThreatEntry.model_validate(_entry(status=ContractStatus.CLOSED))
+    entry = ThreatEntry.model_validate(
+        _entry(status=ContractStatus.CLOSED, closed_in="0.26.0", closed_by="abc1234")
+    )
+    assert entry.closed_in == "0.26.0"
+
+
+def test_open_entry_cannot_carry_closure_fields():
+    """Closure fields on an open gap would read as closed to a skimmer."""
+    with pytest.raises(ValidationError, match="only a closed entry"):
+        ThreatEntry.model_validate(_entry(closed_in="0.26.0"))
+
+
+def test_threat_model_open_gap_ids_excludes_closed():
+    """gap_ids stays complete for the contiguity pin; open_gap_ids is the work."""
+    closed = _entry(
+        status=ContractStatus.CLOSED, closed_in="0.26.0", closed_by="abc1234"
+    )
+    open_entry = _entry(gap_id="VG-SEC-002", status=ContractStatus.PLANNED)
+    model = ThreatModel.model_validate([closed, open_entry])
+    assert model.gap_ids() == {"VG-SEC-001", "VG-SEC-002"}
+    assert model.open_gap_ids() == {"VG-SEC-002"}
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/server/test_turn_percentile_endpoint.py
+++ b/src/voicegateway/tests/server/test_turn_percentile_endpoint.py
@@ -59,7 +59,7 @@ def storage(tmp_path):
 async def _seed(storage, rows: list[TurnRow]) -> None:
     await storage._ensure_initialized()
     async with storage._conn.session() as db:
-        await turns.create_turns_bulk(db, rows)
+        await turns.create_turns_bulk(db, rows, tenant_id=None)
 
 
 # --------------------------------------------------------------------------

--- a/src/voicegateway/tests/services/test_api_key_service.py
+++ b/src/voicegateway/tests/services/test_api_key_service.py
@@ -37,7 +37,7 @@ async def service(tmp_path):
 
 async def test_create_returns_plaintext_once(service: ApiKeyService) -> None:
     created = await service.create_key(
-        name="prod-bot", tenant_id="acme", issued_by="ops@vg"
+        name="prod-bot", scopes="read", tenant_id="acme", issued_by="ops@vg"
     )
     assert created.plaintext.startswith("vk_")
     assert len(created.plaintext) == 35
@@ -48,7 +48,7 @@ async def test_create_returns_plaintext_once(service: ApiKeyService) -> None:
 
 
 async def test_verify_round_trip(service: ApiKeyService) -> None:
-    created = await service.create_key(name="api-bot")
+    created = await service.create_key(name="api-bot", scopes="read")
     verified = await service.verify(created.plaintext)
     assert verified is not None
     assert verified.id == created.row.id
@@ -56,13 +56,13 @@ async def test_verify_round_trip(service: ApiKeyService) -> None:
 
 
 async def test_verify_rejects_wrong_plaintext(service: ApiKeyService) -> None:
-    await service.create_key(name="real")
+    await service.create_key(name="real", scopes="read")
     assert await service.verify("vk_NOTAREALKEYAAAAAAAAAAAAAAAAAAAAAA") is None
     assert await service.verify("not-a-vk-token") is None
 
 
 async def test_revoke_blocks_future_verify(service: ApiKeyService) -> None:
-    created = await service.create_key(name="ops")
+    created = await service.create_key(name="ops", scopes="read")
     assert await service.revoke(created.row.id) is True
     assert await service.verify(created.plaintext) is None
     # Idempotent: second revoke returns False (already revoked).
@@ -70,8 +70,8 @@ async def test_revoke_blocks_future_verify(service: ApiKeyService) -> None:
 
 
 async def test_list_keys_filters_revoked(service: ApiKeyService) -> None:
-    a = await service.create_key(name="a")
-    b = await service.create_key(name="b")
+    a = await service.create_key(name="a", scopes="read")
+    b = await service.create_key(name="b", scopes="read")
     await service.revoke(a.row.id)
 
     all_keys = await service.list_keys(include_revoked=True)
@@ -81,7 +81,7 @@ async def test_list_keys_filters_revoked(service: ApiKeyService) -> None:
 
 
 async def test_mark_used_is_idempotent(service: ApiKeyService) -> None:
-    created = await service.create_key(name="poller")
+    created = await service.create_key(name="poller", scopes="read")
     assert created.row.last_used_at is None
     await service.mark_used(created.row.id)
     after = await service.get_by_id(created.row.id)
@@ -92,3 +92,20 @@ async def test_mark_used_is_idempotent(service: ApiKeyService) -> None:
     assert again.last_used_at is not None
     # Time advances, so the second stamp is >=
     assert again.last_used_at >= first_stamp
+
+
+async def test_create_refuses_the_wildcard(service: ApiKeyService) -> None:
+    """VG-SEC-006 at the service layer, not only behind the route.
+
+    This is the door the ORM model sat behind: ``ApiKey.scopes`` defaults to
+    ``"*"``, and before 0.26.0 this method never set the field, so the default
+    applied. Asserting here rather than only through the endpoint pins the
+    layer that actually held the bug.
+    """
+    with pytest.raises(ValueError, match="wildcard"):
+        await service.create_key(name="wild", scopes="*")
+
+
+async def test_create_refuses_an_unknown_scope(service: ApiKeyService) -> None:
+    with pytest.raises(ValueError, match="unknown scope"):
+        await service.create_key(name="typo", scopes="raed")

--- a/src/voicegateway/tests/services/test_retention_service.py
+++ b/src/voicegateway/tests/services/test_retention_service.py
@@ -51,6 +51,7 @@ async def _seed_session(
                     cost_usd=0.0,
                 )
             ],
+            tenant_id=None,
         )
 
 
@@ -114,6 +115,7 @@ async def test_in_flight_sessions_never_deleted(storage) -> None:
                     cost_usd=0.0,
                 )
             ],
+            tenant_id=None,
         )
 
     async def provider():

--- a/src/voicegateway/tests/storage/test_api_keys_repo.py
+++ b/src/voicegateway/tests/storage/test_api_keys_repo.py
@@ -188,17 +188,25 @@ async def test_two_keys_with_same_tenant_independent(db) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_default_key_is_tenant_role_wildcard_scope(db) -> None:
-    """A key created without explicit role/scopes gets 'tenant' + '*'."""
+async def test_key_defaults_to_tenant_role_and_no_wildcard(db) -> None:
+    """Role still defaults to 'tenant'. Scopes no longer default at all.
+
+    This test used to assert the key came back with ``"*"``. That default was
+    VG-SEC-006: it made every scope check pass. Role keeps its default because
+    'tenant' is the safe one; scopes has none because there is no safe guess.
+    """
     created = await vk.create_api_key(
         db, name="default-key", scopes="read,write,ingest,admin"
     )
     verified = await vk.verify(db, created.plaintext)
     assert verified is not None
     assert verified.role == "tenant"
-    assert verified.scopes == "*"
+    assert verified.scopes == "admin,ingest,read,write"
     assert verified.has_scope("write") is True
-    assert verified.has_scope("admin") is True  # wildcard covers everything
+    assert verified.has_scope("admin") is True
+    # Not by wildcard: each of those is named. A scope nobody asked for is
+    # still refused, which is the whole point of removing the default.
+    assert verified.has_scope("mcp:read") is False
 
 
 async def test_scoped_key_denies_unlisted_scope(db) -> None:

--- a/src/voicegateway/tests/storage/test_api_keys_repo.py
+++ b/src/voicegateway/tests/storage/test_api_keys_repo.py
@@ -18,7 +18,11 @@ async def db(tmp_path):
 
 async def test_issuance_returns_plaintext_once(db) -> None:
     created = await vk.create_api_key(
-        db, name="prod-bot", tenant_id="acme", issued_by="ops@vg"
+        db,
+        name="prod-bot",
+        tenant_id="acme",
+        issued_by="ops@vg",
+        scopes="read,write,ingest,admin",
     )
     assert created.plaintext.startswith("vk_")
     assert len(created.plaintext) == 35  # vk_ + 32 base32 chars
@@ -29,7 +33,9 @@ async def test_issuance_returns_plaintext_once(db) -> None:
 
 
 async def test_verify_round_trip_returns_id_and_tenant(db) -> None:
-    created = await vk.create_api_key(db, name="bot", tenant_id="acme")
+    created = await vk.create_api_key(
+        db, name="bot", tenant_id="acme", scopes="read,write,ingest,admin"
+    )
     verified = await vk.verify(db, created.plaintext)
     assert verified is not None
     assert verified.id == created.id
@@ -48,14 +54,14 @@ async def test_verify_rejects_unknown_key(db) -> None:
 
 
 async def test_verify_rejects_revoked_key(db) -> None:
-    created = await vk.create_api_key(db, name="bot")
+    created = await vk.create_api_key(db, name="bot", scopes="read,write,ingest,admin")
     assert await vk.verify(db, created.plaintext) is not None
     assert await vk.revoke(db, created.id) is True
     assert await vk.verify(db, created.plaintext) is None
 
 
 async def test_revoke_is_idempotent_observable(db) -> None:
-    created = await vk.create_api_key(db, name="bot")
+    created = await vk.create_api_key(db, name="bot", scopes="read,write,ingest,admin")
     assert await vk.revoke(db, created.id) is True
     # Second revoke returns False because the row is already revoked.
     assert await vk.revoke(db, created.id) is False
@@ -63,7 +69,7 @@ async def test_revoke_is_idempotent_observable(db) -> None:
 
 async def test_revoke_keeps_row_for_audit(db) -> None:
     """OQ5: soft revoke writes revoked_at, does not delete the row."""
-    created = await vk.create_api_key(db, name="bot")
+    created = await vk.create_api_key(db, name="bot", scopes="read,write,ingest,admin")
     await vk.revoke(db, created.id)
     row = await vk.get_by_id(db, created.id)
     assert row is not None
@@ -71,7 +77,7 @@ async def test_revoke_keeps_row_for_audit(db) -> None:
 
 
 async def test_mark_used_updates_last_used_at(db) -> None:
-    created = await vk.create_api_key(db, name="bot")
+    created = await vk.create_api_key(db, name="bot", scopes="read,write,ingest,admin")
     assert created.row.last_used_at is None
     await vk.mark_used(db, created.id)
     refreshed = await vk.get_by_id(db, created.id)
@@ -81,8 +87,10 @@ async def test_mark_used_updates_last_used_at(db) -> None:
 
 async def test_list_keys_excludes_plaintext_and_hash(db) -> None:
     """The ApiKeyRow dataclass intentionally drops ``key_hash``."""
-    await vk.create_api_key(db, name="bot1", tenant_id="acme")
-    await vk.create_api_key(db, name="bot2")
+    await vk.create_api_key(
+        db, name="bot1", tenant_id="acme", scopes="read,write,ingest,admin"
+    )
+    await vk.create_api_key(db, name="bot2", scopes="read,write,ingest,admin")
     rows = await vk.list_keys(db)
     assert len(rows) == 2
     for row in rows:
@@ -93,8 +101,12 @@ async def test_list_keys_excludes_plaintext_and_hash(db) -> None:
 
 
 async def test_list_keys_filter_revoked(db) -> None:
-    active = await vk.create_api_key(db, name="active")
-    revoked = await vk.create_api_key(db, name="revoked")
+    active = await vk.create_api_key(
+        db, name="active", scopes="read,write,ingest,admin"
+    )
+    revoked = await vk.create_api_key(
+        db, name="revoked", scopes="read,write,ingest,admin"
+    )
     await vk.revoke(db, revoked.id)
 
     all_rows = await vk.list_keys(db, include_revoked=True)
@@ -105,7 +117,9 @@ async def test_list_keys_filter_revoked(db) -> None:
 
 
 async def test_unscoped_key_has_null_tenant(db) -> None:
-    created = await vk.create_api_key(db, name="unscoped")
+    created = await vk.create_api_key(
+        db, name="unscoped", scopes="read,write,ingest,admin"
+    )
     assert created.row.tenant_id is None
     verified = await vk.verify(db, created.plaintext)
     assert verified is not None
@@ -114,7 +128,7 @@ async def test_unscoped_key_has_null_tenant(db) -> None:
 
 async def test_list_stale_includes_never_used_keys(db) -> None:
     """Issued-but-never-used keys past the cutoff are stale."""
-    await vk.create_api_key(db, name="brand-new")
+    await vk.create_api_key(db, name="brand-new", scopes="read,write,ingest,admin")
 
     # ``stale_after_days=0`` means anything issued at or before "now"
     # is considered stale, which captures the just-created row.
@@ -124,7 +138,7 @@ async def test_list_stale_includes_never_used_keys(db) -> None:
 
 
 async def test_list_stale_excludes_recently_used_keys(db) -> None:
-    created = await vk.create_api_key(db, name="busy")
+    created = await vk.create_api_key(db, name="busy", scopes="read,write,ingest,admin")
     await vk.mark_used(db, created.id)
 
     # 365-day threshold means nothing should be stale yet.
@@ -133,7 +147,7 @@ async def test_list_stale_excludes_recently_used_keys(db) -> None:
 
 
 async def test_list_stale_excludes_revoked_keys(db) -> None:
-    created = await vk.create_api_key(db, name="dead")
+    created = await vk.create_api_key(db, name="dead", scopes="read,write,ingest,admin")
     await vk.revoke(db, created.id)
     stale = await vk.list_stale(db, stale_after_days=0)
     assert len(stale) == 0
@@ -146,7 +160,7 @@ async def test_list_stale_rejects_negative_threshold(db) -> None:
 
 async def test_create_rejects_empty_name(db) -> None:
     with pytest.raises(ValueError):
-        await vk.create_api_key(db, name="")
+        await vk.create_api_key(db, name="", scopes="read,write,ingest,admin")
 
 
 async def test_get_by_id_returns_none_for_missing(db) -> None:
@@ -154,8 +168,12 @@ async def test_get_by_id_returns_none_for_missing(db) -> None:
 
 
 async def test_two_keys_with_same_tenant_independent(db) -> None:
-    a = await vk.create_api_key(db, name="a", tenant_id="acme")
-    b = await vk.create_api_key(db, name="b", tenant_id="acme")
+    a = await vk.create_api_key(
+        db, name="a", tenant_id="acme", scopes="read,write,ingest,admin"
+    )
+    b = await vk.create_api_key(
+        db, name="b", tenant_id="acme", scopes="read,write,ingest,admin"
+    )
     assert a.plaintext != b.plaintext
     assert a.row.key_prefix != b.row.key_prefix or a.plaintext != b.plaintext
 
@@ -172,7 +190,9 @@ async def test_two_keys_with_same_tenant_independent(db) -> None:
 
 async def test_default_key_is_tenant_role_wildcard_scope(db) -> None:
     """A key created without explicit role/scopes gets 'tenant' + '*'."""
-    created = await vk.create_api_key(db, name="default-key")
+    created = await vk.create_api_key(
+        db, name="default-key", scopes="read,write,ingest,admin"
+    )
     verified = await vk.verify(db, created.plaintext)
     assert verified is not None
     assert verified.role == "tenant"
@@ -193,7 +213,9 @@ async def test_scoped_key_denies_unlisted_scope(db) -> None:
 
 async def test_admin_role_key_is_created_and_verified(db) -> None:
     """A key created with role='admin' comes back with role='admin'."""
-    created = await vk.create_api_key(db, name="ops-key", role="admin")
+    created = await vk.create_api_key(
+        db, name="ops-key", role="admin", scopes="read,write,ingest,admin"
+    )
     verified = await vk.verify(db, created.plaintext)
     assert verified is not None
     assert verified.role == "admin"

--- a/src/voicegateway/tests/storage/test_dead_air_repo.py
+++ b/src/voicegateway/tests/storage/test_dead_air_repo.py
@@ -22,7 +22,7 @@ async def test_create_event_round_trip(tmp_path) -> None:
             duration_ms=3500,
             threshold_used_ms=3000,
         )
-        await dead_air.create_event(db, event)
+        await dead_air.create_event(db, event, tenant_id=None)
 
         listed = await dead_air.list_events_by_session(db, "s1")
         assert len(listed) == 1
@@ -38,7 +38,7 @@ async def test_list_events_ordered_by_started_at_asc(tmp_path) -> None:
             DeadAirEvent("s1", 2000, 100, 50),
         ]
         for e in events:
-            await dead_air.create_event(db, e)
+            await dead_air.create_event(db, e, tenant_id=None)
 
         listed = await dead_air.list_events_by_session(db, "s1")
         assert [e.started_at_ms for e in listed] == [1000, 2000, 3000]
@@ -48,8 +48,10 @@ async def test_count_events_by_session(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
         for i in range(4):
-            await dead_air.create_event(db, DeadAirEvent("s1", i * 1000, 100, 50))
-        await dead_air.create_event(db, DeadAirEvent("s2", 0, 100, 50))
+            await dead_air.create_event(
+                db, DeadAirEvent("s1", i * 1000, 100, 50), tenant_id=None
+            )
+        await dead_air.create_event(db, DeadAirEvent("s2", 0, 100, 50), tenant_id=None)
 
         assert await dead_air.count_events_by_filter(db, "s1") == 4
         assert await dead_air.count_events_by_filter(db, "s2") == 1
@@ -61,7 +63,9 @@ async def test_count_events_by_time_range(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
         for i in range(5):
-            await dead_air.create_event(db, DeadAirEvent("s1", i * 1000, 100, 50))
+            await dead_air.create_event(
+                db, DeadAirEvent("s1", i * 1000, 100, 50), tenant_id=None
+            )
 
         # [2000, 4000) -> started_at_ms in {2000, 3000} -> 2 events.
         n = await dead_air.count_events_by_filter(

--- a/src/voicegateway/tests/storage/test_migration_accounting.py
+++ b/src/voicegateway/tests/storage/test_migration_accounting.py
@@ -1,0 +1,131 @@
+"""Accounting migration/model parity and non-destructive rollback guards."""
+
+from __future__ import annotations
+
+import asyncio
+import runpy
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import BigInteger, create_engine, inspect
+from sqlmodel import SQLModel
+
+from voicegateway.accounting.contracts import (
+    PricingDimension,
+    PricingRevisionCreate,
+    PricingSide,
+)
+from voicegateway.core.config import GatewayConfig
+from voicegateway.core.database import Database
+from voicegateway.models import accounting_model as _accounting_models  # noqa: F401
+from voicegateway.models.api_key_model import ApiKey
+from voicegateway.services.accounting_service import AccountingService, RevisionConflict
+from voicegateway.services.storage_service import StorageService
+
+_TABLES = (
+    "pricing_revisions",
+    "accounting_usage",
+    "accounting_projection_outbox",
+    "accounting_rejections",
+    "accounting_ownership",
+    "prepared_pricing_bindings",
+)
+
+
+def _shape(engine: sa.Engine, table: str) -> dict[str, tuple[str, bool]]:
+    return {
+        item["name"]: (str(item["type"]), bool(item["nullable"]))
+        for item in inspect(engine).get_columns(table)
+    }
+
+
+async def test_accounting_migration_matches_sqlmodel(tmp_path: Path) -> None:
+    database = Database(
+        GatewayConfig(cost_tracking={"db_path": str(tmp_path / "migrated.db")})
+    )
+    await database.run_migrations()
+    migrated = create_engine(f"sqlite:///{database.db_file_path}")
+    declared = create_engine(f"sqlite:///{tmp_path / 'declared.db'}")
+    try:
+        SQLModel.metadata.create_all(
+            declared,
+            tables=[SQLModel.metadata.tables[name] for name in _TABLES]
+            + [ApiKey.__table__],
+        )
+        for table in _TABLES:
+            assert _shape(migrated, table) == _shape(declared, table), table
+        assert (
+            _shape(migrated, "api_keys")["project_ids"]
+            == _shape(declared, "api_keys")["project_ids"]
+        )
+    finally:
+        migrated.dispose()
+        declared.dispose()
+        await database.dispose()
+
+
+def test_every_accounting_nanosecond_column_is_bigint() -> None:
+    for table in _TABLES:
+        for column in SQLModel.metadata.tables[table].columns:
+            if column.name.endswith("_ns"):
+                assert isinstance(column.type, BigInteger), f"{table}.{column.name}"
+
+
+def test_accounting_downgrade_refuses_to_destroy_ledger() -> None:
+    migration = runpy.run_path(
+        str(
+            Path(__file__).resolve().parents[4]
+            / "alembic/versions/a6c9e2f4b817_immutable_accounting_ledger.py"
+        )
+    )
+    with pytest.raises(RuntimeError, match="no destructive downgrade"):
+        migration["downgrade"]()
+
+
+def _revision(revision_id: str) -> PricingRevisionCreate:
+    return PricingRevisionCreate(
+        revision_id=revision_id,
+        side="selling",
+        scope={"offering": "provider/model"},
+        rates=({"dimension": "requests", "unit": "request", "rate": "1"},),
+        unsupported_dimensions=tuple(
+            item for item in PricingDimension if item is not PricingDimension.REQUESTS
+        ),
+    )
+
+
+async def test_concurrent_activation_leaves_one_active_revision(tmp_path: Path) -> None:
+    storage = StorageService(str(tmp_path / "activation.db"))
+    async with storage.session() as session:
+        service = AccountingService(session, tenant_id="tenant-a")
+        for revision_id in ("v0", "v1", "v2"):
+            await service.create_revision(_revision(revision_id))
+        await service.activate_revision(PricingSide.SELLING, "v0")
+
+    async def activate(revision_id: str):
+        async with storage.session() as session:
+            try:
+                await AccountingService(
+                    session, tenant_id="tenant-a"
+                ).activate_revision(
+                    PricingSide.SELLING,
+                    revision_id,
+                    expected_current_revision_id="v0",
+                )
+                return "activated"
+            except RevisionConflict:
+                return "conflict"
+
+    outcomes = await asyncio.gather(activate("v1"), activate("v2"))
+    assert sorted(outcomes) == ["activated", "conflict"]
+    async with storage.session() as session:
+        rows = (
+            await session.execute(
+                sa.select(SQLModel.metadata.tables["pricing_revisions"]).where(
+                    SQLModel.metadata.tables["pricing_revisions"].c.active.is_(True)
+                )
+            )
+        ).all()
+    assert len(rows) == 1
+    await storage.aclose()

--- a/src/voicegateway/tests/storage/test_replay_repo.py
+++ b/src/voicegateway/tests/storage/test_replay_repo.py
@@ -64,7 +64,7 @@ async def test_bulk_write_round_trip(tmp_path) -> None:
             llm("s1", 500, "hi"),
             _state("s1", 510),
         ]
-        n = await replay.bulk_write_events(db, events)
+        n = await replay.bulk_write_events(db, events, tenant_id=None)
         assert n == 3
 
         listed = await replay.read_full_replay(db, "s1")
@@ -78,7 +78,7 @@ async def test_bulk_write_round_trip(tmp_path) -> None:
 async def test_bulk_write_empty_is_noop(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
-        n = await replay.bulk_write_events(db, [])
+        n = await replay.bulk_write_events(db, [], tenant_id=None)
         assert n == 0
 
 
@@ -96,7 +96,7 @@ async def test_delete_replay_cascades_all_four_tables(tmp_path) -> None:
             llm("s1", 100, "b"),
             _state("s1", 200),
         ]
-        await replay.bulk_write_events(db, events)
+        await replay.bulk_write_events(db, events, tenant_id=None)
         await replay.bulk_write_events(
             db,
             [
@@ -113,6 +113,7 @@ async def test_delete_replay_cascades_all_four_tables(tmp_path) -> None:
                     cost_usd=0.00001,
                 )
             ],
+            tenant_id=None,
         )
 
         deleted = await replay.delete_replay(db, "s1")
@@ -125,6 +126,8 @@ async def test_delete_replay_cascades_all_four_tables(tmp_path) -> None:
 async def test_aggregate_storage_per_session(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
-        await replay.bulk_write_events(db, [stt("s1", 0, "hello world")])
+        await replay.bulk_write_events(
+            db, [stt("s1", 0, "hello world")], tenant_id=None
+        )
         size = await replay.aggregate_storage_per_session(db, "s1")
         assert 30 <= size <= 500

--- a/src/voicegateway/tests/storage/test_replay_storage_smoke.py
+++ b/src/voicegateway/tests/storage/test_replay_storage_smoke.py
@@ -85,7 +85,7 @@ async def test_synthetic_one_minute_under_600kb(tmp_path) -> None:
 
     # Persist the captured events via the real repo.
     async with storage._conn.session() as db:
-        n = await replay.bulk_write_events(db, captured)
+        n = await replay.bulk_write_events(db, captured, tenant_id=None)
         assert n == len(captured)
 
         # Sum the payload bytes (the dominant cost term).
@@ -130,7 +130,7 @@ async def test_storage_size_reported_via_aggregate(tmp_path) -> None:
     await capture.close_session("tiny")
 
     async with storage._conn.session() as db:
-        await replay.bulk_write_events(db, captured)
+        await replay.bulk_write_events(db, captured, tenant_id=None)
         size = await replay.aggregate_storage_per_session(db, "tiny")
 
     # 10 small STT chunks: each payload roughly 50 bytes JSON-encoded,

--- a/src/voicegateway/tests/storage/test_turn_ms_width.py
+++ b/src/voicegateway/tests/storage/test_turn_ms_width.py
@@ -96,7 +96,7 @@ async def test_an_out_of_int32_timestamp_round_trips(tmp_path) -> None:
         agent_speak_end_ms=_OVERFLOWING_MS + 2000,
         response_speed_ms=400,
     )
-    await storage.log_turns([row])
+    await storage.log_turns([row], tenant_id=None)
 
     async with storage._conn.session() as db:
         [read_back] = await turns.list_turns_by_session(db, "s-wide")

--- a/src/voicegateway/tests/storage/test_turns_repo.py
+++ b/src/voicegateway/tests/storage/test_turns_repo.py
@@ -37,7 +37,7 @@ async def test_create_turn_and_list_round_trip(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
         t = _row("s1", 0, 1000, 2000, 2200, 4000, 200)
-        await turns.create_turn(db, t)
+        await turns.create_turn(db, t, tenant_id=None)
 
         listed = await turns.list_turns_by_session(db, "s1")
         assert len(listed) == 1
@@ -51,7 +51,7 @@ async def test_create_turns_bulk(tmp_path) -> None:
             _row("s1", i, i * 1000, i * 1000 + 500, response_speed=100 + i)
             for i in range(5)
         ]
-        n = await turns.create_turns_bulk(db, rows)
+        n = await turns.create_turns_bulk(db, rows, tenant_id=None)
         assert n == 5
 
         listed = await turns.list_turns_by_session(db, "s1")
@@ -62,7 +62,7 @@ async def test_create_turns_bulk(tmp_path) -> None:
 async def test_create_turns_bulk_empty_is_noop(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
-        n = await turns.create_turns_bulk(db, [])
+        n = await turns.create_turns_bulk(db, [], tenant_id=None)
         assert n == 0
 
 
@@ -70,7 +70,7 @@ async def test_aggregate_response_speed_returns_percentiles(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
         rows = [_row("s1", i, 0, 0, 0, 0, response_speed=i + 1) for i in range(100)]
-        await turns.create_turns_bulk(db, rows)
+        await turns.create_turns_bulk(db, rows, tenant_id=None)
 
         agg = await turns.aggregate_response_speed(db, "s1")
         assert agg["p50_ms"] is not None
@@ -96,7 +96,9 @@ async def test_aggregate_response_speed_empty_returns_nulls(tmp_path) -> None:
 async def test_aggregate_response_speed_single_value(tmp_path) -> None:
     storage = await _fresh_storage(tmp_path)
     async with storage._conn.session() as db:
-        await turns.create_turn(db, _row("s1", 0, 0, 0, 0, 0, response_speed=250))
+        await turns.create_turn(
+            db, _row("s1", 0, 0, 0, 0, 0, response_speed=250), tenant_id=None
+        )
         agg = await turns.aggregate_response_speed(db, "s1")
         assert agg["p50_ms"] == 250
         assert agg["p95_ms"] == 250
@@ -114,6 +116,7 @@ async def test_count_overlap_turns(tmp_path) -> None:
                 _row("s1", 1, 1500, 2500, 2500, 3000, 0),
                 _row("s1", 2, 3500, 4000, 4000, 5000, 0),
             ],
+            tenant_id=None,
         )
         count = await turns.count_overlap_turns(db, "s1")
         assert count == 1
@@ -128,6 +131,7 @@ async def test_count_overlap_excludes_null_agent_end(tmp_path) -> None:
                 _row("s1", 0, 0, 500, 500, None, None),
                 _row("s1", 1, 100, 1000, 1000, 2000, 0),
             ],
+            tenant_id=None,
         )
         count = await turns.count_overlap_turns(db, "s1")
         assert count == 0

--- a/tools/scripts/gen_authorization_matrix.py
+++ b/tools/scripts/gen_authorization_matrix.py
@@ -62,6 +62,8 @@ def classify(fn) -> str | None:
             )
         cell = fn.__closure__[code.co_freevars.index("scope")]
         return f"scope:{cell.cell_contents}"
+    if qualname == "require_ingest_principal":
+        return "scope:ingest"
     if qualname == "require_principal":
         return "principal"
     return None


### PR DESCRIPTION
## Summary

- add immutable, independently synchronized acquisition-cost and selling-price revisions
- add exact decimal usage rating with pinned revisions and strict measurement states
- add durable, idempotent usage delivery with per-record receipts, restart recovery, ownership controls, and visible loss signals
- integrate native LiveKit STT, TTS, LLM, and realtime accounting into `attach()`
- expose tenant-safe accounting status through the API, dashboard, and read-only MCP surface
- include the prerequisite security-foundation contracts and authorization enforcement

## Release boundary

PostgreSQL/SQLite SQL storage is authoritative for exact accounting. ClickHouse remains supported for legacy request telemetry only; exact-accounting ClickHouse projection is explicitly deferred, no supported accounting read path depends on it, and no misleading `pending_delivery` metric is exposed.

## Verification

- full suite: 4,001 passed, 33 skipped, 3 expected failures
- disposable PostgreSQL 16: migrations, restricted role, isolation, revision immutability, concurrent activation, exact decimal rating, duplicate/conflicting events, mixed receipts, restart, lost acknowledgement, delayed pinned pricing, and acquisition-price privacy
- native LiveKit SDK integration: STT, TTS, LLM, realtime, cancellation, cached usage, shared request IDs, duplicate metrics, missing measurements, ownership modes, tracing, and collector outage/recovery
- Ruff: clean
- mypy: 310 source files clean
- documentation validator: 85 pages clean
- dashboard production build: passed
- isolated wheel import: passed

The 33 skips are classified in the release-candidate document. The three expected failures are existing non-accounting architectural/security debt and do not weaken accounting assertions.

## Deployment and recovery

Deploy schema-capable server code first, then API/dashboard/MCP readers, then SDK producers. Application rollback is supported; destructive ledger downgrade is intentionally refused, with forward recovery documented.

## Deferred

- exact-accounting ClickHouse projection
- exact-ledger file export
- per-caller identity for the shared-token MCP transport

No package was published and no production configuration was changed.
