### PR TITLE
fix(accounting): make revision activation atomic

### DIFF
--- a/src/voicegateway/services/accounting_service.py
+++ b/src/voicegateway/services/accounting_service.py
@@ -8,8 +8,10 @@ import time
 import uuid
 from collections.abc import Sequence
 from decimal import Decimal
+from typing import Any, cast
 
 from sqlalchemy import and_, func, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
@@ -114,31 +116,28 @@ class AccountingService:
             raise LookupError("pricing revision not found")
         if hashlib.sha256(row.content_json.encode()).hexdigest() != row.content_hash:
             raise RevisionConflict("stored pricing revision hash mismatch")
-        current = (
-            await self._session.execute(
-                select(PricingRevision)
-                .where(
-                    col(PricingRevision.tenant_id) == self._tenant_id,
-                    col(PricingRevision.side) == side.value,
-                    col(PricingRevision.scope_key) == row.scope_key,
-                    col(PricingRevision.active).is_(True),
-                )
-                .with_for_update()
-            )
-        ).scalar_one_or_none()
-        if expected_current_revision_id is not None and (
-            current is None or current.revision_id != expected_current_revision_id
-        ):
-            raise RevisionConflict("active revision changed")
-        await self._session.execute(
-            update(PricingRevision)
-            .where(
-                col(PricingRevision.tenant_id) == self._tenant_id,
-                col(PricingRevision.side) == side.value,
-                col(PricingRevision.scope_key) == row.scope_key,
-            )
-            .values(active=False)
+        active_scope = (
+            col(PricingRevision.tenant_id) == self._tenant_id,
+            col(PricingRevision.side) == side.value,
+            col(PricingRevision.scope_key) == row.scope_key,
+            col(PricingRevision.active).is_(True),
         )
+        deactivate = update(PricingRevision).where(*active_scope)
+        if expected_current_revision_id is not None:
+            # A conditional UPDATE is the compare-and-swap. SQLite ignores
+            # SELECT ... FOR UPDATE, whereas concurrent writers serialize this
+            # statement and the loser observes a zero row count after the
+            # winner commits.
+            deactivate = deactivate.where(
+                col(PricingRevision.revision_id) == expected_current_revision_id
+            )
+        result = cast(
+            CursorResult[Any],
+            await self._session.execute(deactivate.values(active=False)),
+        )
+        if expected_current_revision_id is not None and result.rowcount != 1:
+            await self._session.rollback()
+            raise RevisionConflict("active revision changed")
         row.active = True
         self._session.add(row)
         try:


### PR DESCRIPTION
## Root cause

The `v0.26.0` Docker publish and coverage workflows both failed in `test_concurrent_activation_leaves_one_active_revision`. Revision activation used `SELECT ... FOR UPDATE`, but SQLite ignores row locks. Two callers could therefore both read the same expected active revision, deactivate the winner's revision in sequence, and both report success.

## Fix

Use the conditional deactivation update itself as the compare-and-swap. Concurrent SQLite writers serialize that statement; after the winner commits, the loser updates zero rows and returns `RevisionConflict`. PostgreSQL retains the same atomic behavior. The existing partial unique index remains the final invariant guard.

## Verification

- failing SQLite race repeated 100 times: 100 passed
- disposable PostgreSQL 16 release integration: passed
- focused accounting API, synchronization, and migration tests: 23 passed
- exact Docker publish test command: 3,922 passed, 17 skipped, 3 expected failures
- Ruff, mypy, and diff checks: passed

The temporary PostgreSQL service was removed after verification.

## Release note

Do not move or recreate `v0.26.0`. After this PR merges, publish `v0.26.1` so the Docker images contain the corrected activation logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved revision activation to prevent conflicting updates when the active revision changes concurrently.
  - Activation now validates the expected revision and reports a conflict when it is no longer current.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->