### PR TITLE
fix(api): validate project budget actions

### DIFF
--- a/docs/api/http-api.md
+++ b/docs/api/http-api.md
@@ -592,6 +592,9 @@ Create a new project (stored in SQLite).
 }
 ```
 
+`budget_action` must be `warn`, `throttle`, or `block`. Both create and update requests
+return `400 Bad Request` for any other value.
+
 **Response:**
 
 ```json

--- a/src/voicegateway/server/api/projects.py
+++ b/src/voicegateway/server/api/projects.py
@@ -13,6 +13,13 @@ if TYPE_CHECKING:
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 write_dep = Depends(require_scope("write"))
+_VALID_BUDGET_ACTIONS = {"warn", "throttle", "block"}
+
+
+def _validate_budget_action(value: object) -> str:
+    if not isinstance(value, str) or value not in _VALID_BUDGET_ACTIONS:
+        raise HTTPException(400, f"Invalid budget_action '{value}'")
+    return value
 
 
 @router.get("")
@@ -70,12 +77,13 @@ async def create_project(
     pid = body.get("project_id", "")
     if pid in gateway.config.projects:
         raise HTTPException(409, f"Project '{pid}' already exists")
+    budget_action = _validate_budget_action(body.get("budget_action", "warn"))
     await gateway.storage.upsert_managed_project(
         project_id=pid,
         name=body.get("name", pid),
         description=body.get("description", ""),
         daily_budget=float(body.get("daily_budget", 0.0)),
-        budget_action=body.get("budget_action", "warn"),
+        budget_action=budget_action,
         default_stack=body.get("default_stack"),
         stt_model=body.get("stt_model"),
         llm_model=body.get("llm_model"),
@@ -98,12 +106,15 @@ async def update_project(
     managed = await gateway.storage.get_managed_project(project_id)
     if managed is None:
         raise HTTPException(404, f"No managed project '{project_id}'")
+    budget_action = _validate_budget_action(
+        body.get("budget_action", managed.get("budget_action", "warn"))
+    )
     await gateway.storage.upsert_managed_project(
         project_id=project_id,
         name=body.get("name", managed["name"]),
         description=body.get("description", managed.get("description", "")),
         daily_budget=float(body.get("daily_budget", managed.get("daily_budget", 0.0))),
-        budget_action=body.get("budget_action", managed.get("budget_action", "warn")),
+        budget_action=budget_action,
         default_stack=body.get("default_stack", managed.get("default_stack")),
         stt_model=body.get("stt_model", managed.get("stt_model")),
         llm_model=body.get("llm_model", managed.get("llm_model")),

--- a/src/voicegateway/tests/server/test_server.py
+++ b/src/voicegateway/tests/server/test_server.py
@@ -648,10 +648,26 @@ async def test_create_project(client):
         json={
             "project_id": "http-proj",
             "name": "HTTP Project",
+            "budget_action": "block",
         },
     )
     assert resp.status_code == 200
     assert resp.json()["source"] == "db"
+    detail = await client.get("/v1/projects/http-proj")
+    assert detail.json()["budget_action"] == "block"
+
+
+async def test_create_project_rejects_bad_budget_action(client):
+    resp = await client.post(
+        "/v1/projects",
+        json={
+            "project_id": "bad-action",
+            "name": "Invalid",
+            "budget_action": "explode",
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid budget_action 'explode'"
 
 
 async def test_create_project_conflict(client):
@@ -676,6 +692,23 @@ async def test_patch_project(client):
     resp = await client.patch("/v1/projects/update-me", json={"name": "Updated"})
     assert resp.status_code == 200
     assert resp.json()["updated"] is True
+
+
+async def test_patch_project_rejects_bad_budget_action(client):
+    await client.post(
+        "/v1/projects",
+        json={
+            "project_id": "invalid-update",
+            "name": "Original",
+        },
+    )
+    resp = await client.patch(
+        "/v1/projects/invalid-update", json={"budget_action": "explode"}
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid budget_action 'explode'"
+    detail = await client.get("/v1/projects/invalid-update")
+    assert detail.json()["budget_action"] == "warn"
 
 
 async def test_delete_project_yaml_forbidden(client):


### PR DESCRIPTION
Closes #169.

- Validate the resolved `budget_action` before either project write path reaches storage.
- Reject unknown or non-string values with HTTP 400 while preserving `warn`, `throttle`, and `block`.
- Cover create, update, valid persistence, and rejected-update state preservation; document the HTTP contract.

Validation: Ruff and mypy passed; 3,944 unit tests passed with 24 skipped, 36 deselected, and 3 expected failures; the docs validator passed all 85 pages.

AI disclosure: Implemented with Codex assistance and manually reviewed and tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Project creation and updates now reject unsupported budget actions with a clear `400 Bad Request` response.
  - Valid budget actions are limited to `warn`, `throttle`, and `block`.
  - Invalid updates no longer overwrite the existing budget action.
  - Omitting the budget action defaults new projects to `warn` and preserves the stored value during updates.

- **Documentation**
  - Updated the HTTP API documentation to describe accepted budget actions, defaults, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->